### PR TITLE
Add relocation handler for R_AARCH64_JUMP26 and R_AARCH64_CALL26

### DIFF
--- a/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/util/bin/format/elf/relocation/AARCH64_ElfRelocationHandler.java
+++ b/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/util/bin/format/elf/relocation/AARCH64_ElfRelocationHandler.java
@@ -142,7 +142,9 @@ public class AARCH64_ElfRelocationHandler extends ElfRelocationHandler {
 				break;
 			}
 
+			// B:  ((S+A-P) >> 2) & 0x3ffffff.
 			// BL: ((S+A-P) >> 2) & 0x3ffffff
+			case AARCH64_ElfRelocationConstants.R_AARCH64_JUMP26:
 			case AARCH64_ElfRelocationConstants.R_AARCH64_CALL26: {
 				int oldValue = memory.getInt(relocationAddress, isBigEndianInstructions);
 				newValue = (symbolValue + addend);


### PR DESCRIPTION
This fixes an issue similar to #764, but for AARCH64