### PR TITLE
Fix AAA, AAM, DAA, DAS x86 intructions + typo fix

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -2237,9 +2237,9 @@ Suffix3D: imm8        is imm8 [ suffix3D=imm8; ] { }
 
 # Instructions in alphabetical order
 
-:AAA			is vexMode=0 & bit64=0 & byte=0x37		{ local car = ((AL & 0xf) > 9) | AF; AL = (AL+6*car)&0xf; AH=AH+car; CF=car; AF=car; }
+:AAA			is vexMode=0 & bit64=0 & byte=0x37		{ local car = ((AL & 0xf) > 9) | (AF == 1); AL = (AL+6*car)&0xf; AH=AH+car; CF=car; AF=car; }
 :AAD imm8		is vexMode=0 & bit64=0 & byte=0xd5; imm8	{ AL = AL + imm8*AH; AH=0; resultflags(AX); }
-:AAM imm8		is vexMode=0 & bit64=0 & byte=0xd4; imm8	{ AH = AL/imm8; AL = AL & imm8; resultflags(AX); }
+:AAM imm8		is vexMode=0 & bit64=0 & byte=0xd4; imm8	{ AH = AL/imm8; AL = AL % imm8; resultflags(AX); }
 :AAS			is vexMode=0 & bit64=0 & byte=0x3f		{ local car = ((AL & 0xf) > 9) | AF; AL = (AL-6*car)&0xf; AH=AH-car; CF=car; AF=car; }
 
 :ADC AL,imm8		is vexMode=0 & byte=0x14; AL & imm8						{ addCarryFlags( AL, imm8:1 ); resultflags( AL ); }
@@ -2979,14 +2979,14 @@ define pcodeop cpuid_brand_part3_info;
 }
 
 
-:DAA            is vexMode=0 & bit64=0 & byte=0x27       { local car = ((AL & 0xf) > 9) | AF;
+:DAA            is vexMode=0 & bit64=0 & byte=0x27       { local car = ((AL & 0xf) > 9) | (AF == 1);
                            AL = AL + 6 * car;
                            CF = CF | car * carry(AL,6);
                            AF = car;
                            car = ((AL & 0xf0) > 0x90) | CF;
                            AL = AL + 0x60 * car;
                            CF = car; }
-:DAS            is vexMode=0 & bit64=0 & byte=0x2f       { local car = ((AL & 0xf) > 9) | AF;
+:DAS            is vexMode=0 & bit64=0 & byte=0x2f       { local car = ((AL & 0xf) > 9) | (AF == 1);
                            AL = AL - 6 * car;
                            CF = CF | car * (AL < 6);
                            AF = car;
@@ -4429,7 +4429,7 @@ define pcodeop invalidInstructionException;
 @ifdef IA64
 :VMCLEAR m64    is vexMode=0 & $(PRE_66) & byte=0x0f; byte=0xc7; ( mod != 0b11 & reg_opcode=6 ) ... & m64 { vmclear(m64); }
 @endif
-#TODO: invockes a VM function specified in EAX
+#TODO: invokes a VM function specified in EAX
 :VMFUNC EAX     is vexMode=0 & byte=0x0f; byte=0x01; byte=0xd4 & EAX                         { vmfunc(EAX); }
 #TODO: this launches the VM managed by the current VMCS.  How is the VMCS expressed for the emulator?  For Ghidra analysis?
 :VMLAUNCH       is vexMode=0 & byte=0x0f; byte=0x01; byte=0xc2                          { vmlaunch(); }


### PR DESCRIPTION
According to Intel manual, the AAM instruction has a MOD, not an AND. Likely a typo. More, (AF == 1) added instead of AF (but I think it's pretty much the same)
+ bonus typo fix