### PR TITLE
Add option to hoist menu bar out of window on macOS

### DIFF
--- a/Ghidra/RuntimeScripts/Common/support/launch.properties
+++ b/Ghidra/RuntimeScripts/Common/support/launch.properties
@@ -65,6 +65,9 @@ VMARGS=-Dfont.size.override=
 # Disable alternating row colors in tables
 #VMARGS=-Ddisable.alternating.row.colors=true
 
+# Hoist the menu bar out of the window on macOS
+#VMARGS=-Dapple.laf.useScreenMenuBar=true
+
 # The ContinuesInterceptor allows the import process to proceed if parsing corrupted headers
 # generates uncaught exceptions.  Disabling it can be helpful when trying to debug what went
 # wrong because the ContinuesIntercepter affects the usefulness of the stack trace.


### PR DESCRIPTION
A small quality-of-life improvement on macOS, which has its own system-wide menu bar. The menu bar can get a bit flickery during decompilation (I assume that Ghidra's changing the menu items and macOS is animating the modifications) but hopefully it's not too awful. FWIW, here's a screenshot:

<img width="1280" alt="Screen Shot 2019-05-03 at 23 38 18" src="https://user-images.githubusercontent.com/13786931/57175099-8ad65800-6dfc-11e9-87c5-2d359045db80.png">
