### PR TITLE
Fix: Handle DWARF compilation units without a compile unit DIE

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
@@ -167,10 +167,10 @@ public class DWARFCompilationUnit {
 			new DWARFCompilationUnit(dwarfProgram, startOffset, endOffset, length, format, version,
 				abbreviationOffset, pointerSize, cuNumber, firstDIEOffset, abbrMap);
 
-		DebugInfoEntry compileUnitDIE =
-			DebugInfoEntry.read(debugInfoBR, cu, dwarfProgram.getAttributeFactory());
-
 		try {
+			DebugInfoEntry compileUnitDIE =
+				DebugInfoEntry.read(debugInfoBR, cu, dwarfProgram.getAttributeFactory());
+
 			DWARFCompileUnit compUnit = DWARFCompileUnit.read(
 				DIEAggregate.createSingle(compileUnitDIE), dwarfProgram.getDebugLine());
 			cu.setCompileUnit(compUnit);


### PR DESCRIPTION
I have a Mach-O file and accompanying DWARF that has compilation units that are empty. Loaded into ghidra, this results in the following exception:
```
Error during DWARFAnalyzer import
java.io.IOException: Abbreviation code 6764 not found in the abbreviation map for the compunit Compliation Unit [Start:0x197ce] [Length:0x7] AbbreviationOffset:0x0] [CompileUnit: not present]
```

`dwarfdump` agrees:
```
0x000197c1:   DW_TAG_typedef [20]  
                DW_AT_type [DW_FORM_ref_addr]   (0x00000000000077ad "char*")
                DW_AT_name [DW_FORM_strp]       ( .debug_str[0x0000e352] = "__builtin_va_list")
                DW_AT_decl_file [DW_FORM_data1] ("<snip>/xnu/osfmk/kdp/processor_
core.c")
                DW_AT_decl_line [DW_FORM_data2] (729)

0x000197cd:   NULL
0x000197ce: Compile Unit: length = 0x00000007 version = 0x0004 abbr_offset = 0x0000 addr_size = 0x08 (next unit at 0x000197d9)
<compile unit can't be parsed!>

0x000197d9: Compile Unit: length = 0x000034ec version = 0x0004 abbr_offset = 0x0000 addr_size = 0x08 (next unit at 0x0001ccc9)

0x000197e4: DW_TAG_compile_unit [1] *
              DW_AT_producer [DW_FORM_strp]     ( .debug_str[0x00000001] = "Apple LLVM version 10.0.0 (clang-1000.11.45.5)")
              DW_AT_language [DW_FORM_data2]    (DW_LANG_C99)
              DW_AT_name [DW_FORM_strp] ( .debug_str[0x0001120e] = "<snip>/xnu/osfmk/ipc/ipc_entry.c")
              DW_AT_stmt_list [DW_FORM_sec_offset]      (0x00007434)
              DW_AT_comp_dir [DW_FORM_strp]     ( .debug_str[0x0000853f] = "<snip>/xnu/BUILD/obj/RELEASE_ARM64_T8011/osfmk/RELEASE")
              DW_AT_APPLE_optimized [DW_FORM_flag_present]      (true)
              DW_AT_low_pc [DW_FORM_addr]       (0xfffffff0070e9570)
              DW_AT_high_pc [DW_FORM_data4]     (0x00000b34)
```

This pull request removes the assumption that all compilation units have compile unit DIE's and allows the DWARF parser to continue.