### PR TITLE
Func proto type locks are not properly propagated

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -846,6 +846,13 @@ SymbolEntry *ActionConstantPtr::isPointer(AddrSpace *spc,Varnode *vn,PcodeOp *op
     case CPUI_RETURN:
     case CPUI_CALL:
     case CPUI_CALLIND:
+    {
+      FuncCallSpecs* otherfc = FuncCallSpecs::getFspecFromConst(op->getIn(0)->getAddr());
+      if (otherfc != (FuncCallSpecs*)0 && otherfc->numParams() > op->getSlot(vn) - 1) {
+        ProtoParameter* pp = otherfc->getParam(op->getSlot(vn) - 1);
+        if (pp->getType()->getMetatype() != TYPE_PTR && pp->isTypeLocked()) return (SymbolEntry*)0;
+      }
+    }
       // A constant parameter or return value could be a pointer
       if (!glb->infer_pointers)
 	return (SymbolEntry *)0;


### PR DESCRIPTION
This is a reasonable workaround for a deeply engrained flaw in the decompiler.

Let us understand the problem first.

An external function prototype such as: HWND GetDlgItem(HWND, int) gives a lot of locked type information which one would expect would propagate.  But GetDlgItem(arg_4, 0x1071) gets decompiled as GetDlgItem(arg_4, $$undef_0x00000000) because constant pointer inference thinks 0x1071 could be a data segment pointer.

Why is the type not locked?

The type is transfered via ActionInferTypes::writeback where it uses vn->getTempType() and then vn->updateType(ct, false, false) to update the type without locking it.  Where does the temp type come from?

ActionInferTypes::buildLocaltypes set the temp type based on vn->getLocalType() which in turn calls op->inputTypeLocal a wrapper for getInputLocal which in turn will look up the type from the function prototype which clearly marks it as locked (for e.g. TypeOpCall::getInputLocal or CallInd/CallOther).  But only the data type is returned not the symbol which mentions its lock status flag since ProtoParameter which contains the symbol is not returned.

The best fix for this is that not only is the temp type propagated but the temp symbol e.g. tempmapentry instead of just mapentry which is there now.  Now when the type is applied, instead of always not locking, the symbol can be analyzed for lock status.

This is a pretty large bug in the decompiler and significantly diminishes the output quality in cases when function prototypes for sub-functions are known and specified in detail.

Otherwise the real fix involves changing all inputTypeLocal and getInputLocal calls to add an additional parameter taking a pointer to a pointer to a symbol type that will be returned.  A tempmapentry would be added to keep the mapentry for this symbol along with the temp type.  When the temp type is applied, the type lock flag would then be set accordingly.  Its not a difficult change as it involves primarily typeop.cc/op.hh and coreaction.cc but also will effect varnode.cc and merge.cc in one place each.

Please advise.