### PR TITLE
Report errors about labels in macros.

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
@@ -1537,7 +1537,7 @@ public class SleighCompile extends SleighBase {
 		entry("buildMacro", sym, rtl);
 		String errstring = checkSymbols(symtab.getCurrentScope());
 		if (errstring.length() != 0) {
-			reportError(sym.getLocation(), " in definition of macro " + sym.getName() + ":");
+			reportError(sym.getLocation(), " in definition of macro " + sym.getName() + ":" + errstring);
 			return;
 		}
 		if (!expandMacros(rtl)) {


### PR DESCRIPTION
**Describe the bug**
When parsing a spec that contains a macro with a label-related error, the error message does not contain enough information to easily debug the error.

**To Reproduce**
With Ghidra 9.0.2, using the attached spec file [mistake.slaspec](https://github.com/NationalSecurityAgency/ghidra/files/3123914/mistake.txt):
`sleigh.bat -x -u -l -n -t -e -f mistake.slaspec`

    ERROR mistake.slaspec:14:  in definition of macro do_stuff:  (SleighCompile)
    ERROR mistake.slaspec:21: in table "instruction" constructor from mistake.slaspec:21 (SleighCompile)
    ERROR    Main section: Could not expand macros (SleighCompile)
    ERROR No output produced (SleighCompile)

**Post-fix**

    ERROR mistake.slaspec:14:  in definition of macro do_stuff:    Label <unused_label> was placed but not used (SleighCompile)
    ERROR mistake.slaspec:21: in table "instruction" constructor from mistake.slaspec:21 (SleighCompile)
    ERROR    Main section: Could not expand macros (SleighCompile)
    ERROR No output produced (SleighCompile)