### PR TITLE
x86: fix ELF R_X86_64_GOT32/R_X86_64_PLT32 reloc

### DIFF
--- a/Ghidra/Processors/x86/src/main/java/ghidra/app/util/bin/format/elf/relocation/X86_64_ElfRelocationHandler.java
+++ b/Ghidra/Processors/x86/src/main/java/ghidra/app/util/bin/format/elf/relocation/X86_64_ElfRelocationHandler.java
@@ -89,11 +89,13 @@ public class X86_64_ElfRelocationHandler extends ElfRelocationHandler {
 				int ivalue = (int) (symbolValue & 0xffffffff);
 				memory.setInt(relocationAddress, ivalue);
 				break;
-			// we punt on these because they're not linked yet!
 			case X86_64_ElfRelocationConstants.R_X86_64_GOT32:
+				value = symbolValue + addend;
+				memory.setInt(relocationAddress, (int) value);
+				break;
 			case X86_64_ElfRelocationConstants.R_X86_64_PLT32:
-				value = symbolValue;
-				memory.setLong(relocationAddress, value);
+				value = symbolValue + addend - offset;
+				memory.setInt(relocationAddress, (int) value);
 				break;
 			case X86_64_ElfRelocationConstants.R_X86_64_GLOB_DAT:
 			case X86_64_ElfRelocationConstants.R_X86_64_JUMP_SLOT:


### PR DESCRIPTION
R_X86_64_GOT32/R_X86_64_PLT32 are 32-bit entries but the ELF
RelocationHandler rewrites longs (64-bit), overwriting the following
bytes with the 64-bit sign-extension thus overwriting the next instructions.

We can demonstrate with the following example:

```
/* shared.c */
void function(void);
void shared_function(void)
{
        function();
        function();
}
```

Compile with
```
cc  -fPIC -c -o shared.o shared.c
```

and analyze with Ghidra

![plt32_reloc](https://user-images.githubusercontent.com/5475997/63076174-293c8400-bee9-11e9-9342-800d99446ce0.png)

Rewrite int (32-bit) instead and properly relocate entries using
addend and offset fields as defined in AMD64 ABI gives:

![pl32_reloc_fixed](https://user-images.githubusercontent.com/5475997/63105052-e2747b80-bf34-11e9-9203-8a56e7c08454.png)

I am not sure if this could break in other places but it sounds to me like writing 64-bit values back is wrong.