### PR TITLE
Remove IO default memory block from 6502 pspec

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.pspec
+++ b/Ghidra/Processors/6502/data/languages/6502.pspec
@@ -40,8 +40,7 @@
   </default_symbols>
   
   <default_memory_blocks>
-    <memory_block name="IO" start_address="0" length="0x20" initialized="false"/>
-    <memory_block name="LOW_RAM" start_address="0x20" length="0xff" initialized="false"/>
-    <memory_block name="STACK" start_address="0x0100" length="0x01ff" initialized="false"/>
+    <memory_block name="LOW_RAM" start_address="0x0000" length="0x0100" initialized="false"/>
+    <memory_block name="STACK" start_address="0x0100" length="0x0100" initialized="false"/>
   </default_memory_blocks>
 </processor_spec>


### PR DESCRIPTION
This pull request removes the IO memory block from the `default_memory_blocks` list in the 6502 `pspec` file and modifies the "LOW_RAM" memory block start address to be `0x0`.

This allows the default memory blocks to load successfully during a 6502 file import.

Closes #864 