### PR TITLE
Fix forgotten version bump for Generic Module.manifest

### DIFF
--- a/Ghidra/Framework/Generic/Module.manifest
+++ b/Ghidra/Framework/Generic/Module.manifest
@@ -4,5 +4,5 @@ MODULE FILE LICENSE: lib/jdom-legacy-1.1.3.jar JDOM License
 MODULE FILE LICENSE: lib/log4j-api-2.8.2.jar Apache License 2.0
 MODULE FILE LICENSE: lib/log4j-core-2.8.2.jar Apache License 2.0
 MODULE FILE LICENSE: lib/commons-collections4-4.1.jar Apache License 2.0
-MODULE FILE LICENSE: lib/commons-lang3-3.5.jar Apache License 2.0
+MODULE FILE LICENSE: lib/commons-lang3-3.9.jar Apache License 2.0
 MODULE FILE LICENSE: lib/commons-io-2.6.0.jar Apache License 2.0


### PR DESCRIPTION
Commit 3402c18b25a34c7804784ad32997db523b5b36d6 forgot to bump the version number here: https://github.com/NationalSecurityAgency/ghidra/blob/3402c18b25a34c7804784ad32997db523b5b36d6/Ghidra/Framework/Generic/Module.manifest#L7

This prevents ghidra from being built due to licensing issues.