### PR TITLE
AVR8: Improve operands for load/store instructions

### DIFF
--- a/Ghidra/Processors/Atmel/data/languages/avr8.sinc
+++ b/Ghidra/Processors/Atmel/data/languages/avr8.sinc
@@ -658,7 +658,8 @@ define pcodeop break;
 	RdFull = val:1;
 }
 
-:elpm RdFull, Z^"+" is phase=1 & ophi7=0x48 & oplow4=0x7 & RdFull & Z { 
+ElpmPlus: Z^"+" is Z {}
+:elpm RdFull, ElpmPlus is phase=1 & ophi7=0x48 & oplow4=0x7 & RdFull & ElpmPlus {
 	ptr:3 = zext(Z) | (zext(RAMPZ) << 16);
 	tmp:2 = *[code]:2 (ptr >> 1);
 	val:2 = (tmp >> (Z & 0x1));
@@ -748,10 +749,9 @@ define pcodeop break;
 }
 
 # ld Rd,Y+ ; ld Rd, X+; ld Rd, Z+
-:ld RdFull,RstPtr"+" is phase=1 & ophi7=0x48 & oplow2=0x01 & RdFull & RstPtr {
-  tmp:2 = RstPtr;
-  RdFull = *[mem]:1 tmp;
-  RstPtr = RstPtr + 0x01;
+LdPlus: RstPtr^"+" is RstPtr { tmp:2 = RstPtr; RstPtr = RstPtr + 0x01; export tmp; }
+:ld RdFull,LdPlus is phase=1 & ophi7=0x48 & oplow2=0x01 & RdFull & LdPlus {
+  RdFull = *[mem]:1 LdPlus;
 }
 # ld Rd,-Y ; ld Rd, -X; ld Rd, -Z
 LdPredec:  "-"^RstPtr  is RstPtr { RstPtr = RstPtr - 0x01; export RstPtr; }
@@ -762,9 +762,9 @@ LdPredec:  "-"^RstPtr  is RstPtr { RstPtr = RstPtr - 0x01; export RstPtr; }
 
 # ldd Rd,Y+q
 # ldd Rd,Z+q
-:ldd RdFull,Rstq"+"q6 is phase=1 & ophi2=0x2 & opbit12=0 & opbit9=0 & Rstq & RdFull & q6 { 
-  local ptr = Rstq + zext(q6);
-  RdFull = *[mem]:1 ptr;
+LddYq: Rstq^"+"^q6 is Rstq & q6 { local ptr = Rstq + zext(q6); export ptr; }
+:ldd RdFull,LddYq is phase=1 & ophi2=0x2 & opbit12=0 & opbit9=0 & LddYq & RdFull {
+  RdFull = *[mem]:1 LddYq;
 }
 
 # Rd,K
@@ -804,7 +804,8 @@ LdPredec:  "-"^RstPtr  is RstPtr { RstPtr = RstPtr - 0x01; export RstPtr; }
   RdFull = val:1;
 }
 # lpm Rd,Z+
-:lpm RdFull,Z"+" is phase=1 & ophi7=0x48 & op1to3=0x2 & RdFull & Z & opbit0=1 { 
+LpmPlus: Z^"+" is Z {}
+:lpm RdFull,LpmPlus is phase=1 & ophi7=0x48 & op1to3=0x2 & RdFull & LpmPlus & opbit0=1 {
   ptr:3 = zext(Z);
   tmp:2 = *[code]:2 (ptr >> 1);
   val:2 = (tmp >> (Z & 0x1));
@@ -976,7 +977,8 @@ define pcodeop store_program_mem;  # make this stand out.
   *[code]:2 ptr = R1R0;
   store_program_mem();
 }
-:spm Z^"+" is phase=1 & ophi16=0x95f8 & Z { 
+SpmPlus: Z^"+" is Z {}
+:spm SpmPlus is phase=1 & ophi16=0x95f8 & SpmPlus {
   ptr:3 = zext(Z) << 1;
   *[code]:2 ptr = R1R0;
   Z = Z + 1;


### PR DESCRIPTION
Currently, the operators for post-incremented or offset source operands
associated with various memory access instructions are separators
rather than components of the operand. As a result, inferred references
split the register and the operator when rendered in the listing, making
it easy to overlook the operator. For example:

lpm R0,Z=>DAT_code_000455+

This patch mimics logic already in place for the st and std
instructions, which include the post-increment operator or offset as
part of the operand. For example:

st X+=>DAT_mem_0100,R0