### PR TITLE
GT-3012 - fix FSRL path generation on windows.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
@@ -15,7 +15,10 @@
  */
 package ghidra.formats.gfilesystem;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
@@ -394,7 +397,8 @@ public class FileSystemService {
 	 * @return {@link FSRL} pointing to the same file, never null
 	 */
 	public FSRL getLocalFSRL(File f) {
-		return localFS.getFSRL().withPath(FilenameUtils.separatorsToUnix(f.getPath()));
+		return localFS.getFSRL().withPath(
+			FSUtilities.appendPath("/", FilenameUtils.separatorsToUnix(f.getPath())));
 	}
 
 	/**


### PR DESCRIPTION
FSRLs were being generated without a leading "/".  When using batch
import on a local directory, the mismatch between a correct FSRL and a
FSRL with a missing "/" caused truncated folder names to be created.