### PR TITLE
Fixed PIC16 instruction MOVIW ("Status Affected: Z")

### DIFF
--- a/Ghidra/Processors/PIC/data/languages/pic16_instructions.sinc
+++ b/Ghidra/Processors/PIC/data/languages/pic16_instructions.sinc
@@ -737,10 +737,12 @@ srcFSRk: sk6"["fsrk"]" is fsrk & sk6 {
 
 :MOVIW srcFSR			is op11=2 & srcFSR {
 	W = srcFSR;
+	setResultFlags(W);
 }
 
 :MOVIW srcFSRk			is op7=0x7e & srcFSRk {
 	W = srcFSRk;
+	setResultFlags(W);
 }
 
 :MOVWI srcFSR			is op11=3 & srcFSR {


### PR DESCRIPTION
Added setResultFlags(W); for PIC16 instruction MOVIW, because this instruction affects Z, according to the PIC documentation.

<img width="291" alt="image" src="https://user-images.githubusercontent.com/6257627/64039977-35b51380-cb5c-11e9-903f-e6438c88cdef.png">
