### PR TITLE
Comment out of bound causes decompiler crash

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/comment.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/comment.cc
@@ -295,7 +295,7 @@ bool CommentSorter::findPosition(Subsort &subsort,Comment *comm,const Funcdata *
     --opiter;
     PcodeOp *op = (*opiter).second;
     BlockBasic *block = op->getParent();
-    if (block->contains(comm->getAddr())) { // If the op's block contains the address
+    if ((block != (BlockBasic*)0) && block->contains(comm->getAddr())) { // If the op's block contains the address
       // Treat the comment as being in this block at the very end
       subsort.setBlock(block->getIndex(),0xffffffff);
       return true;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/comment.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/comment.cc
@@ -301,7 +301,7 @@ bool CommentSorter::findPosition(Subsort &subsort,Comment *comm,const Funcdata *
       return true;
     }
   }
-  if ((backupOp->getParent() != (BlockBasic*)0) && backupOp != (PcodeOp *)0) {
+  if (backupOp != (PcodeOp *)0 && (backupOp->getParent() != (BlockBasic*)0)) {
     // Its possible the op migrated from its original basic block.
     // Since the address matches exactly, hang the comment on it
     subsort.setBlock(backupOp->getParent()->getIndex(),(uint4)backupOp->getSeqNum().getOrder());

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/comment.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/comment.cc
@@ -283,7 +283,7 @@ bool CommentSorter::findPosition(Subsort &subsort,Comment *comm,const Funcdata *
   if (opiter != fd->endOpAll()) {	// If there is an op at or after the comment
     PcodeOp *op = (*opiter).second;
     BlockBasic *block = op->getParent();
-    if (block->contains(comm->getAddr())) { // If the op's block contains the address
+    if ((block != (BlockBasic*)0) && block->contains(comm->getAddr())) { // If the op's block contains the address
       // Associate comment with this op
       subsort.setBlock(block->getIndex(), (uint4)op->getSeqNum().getOrder());
       return true;
@@ -301,7 +301,7 @@ bool CommentSorter::findPosition(Subsort &subsort,Comment *comm,const Funcdata *
       return true;
     }
   }
-  if (backupOp != (PcodeOp *)0) {
+  if ((backupOp->getParent() != (BlockBasic*)0) && backupOp != (PcodeOp *)0) {
     // Its possible the op migrated from its original basic block.
     // Since the address matches exactly, hang the comment on it
     subsort.setBlock(backupOp->getParent()->getIndex(),(uint4)backupOp->getSeqNum().getOrder());


### PR DESCRIPTION
If the client considers the function EOL comments to be in ranges the decompiler does not have a basic block defined for such as a jump table, etc, then the decompiler crashes because it fails to do a null pointer check.  The solution is simple and included.

Tested and working.