### PR TITLE
Infinite loop on jump tables in 64 bit addressing

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
@@ -419,12 +419,12 @@ int4 JumpBasic::getStride(Varnode *vn)
 
 {
   uintb mask = vn->getNZMask();
-  int4 stride = 1;
+  int4 stride = 1; //64-bit mask will overflow this to 0
   while((mask&1)==0) {
     mask >>= 1;
     stride <<= 1;
   }
-  if (stride > 32) return 1;
+  if (stride > 32 || stride == 0) return 1;
   return stride;
 }
 


### PR DESCRIPTION
Jump tables with a NZMask of 0xFFFF000000000000 would cause the int4 stride value to overflow to 0 on shift left after 32 times.  At that point a 0 stride is returned.  In the range this then causes a modulo division by 0 which VS2019 caught immediately.  However in the current code somehow the division by 0 is not thrown and instead it just causes an infinite querying loop of the same address.

It starts addressing #729 as MIPS can this NZMask detected quite frequently - still getting too many branches however when the jump table should be easily recovered.

It appears that 0xFFFF000000000000 being the stride is likely the cause of the too many jump targets bug as well.  Perhaps this should be fixed to be 64 bit not by simply avoiding 0.