### PR TITLE
Fix thunk functions not being properly namespace-qualified.

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/FunctionSymbol.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/FunctionSymbol.java
@@ -264,6 +264,22 @@ public class FunctionSymbol extends SymbolDB {
 		return super.getName();
 	}
 
+	/**
+	 * @see ghidra.program.model.symbol.Symbol#getParentNamespace()
+	 */
+	@Override
+	public Namespace getParentNamespace() {
+		if (getSource() == SourceType.DEFAULT) {
+			// Check for thunk function
+			Symbol thunkedSymbol = getThunkedSymbol();
+			if (thunkedSymbol instanceof FunctionSymbol) {
+				FunctionSymbol thunkedFuncSym = (FunctionSymbol) thunkedSymbol;
+				return thunkedFuncSym.getParentNamespace();
+			}
+		}
+		return super.getParentNamespace();
+	}
+
 //	@Override
 //	public void setNameAndNamespace(String newName, Namespace newNamespace, SourceType source)
 //			throws DuplicateNameException, InvalidInputException, CircularDependencyException {


### PR DESCRIPTION
Thunk functions delegate getName() messages to their thunked functions, but not
getParentNamespace(). This resulted in calls to thunk functions not being
appropriately qualified with their namespaces when they should be.