### PR TITLE
Build PDB.exe using MSBuild instead of devenv

### DIFF
--- a/Ghidra/Features/PDB/build.gradle
+++ b/Ghidra/Features/PDB/build.gradle
@@ -49,13 +49,13 @@ if ("win64".equals(getCurrentPlatformName())) {
 		
 		def projectPathWindows = projectPath.replace("/", File.separator)
 		def solutionPathWindows = "${projectPathWindows}\\src\\pdb\\pdb.sln"
-		def outputPathWindows = "${projectPathWindows}\\build\\os\\win64\\pdb.exe"
+		def platformToolset = 'v' + MSVC_TOOLS_VERSION.substring(0, 4).replace('.', '');
 		
 		doFirst {
 			file("build/os/win64").mkdirs()
 			new File(solutionBatchFilePath).withWriter { out ->
 				out.println "call " + VISUAL_STUDIO_VCVARS_CMD
-				out.println "devenv ${solutionPathWindows} /build Release /project pdb"
+				out.println "msbuild ${solutionPathWindows} /p:Configuration=Release /p:PlatformToolset=${platformToolset} /p:WindowsTargetPlatformVersion=${MSVC_SDK_VERSION}"
 			}
 		}
 		


### PR DESCRIPTION
In addition to replacing just with MSBuild, I also pass
MSVC toolset using PlatformToolset property and Windows SDK using
WindowsTargetPlatformVersion property.

relates to #999