### PR TITLE
Symbol environment may start with uppercase SRV

### DIFF
--- a/Ghidra/Features/PDB/src/main/java/pdb/PdbSymbolServerPlugin.java
+++ b/Ghidra/Features/PDB/src/main/java/pdb/PdbSymbolServerPlugin.java
@@ -257,7 +257,7 @@ public class PdbSymbolServerPlugin extends Plugin {
 		//    srv*[local cache]*[private symbol server]*https://msdl.microsoft.com/download/symbols
 		//    srv*c:\symbols*https://msdl.microsoft.com/download/symbols
 
-		if (!envString.startsWith("srv")) {
+		if (!envString.startsWith("srv") && !envString.startsWith("SRV")) {
 			return;
 		}
 


### PR DESCRIPTION
`parseSymbolEnv` shouldn't reject symbol environment variables, starting with uppercase "SRV".