### PR TITLE
PDB.exe building issue in Win10 and VS19

### DIFF
--- a/Ghidra/Features/PDB/src/pdb/cpp/main.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/main.cpp
@@ -17,6 +17,7 @@
 #include "pdb.h"
 #include "iterate.h"
 #include <signal.h>
+#include <memory>
 
 void segvHandler(int /*sig*/) {
 	exit(1);	// Just die - prevents OS from popping-up a dialog

--- a/Ghidra/Features/PDB/src/pdb/cpp/main.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/main.cpp
@@ -17,7 +17,7 @@
 #include "pdb.h"
 #include "iterate.h"
 #include <signal.h>
-#include <memory>
+
 
 void segvHandler(int /*sig*/) {
 	exit(1);	// Just die - prevents OS from popping-up a dialog

--- a/Ghidra/Features/PDB/src/pdb/cpp/main.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/main.cpp
@@ -17,7 +17,7 @@
 #include "pdb.h"
 #include "iterate.h"
 #include <signal.h>
-
+#include <memory>
 
 void segvHandler(int /*sig*/) {
 	exit(1);	// Just die - prevents OS from popping-up a dialog

--- a/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
+++ b/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
@@ -13,18 +13,18 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{343E9778-3C04-476E-8F90-A114AA7AA108}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
When you want to build pdb solution, it shows you the following errors:

error C2039:  'unique_ptr': is not a member of 'std'
error C2065:  'unique_ptr': undeclared identifier
error C2275:  'PDBApiContext': illegal use of this type as an expression
...

These error nags because developer misses to include the memory header file. I include it and finally, I could rebuild the PDB solution successfully. 