### PR TITLE
PluginPackageComponent redesign - overlap fix

### DIFF
--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/PluginManagerComponent.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/PluginManagerComponent.java
@@ -75,70 +75,101 @@ public class PluginManagerComponent extends JPanel implements ChangeListener, Sc
 		tool.showDialog(pluginTableDialog);
 	}
 
-	class PluginPackageComponent extends JPanel {
-		private Color BG = Color.white;
+	private class PluginPackageComponent extends JPanel {
+		private static final long serialVersionUID = 1L;
+		private final Color BG = Color.white;
 		private final PluginPackage pluginPackage;
-		private JCheckBox jCheckBox;
-
-		PluginPackageComponent(PluginPackage pluginPackage) {
-			super(new BorderLayout());
-			setBackground(BG);
-			this.pluginPackage = pluginPackage;
-			JPanel panel = new JPanel(new HorizontalLayout(0));
-			panel.setBackground(BG);
-			jCheckBox = new JCheckBox();
+		private final JCheckBox jCheckBox;
+		
+		private void initizalizeCheckBoxSection() {
+			final JPanel checkboxPanel = new JPanel(new HorizontalLayout(0));
+			checkboxPanel.setBackground(BG);
+			
 			jCheckBox.addActionListener(e -> checkBoxClicked());
 			if (!pluginPackage.isfullyAddable()) {
 				jCheckBox.setEnabled(false);
 			}
-			panel.add(Box.createHorizontalStrut(10));
 			jCheckBox.setBackground(BG);
-			panel.add(jCheckBox);
-			panel.add(Box.createHorizontalStrut(10));
-			JLabel label =
+			
+			checkboxPanel.add(Box.createHorizontalStrut(10));
+			checkboxPanel.add(jCheckBox);
+			checkboxPanel.add(Box.createHorizontalStrut(10));
+			
+			final JLabel iconLabel =
 				new JLabel(ResourceManager.getScaledIcon(pluginPackage.getIcon(), 32, 32, 32));
-			label.setBackground(BG);
-			panel.add(label);
-			panel.add(Box.createHorizontalStrut(10));
-			add(panel, BorderLayout.WEST);
-
-			JPanel labelPanel = new JPanel(new VerticalLayout(3));
-			labelPanel.setBorder(BorderFactory.createEmptyBorder(4, 0, 0, 0));
+			iconLabel.setBackground(BG);
+			
+			checkboxPanel.add(iconLabel);
+			checkboxPanel.add(Box.createHorizontalStrut(10));
+			checkboxPanel.setPreferredSize(new Dimension(84, 70));
+			
+			add(checkboxPanel, BorderLayout.WEST);
+		}
+		
+		private void initializeLabelSection() {
+			final JPanel centerPanel = new JPanel(new GridBagLayout());
+			centerPanel.setBackground(BG);
+			
+			final JPanel labelPanel = new JPanel(new VerticalLayout(3));
 			labelPanel.setBackground(BG);
-			label = new JLabel(pluginPackage.getName());
-			//label.setVerticalAlignment(SwingConstants.TOP);
-			label.setFont(label.getFont().deriveFont(18f));
-			label.setForeground(Color.BLACK);
-			labelPanel.add(label);
-			HyperlinkComponent hyper =
-				new HyperlinkComponent("<html> <a href=\"Configure\">Configure</a>");
-			hyper.addHyperlinkListener("Configure", e -> {
-				if (e.getEventType() == EventType.ACTIVATED) {
-					managePlugins(PluginPackageComponent.this.pluginPackage);
-				}
-			});
-			hyper.setBackground(BG);
-			labelPanel.add(hyper);
-			labelPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 40));
-
-			add(labelPanel);
-			String htmlDescription = getHTMLDescription();
-			JLabel descriptionlabel = new JLabel(htmlDescription);
+			
+			final JLabel nameLabel = new JLabel(pluginPackage.getName());
+			nameLabel.setFont(nameLabel.getFont().deriveFont(18f));
+			nameLabel.setForeground(Color.BLACK);
+			labelPanel.add(nameLabel);
+			
+			final HyperlinkComponent configureHyperlink = createConfigureHyperlink();
+			labelPanel.add(configureHyperlink);
+			
+			labelPanel.setBorder(BorderFactory.createEmptyBorder(0, 25, 0, 40));
+			centerPanel.add(labelPanel);
+			
+			add(centerPanel);
+		}
+		
+		private HyperlinkComponent createConfigureHyperlink() {
+			final HyperlinkComponent configureHyperlink =
+					new HyperlinkComponent("<html> <a href=\"Configure\">Configure</a>");
+				configureHyperlink.addHyperlinkListener("Configure", e -> {
+					if (e.getEventType() == EventType.ACTIVATED) {
+						managePlugins(PluginPackageComponent.this.pluginPackage);
+					}
+				});
+				configureHyperlink.setBackground(BG);
+				return configureHyperlink;
+		}
+		
+		private String enchanceDescription(final String text) {
+			return String.format("<html><body style='width: 300px'>%s</body></html>", text);
+		}
+		
+		private void initializeDescriptionSection() {
+			final String htmlDescription = enchanceDescription(pluginPackage.getDescription());
+			
+			final JLabel descriptionlabel = new JLabel(htmlDescription);
 			descriptionlabel.setForeground(Color.GRAY);
 			descriptionlabel.setBorder(BorderFactory.createEmptyBorder(5, 0, 0, 0));
 			descriptionlabel.setVerticalAlignment(SwingConstants.TOP);
-			descriptionlabel.setPreferredSize(new Dimension(300, 60));
 			descriptionlabel.setToolTipText(
 				HTMLUtilities.toWrappedHTML(pluginPackage.getDescription(), 80));
+			
 			add(descriptionlabel, BorderLayout.EAST);
+		}
+		
+		PluginPackageComponent(PluginPackage pluginPackage) {
+			super(new BorderLayout());
+			setBackground(BG);
+			
+			this.pluginPackage = pluginPackage;
+			this.jCheckBox = new JCheckBox();
+			
+			initizalizeCheckBoxSection();
+			initializeLabelSection();
+			initializeDescriptionSection();
+
 			setBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED, Color.LIGHT_GRAY,
 				Color.DARK_GRAY));
 			updateCheckBoxState();
-		}
-
-		private String getHTMLDescription() {
-			String description = pluginPackage.getDescription();
-			return HTMLUtilities.toHTML(description);
 		}
 
 		protected void checkBoxClicked() {


### PR DESCRIPTION
This is a redesign of PluginPackageComponent to fix overlapping borders in 'experimental' section. Fix works on all look and feels and with any possible size of plugin description.
Plugin name and configure link are centered to checkbox and description.
 

Before fix Nimbus:
![Screenshot_2019-04-07_00-42-24](https://user-images.githubusercontent.com/11246021/55686464-0275ac00-5951-11e9-9687-053c4b91c5a0.png)

After fix Nimbus:
![Screenshot_2019-04-07_18-25-17](https://user-images.githubusercontent.com/11246021/55686517-ce4ebb00-5951-11e9-95de-c0ea6ca9d479.png)

After fix GTK:
![Screenshot_2019-04-07_18-24-07](https://user-images.githubusercontent.com/11246021/55686521-e1618b00-5951-11e9-9b7d-d3a959b0d26a.png)

After fix GTK - 3 times bigger descriptions:
![Screenshot_2019-04-07_17-36-26](https://user-images.githubusercontent.com/11246021/55686544-27b6ea00-5952-11e9-9460-359cb0045139.png)

After fix Nimbus - 3 times bigger description and longer panel: 
![Screenshot_2019-04-07_17-35-20](https://user-images.githubusercontent.com/11246021/55686602-d22f0d00-5952-11e9-8dc3-62f49606e73f.png)
 
