### PR TITLE
Decompiler crash with call injection

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
@@ -1307,6 +1307,7 @@ void FlowInfo::injectPcode(void)
       injectUserOp(op);
     }
     else {	// CPUI_CALL or CPUI_CALLIND
+      if (op->getIn(0)->getAddr().getSpace()->getType() != IPTR_FSPEC) continue;
       FuncCallSpecs *fc = FuncCallSpecs::getFspecFromConst(op->getIn(0)->getAddr());
       if (fc->isInline()) {
 	if (fc->getInjectId() >= 0) {


### PR DESCRIPTION
CPUI_CALL/IND do not guarantee the first argument is an FSPEC.  All other places check before trying to assume it, while others do not and can crash.  I ran into this bug when I applied my own fix in constant pointers and also forget to check this exact case.  I do not know exactly why this call does not have the check but its certainly a normal possibility in the decompiler.

A small audit of getFspecFromConst shows that every other place where it is used has the check, this is a single obvious bug.

Tested and working fine.