### PR TITLE
fix issue #327: Align virtualSize while importing PE files

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
@@ -313,7 +313,11 @@ public class FileHeader implements StructConverter {
 	            int sizeOfRawData = sectionHeaders[i].getSizeOfRawData();
 	    		sizeOfRawData  = PortableExecutable.computeAlignment(sizeOfRawData, optHeader.getFileAlignment());
 	    		sectionHeaders[i].setSizeOfRawData(sizeOfRawData);
-	    		
+
+	            int virtualSize = sectionHeaders[i].getVirtualSize();
+    			virtualSize  = PortableExecutable.computeAlignment(virtualSize, optHeader.getSectionAlignment());
+	    		sectionHeaders[i].setVirtualSize(virtualSize);
+
 	            tmpIndex += SectionHeader.IMAGE_SIZEOF_SECTION_HEADER;
 	        }
         }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/PortableExecutable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/PortableExecutable.java
@@ -184,7 +184,7 @@ public class PortableExecutable {
 	}
 
 	public static int computeAlignment(int value, int alignment) {
-		if ((value % alignment) == 0) {
+		if ( alignment == 0 || (value % alignment) == 0) {
 			return value;
 		}
 		int a = ((value + alignment) / alignment) * alignment;


### PR DESCRIPTION
also fixed division by zero if PE has fileAlignment = 0

This fixes all issues of #327.
The PE loading now behaves almost like the Windows native loader. The only difference is that we truncate the uninitialized data. The line to remove to gain full Windows PE loader behaviour (at least to the extend I observed it) is noted in a comment.