### PR TITLE
Decompiler: Support more 64-bit Linux hosts

### DIFF
--- a/GPL/build.gradle
+++ b/GPL/build.gradle
@@ -11,6 +11,8 @@ String getCurrentPlatformName() {
 		
 	boolean isX86_32 = archName.equals("x86") || archName.equals("i386");
 	boolean isX86_64 = archName.equals("x86_64") || archName.equals("amd64");
+	boolean isPPC64 = archName.equals("ppc64") || archName.equals("ppc64le")
+	boolean isAARCH64 = archName.equals("aarch64")
 
 	if (osName.startsWith("Windows")) {
 		if (isX86_32) {
@@ -21,7 +23,7 @@ String getCurrentPlatformName() {
 		}
 	}
 	else if (osName.startsWith("Linux")) {
-		if (isX86_64) {
+		if (isX86_64 || isPPC64 || isAARCH64) {
 			return 'linux64'
 		}
 	}

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
@@ -17,7 +17,7 @@ ifeq ($(OS),Linux)
 ifndef ARCH
   ARCH=$(CPU)
 endif
-ifeq ($(ARCH),x86_64)
+ifneq ($(filter x86_64 ppc64 ppc64le aarch64,$(ARCH)),)
   ARCH_TYPE=-m64
   OSDIR=linux64
 else

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
@@ -101,6 +101,59 @@ typedef char int1;
 typedef uint8 uintp;
 #endif
 
+#if defined (__linux__) && defined (__powerpc64__)
+#ifdef __LITTLE_ENDIAN__
+#define HOST_ENDIAN 0
+#else
+#define HOST_ENDIAN 1
+#endif
+typedef unsigned int uintm;
+typedef int intm;
+typedef unsigned long uint8;
+typedef long int8;
+typedef unsigned int uint4;
+typedef int int4;
+typedef unsigned short uint2;
+typedef short int2;
+typedef unsigned char uint1;
+typedef signed char int1;
+typedef uint8 uintp;
+#endif
+
+#if defined (__linux__) && defined (__aarch64__)
+#ifdef __ARM_BIG_ENDIAN
+#define HOST_ENDIAN 1
+#else
+#define HOST_ENDIAN 0
+#endif
+typedef unsigned int uintm;
+typedef int intm;
+typedef unsigned long uint8;
+typedef long int8;
+typedef unsigned int uint4;
+typedef int int4;
+typedef unsigned short uint2;
+typedef short int2;
+typedef unsigned char uint1;
+typedef signed char int1;
+typedef uint8 uintp;
+#endif
+
+#if defined (__linux__) && defined (__riscv) && (__riscv_xlen == 64)
+#define HOST_ENDIAN 0
+typedef unsigned int uintm;
+typedef int intm;
+typedef unsigned long uint8;
+typedef long int8;
+typedef unsigned int uint4;
+typedef int int4;
+typedef unsigned short uint2;
+typedef short int2;
+typedef unsigned char uint1;
+typedef signed char int1;
+typedef uint8 uintp;
+#endif
+
 #if defined(_WINDOWS)
 
 #if defined(_WIN64)

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Architecture.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Architecture.java
@@ -21,6 +21,8 @@ public enum Architecture {
 	X86_64("x86_64", "amd64"),
 	POWERPC("ppc"),
 	POWERPC_64("ppc64"),
+	POWERPC_64LE("ppc64le"),
+	ARM_64("aarch64"),
 	UNKNOWN("Unknown Architecture");
 
 	/**

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
@@ -51,6 +51,21 @@ public enum Platform {
 	LINUX_64(OperatingSystem.LINUX, Architecture.X86_64, "linux64", ".so", ""),
 
 	/**
+	 * Identifies a Linux OS.
+	 */
+	LINUX_64_PPC(OperatingSystem.LINUX, Architecture.POWERPC_64, "linux64", ".so", ""),
+
+	/**
+	 * Identifies a Linux OS.
+	 */
+	LINUX_64_PPCLE(OperatingSystem.LINUX, Architecture.POWERPC_64LE, "linux64", ".so", ""),
+
+	/**
+	 * Identifies a Linux OS.
+	 */
+	LINUX_64_ARM(OperatingSystem.LINUX, Architecture.ARM_64, "linux64", ".so", ""),
+
+	/**
 	 * Identifies a Linux OS, the architecture for which we do not know or have not encountered
 	 */
 	LINUX_UKNOWN(OperatingSystem.LINUX, Architecture.UNKNOWN, "linux32", ".so", ""),

--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,8 @@ String getCurrentPlatformName() {
 		
 	boolean isX86_32 = archName.equals("x86") || archName.equals("i386");
 	boolean isX86_64 = archName.equals("x86_64") || archName.equals("amd64");
+	boolean isPPC64 = archName.equals("ppc64") || archName.equals("ppc64le")
+	boolean isAARCH64 = archName.equals("aarch64")
 
 	if (osName.startsWith("Windows")) {
 		if (isX86_32) {
@@ -245,7 +247,7 @@ String getCurrentPlatformName() {
 		}
 	}
 	else if (osName.startsWith("Linux")) {
-		if (isX86_64) {
+		if (isX86_64 || isPPC64 || isAARCH64) {
 			return 'linux64'
 		}
 	}


### PR DESCRIPTION
This adds support for building the decompiler on more 64-bit Linux hosts, namely Linux/ppc64 (big and little endian), Linux/arm64 (big and little endian) and Linux/riscv.