### PR TITLE
PIC16: renamed WREG to W so that the decompiler can use it properly as a function parameter

### DIFF
--- a/Ghidra/Processors/PIC/data/languages/pic16_instructions.sinc
+++ b/Ghidra/Processors/PIC/data/languages/pic16_instructions.sinc
@@ -49,7 +49,7 @@ attach variables [ fregCore ] [
 
 @elif PROCESSOR == "PIC_16F"
 attach variables [ fregCore ] [
-	INDF0	INDF1	PCL		STATUS	FSR0L	FSR0H	FSR1L	FSR1H	BSR	WREG	PCLATH	INTCON	_ _ _ _
+	INDF0	INDF1	PCL		STATUS	FSR0L	FSR0H	FSR1L	FSR1H	BSR	W	PCLATH	INTCON	_ _ _ _
 ];
 
 attach names [IntConBits] [ IOCIF INTF TMR0IF IOCIE INTE TMR0IE PEIE GIE  ];


### PR DESCRIPTION
This is a small fix for the PIC16 family:
When the working register W was used as a function parameter, the decompiler would show an additional variable WREG inside the function.
Changing the name from WREG to W in pic16_instructions.sinc fixes this problem.