### PR TITLE
VarMap stable_sort throws Invalid Comparator

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
@@ -289,17 +289,7 @@ bool RangeHint::compareRanges(const RangeHint *a,const RangeHint *b)
   type_metatype bmeta = b->type->getMetatype();
   if (ameta != bmeta)
     return (ameta < bmeta);		// Order more specific types first
-  return true;
-}
-
-bool RangeHint::rangesEqual(const RangeHint* a, const RangeHint* b)
-{
-	if (a->sstart == b->sstart && a->size == b->size) {
-		type_metatype ameta = a->type->getMetatype();
-		type_metatype bmeta = b->type->getMetatype();
-		return (ameta == bmeta);
-	}
-	return false;
+  return false; //comp(x, x) must be false for strict weak ordering
 }
 
 /// \param spc is the (stack) address space associated with this function's local variables
@@ -793,10 +783,7 @@ void MapState::addRange(uintb st,Datatype *ct,uint4 fl,RangeHint::RangeType rt,i
   sign_extend(sst,spaceid->getAddrSize()*8-1);
   sst = (intb)AddrSpace::addressToByte(sst,spaceid->getWordSize());
   RangeHint *range = new RangeHint(st,sz,sst,ct,fl,rt,hi);
-  if (std::find_if(maplist.begin(), maplist.end(), [range](RangeHint* rh) {
-	  return RangeHint::rangesEqual(rh, range);
-	  }) == maplist.end())
-    maplist.push_back(range);
+  maplist.push_back(range);
 #ifdef OPACTION_DEBUG
   if (debugon) {
     ostringstream s;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
@@ -292,6 +292,16 @@ bool RangeHint::compareRanges(const RangeHint *a,const RangeHint *b)
   return true;
 }
 
+bool RangeHint::rangesEqual(const RangeHint* a, const RangeHint* b)
+{
+	if (a->sstart == b->sstart && a->size == b->size) {
+		type_metatype ameta = a->type->getMetatype();
+		type_metatype bmeta = b->type->getMetatype();
+		return (ameta == bmeta);
+	}
+	return false;
+}
+
 /// \param spc is the (stack) address space associated with this function's local variables
 /// \param fd is the function associated with these local variables
 /// \param g is the Architecture
@@ -783,7 +793,10 @@ void MapState::addRange(uintb st,Datatype *ct,uint4 fl,RangeHint::RangeType rt,i
   sign_extend(sst,spaceid->getAddrSize()*8-1);
   sst = (intb)AddrSpace::addressToByte(sst,spaceid->getWordSize());
   RangeHint *range = new RangeHint(st,sz,sst,ct,fl,rt,hi);
-  maplist.push_back(range);
+  if (std::find_if(maplist.begin(), maplist.end(), [range](RangeHint* rh) {
+	  return RangeHint::rangesEqual(rh, range);
+	  }) == maplist.end())
+    maplist.push_back(range);
 #ifdef OPACTION_DEBUG
   if (debugon) {
     ostringstream s;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
@@ -73,6 +73,7 @@ public:
   bool absorb(RangeHint *b);	///< Try to absorb the other RangeHint into \b this
   bool merge(RangeHint *b,AddrSpace *space,TypeFactory *typeFactory);	///< Try to form the union of \b this with another RangeHint
   static bool compareRanges(const RangeHint *a,const RangeHint *b);	///< Compare to RangeHint pointers
+  static bool rangesEqual(const RangeHint* a, const RangeHint* b);
 };
 
 class ProtoModel;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
@@ -73,7 +73,6 @@ public:
   bool absorb(RangeHint *b);	///< Try to absorb the other RangeHint into \b this
   bool merge(RangeHint *b,AddrSpace *space,TypeFactory *typeFactory);	///< Try to form the union of \b this with another RangeHint
   static bool compareRanges(const RangeHint *a,const RangeHint *b);	///< Compare to RangeHint pointers
-  static bool rangesEqual(const RangeHint* a, const RangeHint* b);
 };
 
 class ProtoModel;


### PR DESCRIPTION
Can thank Visual Studio 2019 debug build for finding this one.  Only debug build runtime error but this is a legitimate violation of C++ standards.

stable_sort requires a weak strict ordering yet inspection showed duplicates were ending up in the maplist.  In this case the less than comparison is not true - but true is returned.

First solution to remove duplicates is complexity-wise not ideal - O(n^2).  But it certainly works to prevent this bug.

Update: backed it out and just return false instead of true when equal - according to docs this is the only correct behavior.  It was simply a bug if duplicates are too be allowed.  If duplicates are not to be allowed, a std::unique() operator can efficiently deal with it after the stable_sort - but this change now conservatively preserves original functionality.

For more information to prove this see the docs:
https://en.cppreference.com/w/cpp/algorithm/stable_sort

Every other usage of stable_sort in Ghidra is correct in the equivalence case.

Tested and working.