### PR TITLE
Minor code refactoring

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/MemoryMapPlugin/Memory_Map.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/MemoryMapPlugin/Memory_Map.htm
@@ -256,8 +256,7 @@
           <TABLE x-use-null-cells="" width="100%">
             <TBODY>
               <TR>
-                <TD align="center" width="100%"><IMG border=1 src="images/BitOverlayAddresses.png" border=
-                "0"></TD>
+                <TD align="center" width="100%"><IMG border=1 src="images/BitOverlayAddresses.png"></TD>
               </TR>
             </TBODY>
           </TABLE>

--- a/Ghidra/Features/Python/ghidra_scripts/python_basics.py
+++ b/Ghidra/Features/Python/ghidra_scripts/python_basics.py
@@ -46,7 +46,7 @@ if 4 not in my_list:
 if type(my_dictionary) == type(dict):
     print "my_dictionary is a dictionary!"
 
-if my_null is None and 2 + 2 == 4:
+if my_null is None:
     print "my_null is None and 2 + 2 == 4!"
 
 # Python loops

--- a/Ghidra/Features/VersionTracking/src/main/help/help/topics/VersionTrackingPlugin/providers/VT_Matches_Table.html
+++ b/Ghidra/Features/VersionTracking/src/main/help/help/topics/VersionTrackingPlugin/providers/VT_Matches_Table.html
@@ -238,7 +238,7 @@
 	        </TR>
 	                
 	        <TR>
-	          <TD nowrap nowrap valign="top">Destination Label Type</TD>
+	          <TD nowrap valign="top">Destination Label Type</TD>
 	          <TD valign="top">The source of the label in the destination program.  (Imported, Analysis, User Defined, etc.)</TD>
 	        </TR>
 	        
@@ -256,7 +256,7 @@
 	        </TR> 
 	        
 	        <TR>
-	          <TD nowrap nowrap valign="top"># Conflicting</TD>
+	          <TD nowrap valign="top"># Conflicting</TD>
 	          <TD valign="top">
 	          The number of unique associations with either the same source or same destination address.
 	          <br><br>


### PR DESCRIPTION
- **Duplicate HTML element attributes**:
  > *nowrap* declared twice.

- **Conflicting border values**:
  > *Border* attribute has the same name as another attribute of the same element, but a different value.

- **Comparison of constants**:
  > Comparison of constants will always return constant, removing unnecessary `and 2 + 2 == 4` statement which will always return true.
https://cwe.mitre.org/data/definitions/571.html
https://cwe.mitre.org/data/definitions/570.html