### PR TITLE
Fix bad memory addresses for string arguments

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -1407,9 +1407,8 @@ bool PrintC::pushPtrCharConstant(uintb val,const TypePointer *ct,const Varnode *
   if (stringaddr.isInvalid()) return false;
   if (!glb->symboltab->getGlobalScope()->isReadOnly(stringaddr,1,Address()))
     return false;	     // Check that string location is readonly
-  uint4 flags; //volatile memory should indicate hole is not mapped in target
-  glb->symboltab->getGlobalScope()->queryProperties(stringaddr,1,Address(),flags);
-  if ((flags & Varnode::volatil)!=0) return false;
+  SymbolEntry* ent = glb->symboltab->getGlobalScope()->queryContainer(stringaddr, 1, Address());
+  if (ent == (SymbolEntry*)0 || ent->getSymbol() == (Symbol*)0) return false;
 
   ostringstream str;
   Datatype *subct = ct->getPtrTo();

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -1407,6 +1407,9 @@ bool PrintC::pushPtrCharConstant(uintb val,const TypePointer *ct,const Varnode *
   if (stringaddr.isInvalid()) return false;
   if (!glb->symboltab->getGlobalScope()->isReadOnly(stringaddr,1,Address()))
     return false;	     // Check that string location is readonly
+  uint4 flags; //volatile memory should indicate hole is not mapped in target
+  glb->symboltab->getGlobalScope()->queryProperties(stringaddr,1,Address(),flags);
+  if ((flags & Varnode::volatil)!=0) return false;
 
   ostringstream str;
   Datatype *subct = ct->getPtrTo();


### PR DESCRIPTION
Bad memory addresses for string arguments should not be printed - only volatile can help detect this currently.  But volatile memory implies it is not mapped into the address space and thus the numeric value should be emitted instead.

A classical example, perhaps the most so, is Microsoft's LoadCursor function:
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadcursora

```
HCURSOR LoadCursorA(
  HINSTANCE hInstance,
  LPCSTR    lpCursorName
);


Value | Meaning
-- | --
IDC_APPSTARTING MAKEINTRESOURCE(32650) | Standard arrow and small hourglass
```

And so on and so forth.  But this will confuse Ghidra since it has no way of knowing that a readonly hole is not mapped into the address space.  The correct behavior is to emit a numeric value.  Better yet would be to emit the macro MAKEINTRESOURCE but this would require a very complex type system.

This bug does not appear always to manifest. And I am going to give my definition about volatility as I realize it can have a deeper effect in the decompilation engine:
volatile for unmapped memory should be based on the life of the system
volatile for mapped memory should be based on the life of the program
volatile for stack and registers should be based on the life of a function
const and unique would not be volatile ever, though a join space could be comprised of members who are volatile
Anyway if this change is incorrect I would like to know more about volatility and how it can in fact be solved.

After further thinking, since the original idea was to find a hole - properties are not appropriate and my definition of volatile is not correct regardless as it seems more to be more about at the processor caching level as per the C volatile keyword.  Original fix irrelevant.

Now a simple queryContainer can yield a SymbolEntry with a Symbol attached and if it does not, then the analysis did not find data there so we have nothing to print.  This is in good spirit with the description and the way the expected check for this fix would be obviously done.

Tested and working.