### PR TITLE
FrameDescriptionEntry: Ignore decoded null references

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/exceptionhandlers/gcc/structures/ehFrame/FrameDescriptionEntry.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/exceptionhandlers/gcc/structures/ehFrame/FrameDescriptionEntry.java
@@ -616,7 +616,7 @@ public class FrameDescriptionEntry extends GccAnalysisClass {
 		createAndCommentData(program, augmentationDataAddr, lsdaDecoder.getDataType(program),
 			lsdaComment, CodeUnit.EOL_COMMENT);
 
-		if (augmentationDataAddr.equals(lsdaAddr)) {
+		if (augmentationDataAddr.equals(lsdaAddr) || lsdaAddr.getOffset() == 0) {
 			// decoded a reference that returned here -- a null reference
 			return;
 		}


### PR DESCRIPTION
Changed to not log an error message when lsdaAddr is a null reference.