### PR TITLE
add Mac OS X horizontal scroll with mouse wheel

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/fieldpanel/FieldPanel.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/fieldpanel/FieldPanel.java
@@ -1428,7 +1428,16 @@ public class FieldPanel extends JPanel
 			}
 			else {
 				hoverHandler.stopHover();
-				scrollView(scrollAmount);
+
+				if (e.isShiftDown()) {
+					// horizontal scroll (only move viewport)
+                    if (viewport != null) {
+						Point pos = viewport.getViewPosition();
+						viewport.setViewPosition(new Point(Math.max(0, pos.x + scrollAmount), pos.y));
+					}
+				} else {
+					scrollView(scrollAmount);
+				}
 			}
 			e.consume();
 		}

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/fieldpanel/FieldPanel.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/fieldpanel/FieldPanel.java
@@ -1431,11 +1431,13 @@ public class FieldPanel extends JPanel
 
 				if (e.isShiftDown()) {
 					// horizontal scroll (only move viewport)
-                    if (viewport != null) {
+					if (viewport != null) {
 						Point pos = viewport.getViewPosition();
-						viewport.setViewPosition(new Point(Math.max(0, pos.x + scrollAmount), pos.y));
+						viewport.setViewPosition(
+							new Point(Math.max(0, pos.x + scrollAmount), pos.y));
 					}
-				} else {
+				}
+				else {
 					scrollView(scrollAmount);
 				}
 			}


### PR DESCRIPTION
This is useful when using Mac OS X desktop with touchpad, so that two fingers scrolling can work correctly