### PR TITLE
More than 20 operands crashes sleigh parser

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/context.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/context.hh
@@ -187,6 +187,7 @@ inline void ParserContext::allocateOperand(int4 i,ParserWalkerChange &walker) {
   ConstructState *opstate = &state[alloc++];
   opstate->parent = walker.point;
   opstate->ct = (Constructor *)0;
+  if (walker.point->resolve.size() <= i) walker.point->resolve.resize(i + 1);
   walker.point->resolve[i] = opstate;
   walker.breadcrumb[walker.depth++] += 1;
   walker.point = opstate;


### PR DESCRIPTION
I have an x86-64 opcode starting with the 16 byte stream 0x00000000100b1437:
0x66 0x0f 0xfc 0xc2 0x66 0x0f 0x6f 0xd0 0xf3 0x0f 0x6f 0x44 0x02 0x10 0x48 0x83

```
100B1437: paddb   xmm0, xmm2
100B143B: movdqa  xmm2, xmm0
100B143F: movdqu  xmm0, xmmword ptr [rdx+rax+10h]
100B1445: (partial) add     rax, 20h
100B1449: …
```
sleigh.cc initializes the operands to a fixed value of 20: DisassemblyCache::initialize -> pos->initialize(75,20,constspace);

Yet this should be dynamically resized in appropriate cases as this byte sequence led to a 21st operand and a crash.  allocateOperand should be a sure place as its the only setter before all the various getters.