### PR TITLE
Fix equals method in VarnodeAST

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeAST.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeAST.java
@@ -223,7 +223,7 @@ public class VarnodeAST extends Varnode {
 		if (isInput() != vn.isInput())
 			return false;
 		if (def != null)
-			return (def.getSeqnum() == vn.getDef().getSeqnum());
+			return (def.getSeqnum().equals(vn.getDef().getSeqnum()));
 		return true;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeAST.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeAST.java
@@ -222,8 +222,12 @@ public class VarnodeAST extends Varnode {
 			return false;
 		if (isInput() != vn.isInput())
 			return false;
-		if (def != null)
-			return (def.getSeqnum().equals(vn.getDef().getSeqnum()));
+		if (def != null) {
+			PcodeOp vnDef = vn.getDef();
+			if (vnDef == null)
+				return false;
+			return (def.getSeqnum().equals(vnDef.getSeqnum()));
+		}
 		return true;
 	}
 


### PR DESCRIPTION
This fixes the error in the `equals` method of `VarnodeAST` discussed in issue #676.