### PR TITLE
Callfixup for _guard_dispatch_icall on x86-64-win

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86-smm.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-smm.cspec
@@ -105,4 +105,12 @@
       <register name="SS"/>
     </unaffected>
   </prototype>
+  <callfixup name="guard_dispatch_icall">
+    <target name="_guard_dispatch_icall"/>
+    <pcode>
+      <body><![CDATA[
+        goto [RAX];
+      ]]></body>
+    </pcode>
+  </callfixup>
 </compiler_spec>


### PR DESCRIPTION
The added _callfixup_ allows the Decompiler to correctly recognize CFG function targets.

This implements the suggested changes from issue #318.