### PR TITLE
Fixed Typo in DevGuide.md

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -194,7 +194,7 @@ On macOS:
 gradle buildNatives_osx64
 ```
 
-On macOS:
+On Windows:
 
 ```bash
 gradle buildNatives_win64


### PR DESCRIPTION
Fixed a heading for a command, windows command was written under macOS.