### PR TITLE
Use HTTPS for Microsoft symbol server URL

### DIFF
--- a/Ghidra/Configurations/Public_Release/data/PDB_SYMBOL_SERVER_URLS.pdburl
+++ b/Ghidra/Configurations/Public_Release/data/PDB_SYMBOL_SERVER_URLS.pdburl
@@ -1,1 +1,1 @@
-Internet,http://msdl.microsoft.com/download/symbols
+Internet,https://msdl.microsoft.com/download/symbols

--- a/Ghidra/Features/PDB/src/screen/java/help/screenshot/PdbScreenShots.java
+++ b/Ghidra/Features/PDB/src/screen/java/help/screenshot/PdbScreenShots.java
@@ -69,7 +69,7 @@ public class PdbScreenShots extends GhidraScreenShotGenerator {
 	public void testKnownSymbolServerURLsDialog() throws Exception {
 
 		List<URLChoice> urlChoices = new ArrayList<URLChoice>();
-		urlChoices.add(new URLChoice("Internet", "http://msdl.microsoft.com/download/symbols"));
+		urlChoices.add(new URLChoice("Internet", "https://msdl.microsoft.com/download/symbols"));
 		urlChoices.add(new URLChoice("My Network", "https://my_symbol_server.my.org"));
 
 		final ObjectChooserDialog<URLChoice> urlDialog =


### PR DESCRIPTION
To prevent man-in-the-middle attack, it's better to use HTTPS for symbol downloading whenever possible. WinDbg also uses https://msdl.microsoft.com/download/symbols by default.