### PR TITLE
Exception in sleigh

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghpatexpress/OperandValue.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghpatexpress/OperandValue.java
@@ -50,6 +50,8 @@ public class OperandValue extends PatternValue {
 
 	@Override
 	public TokenPattern genMinPattern(VectorSTL<TokenPattern> ops) {
+		if (index >= ops.size())
+			return null;
 		return ops.get(index);
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghsymbol/Constructor.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghsymbol/Constructor.java
@@ -542,7 +542,10 @@ public class Constructor {
 				}
 			}
 			else if (defexp != null) {
-				oppattern.push_back(defexp.genMinPattern(oppattern));
+				TokenPattern tmppat = defexp.genMinPattern(oppattern);
+				if (null == tmppat)
+				    throw new SleighError("operand " + sym.getName() + " has an issue", location);
+				oppattern.push_back(tmppat);
 			}
 			else {
 				throw new SleighError("operand " + sym.getName() + " is undefined", location);


### PR DESCRIPTION
Came across an index out of bounds when writing sleigh.  Not sure what the real issue is or what a real fix would be, but this commit avoids the exception and prints out the location info with a message.

Something along the lines of the following was the exception
`foobar: reloc is op0811 [ reloc = op0811; ] { local tmp:4 = reloc; export tmp; }`