### PR TITLE
Call UIManager.getDefaults() instead of UIManager.getLookAndFeel().getDefaults()

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/menu/DockingCheckboxMenuItemUI.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/menu/DockingCheckboxMenuItemUI.java
@@ -26,9 +26,8 @@ import javax.swing.plaf.MenuItemUI;
 
 public class DockingCheckboxMenuItemUI extends DockingMenuItemUI {
 	public static ComponentUI createUI(JComponent c) {
-		LookAndFeel underlying = UIManager.getLookAndFeel();
 		DockingCheckboxMenuItemUI result = new DockingCheckboxMenuItemUI();
-		result.ui = (MenuItemUI) underlying.getDefaults().getUI(c);
+		result.ui = (MenuItemUI) UIManager.getDefaults().getUI(c);
 		return result;
 	}
 }

--- a/Ghidra/Framework/Docking/src/main/java/docking/menu/DockingMenuItemUI.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/menu/DockingMenuItemUI.java
@@ -67,9 +67,8 @@ public class DockingMenuItemUI extends MenuItemUI {
 	protected MenuItemUI ui;
 
 	public static ComponentUI createUI(JComponent c) {
-		LookAndFeel underlying = UIManager.getLookAndFeel();
 		DockingMenuItemUI result = new DockingMenuItemUI();
-		result.ui = (MenuItemUI) underlying.getDefaults().getUI(c);
+		result.ui = (MenuItemUI) UIManager.getDefaults().getUI(c);
 		return result;
 	}
 

--- a/Ghidra/Framework/Docking/src/main/java/docking/menu/DockingMenuUI.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/menu/DockingMenuUI.java
@@ -22,9 +22,8 @@ import javax.swing.plaf.MenuItemUI;
 
 public class DockingMenuUI extends DockingMenuItemUI {
 	public static ComponentUI createUI(JComponent c) {
-		LookAndFeel underlying = UIManager.getLookAndFeel();
 		DockingMenuUI result = new DockingMenuUI();
-		result.ui = (MenuItemUI) underlying.getDefaults().getUI(c);
+		result.ui = (MenuItemUI) UIManager.getDefaults().getUI(c);
 		return result;
 	}
 }

--- a/Ghidra/Framework/Docking/src/main/java/ghidra/docking/util/DockingWindowsLookAndFeelUtils.java
+++ b/Ghidra/Framework/Docking/src/main/java/ghidra/docking/util/DockingWindowsLookAndFeelUtils.java
@@ -204,7 +204,7 @@ public class DockingWindowsLookAndFeelUtils {
 			case NIMBUS_LOOK_AND_FEEL:
 				// fix scroll bar grabber disappearing.  See https://bugs.openjdk.java.net/browse/JDK-8134828
 				// This fix looks like it should not cause harm even if the bug is fixed on the jdk side.
-				UIDefaults defaults = lookAndFeel.getDefaults();
+				UIDefaults defaults = UIManager.getDefaults();
 				defaults.put("ScrollBar.minimumThumbSize", new Dimension(30, 30));
 				break;
 		}
@@ -275,8 +275,7 @@ public class DockingWindowsLookAndFeelUtils {
 
 	/** Allows you to globally set the font size (don't use this method!) */
 	private static void setGlobalFontSizeOverride(int fontSize) {
-		LookAndFeel lookAndFeel = UIManager.getLookAndFeel();
-		UIDefaults defaults = lookAndFeel.getDefaults();
+		UIDefaults defaults = UIManager.getDefaults();
 
 		Set<Entry<Object, Object>> set = defaults.entrySet();
 		Iterator<Entry<Object, Object>> iterator = set.iterator();


### PR DESCRIPTION
On macOS, a profiler shows a significant amount of time being spent in `AquaLookAndFeel.getDefaults()`.  It's not very expensive in an absolute sense; a quick Python benchmark[1] shows that it takes about 0.5ms on my machine.  But Ghidra calls it very often – 22 times upon right clicking, 170 times upon using "Show References to Address".  Also, `UIDefaults` objects cache requested properties to speed up repeated requests, but calling `getDefaults()` directly on the `LookAndFeel` returns a new object each time, limiting the opportunity to cache.

As potential replacements, I considered the static methods `UIManager.getLookAndFeelDefaults()` and `UIManager.getDefaults()`.  Both methods return a cached object rather than creating a new one.  According to the documentation, `getLookAndFeelDefaults` "returns the UIDefaults from the current look and feel, that were obtained at the time the look and feel was installed."  Thus, it's more similar to what Ghidra is currently doing.  `getDefaults`, on the other hand, "resolve[s] using the logic specified in the class documentation".  Quoting the documentation in question:

> `UIManager` manages three sets of `UIDefaults`. In order, they are:
>
> - Developer defaults. With few exceptions Swing does not alter the developer defaults; these are intended to be modified and used by the developer.
> - Look and feel defaults. The look and feel defaults are supplied by the look and feel at the time it is installed as the current look and feel (`setLookAndFeel()` is invoked). The look and feel defaults can be obtained using the `getLookAndFeelDefaults()` method.
> - System defaults. The system defaults are provided by Swing.
>
> Invoking any of the various `get` methods results in checking each of the defaults, in order, returning the first `non-null` value.

I don't see any reason that considering developer and system defaults would break anything, and it seems more correct, so this PR uses `getDefaults()`, not `getLookAndFeelDefaults()`.

Note that in at least one case, `fixupLookAndFeelIssues`, the code calls `put` on the defaults object, so using `UIManager.getDefaults()` means that it now sets a developer default rather than modifying the look and feel default.  Again, this seems more correct, and I verified that the property it sets (minimum thumb size for Nimbus) is still reflected in the UI after the change. 

[1]
```python
import timeit
from javax.swing import UIManager
laf = UIManager.getLookAndFeel()
print timeit.timeit(laf.getDefaults, number=1000) / 1000.
```
