### PR TITLE
Fix #364 - broken error reporting from sleigh parser

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/antlr/ghidra/sleigh/grammar/SleighParser.g
+++ b/Ghidra/Framework/SoftwareModeling/src/main/antlr/ghidra/sleigh/grammar/SleighParser.g
@@ -16,6 +16,13 @@ import DisplayParser, SemanticParser;
 		gDisplayParser.setLexer(lexer);
 		gSemanticParser.setLexer(lexer);
 	}
+
+	@Override
+	public void setEnv(ParsingEnvironment env) {
+		super.setEnv(env);
+		gDisplayParser.setEnv(env);
+		gSemanticParser.setEnv(env);
+	}
 }
 
 /**


### PR DESCRIPTION
SleighParser contains a SleighParser_DisplayParser and SleighParser_SemanticParser.  When a parsing error occurs, these sub-parsers rely on a ParsingEnvironment to generate a helpful error report. 

When the SleighParser was set up it was not passing its ParsingEnvironment to the sub-parsers, causing a NullPointerException and the loss of any useful error message.  This pull request just propagates the environment to the sub-parsers.

With this fix, running the original command from the issue now produces the following:

    ERROR mistake.slaspec line 15: missing RPAREN, unexpected KEY_GOTO at 'goto':

        if ((op == 0) goto <foo>;
    ------------------^
     (SleighParser_SemanticParser)
    ERROR Unrecoverable error(s), halting compilation (SleighCompile) ghidra.sleigh.grammar.BailoutException: Abort
            at ghidra.sleigh.grammar.AbstractSleighParser.bail(AbstractSleighParser.java:35)
            at ghidra.sleigh.grammar.SleighParser.spec(SleighParser.java:501)
            at ghidra.pcodeCPort.slgh_compile.SleighCompileLauncher.run_compilation(SleighCompileLauncher.java:354)
            at ghidra.pcodeCPort.slgh_compile.SleighCompileLauncher.runMain(SleighCompileLauncher.java:268)
            at ghidra.pcodeCPort.slgh_compile.SleighCompileLauncher.launch(SleighCompileLauncher.java:72)
            at ghidra.GhidraLauncher.main(GhidraLauncher.java:78)