### PR TITLE
6805 definition - fix vendor in sla spec comment

### DIFF
--- a/Ghidra/Processors/6805/data/languages/6805.slaspec
+++ b/Ghidra/Processors/6805/data/languages/6805.slaspec
@@ -1,4 +1,4 @@
-# sleigh specification file for Intel 6805
+# sleigh specification file for Motorola 6805
 @define SWI_VECTOR "0x3FFC"
 define endian=big;
 define alignment=1;


### PR DESCRIPTION
Minor and non-functional issue but it's been annoying me every time I open the source file - the 6805 is/was a Motorola architecture, not an Intel one.