### PR TITLE
decompiler: fix '#error config.h must be included before this header'

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/loadimage_bfd.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/loadimage_bfd.hh
@@ -21,7 +21,31 @@
 #define __LOADIMAGE_BFD__
 
 #include "loadimage.hh"
+
+// bfd.h requires PACKAGE/PACKAGE_VERSION to be defined
+// https://sourceware.org/bugzilla/show_bug.cgi?id=14243
+
+#ifndef PACKAGE
+  #define PACKAGE
+  #define __LOADIMAGE_BFD__DEFINED_PACKAGE
+#endif
+
+#ifndef PACKAGE_VERSION
+  #define PACKAGE_VERSION
+  #define __LOADIMAGE_BFD__DEFINED_PACKAGE_VERSION
+#endif
+
 #include <bfd.h>
+
+#ifdef __LOADIMAGE_BFD__DEFINED_PACKAGE
+  #undef PACKAGE
+  #undef __LOADIMAGE_BFD__DEFINED_PACKAGE
+#endif
+
+#ifdef __LOADIMAGE_BFD__DEFINED_PACKAGE_VERSION
+  #undef PACKAGE_VERSION
+  #undef __LOADIMAGE_BFD__DEFINED_PACKAGE_VERSION
+#endif
 
 struct ImportRecord {
   string dllname;


### PR DESCRIPTION
See https://sourceware.org/bugzilla/show_bug.cgi?id=14243