### PR TITLE
Fixed detection of VS SDK and VCTools Versions

### DIFF
--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -20,25 +20,6 @@ apply plugin: 'c'
 project.ext.VISUAL_STUDIO_BASE_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017"
 project.ext.WINDOWS_KITS_DIR = "C:/Program Files (x86)/Windows Kits/10"
 
-/****************************************************************************
- * Method for extracting value from <name>=<value> pairs
- ****************************************************************************/
-ext.getEnvironmentValue = { envLines, name ->
-	String assignment = name + "="
-	for (String line : envLines) {
-		if (line.startsWith(assignment)) {
-			String[] parts = line.split("=")
-			String value = parts[1].trim()
-			// remove trailing \ if present
-			if (value.endsWith("\\")) {
-				value = value.substring(0, value.length()-1)
-			}
-			return value
-		}
-	}
-	return null
-}
-
 // Ok, this is stupid, but mac and linux can't handle files paths that start with c:
 // These paths are actually only used when running on windows, but the paths gets evaulated
 // as a file no matter what platform you run gradle on.  So the best solution I can think of is as
@@ -57,14 +38,12 @@ if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
 	// WINVER property a value of "0x0601" which may be specified to the compiler/linker.
 	// If using a VS Solution this must be specified within the project file(s).
 	project.ext.WINVER = "0x0601"
-	
+
 	// Rely on vcvars script to supply SDK versions
-	def c = VISUAL_STUDIO_VCVARS_CMD + " && env"
-	String envText = c.execute().text
-	String[] envLines = c.execute().text.split("\n")
-	project.ext.MSVC_SDK_VERSION = getEnvironmentValue(envLines, "WINDOWSSDKVERSION")
+	def COMMAND = "cmd /c ${VISUAL_STUDIO_VCVARS_CMD} > nul && cmd /c echo"
+	project.ext.MSVC_SDK_VERSION = "${COMMAND} %WINDOWSSDKVERSION%".execute().text.replace('\\', '')
 	println "Visual Studio SDK Version: ${MSVC_SDK_VERSION}"
-	project.ext.MSVC_TOOLS_VERSION = getEnvironmentValue(envLines, "VCTOOLSVERSION")
+	project.ext.MSVC_TOOLS_VERSION = "${COMMAND} %VCTOOLSVERSION%".execute().text.replace('\\', '')
 	println "Visual Studio VCTools Version: ${MSVC_TOOLS_VERSION}"
 }
 else {


### PR DESCRIPTION
Initially the detection of the Visual Studio SDK and VCTools versions were returning null. This was due to case sensitivity. The following changes are case insensitive, allow the removal of the ext.getEnvironmentValue method and remove the need for env to be in the system PATH. This was also tested with Visual Studio 2019 to ensure it will work in the future.