### PR TITLE
Callfixup for _guard_dispatch_icall on x86-64-win

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86-64-win.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-64-win.cspec
@@ -151,7 +151,7 @@
     <target name="_guard_dispatch_icall"/>
     <pcode>
       <body><![CDATA[
-        goto [RAX];
+        call [RAX];
       ]]></body>
     </pcode>
   </callfixup>

--- a/Ghidra/Processors/x86/data/languages/x86-64-win.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-64-win.cspec
@@ -147,4 +147,12 @@
       <range space="stack" first="8" last="39"/>
     </localrange>
   </prototype>
+  <callfixup name="guard_dispatch_icall">
+    <target name="_guard_dispatch_icall"/>
+    <pcode>
+      <body><![CDATA[
+        goto [RAX];
+      ]]></body>
+    </pcode>
+  </callfixup>
 </compiler_spec>


### PR DESCRIPTION
The added callfixup allows the Decompiler to correctly recognize CFG function targets.

This implements the suggested changes from issue #318.