### PR TITLE
Mixing un/locked argument types cause crash

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -1652,7 +1652,7 @@ void ScopeInternal::clearCategory(int4 cat)
     int4 sz = category[cat].size();
     for(int4 i=0;i<sz;++i) {
       Symbol *sym = category[cat][i];
-      removeSymbol(sym);
+      if (sym != (Symbol*)0) removeSymbol(sym);
     }
   }
   else {

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -1696,6 +1696,7 @@ void ScopeInternal::clearUnlockedCategory(int4 cat)
     int4 sz = category[cat].size();
     for(int4 i=0;i<sz;++i) {
       Symbol *sym = category[cat][i];
+      if (sym == (Symbol*)0) continue;
       if (sym->isTypeLocked()) { // Only hold if TYPE locked
 	if (!sym->isNameLocked()) { // Clear an unlocked name
 	  if (!sym->isNameUndefined()) {

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -1507,7 +1507,7 @@ SymbolEntry *ScopeInternal::addMapInternal(Symbol *sym,uint4 exfl,const Address 
     
   list<SymbolEntry>::iterator iter = rangemap->insert(initdata,addr.getOffset(),lastaddress.getOffset());
   // Store reference to map in symbol
-  if (sym->isTypeLocked()) sym->mapentry.push_back(iter);
+  sym->mapentry.push_back(iter);
   return &(*iter);
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -1507,7 +1507,7 @@ SymbolEntry *ScopeInternal::addMapInternal(Symbol *sym,uint4 exfl,const Address 
     
   list<SymbolEntry>::iterator iter = rangemap->insert(initdata,addr.getOffset(),lastaddress.getOffset());
   // Store reference to map in symbol
-  sym->mapentry.push_back(iter);
+  if (sym->isTypeLocked()) sym->mapentry.push_back(iter);
   return &(*iter);
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
@@ -3186,7 +3186,7 @@ void FuncProto::updateInputTypes(const vector<Varnode *> &triallist,ParamActive 
     if (trial.isUsed()) {
       Varnode *vn = triallist[trial.getSlot()-1];
       if (!vn->isMark()) {
-	if (getParam(count)->isTypeLocked()) {
+	if (count < numParams() && getParam(count)->isTypeLocked()) {
 	  count++; continue;
 	}
         store->clearInput(count);
@@ -3224,7 +3224,7 @@ void FuncProto::updateInputNoTypes(const vector<Varnode *> &triallist,ParamActiv
     if (trial.isUsed()) {
       Varnode *vn = triallist[trial.getSlot()-1];
       if (!vn->isMark()) {
-	if (getParam(count)->isTypeLocked()) {
+	if (count < numParams() && getParam(count)->isTypeLocked()) {
 	  count++; continue;
 	}
         store->clearInput(count);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
@@ -3186,7 +3186,7 @@ void FuncProto::updateInputTypes(const vector<Varnode *> &triallist,ParamActive 
     if (trial.isUsed()) {
       Varnode *vn = triallist[trial.getSlot()-1];
       if (!vn->isMark()) {
-	if (count < numParams() && getParam(count)->isTypeLocked()) {
+	if (count < numParams() && getParam(count) != (ProtoParameter*)0 && getParam(count)->isTypeLocked()) {
 	  count++; continue;
 	}
         store->clearInput(count);
@@ -3224,7 +3224,7 @@ void FuncProto::updateInputNoTypes(const vector<Varnode *> &triallist,ParamActiv
     if (trial.isUsed()) {
       Varnode *vn = triallist[trial.getSlot()-1];
       if (!vn->isMark()) {
-	if (count < numParams() && getParam(count)->isTypeLocked()) {
+	if (count < numParams() && getParam(count) != (ProtoParameter*)0 && getParam(count)->isTypeLocked()) {
 	  count++; continue;
 	}
         store->clearInput(count);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
@@ -3060,7 +3060,7 @@ bool FuncProto::isInputLocked(void) const
   if ((flags&voidinputlock)!=0) return true;
   if (numParams()==0) return false;
   ProtoParameter *param = getParam(0);
-  if (param->isTypeLocked()) return true;
+  if (param != (ProtoParameter*)0 && param->isTypeLocked()) return true;
   return false;
 }
 
@@ -3434,7 +3434,7 @@ bool FuncProto::possibleInputParam(const Address &addr,int4 size) const
       bool locktest = false;	// Have tested against locked symbol
       for(int4 i=0;i<num;++i) {
 	ProtoParameter *param = getParam(i);
-	if (!param->isTypeLocked()) continue;
+	if (param == (ProtoParameter*)0 || !param->isTypeLocked()) continue;
 	locktest = true;
 	Address iaddr = param->getAddress();
 	// If the parameter already exists, the varnode must be justified in the parameter relative
@@ -3494,7 +3494,7 @@ bool FuncProto::unjustifiedInputParam(const Address &addr,int4 size,VarnodeData 
       bool locktest = false;	// Have tested against locked symbol
       for(int4 i=0;i<num;++i) {
 	ProtoParameter *param = getParam(i);
-	if (!param->isTypeLocked()) continue;
+	if (param == (ProtoParameter*)0 || !param->isTypeLocked()) continue;
 	locktest = true;
 	Address iaddr = param->getAddress();
 	// If the parameter already exists, test if -addr- -size- is improperly contained in param

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -1869,14 +1869,16 @@ void PrintC::emitPrototypeInputs(const FuncProto *proto)
       if (i!=0)
 	emit->print(",");
       ProtoParameter *param = proto->getParam(i);
-      Symbol *sym = param->getSymbol();
+      Symbol *sym = param == (ProtoParameter*)0 ? (Symbol*)0 : param->getSymbol();
       if (sym != (Symbol *)0)
 	emitVarDecl(sym);
       else {
 	// Emit type without name, if there is no backing symbol
-	pushTypeStart(param->getType(),true);
+	Datatype* dt = param == (ProtoParameter*)0 ?
+	  proto->getArch()->types->getBase(1, TYPE_UNKNOWN) : param->getType();
+	pushTypeStart(dt,true);
 	pushAtom(Atom("",blanktoken,EmitXml::no_color));
-	pushTypeEnd(param->getType());
+	pushTypeEnd(dt);
 	recurse();
       }
     }


### PR DESCRIPTION
This problem looks to be rather deeply ingrained in the func proto model.  The model works for all input parameters being type locked or none being type locked.  It infers off the first parameter in the function spec prototype as to whether they are locked.  However, just because the Java client follows this pattern strictly hardly makes it correct behavior.  If a client does mix type locks, it will cause a crash in a variety of places for a variety of reasons - no mitigations or handling whatsoever exists.

If 1 argument is specified and its type is unknown so it is unlocked while others can be locked (perhaps the others are passed as arguments to  well known functions for example).  The model for the function however is not known and not locked.  Then prototype analysis will NULL out the first argument while detecting additional arguments in slots 2-...  This sets up a good variety of crash places.  I am fixing a few that I specifically found crashed and will continue fixing them as I find them since not all getParam() places are possible when calls like isInputLocked return false.  It will clear out all the parameters in this case and leave dangling pointers in varnodes.

The decompiler warns with a comment about not model locking while locking parameter types - but again there are too many cases where types of inputs are known with certainty and the function type itself is not.  From a practical standpoint, this is a must implement.  Of course, it only applies to the current function decompiled.  All functions called from that function could have their parameters locked or not since the same level of function prototype analysis is not applied.

But clearly resilience is the best of all worlds here especially when the warning message implies this should be possible.

For the record, ScopeInternal::clearCategory is what removes the symbol to begin with and it sets off a cascade of problems.  Specifically it sees it is not "SizeTypeLocked" meaning type lock with an unknown type which indicates certainty about size.

The easy thing to do is on the main function being decompiled, simply type lock all function arguments (category 0) - whether unknown or not, the former being a size type lock, the latter being a specific type lock.  I suppose if it is not the last argument, it hardly makes sense otherwise but nonetheless this seems like a strange requirement that is not exactly documented clearly anywhere.

Tested and working.  It does not crash anymore and is more resilient to crashing though this is best described as a workaround and not a total fix as the partial unlocked arguments are not properly being recovered and a better algorithm would be needed for this.  