### PR TITLE
Change CDT 8.6.0 d/l step to use auto mirrors

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -303,11 +303,12 @@ Building the GhidraDev plugin for Eclipse requires the CDT and PyDev plugins for
 Download `cdt-8.6.0.zip` from The Eclipse Foundation, and place it in a directory named:
 `ghidra.bin/GhidraBuild/EclipsePlugins/GhidraDev/buildDependencies/`. Note that
 `ghidra.bin` must be a sibling of `ghidra`.
-To respect the Eclipse Project's resources, you may need to download the file using a browser, or at the very least, locate a suitable mirror on your own:
 
 ```bash
 cd ~/Downloads   # Or wherever
-curl -OL https://$CHOOSE_YOUR_MIRROR/pub/eclipse/tools/cdt/releases/8.6/cdt-8.6.0.zip
+curl -OL 'http://www.eclipse.org/downloads/download.php?r=1&protocol=https&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
+curl -o 'cdt-8.6.0.zip.sha512' -L --retry 3 'http://www.eclipse.org/downloads/sums.php?type=sha512&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
+sha512sum -c 'cdt-8.6.0.zip.sha512'
 mkdir -p ~/git/ghidra.bin/GhidraBuild/EclipsePlugins/GhidraDev/buildDependencies/
 cp ~/Downloads/cdt-8.6.0.zip ~/git/ghidra.bin/GhidraBuild/EclipsePlugins/GhidraDev/buildDependencies/
 ```


### PR DESCRIPTION
Per https://bugs.eclipse.org/bugs/show_bug.cgi?id=134634#c3 this mirror redirection feature is not well known, but it works and it removes a decision point from an otherwise copy-and-paste set of steps.

The `r=1` query fragment causes Eclipse.org's download.php to pass a redirect directly back to the client rather than a mirror list:
https://git.eclipse.org/c/www.eclipse.org/downloads.git/tree/download.php#n97

Sadly it appears that including the `protocol=https` query element is wasted effort since that value is unconditionally overridden:
https://git.eclipse.org/c/www.eclipse.org/downloads.git/tree/download.php#n173