### PR TITLE
Adds support for building aarch64 host platform.

### DIFF
--- a/GPL/build.gradle
+++ b/GPL/build.gradle
@@ -11,6 +11,7 @@ String getCurrentPlatformName() {
 		
 	boolean isX86_32 = archName.equals("x86") || archName.equals("i386");
 	boolean isX86_64 = archName.equals("x86_64") || archName.equals("amd64");
+	boolean isARM64 = archName.equals("aarch64");
 
 	if (osName.startsWith("Windows")) {
 		if (isX86_32) {
@@ -21,7 +22,7 @@ String getCurrentPlatformName() {
 		}
 	}
 	else if (osName.startsWith("Linux")) {
-		if (isX86_64) {
+		if (isX86_64 || isARM64) {
 			return 'linux64'
 		}
 	}

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
@@ -101,6 +101,25 @@ typedef char int1;
 typedef uint8 uintp;
 #endif
 
+#if defined (__linux__) && defined (__aarch64__)
+#ifdef __ARM_BIG_ENDIAN
+#define HOST_ENDIAN 1
+#else
+#define HOST_ENDIAN 0
+#endif
+typedef unsigned int uintm;
+typedef int intm;
+typedef unsigned long uint8;
+typedef long int8;
+typedef unsigned int uint4;
+typedef int int4;
+typedef unsigned short uint2;
+typedef short int2;
+typedef unsigned char uint1;
+typedef signed char int1;
+typedef uint8 uintp;
+#endif
+
 #if defined(_WINDOWS)
 
 #if defined(_WIN64)

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Architecture.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Architecture.java
@@ -21,6 +21,7 @@ public enum Architecture {
 	X86_64("x86_64", "amd64"),
 	POWERPC("ppc"),
 	POWERPC_64("ppc64"),
+	AARCH64("aarch64"),
 	UNKNOWN("Unknown Architecture");
 
 	/**

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
@@ -51,6 +51,11 @@ public enum Platform {
 	LINUX_64(OperatingSystem.LINUX, Architecture.X86_64, "linux64", ".so", ""),
 
 	/**
+	 * Identifies a Linux OS.
+	 */
+	LINUX_AARCH64(OperatingSystem.LINUX, Architecture.AARCH64, "linux64", ".so", ""),
+
+	/**
 	 * Identifies a Linux OS, the architecture for which we do not know or have not encountered
 	 */
 	LINUX_UKNOWN(OperatingSystem.LINUX, Architecture.UNKNOWN, "linux32", ".so", ""),

--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,7 @@ String getCurrentPlatformName() {
 		
 	boolean isX86_32 = archName.equals("x86") || archName.equals("i386");
 	boolean isX86_64 = archName.equals("x86_64") || archName.equals("amd64");
+	boolean isARM64 = archName.equals("aarch64");
 
 	if (osName.startsWith("Windows")) {
 		if (isX86_32) {
@@ -245,7 +246,7 @@ String getCurrentPlatformName() {
 		}
 	}
 	else if (osName.startsWith("Linux")) {
-		if (isX86_64) {
+		if (isX86_64 || isARM64) {
 			return 'linux64'
 		}
 	}


### PR DESCRIPTION
Combine with https://github.com/NationalSecurityAgency/ghidra/pull/571 to build on aarch64 host. Borrowed aarch64 section from https://github.com/NationalSecurityAgency/ghidra/pull/395

Works on my aarch64 chromebook. Tested that decompiler is working with a simple crackmes tutorial, https://www.youtube.com/watch?v=fTGTnrgjuGA