### PR TITLE
PDB: add char16_t/char32_t types to BASIC_TYPE_STRINGS.

### DIFF
--- a/Ghidra/Features/PDB/src/pdb/cpp/symbol.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/symbol.cpp
@@ -164,7 +164,9 @@ static wchar_t* BASIC_TYPE_STRINGS [] = {
 		L"<complex>",
 		L"<bit>",
 		L"BSTR",
-		L"HRESULT"
+		L"HRESULT",
+		L"char16_t",
+		L"char32_t"
 };
 
 BSTR getName(IDiaSymbol * pSymbol) {


### PR DESCRIPTION
As proposed by kant2002 in issue #94 adding the two types `char16_t`, and `char32_t` to `BASIC_TYPE_STRINGS` fixes the parsing errors introduced e.g. by VS 2019 PDB files.

Before:
![image](https://user-images.githubusercontent.com/703785/59447821-3a431900-8e04-11e9-98aa-225dcc016d97.png)

After:
![image](https://user-images.githubusercontent.com/703785/59448006-9312b180-8e04-11e9-9c4e-f58b4381463b.png)
