### PR TITLE
Link to OperandType in documentation

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/Instruction.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/Instruction.java
@@ -100,6 +100,8 @@ public interface Instruction extends CodeUnit, ProcessorContext {
 	 *
 	 * @param opIndex the index of the operand. (zero based)
 	 * @return the type of the operand.
+	 *
+	 * @see OperandType
 	 */
 	public int getOperandType(int opIndex);
 


### PR DESCRIPTION
getOperandType(int) returns int, so it's not otherwise clear how to
interpret the result.