### PR TITLE
Segmented Constant Ptrs fail to resolve and display properly

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -946,7 +946,7 @@ int4 ActionConstantPtr::apply(Funcdata &data)
     entry = isPointer(rspc,vn,op,rampoint,data);
     vn->setPtrCheck();		// Set check flag AFTER searching for symbol
     if (entry != (SymbolEntry *)0) {
-      data.spacebaseConstant(op,slot,entry,rampoint,vn->getOffset(),vn->getSize());
+      data.spacebaseConstant(op,slot,entry,rampoint,entry->getAddr().getOffset(),vn->getSize());
       if ((opc == CPUI_INT_ADD)&&(slot==1))
 	data.opSwapInput(op,0,1);
       count += 1;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -946,7 +946,7 @@ int4 ActionConstantPtr::apply(Funcdata &data)
     entry = isPointer(rspc,vn,op,rampoint,data);
     vn->setPtrCheck();		// Set check flag AFTER searching for symbol
     if (entry != (SymbolEntry *)0) {
-      data.spacebaseConstant(op,slot,entry,rampoint,vn->getOffset(),vn->getSize());
+      data.spacebaseConstant(op,slot,entry,rampoint,rampoint.getOffset(),vn->getSize());
       if ((opc == CPUI_INT_ADD)&&(slot==1))
 	data.opSwapInput(op,0,1);
       count += 1;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -946,7 +946,7 @@ int4 ActionConstantPtr::apply(Funcdata &data)
     entry = isPointer(rspc,vn,op,rampoint,data);
     vn->setPtrCheck();		// Set check flag AFTER searching for symbol
     if (entry != (SymbolEntry *)0) {
-      data.spacebaseConstant(op,slot,entry,rampoint,rampoint.getOffset(),rampoint.getAddrSize());
+      data.spacebaseConstant(op,slot,entry,rampoint,vn->getOffset(),vn->getSize());
       if ((opc == CPUI_INT_ADD)&&(slot==1))
 	data.opSwapInput(op,0,1);
       count += 1;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -946,7 +946,7 @@ int4 ActionConstantPtr::apply(Funcdata &data)
     entry = isPointer(rspc,vn,op,rampoint,data);
     vn->setPtrCheck();		// Set check flag AFTER searching for symbol
     if (entry != (SymbolEntry *)0) {
-      data.spacebaseConstant(op,slot,entry,rampoint,entry->getAddr().getOffset(),vn->getSize());
+      data.spacebaseConstant(op,slot,entry,rampoint,rampoint.getOffset(),rampoint.getAddrSize());
       if ((opc == CPUI_INT_ADD)&&(slot==1))
 	data.opSwapInput(op,0,1);
       count += 1;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -599,7 +599,8 @@ void PrintC::opIntZext(const PcodeOp *op)
       opHiddenFunc(op);
     else
       opTypeCast(op);
-  }
+  } else if (op->getIn(0)->getSize() >= op->getOut()->getSize())
+    pushVnImplied(op->getIn(0), op, mods);
   else
     opFunc(op);
 }


### PR DESCRIPTION
Final output when near pointer constants are guessed and resolved always has a ZEXT42() around the pointers which clutters the output and reduces its quality.  Further the resolved 4 byte pointer is thrown out in favor of the original pointer which then will be requeried, not resolved and displayed wrong as a 0-segment based RAM pointer.

Ultimately the ZEXT introduced in Funcdata::spacebaseConstant via ActionConstantPtr::apply was just a forced size change anyway.  The problem really is that it is printing when a ZEXT42 makes no real sense as its just a truncation representing that the far pointer lookup still needs to be treated as a near pointer.

Tested and working.  The working assumption is that ZEXT from a bigger size to a smaller size is only used as a special placeholder operation and can be trimmed on output otherwise CPUI_SUBPIECE should be used - this is a fair optimization and a much safer one than the original proposal which sought to change other aspects but the syntax tree is perfectly kept and the change should happen at the last minute if no other special truncation op is present.

Handles half of the report in #817 