### PR TITLE
Fix platform mislabeling in DevGuide.md

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -194,7 +194,7 @@ On macOS:
 gradle buildNatives_osx64
 ```
 
-On macOS:
+On Windows:
 
 ```bash
 gradle buildNatives_win64


### PR DESCRIPTION
I noticed this when following the guide to setup my environment. This appears to have been a minor mistake from copy-pasting.