### PR TITLE
Processors/x86: implement the PF flag

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -1904,7 +1904,17 @@ macro subCarryFlags ( op1, op2 ) {
 macro resultflags(result) {
  SF = result s< 0;
  ZF = result == 0;
- # PF, AF not implemented
+ local ext1:8 = zext(result);
+ local ext2 = ext1 >> 4;
+ local ext3 = ext1 ^ ext2;
+ local ext4 = ext3 >> 2;
+ local ext5 = ext3 ^ ext4;
+ local ext6 = ext5 >> 1;
+ local ext7 = ext5 ^ ext6;
+ local ext8:8 = 1;
+ local ext9 = ext7 & ext8;
+ PF = (ext9 == 0);
+ # AF not implemented
 }
 
 macro shiftresultflags(result,count) {
@@ -1916,7 +1926,18 @@ macro shiftresultflags(result,count) {
 
  local newZF = (result == 0);
  ZF = (!notzero & ZF) | (notzero & newZF);
- # PF, AF not implemented
+ local ext1:8 = zext(result);
+ local ext2 = ext1 >> 4;
+ local ext3 = ext1 ^ ext2;
+ local ext4 = ext3 >> 2;
+ local ext5 = ext3 ^ ext4;
+ local ext6 = ext5 >> 1;
+ local ext7 = ext5 ^ ext6;
+ local ext8:8 = 1;
+ local ext9 = ext7 & ext8;
+ local newPF = (ext9 == 0);
+ PF = (!notzero & PF) | (notzero & newPF);
+ # AF not implemented
 }
 
 macro subflags(op1,op2) {


### PR DESCRIPTION
This patch comes from @RolfRolles as I took it here: https://github.com/RolfRolles/GhidraPAL/blob/2af31f03745cb16459e8dbe5bed9c9b302d35443/ia.diff I am not the original author.

This implements the PF flags which makes decompilation work in some cases such as a JP instruction. Seemed to work pretty well on the binary I was reversing and it would improve the decompilation quite significantly.