### PR TITLE
Fix external refs not working on some systems

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -965,7 +965,7 @@ int4 ActionDeindirect::apply(Funcdata &data)
   for(int4 i=0;i<data.numCalls();++i) {
     fc = data.getCallSpecs(i);
     op = fc->getOp();
-    if (op->code() != CPUI_CALLIND) continue;
+    if (op->code() != CPUI_CALLIND && op->code() != CPUI_CALL) continue; //seg:ptr is not indirect call
     vn = op->getIn(0);
     while(vn->isWritten()&&(vn->getDef()->code()==CPUI_COPY))
       vn = vn->getDef()->getIn(0);


### PR DESCRIPTION
External references on x86-16 win use a far call CALLF instruction translated in sleigh as a CPUI_CALL and Ghidra will never query the details of the external symbol due to this handling only for CPUI_CALLIND.

This should fix the bug in #770 