### PR TITLE
Update x86 16 bit processor binding for IDA

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86.ldefs
+++ b/Ghidra/Processors/x86/data/languages/x86.ldefs
@@ -58,7 +58,8 @@
 	<external_name tool="IDA-PRO" name="80386r"/>
 	<external_name tool="IDA-PRO" name="80486r"/>
 	<external_name tool="IDA-PRO" name="80586r"/>
-  </language>
+	<external_name tool="IDA-PRO" name="metapc"/>
+    </language>
     <language processor="x86"
             endian="little"
             size="64"


### PR DESCRIPTION
x86 16-bit in IDA Pro >= 7.0 with 64-bit address space and probably earlier uses the metapc processor type and not any of those listed anymore.  I am not sure how many others should also be included but probably all of them.  The bit size is the primary selection, not the processor type anymore so although metapc is confirmed, perhaps the following should also be added as they are under 32-bit:
	<external_name tool="IDA-PRO" name="80686p"/>
	<external_name tool="IDA-PRO" name="k62"/>
	<external_name tool="IDA-PRO" name="p2"/>
	<external_name tool="IDA-PRO" name="p3"/>
	<external_name tool="IDA-PRO" name="athlon"/>
	<external_name tool="IDA-PRO" name="p4"/>

Though this is certainly a legacy IDA 5.x and maybe 6.x issue mainly.  AFAIK, all the >= 7.0 IDA versions use metapc for all x86.  Specific processors were any early feature that was consolidated there.