### PR TITLE
x86/data/patterns/patternconstraints: remove extra text node

### DIFF
--- a/Ghidra/Processors/x86/data/patterns/patternconstraints.xml
+++ b/Ghidra/Processors/x86/data/patterns/patternconstraints.xml
@@ -15,7 +15,7 @@
   </language>
   
   <language id="x86:LE:64:default">
-    <compiler id="windows">"data/patternconstraints.xml"
+    <compiler id="windows">
       <patternfile>x86-64win_patterns.xml</patternfile>
     </compiler>
     <compiler id="gcc">


### PR DESCRIPTION
removing a line that appears to be superfluous. also, fix indentation.

unfortunately, i have *not* tested this, as i noticed this apparent extra line during a visual inspection. i don't have a build environment currently configured.