### PR TITLE
Segmented pointer additions wrong offset inference

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -862,6 +862,10 @@ SymbolEntry *ActionConstantPtr::isPointer(AddrSpace *spc,Varnode *vn,PcodeOp *op
     case CPUI_INT_ADD:
       outvn = op->getOut();
       if (outvn->getType()->getMetatype()==TYPE_PTR) {
+        BlockBasic* curblock = op->getParent();
+        list<PcodeOp*>::iterator iter = op->getBasicIter();
+        if (++iter != curblock->endOp() && //if part of a segment op cannot process here!
+          (*iter)->code() == CPUI_SEGMENTOP) return (SymbolEntry*)0;
 	int4 slot = op->getSlot(vn);
 	// Is there another pointer base in this expression
 	if (op->getIn(1-slot)->getType()->getMetatype()==TYPE_PTR)


### PR DESCRIPTION
A reference such as ```es:[bx+1D70h]``` should print out correctly as: bx_var + 0x1d70.  Currently it prints as an offset from coincidental data segment location found at 0x1D70 as &ram0x000006D0+bx_var.  For es:[bx+1d80] it would be &ram0x000006D0+(bx+var+0x10) and so forth.

Looking at the next instruction to figure out where the output is bound does not seem like the ideal approach but its the easiest approach I could come up with as the SEGMENTOP would always come immediately after.  Obviously the DS segment is not used so just guessing here is totally ridiculous when the SEGMENTOP that happens in the next opcode binds to the ES segment.  Basically it ruins the clean output and wrongly queryies for nonsense addresses.

Tested and working.