### PR TITLE
 PowerPC VLE - Interrupt Handler Efficiency Instructions

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/ppc_64.pspec
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_64.pspec
@@ -626,8 +626,8 @@
 	<register name="spr23b" group="SPR_UNNAMED"/>
   	<register name="spr23c" group="SPR_UNNAMED"/>
   	<register name="spr23d" group="SPR_UNNAMED"/>
-  	<register name="spr23e" group="SPR_UNNAMED"/>
-  	<register name="spr23f" group="SPR_UNNAMED"/>
+  	<register name="spr23e" rename="DSRR0" group="SPR"/>
+  	<register name="spr23f" rename="DSRR0" group="SPR"/>
 	
 	<register name="spr240" group="SPR_UNNAMED"/>
   	<register name="spr241" group="SPR_UNNAMED"/>

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_64.pspec
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_64.pspec
@@ -627,7 +627,7 @@
   	<register name="spr23c" group="SPR_UNNAMED"/>
   	<register name="spr23d" group="SPR_UNNAMED"/>
   	<register name="spr23e" rename="DSRR0" group="SPR"/>
-  	<register name="spr23f" rename="DSRR0" group="SPR"/>
+  	<register name="spr23f" rename="DSRR1" group="SPR"/>
 	
 	<register name="spr240" group="SPR_UNNAMED"/>
   	<register name="spr241" group="SPR_UNNAMED"/>

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_common.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_common.sinc
@@ -59,7 +59,7 @@ define register offset=0x1000 size=$(REGISTER_SIZE)
 	[ spr000 XER    spr002 spr003 spr004 spr005 spr006 spr007 LR     CTR    spr00a spr00b spr00c spr00d spr00e spr00f 
 	  spr010 spr011 spr012 spr013 spr014 spr015 spr016 spr017 spr018 spr019 SRR0   SRR1   spr01c spr01d spr01e spr01f 
 	  spr020 spr021 spr022 spr023 spr024 spr025 spr026 spr027 spr028 spr029 spr02a spr02b spr02c spr02d spr02e spr02f
-	  spr030 spr031 spr032 spr033 spr034 spr035 spr036 spr037 spr038 spr039 CSRR0 CSRR1 spr03c spr03d spr03e spr03f
+	  spr030 spr031 spr032 spr033 spr034 spr035 spr036 spr037 spr038 spr039 spr03a spr03b spr03c spr03d spr03e spr03f
 	  spr040 spr041 spr042 spr043 spr044 spr045 spr046 spr047 spr048 spr049 spr04a spr04b spr04c spr04d spr04e spr04f
 	  spr050 spr051 spr052 spr053 spr054 spr055 spr056 spr057 spr058 spr059 spr05a spr05b spr05c spr05d spr05e spr05f
 	  spr060 spr061 spr062 spr063 spr064 spr065 spr066 spr067 spr068 spr069 spr06a spr06b spr06c spr06d spr06e spr06f
@@ -91,7 +91,7 @@ define register offset=0x1000 size=$(REGISTER_SIZE)
 	  spr200 spr201 spr202 spr203 spr204 spr205 spr206 spr207 spr208 spr209 spr20a spr20b spr20c spr20d spr20e spr20f
 	  spr210 spr211 spr212 spr213 spr214 spr215 spr216 spr217 spr218 spr219 spr21a spr21b spr21c spr21d spr21e spr21f
 	  spr220 spr221 spr222 spr223 spr224 spr225 spr226 spr227 spr228 spr229 spr22a spr22b spr22c spr22d spr22e spr22f
-	  spr230 spr231 spr232 spr233 spr234 spr235 spr236 spr237 spr238 spr239 spr23a spr23b spr23c spr23d DSRR0 DSRR1
+	  spr230 spr231 spr232 spr233 spr234 spr235 spr236 spr237 spr238 spr239 spr23a spr23b spr23c spr23d spr23e spr23f
 	  spr240 spr241 spr242 spr243 spr244 spr245 spr246 spr247 spr248 spr249 spr24a spr24b spr24c spr24d spr24e spr24f
 	  spr250 spr251 spr252 spr253 spr254 spr255 spr256 spr257 spr258 spr259 spr25a spr25b spr25c spr25d spr25e spr25f
 	  spr260 spr261 spr262 spr263 spr264 spr265 spr266 spr267 spr268 spr269 spr26a spr26b spr26c spr26d spr26e spr26f
@@ -1125,12 +1125,12 @@ attach variables SPRVAL [
 	spr017	spr037	spr057	spr077	spr097	spr0b7	spr0d7	spr0f7	spr117	spr137	spr157	spr177	spr197	spr1b7	spr1d7	spr1f7	spr217	spr237	spr257	spr277	spr297	spr2b7	spr2d7	spr2f7	spr317	spr337	spr357	spr377	spr397	spr3b7	spr3d7	spr3f7
 	spr018	spr038	spr058	spr078	spr098	spr0b8	spr0d8	spr0f8	spr118  spr138	spr158	spr178	spr198	spr1b8	spr1d8	spr1f8	spr218	spr238	spr258	spr278	spr298	spr2b8	spr2d8	spr2f8	spr318	spr338	spr358	spr378	spr398	spr3b8  spr3d8 	spr3f8
     spr019	spr039	spr059	spr079	spr099	spr0b9	spr0d9	spr0f9	spr119	spr139	spr159	spr179	spr199	spr1b9	spr1d9	spr1f9	spr219	spr239	spr259	spr279	spr299	spr2b9	spr2d9	spr2f9	spr319	spr339	spr359	spr379	spr399	spr3b9  spr3d9	spr3f9
-	SRR0 	CSRR0	spr05a	spr07a	spr09a	spr0ba	spr0da	spr0fa	spr11a  spr13a	spr15a	spr17a	spr19a	spr1ba	spr1da	spr1fa	spr21a	spr23a	spr25a	spr27a	spr29a	spr2ba	spr2da	spr2fa	spr31a	spr33a	spr35a	spr37a	spr39a	spr3ba	spr3da 	spr3fa
-	SRR1	CSRR1	spr05b	spr07b	spr09b	spr0bb	spr0db	spr0fb	spr11b	spr13b	spr15b	spr17b	spr19b	spr1bb	spr1db	spr1fb	spr21b	spr23b	spr25b	spr27b	spr29b	spr2bb	spr2db	spr2fb	spr31b	spr33b	spr35b	spr37b	spr39b	spr3bb	spr3db 	spr3fb
+	SRR0 	spr03a	spr05a	spr07a	spr09a	spr0ba	spr0da	spr0fa	spr11a  spr13a	spr15a	spr17a	spr19a	spr1ba	spr1da	spr1fa	spr21a	spr23a	spr25a	spr27a	spr29a	spr2ba	spr2da	spr2fa	spr31a	spr33a	spr35a	spr37a	spr39a	spr3ba	spr3da 	spr3fa
+	SRR1	spr03b	spr05b	spr07b	spr09b	spr0bb	spr0db	spr0fb	spr11b	spr13b	spr15b	spr17b	spr19b	spr1bb	spr1db	spr1fb	spr21b	spr23b	spr25b	spr27b	spr29b	spr2bb	spr2db	spr2fb	spr31b	spr33b	spr35b	spr37b	spr39b	spr3bb	spr3db 	spr3fb
 	spr01c	spr03c	spr05c	spr07c	spr09c	spr0bc	spr0dc	spr0fc	TBLw    spr13c	spr15c	spr17c	spr19c	spr1bc	spr1dc	spr1fc	spr21c	spr23c	spr25c	spr27c	spr29c	spr2bc	spr2dc	spr2fc	spr31c	spr33c	spr35c	spr37c	spr39c	spr3bc	spr3dc	spr3fc
 	spr01d	spr03d	spr05d	spr07d	spr09d	spr0bd	spr0dd	spr0fd	TBUw    spr13d	spr15d	spr17d	spr19d	spr1bd	spr1dd	spr1fd	spr21d	spr23d	spr25d	spr27d	spr29d	spr2bd	spr2dd	spr2fd	spr31d	spr33d	spr35d	spr37d	spr39d	spr3bd	spr3dd	spr3fd
-	spr01e	spr03e	spr05e	spr07e	spr09e  spr0be	spr0de	spr0fe	spr11e	spr13e	spr15e	spr17e	spr19e	spr1be	spr1de	spr1fe	spr21e	DSRR0	spr25e	spr27e	spr29e	spr2be	spr2de	spr2fe	spr31e	spr33e	spr35e	spr37e	spr39e	spr3be	spr3de	spr3fe
-	spr01f	spr03f	spr05f	spr07f	spr09f	spr0bf	spr0df	spr0ff	spr11f  spr13f	spr15f	spr17f	spr19f	spr1bf	spr1df	spr1ff	spr21f	DSRR1	spr25f	spr27f	spr29f	spr2bf	spr2df	spr2ff	spr31f	spr33f	spr35f	spr37f	spr39f	spr3bf	spr3df	spr3ff
+	spr01e	spr03e	spr05e	spr07e	spr09e  spr0be	spr0de	spr0fe	spr11e	spr13e	spr15e	spr17e	spr19e	spr1be	spr1de	spr1fe	spr21e	spr23e	spr25e	spr27e	spr29e	spr2be	spr2de	spr2fe	spr31e	spr33e	spr35e	spr37e	spr39e	spr3be	spr3de	spr3fe
+	spr01f	spr03f	spr05f	spr07f	spr09f	spr0bf	spr0df	spr0ff	spr11f  spr13f	spr15f	spr17f	spr19f	spr1bf	spr1df	spr1ff	spr21f	spr23f	spr25f	spr27f	spr29f	spr2bf	spr2df	spr2ff	spr31f	spr33f	spr35f	spr37f	spr39f	spr3bf	spr3df	spr3ff
 ];
 
 ##

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_common.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_common.sinc
@@ -1685,13 +1685,6 @@ macro loadReg(reg) {
 	tea = tea+4;
 }
 
-@ifdef BIT_64
-macro loadRegHigh(reg) {
-      reg[32,32] = *:4(tea);
-      tea = tea + 4;
-}
-@endif
-
 macro loadRegisterPartial(reg, ea, sa) {
         mask:$(REGISTER_SIZE) = 0xffffffff;
         sa = ((4-sa) & 3) * 8;
@@ -1722,14 +1715,6 @@ macro storeReg(reg) {
 @endif
 	tea = tea+4;
 }	
-
-@ifdef BIT_64
-macro storeRegHigh(reg) {
-      *:4(tea) = reg[32,32];
-      tea = tea + 4;
-}
-@endif
-
 
 macro storeRegisterPartial(reg, ea, sa) {
 @ifdef BIT_64

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_common.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_common.sinc
@@ -59,7 +59,7 @@ define register offset=0x1000 size=$(REGISTER_SIZE)
 	[ spr000 XER    spr002 spr003 spr004 spr005 spr006 spr007 LR     CTR    spr00a spr00b spr00c spr00d spr00e spr00f 
 	  spr010 spr011 spr012 spr013 spr014 spr015 spr016 spr017 spr018 spr019 SRR0   SRR1   spr01c spr01d spr01e spr01f 
 	  spr020 spr021 spr022 spr023 spr024 spr025 spr026 spr027 spr028 spr029 spr02a spr02b spr02c spr02d spr02e spr02f
-	  spr030 spr031 spr032 spr033 spr034 spr035 spr036 spr037 spr038 spr039 spr03a spr03b spr03c spr03d spr03e spr03f
+	  spr030 spr031 spr032 spr033 spr034 spr035 spr036 spr037 spr038 spr039 CSRR0 CSRR1 spr03c spr03d spr03e spr03f
 	  spr040 spr041 spr042 spr043 spr044 spr045 spr046 spr047 spr048 spr049 spr04a spr04b spr04c spr04d spr04e spr04f
 	  spr050 spr051 spr052 spr053 spr054 spr055 spr056 spr057 spr058 spr059 spr05a spr05b spr05c spr05d spr05e spr05f
 	  spr060 spr061 spr062 spr063 spr064 spr065 spr066 spr067 spr068 spr069 spr06a spr06b spr06c spr06d spr06e spr06f
@@ -91,7 +91,7 @@ define register offset=0x1000 size=$(REGISTER_SIZE)
 	  spr200 spr201 spr202 spr203 spr204 spr205 spr206 spr207 spr208 spr209 spr20a spr20b spr20c spr20d spr20e spr20f
 	  spr210 spr211 spr212 spr213 spr214 spr215 spr216 spr217 spr218 spr219 spr21a spr21b spr21c spr21d spr21e spr21f
 	  spr220 spr221 spr222 spr223 spr224 spr225 spr226 spr227 spr228 spr229 spr22a spr22b spr22c spr22d spr22e spr22f
-	  spr230 spr231 spr232 spr233 spr234 spr235 spr236 spr237 spr238 spr239 spr23a spr23b spr23c spr23d spr23e spr23f
+	  spr230 spr231 spr232 spr233 spr234 spr235 spr236 spr237 spr238 spr239 spr23a spr23b spr23c spr23d DSRR0 DSRR1
 	  spr240 spr241 spr242 spr243 spr244 spr245 spr246 spr247 spr248 spr249 spr24a spr24b spr24c spr24d spr24e spr24f
 	  spr250 spr251 spr252 spr253 spr254 spr255 spr256 spr257 spr258 spr259 spr25a spr25b spr25c spr25d spr25e spr25f
 	  spr260 spr261 spr262 spr263 spr264 spr265 spr266 spr267 spr268 spr269 spr26a spr26b spr26c spr26d spr26e spr26f
@@ -1125,12 +1125,12 @@ attach variables SPRVAL [
 	spr017	spr037	spr057	spr077	spr097	spr0b7	spr0d7	spr0f7	spr117	spr137	spr157	spr177	spr197	spr1b7	spr1d7	spr1f7	spr217	spr237	spr257	spr277	spr297	spr2b7	spr2d7	spr2f7	spr317	spr337	spr357	spr377	spr397	spr3b7	spr3d7	spr3f7
 	spr018	spr038	spr058	spr078	spr098	spr0b8	spr0d8	spr0f8	spr118  spr138	spr158	spr178	spr198	spr1b8	spr1d8	spr1f8	spr218	spr238	spr258	spr278	spr298	spr2b8	spr2d8	spr2f8	spr318	spr338	spr358	spr378	spr398	spr3b8  spr3d8 	spr3f8
     spr019	spr039	spr059	spr079	spr099	spr0b9	spr0d9	spr0f9	spr119	spr139	spr159	spr179	spr199	spr1b9	spr1d9	spr1f9	spr219	spr239	spr259	spr279	spr299	spr2b9	spr2d9	spr2f9	spr319	spr339	spr359	spr379	spr399	spr3b9  spr3d9	spr3f9
-	SRR0 	spr03a	spr05a	spr07a	spr09a	spr0ba	spr0da	spr0fa	spr11a  spr13a	spr15a	spr17a	spr19a	spr1ba	spr1da	spr1fa	spr21a	spr23a	spr25a	spr27a	spr29a	spr2ba	spr2da	spr2fa	spr31a	spr33a	spr35a	spr37a	spr39a	spr3ba	spr3da 	spr3fa
-	SRR1	spr03b	spr05b	spr07b	spr09b	spr0bb	spr0db	spr0fb	spr11b	spr13b	spr15b	spr17b	spr19b	spr1bb	spr1db	spr1fb	spr21b	spr23b	spr25b	spr27b	spr29b	spr2bb	spr2db	spr2fb	spr31b	spr33b	spr35b	spr37b	spr39b	spr3bb	spr3db 	spr3fb
+	SRR0 	CSRR0	spr05a	spr07a	spr09a	spr0ba	spr0da	spr0fa	spr11a  spr13a	spr15a	spr17a	spr19a	spr1ba	spr1da	spr1fa	spr21a	spr23a	spr25a	spr27a	spr29a	spr2ba	spr2da	spr2fa	spr31a	spr33a	spr35a	spr37a	spr39a	spr3ba	spr3da 	spr3fa
+	SRR1	CSRR1	spr05b	spr07b	spr09b	spr0bb	spr0db	spr0fb	spr11b	spr13b	spr15b	spr17b	spr19b	spr1bb	spr1db	spr1fb	spr21b	spr23b	spr25b	spr27b	spr29b	spr2bb	spr2db	spr2fb	spr31b	spr33b	spr35b	spr37b	spr39b	spr3bb	spr3db 	spr3fb
 	spr01c	spr03c	spr05c	spr07c	spr09c	spr0bc	spr0dc	spr0fc	TBLw    spr13c	spr15c	spr17c	spr19c	spr1bc	spr1dc	spr1fc	spr21c	spr23c	spr25c	spr27c	spr29c	spr2bc	spr2dc	spr2fc	spr31c	spr33c	spr35c	spr37c	spr39c	spr3bc	spr3dc	spr3fc
 	spr01d	spr03d	spr05d	spr07d	spr09d	spr0bd	spr0dd	spr0fd	TBUw    spr13d	spr15d	spr17d	spr19d	spr1bd	spr1dd	spr1fd	spr21d	spr23d	spr25d	spr27d	spr29d	spr2bd	spr2dd	spr2fd	spr31d	spr33d	spr35d	spr37d	spr39d	spr3bd	spr3dd	spr3fd
-	spr01e	spr03e	spr05e	spr07e	spr09e  spr0be	spr0de	spr0fe	spr11e	spr13e	spr15e	spr17e	spr19e	spr1be	spr1de	spr1fe	spr21e	spr23e	spr25e	spr27e	spr29e	spr2be	spr2de	spr2fe	spr31e	spr33e	spr35e	spr37e	spr39e	spr3be	spr3de	spr3fe
-	spr01f	spr03f	spr05f	spr07f	spr09f	spr0bf	spr0df	spr0ff	spr11f  spr13f	spr15f	spr17f	spr19f	spr1bf	spr1df	spr1ff	spr21f	spr23f	spr25f	spr27f	spr29f	spr2bf	spr2df	spr2ff	spr31f	spr33f	spr35f	spr37f	spr39f	spr3bf	spr3df	spr3ff
+	spr01e	spr03e	spr05e	spr07e	spr09e  spr0be	spr0de	spr0fe	spr11e	spr13e	spr15e	spr17e	spr19e	spr1be	spr1de	spr1fe	spr21e	DSRR0	spr25e	spr27e	spr29e	spr2be	spr2de	spr2fe	spr31e	spr33e	spr35e	spr37e	spr39e	spr3be	spr3de	spr3fe
+	spr01f	spr03f	spr05f	spr07f	spr09f	spr0bf	spr0df	spr0ff	spr11f  spr13f	spr15f	spr17f	spr19f	spr1bf	spr1df	spr1ff	spr21f	DSRR1	spr25f	spr27f	spr29f	spr2bf	spr2df	spr2ff	spr31f	spr33f	spr35f	spr37f	spr39f	spr3bf	spr3df	spr3ff
 ];
 
 ##
@@ -1685,6 +1685,13 @@ macro loadReg(reg) {
 	tea = tea+4;
 }
 
+@ifdef BIT_64
+macro loadRegHigh(reg) {
+      reg[32,32] = *:4(tea);
+      tea = tea + 4;
+}
+@endif
+
 macro loadRegisterPartial(reg, ea, sa) {
         mask:$(REGISTER_SIZE) = 0xffffffff;
         sa = ((4-sa) & 3) * 8;
@@ -1715,6 +1722,14 @@ macro storeReg(reg) {
 @endif
 	tea = tea+4;
 }	
+
+@ifdef BIT_64
+macro storeRegHigh(reg) {
+      *:4(tea) = reg[32,32];
+      tea = tea + 4;
+}
+@endif
+
 
 macro storeRegisterPartial(reg, ea, sa) {
 @ifdef BIT_64

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -591,7 +591,7 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 
 :se_cmpli RX_VLE,OIMM		is $(ISVLE) & OP6_VLE=8 & BIT9_VLE=1 & RX_VLE & OIMM {
 	tmpA:4 = RX_VLE:4;
-	tmpB:4 = OIMM:4 & 0x1f;
+	tmpB:4 = OIMM:4;
 	cr0 = ((tmpA < tmpB) << 3) | ((tmpA > tmpB) << 2) | ((tmpA == tmpB) << 1) | (xer_so & 1);			
 }
 

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -213,33 +213,33 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 :e_ldmvcsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=5
 {
 	tea = d8PlusRaOrZeroAddress;
-	loadRegHigh(spr03a);
-	loadRegHigh(spr03b);
+	loadReg(spr03a);
+	loadReg(spr03b);
 }
 
 # e_ldmvdsrrw 6 (0b0001_10) 0b00110 RA 0b0001_0000 D8
 :e_ldmvdsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=6
 {
 	tea = d8PlusRaOrZeroAddress;
-	loadRegHigh(spr23e);
-	loadRegHigh(spr23f);
+	loadReg(spr23e);
+	loadReg(spr23f);
 }
 
 # e_ldmvgprw 6 (0b0001_10) 0b00000 RA 0b0001_0000 D8
 :e_ldmvgprw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=0
 {
 	tea = d8PlusRaOrZeroAddress;
-	loadRegHigh(r0);
-	loadRegHigh(r3);
-	loadRegHigh(r4);
-	loadRegHigh(r5);
-	loadRegHigh(r6);
-	loadRegHigh(r7);
-	loadRegHigh(r8);
-	loadRegHigh(r9);
-	loadRegHigh(r10);
-	loadRegHigh(r11);
-	loadRegHigh(r12);
+	loadReg(r0);
+	loadReg(r3);
+	loadReg(r4);
+	loadReg(r5);
+	loadReg(r6);
+	loadReg(r7);
+	loadReg(r8);
+	loadReg(r9);
+	loadReg(r10);
+	loadReg(r11);
+	loadReg(r12);
 }
 
 # e_ldmvsprw 6 (0b0001_10) 0b00001 RA 0b0001_0000 D8
@@ -249,7 +249,7 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	#TODO  is there a better way to handle this, CR are 4 bit
 	#      so crall can't be used.  And not much code accesses
 	#      CR in this way, also CRM_CR seems backwards?
-	# loadRegHigh(CR);
+	# loadReg(CR);
 	local tmpCR:4 = *:4 tea;
 	cr0 = zext(tmpCR[0,4]);
 	cr1 = zext(tmpCR[4,4]);
@@ -260,17 +260,17 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	cr6 = zext(tmpCR[24,4]);
 	cr7 = zext(tmpCR[28,4]);
 	tea = tea + 4;
-	loadRegHigh(LR);
-	loadRegHigh(CTR);
-	loadRegHigh(XER);
+	loadReg(LR);
+	loadReg(CTR);
+	loadReg(XER);
 }
 
 # e_ldmvsrrw 6 (0b0001_10) 0b00100 RA 0b0001_0000 D8
 :e_ldmvsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=4
 {
 	tea = d8PlusRaOrZeroAddress;
-	loadRegHigh(SRR0);
-	loadRegHigh(SRR1);
+	loadReg(SRR0);
+	loadReg(SRR1);
 }
 
 :e_lha	D,dPlusRaOrZeroAddress	is $(ISVLE) & OP=14 & D & dPlusRaOrZeroAddress
@@ -348,33 +348,33 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 :e_stmvcsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=5
 {
 	tea = d8PlusRaOrZeroAddress;
-	storeRegHigh(spr03a);
-	storeRegHigh(spr03b);
+	storeReg(spr03a);
+	storeReg(spr03b);
 }
 
 # e_stmvdsrrw 6 (0b0001_10) 0b00110 RA 0b0001_0001 D8
 :e_stmvdsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=6
 {
 	tea = d8PlusRaOrZeroAddress;
-	storeRegHigh(spr23e);
-	storeRegHigh(spr23f);
+	storeReg(spr23e);
+	storeReg(spr23f);
 }
 
 # e_stmvgprw 6 (0b0001_10) 0b00000 RA 0b0001_0001 D8
 :e_stmvgprw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=0
 {
 	tea = d8PlusRaOrZeroAddress;
-	storeRegHigh(r0);
-	storeRegHigh(r3);
-	storeRegHigh(r4);
-	storeRegHigh(r5);
-	storeRegHigh(r6);
-	storeRegHigh(r7);
-	storeRegHigh(r8);
-	storeRegHigh(r9);
-	storeRegHigh(r10);
-	storeRegHigh(r11);
-	storeRegHigh(r12);
+	storeReg(r0);
+	storeReg(r3);
+	storeReg(r4);
+	storeReg(r5);
+	storeReg(r6);
+	storeReg(r7);
+	storeReg(r8);
+	storeReg(r9);
+	storeReg(r10);
+	storeReg(r11);
+	storeReg(r12);
 }
 
 # e_stmvsprw 6 (0b0001_10) 0b00001 RA 0b0001_0001 D8
@@ -382,7 +382,7 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 {
 	tea = d8PlusRaOrZeroAddress;
 	#TODO  SEE TODO in e_ldmvsprw
-	# storeRegHigh(CR);
+	# storeReg(CR);
 	local tmpCR:4 = 0;
 	tmpCR = tmpCR | zext((cr0 & 0xf) << 0);
 	tmpCR = tmpCR | zext((cr1 & 0xf) << 4);
@@ -394,17 +394,17 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	tmpCR = tmpCR | zext((cr7 & 0xf) << 28);
 	*:4 tea = tmpCR;
 	tea = tea + 4;
-	storeRegHigh(LR);
-	storeRegHigh(CTR);
-	storeRegHigh(XER);
+	storeReg(LR);
+	storeReg(CTR);
+	storeReg(XER);
 }
 
 # e_stmvsrrw 6 (0b0001_10) 0b00100 RA 0b0001_0001 D8
 :e_stmvsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=4
 {
 	tea = d8PlusRaOrZeroAddress;
-	storeRegHigh(SRR0);
-	storeRegHigh(SRR1);
+	storeReg(SRR0);
+	storeReg(SRR1);
 }
 
 :e_stw S,dPlusRaOrZeroAddress	is $(ISVLE) & OP=21 & S & dPlusRaOrZeroAddress

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -589,9 +589,9 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	cr0 = ((tmpA < tmpB) << 3) | ((tmpA > tmpB) << 2) | ((tmpA == tmpB) << 1) | (xer_so & 1);		
 }
 
-:se_cmpli RX_VLE,OIM5_VLE		is $(ISVLE) & OP6_VLE=8 & BIT9_VLE=1 & RX_VLE & OIM5_VLE {
+:se_cmpli RX_VLE,OIMM		is $(ISVLE) & OP6_VLE=8 & BIT9_VLE=1 & RX_VLE & OIMM {
 	tmpA:4 = RX_VLE:4;
-	tmpB:4 = OIM5_VLE;
+	tmpB:4 = OIMM:4 & 0x1f;
 	cr0 = ((tmpA < tmpB) << 3) | ((tmpA > tmpB) << 2) | ((tmpA == tmpB) << 1) | (xer_so & 1);			
 }
 

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -209,6 +209,70 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	A = d8PlusRaAddress;
 }
 
+# e_ldmvcsrrw 6 (0b0001_10) 0b00101 RA 0b0001_0000 D8
+:e_ldmvcsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=5
+{
+	tea = dPlusRaOrZeroAddress;
+	loadRegHigh(CSRR0);
+	loadRegHigh(CSRR1);
+}
+
+# e_ldmvdsrrw 6 (0b0001_10) 0b00110 RA 0b0001_0000 D8
+:e_ldmvdsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=6
+{
+	tea = dPlusRaOrZeroAddress;
+	loadRegHigh(DSRR0);
+	loadRegHigh(DSRR1);
+}
+
+# e_ldmvgprw 6 (0b0001_10) 0b00000 RA 0b0001_0000 D8
+:e_ldmvgprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=0
+{
+	tea = dPlusRaOrZeroAddress;
+	loadRegHigh(r0);
+	loadRegHigh(r3);
+	loadRegHigh(r4);
+	loadRegHigh(r5);
+	loadRegHigh(r6);
+	loadRegHigh(r7);
+	loadRegHigh(r8);
+	loadRegHigh(r9);
+	loadRegHigh(r10);
+	loadRegHigh(r11);
+	loadRegHigh(r12);
+}
+
+# e_ldmvsprw 6 (0b0001_10) 0b00001 RA 0b0001_0000 D8
+:e_ldmvsprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=1
+{
+	tea = dPlusRaOrZeroAddress;
+	#TODO  is there a better way to handle this, CR are 4 bit
+	#      so crall can't be used.  And not much code accesses
+	#      CR in this way, also CRM_CR seems backwards?
+	# loadRegHigh(CR);
+	local tmpCR:4 = *:4 tea;
+	cr0 = zext(tmpCR[0,4]);
+	cr1 = zext(tmpCR[4,4]);
+	cr2 = zext(tmpCR[8,4]);
+	cr3 = zext(tmpCR[12,4]);
+	cr4 = zext(tmpCR[16,4]);
+	cr5 = zext(tmpCR[20,4]);
+	cr6 = zext(tmpCR[24,4]);
+	cr7 = zext(tmpCR[28,4]);
+	tea = tea + 4;
+	loadRegHigh(LR);
+	loadRegHigh(CTR);
+	loadRegHigh(XER);
+}
+
+# e_ldmvsrrw 6 (0b0001_10) 0b00100 RA 0b0001_0000 D8
+:e_ldmvsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=4
+{
+	tea = dPlusRaOrZeroAddress;
+	loadRegHigh(SRR0);
+	loadRegHigh(SRR1);
+}
+
 :e_lha	D,dPlusRaOrZeroAddress	is $(ISVLE) & OP=14 & D & dPlusRaOrZeroAddress
 {
 	D = sext(*:2(dPlusRaOrZeroAddress));	
@@ -278,6 +342,69 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 {
 	*:2(d8PlusRaAddress) = S:2;
 	A = d8PlusRaAddress;
+}
+
+# e_stmvcsrrw 6 (0b0001_10) 0b00101 RA 0b0001_0001 D8
+:e_stmvcsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=5
+{
+	tea = dPlusRaOrZeroAddress;
+	storeRegHigh(CSRR0);
+	storeRegHigh(CSRR1);
+}
+
+# e_stmvdsrrw 6 (0b0001_10) 0b00110 RA 0b0001_0001 D8
+:e_stmvdsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=6
+{
+	tea = dPlusRaOrZeroAddress;
+	storeRegHigh(DSRR0);
+	storeRegHigh(DSRR1);
+}
+
+# e_stmvgprw 6 (0b0001_10) 0b00000 RA 0b0001_0001 D8
+:e_stmvgprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=0
+{
+	tea = dPlusRaOrZeroAddress;
+	storeRegHigh(r0);
+	storeRegHigh(r3);
+	storeRegHigh(r4);
+	storeRegHigh(r5);
+	storeRegHigh(r6);
+	storeRegHigh(r7);
+	storeRegHigh(r8);
+	storeRegHigh(r9);
+	storeRegHigh(r10);
+	storeRegHigh(r11);
+	storeRegHigh(r12);
+}
+
+# e_stmvsprw 6 (0b0001_10) 0b00001 RA 0b0001_0001 D8
+:e_stmvsprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=1
+{
+	tea = dPlusRaOrZeroAddress;
+	#TODO  SEE TODO in e_ldmvsprw
+	# storeRegHigh(CR);
+	local tmpCR:4 = 0;
+	tmpCR = tmpCR | zext((cr0 & 0xf) << 0);
+	tmpCR = tmpCR | zext((cr1 & 0xf) << 4);
+	tmpCR = tmpCR | zext((cr2 & 0xf) << 8);
+	tmpCR = tmpCR | zext((cr3 & 0xf) << 12);
+	tmpCR = tmpCR | zext((cr4 & 0xf) << 16);
+	tmpCR = tmpCR | zext((cr5 & 0xf) << 20);
+	tmpCR = tmpCR | zext((cr6 & 0xf) << 24);
+	tmpCR = tmpCR | zext((cr7 & 0xf) << 28);
+	*:4 tea = tmpCR;
+	tea = tea + 4;
+	storeRegHigh(LR);
+	storeRegHigh(CTR);
+	storeRegHigh(XER);
+}
+
+# e_stmvsrrw 6 (0b0001_10) 0b00100 RA 0b0001_0001 D8
+:e_stmvsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=4
+{
+	tea = dPlusRaOrZeroAddress;
+	storeRegHigh(SRR0);
+	storeRegHigh(SRR1);
 }
 
 :e_stw S,dPlusRaOrZeroAddress	is $(ISVLE) & OP=21 & S & dPlusRaOrZeroAddress
@@ -739,7 +866,7 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	tmpX:4 = RX_VLE:4;
 	tmpX = tmpX s>> OIM5_VLE;
 	RX_VLE = sext(tmpX);
-	xer_ca = (RX_VLE s< 0) & (OIM5_VLE:1 > 0);
+	xer_ca = (RX_VLE s< 0) & (OIM5_VLE:1 != 0);
 }
 
 :se_sraw RX_VLE,RY_VLE			is $(ISVLE) & OP6_VLE=16 & BITS_8_9=1 & RX_VLE & RY_VLE {
@@ -747,7 +874,7 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	tmpS:1 = RY_VLE[0,5];
 	tmpX = tmpX s>> tmpS;
 	RX_VLE = sext(tmpX);
-	xer_ca = (RX_VLE s< 0) & (tmpS > 0);
+	xer_ca = (RX_VLE s< 0) & (tmpS != 0);
 }
 
 :e_srwi A,S,SHL					is $(ISVLE) & OP=31 & BIT_0=0 & XOP_1_10=568 & A & SHL & S {

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -210,25 +210,25 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 }
 
 # e_ldmvcsrrw 6 (0b0001_10) 0b00101 RA 0b0001_0000 D8
-:e_ldmvcsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=5
+:e_ldmvcsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=5
 {
-	tea = dPlusRaOrZeroAddress;
-	loadRegHigh(CSRR0);
-	loadRegHigh(CSRR1);
+	tea = d8PlusRaOrZeroAddress;
+	loadRegHigh(spr03a);
+	loadRegHigh(spr03b);
 }
 
 # e_ldmvdsrrw 6 (0b0001_10) 0b00110 RA 0b0001_0000 D8
-:e_ldmvdsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=6
+:e_ldmvdsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=6
 {
-	tea = dPlusRaOrZeroAddress;
-	loadRegHigh(DSRR0);
-	loadRegHigh(DSRR1);
+	tea = d8PlusRaOrZeroAddress;
+	loadRegHigh(spr23e);
+	loadRegHigh(spr23f);
 }
 
 # e_ldmvgprw 6 (0b0001_10) 0b00000 RA 0b0001_0000 D8
-:e_ldmvgprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=0
+:e_ldmvgprw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=0
 {
-	tea = dPlusRaOrZeroAddress;
+	tea = d8PlusRaOrZeroAddress;
 	loadRegHigh(r0);
 	loadRegHigh(r3);
 	loadRegHigh(r4);
@@ -243,9 +243,9 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 }
 
 # e_ldmvsprw 6 (0b0001_10) 0b00001 RA 0b0001_0000 D8
-:e_ldmvsprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=1
+:e_ldmvsprw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=1
 {
-	tea = dPlusRaOrZeroAddress;
+	tea = d8PlusRaOrZeroAddress;
 	#TODO  is there a better way to handle this, CR are 4 bit
 	#      so crall can't be used.  And not much code accesses
 	#      CR in this way, also CRM_CR seems backwards?
@@ -266,9 +266,9 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 }
 
 # e_ldmvsrrw 6 (0b0001_10) 0b00100 RA 0b0001_0000 D8
-:e_ldmvsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=4
+:e_ldmvsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x10 & BITS_21_25=4
 {
-	tea = dPlusRaOrZeroAddress;
+	tea = d8PlusRaOrZeroAddress;
 	loadRegHigh(SRR0);
 	loadRegHigh(SRR1);
 }
@@ -345,25 +345,25 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 }
 
 # e_stmvcsrrw 6 (0b0001_10) 0b00101 RA 0b0001_0001 D8
-:e_stmvcsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=5
+:e_stmvcsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=5
 {
-	tea = dPlusRaOrZeroAddress;
-	storeRegHigh(CSRR0);
-	storeRegHigh(CSRR1);
+	tea = d8PlusRaOrZeroAddress;
+	storeRegHigh(spr03a);
+	storeRegHigh(spr03b);
 }
 
 # e_stmvdsrrw 6 (0b0001_10) 0b00110 RA 0b0001_0001 D8
-:e_stmvdsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=6
+:e_stmvdsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=6
 {
-	tea = dPlusRaOrZeroAddress;
-	storeRegHigh(DSRR0);
-	storeRegHigh(DSRR1);
+	tea = d8PlusRaOrZeroAddress;
+	storeRegHigh(spr23e);
+	storeRegHigh(spr23f);
 }
 
 # e_stmvgprw 6 (0b0001_10) 0b00000 RA 0b0001_0001 D8
-:e_stmvgprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=0
+:e_stmvgprw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=0
 {
-	tea = dPlusRaOrZeroAddress;
+	tea = d8PlusRaOrZeroAddress;
 	storeRegHigh(r0);
 	storeRegHigh(r3);
 	storeRegHigh(r4);
@@ -378,9 +378,9 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 }
 
 # e_stmvsprw 6 (0b0001_10) 0b00001 RA 0b0001_0001 D8
-:e_stmvsprw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=1
+:e_stmvsprw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=1
 {
-	tea = dPlusRaOrZeroAddress;
+	tea = d8PlusRaOrZeroAddress;
 	#TODO  SEE TODO in e_ldmvsprw
 	# storeRegHigh(CR);
 	local tmpCR:4 = 0;
@@ -400,9 +400,9 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 }
 
 # e_stmvsrrw 6 (0b0001_10) 0b00100 RA 0b0001_0001 D8
-:e_stmvsrrw dPlusRaOrZeroAddress is $(ISVLE) & OP=6 & dPlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=4
+:e_stmvsrrw d8PlusRaOrZeroAddress is $(ISVLE) & OP=6 & d8PlusRaOrZeroAddress & XOP_8_VLE=0x11 & BITS_21_25=4
 {
-	tea = dPlusRaOrZeroAddress;
+	tea = d8PlusRaOrZeroAddress;
 	storeRegHigh(SRR0);
 	storeRegHigh(SRR1);
 }


### PR DESCRIPTION
https://www.nxp.com/docs/en/engineering-bulletin/EB696.pdf

Adds 10 additional instructions for multiple register store and load for interrupts.

Also 2 fixes that `sleigh` produced an ERROR for unsigned/signed comparison to zero

fixes #933 