### PR TITLE
Add OpenBSD support

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -176,7 +176,7 @@ However, some features of Ghidra will not be functional until further steps are 
 ### Building the natives
 
 Some of Ghidra's components are built for the native platform.
-We currently support Linux, macOS, and Windows 64-bit x86 systems.
+We currently support Linux, macOS, Windows, and OpenBSD 64-bit x86 systems.
 Others should be possible, but we do not test on them.
 
 Ensure bison and flex are installed and in your `PATH`.
@@ -198,6 +198,11 @@ On Windows:
 
 ```bash
 gradle buildNatives_win64
+```
+
+On OpenBSD:
+```bash
+gradle buildNatives_openbsd64
 ```
 
 This will build the decompiler, the demangler for GNU toolchains, the sleigh compiler, and (on Windows only) the PDB parser.

--- a/GPL/CabExtract/build.gradle
+++ b/GPL/CabExtract/build.gradle
@@ -41,7 +41,7 @@ project.ext.cabextract = "cabextract-1.6"
  *
  * The cabextract tool requires that its 'configure' script is called before make.
  *********************************************************************************/
-['linux64', 'osx64'].each { platform ->
+['linux64', 'osx64', 'openbsd64'].each { platform ->
 		
 	def configureName = "${platform}CabExtractConfigure"
 	def makeName = "${platform}CabExtractMake" // native Make task found automatically

--- a/GPL/DemanglerGnu/Module.manifest
+++ b/GPL/DemanglerGnu/Module.manifest
@@ -1,3 +1,4 @@
 MODULE FILE LICENSE: os/linux64/demangler_gnu GPL 3
 MODULE FILE LICENSE: os/osx64/demangler_gnu GPL 3
+MODULE FILE LICENSE: os/openbsd64/demangler_gnu GPL 3
 MODULE FILE LICENSE: os/win64/demangler_gnu.exe GPL 3

--- a/GPL/DemanglerGnu/build.gradle
+++ b/GPL/DemanglerGnu/build.gradle
@@ -25,6 +25,10 @@ model {
 			architecture 'x86_64'
 			operatingSystem 'osx'
 		}
+		openbsd64 {
+			architecture 'x86_64'
+			operatingSystem 'openbsd'
+		}
 	}	
 }
 
@@ -65,6 +69,7 @@ model {
 			targetPlatform "win64"
 			targetPlatform "linux64"
 			targetPlatform "osx64"
+			targetPlatform "openbsd64"
 			sources {
 				c {
 					source {

--- a/GPL/build.gradle
+++ b/GPL/build.gradle
@@ -1,5 +1,5 @@
 project.ext.BIN_REPO = file("${projectDir}/../../ghidra.bin").absolutePath
-project.ext.set("OS_NAMES", ["osx64", "win32", "win64", "linux64"])
+project.ext.set("OS_NAMES", ["osx64", "win32", "win64", "linux64", "openbsd64"])
 
 /*********************************************************************************
  * Returns the local platform name.
@@ -28,6 +28,11 @@ String getCurrentPlatformName() {
 	else if (osName.startsWith("Mac OS X")) {
 		if (isX86_64) {
 			return 'osx64'
+		}
+	}
+	else if (osName.startsWith("OpenBSD")) {
+		if (isX86_64) {
+			return 'openbsd64'
 		}
 	}
 	throw new GradleException("Unrecognized current platform -> osName = $osName, archName = $archName")

--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -25,8 +25,9 @@ project.ext.VISUAL_STUDIO_VCVARS_CMD = "UNKNOWN"
 project.ext.MSVC_SDK_VERSION = "UNKNOWN"
 project.ext.MSVC_TOOLS_VERSION = "UNKNOWN"
 
-if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
 
+String osName = System.getProperty("os.name")
+if (isWindows(osName)) {
 	project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_DIR + "\\Professional"
 	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
 		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_DIR + "\\Community"
@@ -74,6 +75,10 @@ model {
 		osx64 {
 			architecture 'x86_64'
 			operatingSystem 'osx'
+		}
+		openbsd64 {
+			architecture 'x86_64'
+			operatingSystem 'openbsd'
 		}
 	}	
 }
@@ -208,15 +213,15 @@ gradle.taskGraph.whenReady {
 			File f = t.linkedFile.getAsFile().get()
 			String filename = f.getName()
 			NativePlatform platform = t.targetPlatform.get()
-			String osName = platform.getName()
-			t.linkedFile = p.file("build/os/${osName}/$filename")
+			String platformName = platform.getName()
+			t.linkedFile = p.file("build/os/${platformName}/$filename")
 		}
 		p.tasks.withType(LinkSharedLibrary).each { t ->
 			File f = t.linkedFile.getAsFile().get()
 			String filename = f.getName()
 			NativePlatform platform = t.targetPlatform.get()
-			String osName = platform.getName()
-			t.linkedFile = p.file("build/os/${osName}/$filename")
+			String platformName = platform.getName()
+			t.linkedFile = p.file("build/os/${platformName}/$filename")
 		}
 }
 

--- a/Ghidra/Features/Decompiler/build.gradle
+++ b/Ghidra/Features/Decompiler/build.gradle
@@ -78,9 +78,9 @@ def installPoint = "$rootDir/GhidraDocs/languages/html"
  */
 task buildDecompilerDocumentationPdfs(type: Exec) {
 	// Check the OS before enabling task.
-	if (!(org.gradle.internal.os.OperatingSystem.current().isLinux() 
-		|| org.gradle.internal.os.OperatingSystem.current().isMacOsX())) {
-			println "The '$it.name' task only works on Linux or Mac Os X and is therefore disabled."
+	String osName = System.getProperty("os.name")
+	if (!(isLinux(osName) || isMac(osName) || isOpenBSD(osName))) {
+			println "The '$it.name' task only works on Linux, Mac OS X, or OpenBSD and is therefore disabled."
 			it.enabled = false
 	}
 
@@ -210,10 +210,10 @@ task buildDecompilerDocumentationHtml(type: Exec) {
 
 		// Check the OS before executing command.
 		doFirst {
-			if ( !(org.gradle.internal.os.OperatingSystem.current().isLinux() 
-				|| org.gradle.internal.os.OperatingSystem.current().isMacOsX())) {
-				throw new TaskExecutionException( it,
-					new Exception( "The '$it.name' task only works on Linux or Mac Os X" ))
+			String osName = System.getProperty("os.name")
+			if ( !(isLinux(osName) || isMac(osName) || isOpenBSD(osName)) ) {
+					throw new TaskExecutionException( it,
+					new Exception( "The '$it.name' task only works on Linux, Mac OS X, or OpenBSD" ))
 			}
 		}
 
@@ -249,6 +249,7 @@ model {
 			targetPlatform "win64"
 			targetPlatform "linux64"
 			targetPlatform "osx64"
+			targetPlatform "openbsd64"
 			sources {
 				cpp {
 		            source {
@@ -346,6 +347,7 @@ model {
 			targetPlatform "win64"
 			targetPlatform "linux64"
 			targetPlatform "osx64"
+			targetPlatform "openbsd64"
 			sources {
 				cpp {
 					source {

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
@@ -33,6 +33,13 @@ ifeq ($(OS),Darwin)
   OSDIR=osx64
 endif
 
+ifeq ($(OS),OpenBSD)
+ifeq ($(ARCH),x86_64)
+  ARCH_TYPE=-m64
+  OSDIR=openbsd64
+endif
+endif
+
 CC=gcc
 CXX=g++
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
@@ -86,7 +86,8 @@ typedef char int1;
 typedef uint4 uintp;
 #endif
 
-#if defined (__linux__) && defined (__x86_64__)
+#if (defined (__linux__) && defined (__x86_64__)) || \
+	(defined (__OpenBSD__) && defined (__x86_64__))
 #define HOST_ENDIAN 0
 typedef unsigned int uintm;
 typedef int intm;

--- a/Ghidra/Features/FunctionID/build.gradle
+++ b/Ghidra/Features/FunctionID/build.gradle
@@ -97,10 +97,10 @@ task buildFidDocumentationPdf(type: Exec) {
 
 	// Check the OS before executing command.
 	doFirst {
-		if ( !(org.gradle.internal.os.OperatingSystem.current().isLinux() 
-			|| org.gradle.internal.os.OperatingSystem.current().isMacOsX())) {
+		String osName = System.getProperty("os.name")
+		if ( !(isLinux(osName) || isMac(osName) || isOpenBSD(osName))) {
 			throw new TaskExecutionException( it,
-				new Exception( "The '$it.name' task only works on Linux or Mac Os X" ))
+				new Exception( "The '$it.name' task only works on Linux, Mac OS X, or OpenBSD" ))
 		}
 	}
 

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
@@ -71,6 +71,21 @@ public enum Platform {
 	MAC_UNKNOWN(OperatingSystem.MAC_OS_X, Architecture.UNKNOWN, "osx64", ".dylib", ""),
 
 	/**
+	 * Identifies an OpenBSD OS for the Intel x86 32-bit platform.
+	 */
+	OPENBSD(OperatingSystem.OPENBSD, Architecture.X86, "openbsd32", ".so", ""),
+
+	/**
+	 * Identifies an OpenBSD OS for the Intel x86 64-bit platform.
+	 */
+	OPENBSD_64(OperatingSystem.OPENBSD, Architecture.X86_64, "openbsd64", ".so", ""),
+
+	/**
+	 * Identifies an OpenBSD OS, the architecture for which we do not know or have not encountered
+	 */
+	OPENBSD_UNKNOWN(OperatingSystem.OPENBSD, Architecture.UNKNOWN, "openbsd32", ".so", ""),
+
+	/**
 	 * Identifies an unsupported OS.
 	 */
 	UNSUPPORTED(OperatingSystem.UNSUPPORTED, Architecture.UNKNOWN, null, null, "");
@@ -140,6 +155,13 @@ public enum Platform {
 		if (operatingSystem == OperatingSystem.LINUX) {
 			paths.add("/bin");
 			paths.add("/lib");
+			paths.add("/usr/bin");
+			paths.add("/usr/lib");
+			paths.add("/usr/X11R6/bin");
+			paths.add("/usr/X11R6/lib");
+		}
+		else if (operatingSystem == OperatingSystem.OPENBSD) {
+			paths.add("/bin");
 			paths.add("/usr/bin");
 			paths.add("/usr/lib");
 			paths.add("/usr/X11R6/bin");

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/framework/OperatingSystem.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/framework/OperatingSystem.java
@@ -20,6 +20,7 @@ public enum OperatingSystem {
 	WINDOWS("Windows"),
 	LINUX("Linux"),
 	MAC_OS_X("Mac OS X"),
+	OPENBSD("OpenBSD"),
 	UNSUPPORTED("Unsupported Operating System");
 
 	/**

--- a/Ghidra/RuntimeScripts/build.gradle
+++ b/Ghidra/RuntimeScripts/build.gradle
@@ -17,7 +17,7 @@ rootProject.OS_NAMES.each { platform ->
 	rootProject.tasks.findAll {it.name == "assembleDistribution_$platform"}.each { t -> 
 		def p = this.project
 
-		if (isLinux(platform) || isMac(platform)) {
+		if (isLinux(platform) || isMac(platform) || isOpenBSD(platform)) {
 			t.from ("${p.projectDir}/Linux/support") {
 				into "support"
 			}

--- a/GhidraBuild/Skeleton/os/openbsd64/README.txt
+++ b/GhidraBuild/Skeleton/os/openbsd64/README.txt
@@ -1,0 +1,3 @@
+The "os/openbsd64" directory is intended to hold OpenBSD native binaries
+which this module is dependent upon.   This directory may be eliminated for a specific 
+module if native binaries are not provided for the corresponding platform.

--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -68,6 +68,7 @@ future releases.
   <li>Microsoft Windows 7 or 10 (64-bit)</li>
   <li>Linux (64-bit, CentOS 7 is preferred)</li>
   <li>macOS (OS X) 10.8.3+ (Mountain Lion or later)</li>
+  <li>OpenBSD (64-bit)</li>
 </ul>
 <blockquote><p><b>NOTE: </b>All 32-bit OS installations are now deprecated. Please contact the
 Ghidra team if you have a specific need.</p></blockquote>

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ apply from: "gradle/support/loadApplicationProperties.gradle"
  *		project.OS_NAMES.each {...}
  ****************************************************************************/
 
-project.ext.set("OS_NAMES", ["osx64", "win32", "win64", "linux64"])
+project.ext.set("OS_NAMES", ["osx64", "win32", "win64", "linux64", "openbsd64"])
 
 /*********************************************************************************
  * Imports
@@ -89,7 +89,7 @@ clean {
  * Returns true if the platform is a linux machine.
  *********************************************************************************/
 def isLinux(String platformName) {
-	return platformName.startsWith("linux")
+	return platformName.toLowerCase().startsWith("linux")
 }
 
 
@@ -97,15 +97,21 @@ def isLinux(String platformName) {
  * Returns true if the platform is a mac
  *********************************************************************************/
 def isMac(String platformName) {
-	return platformName.startsWith("osx")
+	return platformName.toLowerCase().startsWith("osx")
 }
 
+/*********************************************************************************
+ * Returns true if the platform is an openbsd machine.
+ *********************************************************************************/
+def isOpenBSD(String platformName) {
+	return platformName.toLowerCase().startsWith("openbsd")
+}
 
 /*********************************************************************************
  * Returns true if the platform is a Windows machine.
  *********************************************************************************/
 def isWindows(String platformName) {
-	return platformName.startsWith("win")
+	return platformName.toLowerCase().startsWith("win")
 }
 
 /******************************************************************************************
@@ -247,6 +253,11 @@ String getCurrentPlatformName() {
 	else if (osName.startsWith("Linux")) {
 		if (isX86_64) {
 			return 'linux64'
+		}
+	}
+	else if (osName.startsWith("OpenBSD")) {
+		if (isX86_64) {
+			return 'openbsd64'
 		}
 	}
 	else if (osName.startsWith("Mac OS X")) {

--- a/gradle/root/distribution.gradle
+++ b/gradle/root/distribution.gradle
@@ -387,6 +387,7 @@ task createInstallationZip(type: Zip) { t ->
 		dependsOn ":assembleDistribution_win64"
 		dependsOn ":assembleDistribution_linux64"
 		dependsOn ":assembleDistribution_osx64"
+		dependsOn ":assembleDistribution_openbsd64"
 		dependsOn ":assembleSource"
 	}
 


### PR DESCRIPTION
This change both enables ghidra (mainly the native components) to compile and run under OpenBSD and gets rid of the usage of the internal gradle functions being used to detect OS in several places. Apparently gradle frowns upon using their internal APIs for this sort of thing, since they can change without warning. Here is the relevant PR I tried first to enable OpenBSD detection where the discussion of this took place: https://github.com/gradle/gradle/pull/9179