### PR TITLE
Don't place calculated references on delay slot for MultiInstructionMemReference script

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/MultiInstructionMemReference.java
+++ b/Ghidra/Features/Base/ghidra_scripts/MultiInstructionMemReference.java
@@ -384,12 +384,6 @@ public class MultiInstructionMemReference extends GhidraScript {
 	 * @param scalar used as offset into address space
 	 */
 	private void makeReference(Instruction instruction, int opIndex, Address addr) {
-		if (instruction.getPrototype().hasDelaySlots()) {
-			instruction = instruction.getNext();
-			if (instruction == null) {
-				return;
-			}
-		}
 		if (opIndex == -1) {
 			for (int i = 0; i < instruction.getNumOperands(); i++) {
 				int opType = instruction.getOperandType(i);


### PR DESCRIPTION
I'm using this script (to great success) on MIPS, and I noticed that if I run this script on a `jalr t9`, the (correctly calculated) reference gets placed on the instruction operand in the delay slot instead of on the `jalr`. Is there something I'm not understanding about this choice or is my fix correct?