### PR TITLE
Double segmented resolve bad output in constants

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
@@ -367,7 +367,7 @@ public:
   TypeSpacebase(AddrSpace *id,const Address &frame,Architecture *g)
     : Datatype(0,TYPE_SPACEBASE), localframe(frame) { spaceid = id; glb = g; }
   Scope *getMap(void) const;	///< Get the symbol table indexed by \b this
-  Address getAddress(uintb off,int4 sz,const Address &point) const;	///< Construct an Address given an offset
+  Address getAddress(uintb off,int4 sz,const Address &point,bool ptrCheck) const;	///< Construct an Address given an offset
   virtual Datatype *getSubType(uintb off,uintb *newoff) const;
   virtual int4 compare(const Datatype &op,int4 level) const;
   virtual int4 compareDependency(const Datatype &op) const; // For tree structure


### PR DESCRIPTION
Instead of printing the global variable, relics like "ram0x000006d0" occur because the resolver is run twice, the first time on a near/far pointer, the second time on a RAM address which it treats like a segmented far pointer due to its size - and this is wrong behavior.  Yet the ptr check flag is set specifically to prevent this yet never inquired.