### PR TITLE
AVR8: Fix lpm/elpm implementation in SLEIGH specification

### DIFF
--- a/Ghidra/Processors/Atmel/data/languages/avr8.sinc
+++ b/Ghidra/Processors/Atmel/data/languages/avr8.sinc
@@ -648,20 +648,20 @@ define pcodeop break;
 :elpm is phase=1 & ophi16=0x95d8 {
 	ptr:3 = zext(Z) | (zext(RAMPZ) << 16);
 	tmp:2 = *[code]:2 (ptr >> 1);
-	val:2 = (tmp >> (Z & 0x1));
+	val:2 = (tmp >> (8 * (Z & 0x1)));
 	R0 = val:1; 
 }
 :elpm RdFull, Z is phase=1 & ophi7=0x48 & oplow4=0x6 & RdFull & Z { 
 	ptr:3 = zext(Z) | (zext(RAMPZ) << 16);
 	tmp:2 = *[code]:2 (ptr >> 1);
-	val:2 = (tmp >> (Z & 0x1));
+	val:2 = (tmp >> (8 * (Z & 0x1)));
 	RdFull = val:1;
 }
 
 :elpm RdFull, Z^"+" is phase=1 & ophi7=0x48 & oplow4=0x7 & RdFull & Z { 
 	ptr:3 = zext(Z) | (zext(RAMPZ) << 16);
 	tmp:2 = *[code]:2 (ptr >> 1);
-	val:2 = (tmp >> (Z & 0x1));
+	val:2 = (tmp >> (8 * (Z & 0x1)));
 	RdFull = val:1;
 	ptr = ptr + 1;
 	Z = ptr:2;
@@ -793,21 +793,21 @@ LdPredec:  "-"^RstPtr  is RstPtr { RstPtr = RstPtr - 0x01; export RstPtr; }
 :lpm R0 is phase=1 & ophi16=0x95c8 & R0 {
   ptr:3 = zext(Z);
   tmp:2 = *[code]:2 (ptr >> 1);
-  val:2 = (tmp >> (Z & 0x1));
+  val:2 = (tmp >> (8 * (Z & 0x1)));
   R0 = val:1;
 }
 # lpm Rd,Z
 :lpm RdFull,Z is phase=1 & ophi7=0x48 & op1to3=0x2 & RdFull & Z & opbit0=0 { 
   ptr:3 = zext(Z);
   tmp:2 = *[code]:2 (ptr >> 1);
-  val:2 = (tmp >> (Z & 0x1));
+  val:2 = (tmp >> (8 * (Z & 0x1)));
   RdFull = val:1;
 }
 # lpm Rd,Z+
 :lpm RdFull,Z"+" is phase=1 & ophi7=0x48 & op1to3=0x2 & RdFull & Z & opbit0=1 { 
   ptr:3 = zext(Z);
   tmp:2 = *[code]:2 (ptr >> 1);
-  val:2 = (tmp >> (Z & 0x1));
+  val:2 = (tmp >> (8 * (Z & 0x1)));
   RdFull = val:1;
   Z = Z + 1;
 }


### PR DESCRIPTION
When `Z & 0x1 == 1`, the dereferenced data must be right-shifted 8 bits before assigning `val:1` to the target register.

When `Z & 0x0 == 0`, `val:1` is assigned to the target register straight away.

In short, we can reduce these condition to:

```
	tmp:2 = *[code]:2 (ptr >> 1);
	val:2 = (tmp >> (8 * (Z & 0x1)));
	R0 = val:1;
```

The following screenshot shows that, before the fix, the Basic Constant Reference Analyzer was not able to resolve the address pointed by `X` correctly:

![lpm_before](https://user-images.githubusercontent.com/1223476/58435827-c5ad7200-80c2-11e9-8c54-27be47012b5f.png)

However, after these changes, `X` is resolved correctly:

![lpm_after](https://user-images.githubusercontent.com/1223476/58435829-c80fcc00-80c2-11e9-80d4-d2bbb9b4ad60.png)