### PR TITLE
Bad ranges from client/due to wrap cause a crash

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
@@ -297,11 +297,12 @@ void Range::restoreXml(const Element *el,const AddrSpaceManager *manage)
       break;		// There should be no (space,first,last) attributes
     }
   }
-  if (last < first)
-    	  throw LowlevelError("Illegal range value");
   if (spc == (AddrSpace *)0)
 	  throw LowlevelError("No address space indicated in range tag");
+  first = spc->wrapOffset(first); //otherwise if first needs wrap, will be greater than last!
   last = spc->wrapOffset(last);
+  if (last < first)
+	  throw LowlevelError("Illegal range value");
 }
 
 /// Insert a new Range merging as appropriate to maintain the disjoint cover

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
@@ -297,6 +297,8 @@ void Range::restoreXml(const Element *el,const AddrSpaceManager *manage)
       break;		// There should be no (space,first,last) attributes
     }
   }
+  if (last < first)
+    	  throw LowlevelError("Illegal range value");
   if (spc == (AddrSpace *)0)
 	  throw LowlevelError("No address space indicated in range tag");
   last = spc->wrapOffset(last);


### PR DESCRIPTION
This addresses ranges where the last is less than first.  The range is never validated and it would cause a crash in all sorts of places specifically in my case for ScopeGhidra::processHole when it calls insertRange causing problems with the iterator.  But likely the same issue would occur nearly anywhere its not validated based on the assumption of the coding style.

This crashed the insertRange iterator due to a pointer being end and not being checked - thanks to being compiled in Visual Studio 2019.  Again VS2019 is finding legitimate bugs that were previously unfound due to its various checks.

In my case, "0xFFFFFFFFFFFFFFFF" was queried for a mapped symbol and the client correctly responds that there is a hole with
start="0xFFFFFFFFFFFFFFFF" end="0xFFFFFFFFFFFFFFFF" which then with the wrapping of end, caused end="0x00000000FFFFFFFF" making it smaller than start.