### PR TITLE
Potentially ambiguous macro operator names used

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.cc
@@ -910,7 +910,7 @@ string TypeOpIntZext::getOperatorName(const PcodeOp *op) const
 {
   ostringstream s;
   
-  s << name << dec << op->getIn(0)->getSize() << op->getOut()->getSize();
+  s << name << dec << op->getIn(0)->getSize() << "_" << op->getOut()->getSize();
   return s.str();
 }
 
@@ -936,7 +936,7 @@ string TypeOpIntSext::getOperatorName(const PcodeOp *op) const
 {
   ostringstream s;
   
-  s << name << dec << op->getIn(0)->getSize() << op->getOut()->getSize();
+  s << name << dec << op->getIn(0)->getSize() << "_" << op->getOut()->getSize();
   return s.str();
 }
 
@@ -1510,7 +1510,7 @@ string TypeOpPiece::getOperatorName(const PcodeOp *op) const
 {
   ostringstream s;
 
-  s << name << dec << op->getIn(0)->getSize() << op->getIn(1)->getSize();
+  s << name << dec << op->getIn(0)->getSize() << "_" << op->getIn(1)->getSize();
   return s.str();
 }
 
@@ -1537,7 +1537,7 @@ string TypeOpSubpiece::getOperatorName(const PcodeOp *op) const
 {
   ostringstream s;
 
-  s << name << dec << op->getIn(0)->getSize() << op->getOut()->getSize();
+  s << name << dec << op->getIn(0)->getSize() << "_" << op->getOut()->getSize();
   return s.str();
 }
 


### PR DESCRIPTION
4 operators are emitted in finally C code: ZEXT, SEXT, CONCAT, SUB
Although generally the sizes are just one character (from 1 to 8) potentially numeric values can be 16 bytes long.
The suffix 112 to any of these for example.  Could be 1 byte and 12 bytes.  Or 11 bytes and 2 bytes.  Obviously the naming convention here is poorly chosen.

However that being said, this behavior could be deliberately depended upon in other areas though AFAIK only custom tools would do so.  It is better to change it earlier than later partly for that reason as tools could learn to depend on the behavior as opposed to doing what I have done and choosing to fix the ambiguity in the C source to begin with.

Alternatively, the C emitting code could have another display option with a flag to emit ugly mathematical C-style code:
Here are my notes to eliminate all macros - better yet it could track macro usage and emit them as #define statements.
How should this be done?

```
ZEXT#(I)_#(O) - cast to unsigned #(O) size
SEXT#(I)_#(O) - cast to signed #(O) size
#define CONCAT(SZI1, SZI2, VAL1, VAL2) (((VAL1) << (SZI2 * 8)) | (VAL2))
CONCAT#(I1)_#(I2) - shift left/or idiom
#define SUB(SZI, SZO, VAL) (((VAL) >> (SZ1 * 8)) & ((~0ull) >> (64 - SZO * 8)))
SUB#(I)_#(O) - shift right/and idiom, careful that 64 bits does not get truncated
#define CARRY(SZ, VAL1, VAL2) (((((1ull << (SZ * 8 - 1)) & (VAL1)) != 0) && (((1ull << (SZ * 8 - 1)) & (VAL2)) != 0)) || (((1ull << (SZ * 8 - 1)) & (VAL1)) ^ ((1ull << (SZ * 8 - 1)) & (VAL2))) != 0 && (((VAL1) + (VAL2)) & (1ull << (SZ * 8 - 1))) == 0)
CARRY#(I) - addition comparison idiom - both high bits are set or one high bit is set and their addition causes the high bit to clear 0 1 0/1 0 0/1 1 _
#define SCARRY(SZ, VAL1, VAL2) (((1ull << (SZ * 8 - 1)) & (VAL1)) == ((1ull << (SZ * 8 - 1)) & (VAL2)) && (((VAL1) + (VAL2)) & (1ull << (SZ * 8 - 1))) != ((1ull << (SZ * 8 - 1)) & (VAL1)))
SCARRY#(I) - signed addition comparison idiom - both are positive or both are negative and their addition causes the high bit to be opposite of inputs 0 0 1/1 1 0
#define SBORROW(SZ, VAL1, VAL2) (((1ull << (SZ * 8 - 1)) & (VAL1)) != ((1ull << (SZ * 8 - 1)) & (VAL2)) && (((VAL1) - (VAL2)) & (1ull << (SZ * 8 - 1))) != ((1ull << (SZ * 8 - 1)) & (VAL1)))
SBORROW#(I) - signed subtraction comparison idiom - one is negative and one is positive and their subtraction causes the high bit to be opposite first input/same as second input 0 1 1/1 0 0
NAN - needs math.h along with ABS, SQRT, CEIL, FLOOR, ROUND
ABS - fabs, fabsf, fabsl
SQRT - sqrtf, sqrt, sqrtl
CEIL - ceil, ceilf, ceill
FLOOR - floor, floorf, floorl
ROUND - round, roundf, roundl
```