### PR TITLE
Fix x86-16 Windows cspec for stdcall ambiguity

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86-16.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-16.cspec
@@ -179,4 +179,9 @@
       <register name="DF"/>
     </unaffected>
   </prototype>
+  <resolveprototype name="__stdcall16far/__stdcall16near">
+     <model name="__stdcall16near"/>      <!-- The default case -->
+     <model name="__stdcall16far"/>
+  </resolveprototype>
+  <eval_current_prototype name="__stdcall16far/__stdcall16near"/>
 </compiler_spec>


### PR DESCRIPTION
x86-64-win.cspec deals with __fastcall and __thiscall by simply (somewhat misleadingly) specifying extrapop="8" and letting the resolution occur in the decompiler.  Really it should be "8 + args"

x86win.cspec deals with __stdcall, __thiscall and __fastcall by specifying extrapop="unknown" which although true fails to make an expectation that "unknown" means "4 + args" and it would be a stretch to say it could be inferred from pentry stack addresses.  It deals with this using a resolveprototype construct and an eval_current_prototype to allow selection instead of the default.

I propose either we do the same for x86-16.cspec or change "unknown" to "4" and use the 64-bit strategy.

This is likely a key part of the source of 4 reported issues although the decompiler should really handle prototype identification better and this is hardly the end of the story.  Problem a new XML attribute is needed - something like the now obsolete "stackshift" which would be an excellent hint!

Currently even with the selector - which all x86-16 bit files generally require - most use a mixture of far and near calling almost never one or the other exclusive.

But this change is a correct start towards fixing this entire area.