### PR TITLE
Generalize and simplify VS directory search. Support VS16 (2019).

### DIFF
--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -17,22 +17,31 @@ apply plugin: 'c'
 
 // Unclear if we can rely on the VisualCpp plugin to identify the correct Visual Studio paths
 
-project.ext.VISUAL_STUDIO_BASE_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017"
+project.ext.VISUAL_STUDIO_BASE_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio"
 project.ext.WINDOWS_KITS_DIR = "C:\\Program Files (x86)\\Windows Kits\\10"
 
-project.ext.VISUAL_STUDIO_INSTALL_DIR = "/"
+project.ext.VISUAL_STUDIO_FOUND = false
+project.ext.VISUAL_STUDIO_INSTALL_DIR = "UNKNOWN"
 project.ext.VISUAL_STUDIO_VCVARS_CMD = "UNKNOWN"
 project.ext.MSVC_SDK_VERSION = "UNKNOWN"
 project.ext.MSVC_TOOLS_VERSION = "UNKNOWN"
 
-if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
-
-	project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_DIR + "\\Professional"
-	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
-		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_DIR + "\\Community"
+def findVsYear(year) {
+	String base_path = project.ext.VISUAL_STUDIO_BASE_DIR + "\\$year\\"
+	def editions = ["Preview", "Enterprise", "Professional", "Community"]
+	editions.each { edition ->
+		String path = base_path + edition
+		if (file(path).exists()) {
+			project.ext.VISUAL_STUDIO_FOUND = true
+			project.ext.VISUAL_STUDIO_INSTALL_DIR = path
+			return
+		}
 	}
-	if (file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
+}
 
+if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+	findVsYear(2017)
+	if (project.ext.VISUAL_STUDIO_FOUND) {
 		println "Visual Studio Path: ${VISUAL_STUDIO_INSTALL_DIR}"
 
 		project.ext.VISUAL_STUDIO_VCVARS_CMD = "\"${VISUAL_STUDIO_INSTALL_DIR}\\VC\\Auxiliary\\Build\\vcvarsall.bat\" x86_amd64"
@@ -85,11 +94,10 @@ task CheckToolChain {
 	// Native C/Cpp plugins will trigger failure if no tool chain found
 	doFirst {
 		if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
-			// ensure that required MS Visual Studio is installed where expected
-			String msg = "Microsoft Visual Studio install not found: ${VISUAL_STUDIO_BASE_DIR}\n" + 
+			// ensure that we know the Visual Studio installation directory
+			String msg = "No Microsoft Visual Studio installs found in ${VISUAL_STUDIO_BASE_DIR}\n" +
 				"Adjust path in Ghidra/GPL/nativeBuildProperties.gradle if needed."
-			if (!file(VISUAL_STUDIO_BASE_DIR).exists() || 
-					!file(VISUAL_STUDIO_INSTALL_DIR).exists()) {
+			if (!VISUAL_STUDIO_FOUND) {
 				throw new GradleException(msg);
 			}	
 		}

--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -40,6 +40,7 @@ def findVsYear(year) {
 }
 
 if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+	findVsYear(2019)
 	findVsYear(2017)
 	if (project.ext.VISUAL_STUDIO_FOUND) {
 		println "Visual Studio Path: ${VISUAL_STUDIO_INSTALL_DIR}"

--- a/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
+++ b/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
@@ -13,18 +13,21 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{343E9778-3C04-476E-8F90-A114AA7AA108}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '15.0'">8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' != '15.0'">10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '15.0'">v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '15.0'">v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
This is an alternative to #730.

Changes (not in comparison to #730):

* Generalized search function enables to easily support newer versions in the future.
* Supports VS16 (2019)
* Supports the Preview and Enterprise editions.
* The edition preference is:
  1. Preview
  2. Enterprise
  3. Professional
  4. Community
* VS16 (2019) is preferred over VS15 (2017) to incentivise use of newer software.

Future:
1. Use COM or `vswhere.exe` to support custom installation directories.
2. Allowing choosing a preferred installation.

Fixes #699.