### PR TITLE
Make bash scripts more portable

### DIFF
--- a/Ghidra/RuntimeScripts/Linux/ghidraRun
+++ b/Ghidra/RuntimeScripts/Linux/ghidraRun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------
 # Ghidra launch

--- a/Ghidra/RuntimeScripts/Linux/server/ghidraSvr
+++ b/Ghidra/RuntimeScripts/Linux/server/ghidraSvr
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 #---------------------------------------------------------------------------------------
 # Ghidra Server Script (see svrREADME.html for usage details)

--- a/Ghidra/RuntimeScripts/Linux/server/svrAdmin
+++ b/Ghidra/RuntimeScripts/Linux/server/svrAdmin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ***********************************************************
 # ** Arguments (each -argument option may be repeated):
 # **   [-add <sid>] [-remove <sid>] [-reset <sid>] [-dn <sid> "<x500_distinguished_name>"] 

--- a/Ghidra/RuntimeScripts/Linux/server/svrInstall
+++ b/Ghidra/RuntimeScripts/Linux/server/svrInstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OS=`uname -s`
 

--- a/Ghidra/RuntimeScripts/Linux/server/svrUninstall
+++ b/Ghidra/RuntimeScripts/Linux/server/svrUninstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OS=`uname -s`
 

--- a/Ghidra/RuntimeScripts/Linux/support/analyzeHeadless
+++ b/Ghidra/RuntimeScripts/Linux/support/analyzeHeadless
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------------------------------------
 # Ghidra Headless Analyzer launch (see analyzeHeadlessREADME.html)

--- a/Ghidra/RuntimeScripts/Linux/support/buildGhidraJar
+++ b/Ghidra/RuntimeScripts/Linux/support/buildGhidraJar
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------
 # Build a Ghidra jar

--- a/Ghidra/RuntimeScripts/Linux/support/convertStorage
+++ b/Ghidra/RuntimeScripts/Linux/support/convertStorage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------
 # Ghidra Filesystem Conversion launch

--- a/Ghidra/RuntimeScripts/Linux/support/dumpGhidraThreads
+++ b/Ghidra/RuntimeScripts/Linux/support/dumpGhidraThreads
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------
 # Ghidra Debug Thread Dumper launch

--- a/Ghidra/RuntimeScripts/Linux/support/ghidraDebug
+++ b/Ghidra/RuntimeScripts/Linux/support/ghidraDebug
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------
 # Ghidra debug launch

--- a/Ghidra/RuntimeScripts/Linux/support/launch.sh
+++ b/Ghidra/RuntimeScripts/Linux/support/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 umask 027
 

--- a/Ghidra/RuntimeScripts/Linux/support/pythonRun
+++ b/Ghidra/RuntimeScripts/Linux/support/pythonRun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------
 # Ghidra Python launch

--- a/Ghidra/RuntimeScripts/Linux/support/sleigh
+++ b/Ghidra/RuntimeScripts/Linux/support/sleigh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------
 # Ghidra Sleigh language compiler launch


### PR DESCRIPTION
Not every OS installs bash at /bin/bash. OpenBSD for instance installs bash at /usr/local/bin/bash. /usr/bin/env's location is defined by POSIX, so this will Always Work(R).

This makes ghidra run out-of-the-box on OpenBSD :)