### PR TITLE
Fix error message when VS do not found

### DIFF
--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -51,7 +51,7 @@ task CheckToolChain {
 		if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
 			// ensure that required MS Visual Studio is installed where expected
 			String msg = "Microsoft Visual Studio install not found: ${VISUAL_STUDIO_BASE_DIR}\n" + 
-				"Adjust path in Ghidra/GPL/nativeBuildProperties.gradle if needed."
+				"Adjust path in Ghidra/GPL/vsconfig.gradle if needed."
 			if (!file(VISUAL_STUDIO_BASE_DIR).exists() || !file(VISUAL_STUDIO_INSTALL_DIR).exists()) {
 				throw new GradleException(msg);
 			}	


### PR DESCRIPTION
This change required after code for finding VS location was moved
to vsconfig.gradle and this message was not changed appropriately.