### PR TITLE
Add a definition for the TEQP (TEQccP) instruction.

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -5582,6 +5582,40 @@ armEndianNess: "BE" is c0031=0xf1010200 { export 1:1; }
   affectflags();
 }
 
+:teq^COND^"p" rn,shift1 		is $(AMODE) &  COND & c2024=19 & rn & c1215=15 & c2627=0 & shift1
+{
+  build COND;
+  build rn;
+  build shift1;
+  local tmp = rn^shift1;
+  logicflags();
+  resultflags(tmp);
+  affectflags();
+}
+
+:teq^COND^"p" rn,shift2 		is $(AMODE) &  COND & c2024=19 & rn & c1215=15 & c2627=0 & shift2
+{
+  build COND;
+  build rn;
+  build shift2;
+  local tmp = rn^shift2;
+  logicflags();
+  resultflags(tmp);
+  affectflags();
+}
+
+:teq^COND^"p" rn,shift3 		is $(AMODE) &  COND & c2024=19 & rn & c1215=15 & c2627=0 & shift3
+{
+  build COND;
+  build rn;
+  build shift3;
+  local tmp = rn^shift3;
+  logicflags();
+  resultflags(tmp);
+  affectflags();
+}
+
+
 :tst^COND rn,shift1 		is $(AMODE) &  COND & c2024=17 & rn & c1215=0 & c2627=0 & shift1
 {
   build COND;


### PR DESCRIPTION
In reference to #654.

Note that this doesn't take into account the subtleties of what TEQP
does -- for more information on this, see
https://www.heyrick.co.uk/armwiki/The_Status_register#Legacy_processors_.2826_bit.29

It will, however, stop Ghidra from completely freaking out when it sees
this instruction in old RISC OS 26bit-PC code.

TODO, make this behave (in SLEIGH) like a PSR update (MSR CPSR, ...) but
note that the PSR bit order is different to the 26bit ARM PSR so fudging
will be needed.