### PR TITLE
Add integrationTestReport task

### DIFF
--- a/gradle/javaTestProject.gradle
+++ b/gradle/javaTestProject.gradle
@@ -86,6 +86,9 @@ task pcodeTest (type: Test) { t ->
 rootProject.unitTestReport {
 	reportOn this.project.test
 }
+rootProject.integrationTestReport {
+	reportOn this.project.integrationTest
+}
 rootProject.pcodeTestReport {
 	reportOn this.project.pcodeTest
 }

--- a/gradle/root/test.gradle
+++ b/gradle/root/test.gradle
@@ -331,6 +331,17 @@ task unitTestReport(type: TestReport) { t ->
 	outputs.upToDateWhen {false}
 }
 
+/*********************************************************************************
+ * INTEGRATION TEST REPORT
+ *
+ * Summary:	Runs all integration tests and generates a single report.
+ *
+ *********************************************************************************/
+task integrationTestReport(type: TestReport) { t ->
+	group "test"
+	destinationDir = file("$reportDir/integrationTests")
+	outputs.upToDateWhen {false}
+}
 
 
 /*********************************************************************************

--- a/gradle/root/test.gradle
+++ b/gradle/root/test.gradle
@@ -327,7 +327,8 @@ task parallelCombinedTestReport(type: TestReport) { t ->
  *********************************************************************************/
 task unitTestReport(type: TestReport) { t ->
 	group "test"
-	destinationDir = file("$reportDir/unitTests")
+    description "Run unit tests and save HTML report."
+    destinationDir = file("$reportDir/unitTests")
 	outputs.upToDateWhen {false}
 }
 
@@ -339,7 +340,8 @@ task unitTestReport(type: TestReport) { t ->
  *********************************************************************************/
 task integrationTestReport(type: TestReport) { t ->
 	group "test"
-	destinationDir = file("$reportDir/integrationTests")
+    description "Run unit integrtion tests and save HTML report."
+    destinationDir = file("$reportDir/integrationTests")
 	outputs.upToDateWhen {false}
 }
 

--- a/gradle/root/test.gradle
+++ b/gradle/root/test.gradle
@@ -340,7 +340,7 @@ task unitTestReport(type: TestReport) { t ->
  *********************************************************************************/
 task integrationTestReport(type: TestReport) { t ->
 	group "test"
-    description "Run unit integrtion tests and save HTML report."
+    description "Run integration tests and save HTML report."
     destinationDir = file("$reportDir/integrationTests")
 	outputs.upToDateWhen {false}
 }


### PR DESCRIPTION
This task will run integrationTest task and save all test reports in the
`$reportDir/integrationTestReports` folder

This was requested in #832 by @adamopolous