### PR TITLE
Update module.manifest commons-lang version to match build.gradle

### DIFF
--- a/Ghidra/Framework/Generic/Module.manifest
+++ b/Ghidra/Framework/Generic/Module.manifest
@@ -4,5 +4,5 @@ MODULE FILE LICENSE: lib/jdom-legacy-1.1.3.jar JDOM License
 MODULE FILE LICENSE: lib/log4j-api-2.8.1.jar Apache License 2.0
 MODULE FILE LICENSE: lib/log4j-core-2.8.1.jar Apache License 2.0
 MODULE FILE LICENSE: lib/commons-collections4-4.1.jar Apache License 2.0
-MODULE FILE LICENSE: lib/commons-lang3-3.5.jar Apache License 2.0
+MODULE FILE LICENSE: lib/commons-lang3-3.9.jar Apache License 2.0
 MODULE FILE LICENSE: lib/commons-io-2.6.0.jar Apache License 2.0


### PR DESCRIPTION
The build.gradle commons-lang version was recently updated, but the manifest was missed. 
This results in an error during the build process.

This updates the versions to match so the license can be found. 

Related change to build.gradle: 3402c18b25a34c7804784ad32997db523b5b36d6

Error message during `gradle buildGhidra`:
```
FAILURE: Build failed with an exception.

* Where:
Script '/home/gradle/ghidra/gradle/support/ip.gradle' line: 89

* What went wrong:
Execution failed for task ':Generic:ip'.
> No License specified for external library: lib/commons-lang3-3.9.jar in module /home/gradle/ghidra/Ghidra/Framework/Generic. Expression: map.containsKey(relativePath)

```