### PR TITLE
Constant function pointers not resolving

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -833,7 +833,8 @@ SymbolEntry *ActionConstantPtr::isPointer(AddrSpace *spc,Varnode *vn,PcodeOp *op
   bool needexacthit;
   Architecture *glb = data.getArch();
   Varnode *outvn;
-  if (vn->getType()->getMetatype() == TYPE_PTR) { // Are we explicitly marked as a pointer
+  if (vn->getType()->getMetatype() == TYPE_PTR ||
+      vn->getType()->getMetatype() == TYPE_CODE) { // Are we explicitly marked as a pointer
     rampoint = glb->resolveConstant(spc,vn->getOffset(),vn->getSize(),op->getAddr());
     needexacthit = false;
   }


### PR DESCRIPTION
Currently a constant function pointer will appear as a number as TYPE_CODE is not considered for the constant resolver and only TYPE_PTR but both code and data should be considered.