### PR TITLE
Added # symbol to issue numbers

### DIFF
--- a/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
+++ b/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
@@ -37,10 +37,10 @@
 <li><I>Decompiler</I>. Updated the Decompiler's Copy Action to the copy the symbol under the cursor when there is no selection. (Issue #411)</li>
 <li><I>Decompiler</I>. Fixed broken <I>External Navigation: Navigate to External Program</I> option.</li>
 <li><I>Decompiler</I>. The decompiler's logic for handling optimized division has been updated to recognize forms typically found in executables generated with more recent 64-bit compilers. (Issue #668)</li>
-<li><I>Decompiler</I>. Implemented call-fixup for x64 chkstk function. (Issue #670, 671)</li>
+<li><I>Decompiler</I>. Implemented call-fixup for x64 chkstk function. (Issue #670, #671)</li>
 <li><I>Decompiler</I>. The decompiler simplifies many new sign-bit extraction forms used in optimized division and comparison expressions.</li>
-<li><I>Documentation</I>. Fixed typos and other errors in GitHub-related documentation. (Issue #345, 361, 370, 375, 398)</li>
-<li><I>Documentation</I>. Added documentation to the dev guide on how to run unit/integration tests. (Issue #815, 832)</li>
+<li><I>Documentation</I>. Fixed typos and other errors in GitHub-related documentation. (Issue #345, #361, #370, #375, #398)</li>
+<li><I>Documentation</I>. Added documentation to the dev guide on how to run unit/integration tests. (Issue #815, #832)</li>
 <li><I>Function Graph</I>. Updated the Function Graph to show the current program selection when zoomed-out.</li>
 <li><I>Function Graph</I>. Added an option to the Function Graph to allow more complex edge routing that will go around non-incident vertices. See the Tool Options for more information and to enable this feature. (Issue #811)</li>
 <li><I>GUI</I>. Added listener to Script Table Dialog that will get notified when the dialog closes.</li>
@@ -53,7 +53,7 @@
 <li><I>GUI</I>. Added the ability to assign key bindings to show individual component providers. (Issue #539)</li>
 <li><I>GUI</I>. Fixed rendering issue in the Search Results table's Preview column. (Issue #550)</li>
 <li><I>Importer</I>. Updated x86 16-bit processor binding for IDA. (Issue #771)</li>
-<li><I>Importer:PE</I>. PeLoader better accounts for section alignment when laying out memory blocks, allowing additional bytes from the file to be loaded into memory. (Issue #327, 418)</li>
+<li><I>Importer:PE</I>. PeLoader better accounts for section alignment when laying out memory blocks, allowing additional bytes from the file to be loaded into memory. (Issue #327, #418)</li>
 <li><I>Importer:PE</I>. Removed out-of-place call to demangler and laying down of types from the PeLoader. This fix enables demangling and other analyzers to be applied correctly and in the proper order.</li>
 <li><I>Importer:PE</I>. PeLoader now adds TLS callback functions as entry points. (Issue #102)</li>
 <li><I>Languages</I>. Added new Task Monitor service to better handle user experience when there are delays in building languages.</li>
@@ -65,7 +65,7 @@
 <li><I>Languages</I>. Added MIPS special 0x1f patterns. (Issue #709)</li>
 <li><I>Multi-user</I>. Added a script to allow repository admins the ability to terminate multiple file checkouts belonging to an individual user.</li>
 <li><I>PDB</I>. Now using HTTPS for Microsoft symbol server URL. (Issue #369)</li>
-<li><I>PDB</I>. PDB processing can now store data types that contain forward slashes under a CategoryPath. (Issue #94, 182)</li>
+<li><I>PDB</I>. PDB processing can now store data types that contain forward slashes under a CategoryPath. (Issue #94, #182)</li>
 <li><I>Program API</I>. Added SHA256 hash to Program metadata and API. (Issue #331)</li>
 <li><I>Scripting</I>. Updated Script Table Chooser Dialog to fix bug with tracking work items, to add new API methods for item removal and dialog closed notification, and to prevent the same item from being worked on more than once. (Issue #307)</li>
 <li><I>Testing:Junits</I>. <font face="courier">test.gradle getLogFileUrl()</font> no longer searches <I>user.dir</I> for <I>log4j</I> properties file. (Issue #499)</li>
@@ -116,14 +116,14 @@
 <li><I>Languages</I>. Added 6502 <font face="courier">I</font> status bit save and restore per PR-362. (Issue #469)</li>
 <li><I>Languages</I>. Corrected alternate register definition in z80 processor. (Issue #520)</li>
 <li><I>Languages</I>. Reviewed all processor modules for GhidraSleighEditor syntax errors.</li>
-<li><I>Languages</I>. Added support for RD/WR/FS/GSBASE instructions in x86. (Issue #554, 555)</li>
+<li><I>Languages</I>. Added support for RD/WR/FS/GSBASE instructions in x86. (Issue #554, #555)</li>
 <li><I>Languages</I>. Fixed AAM x86 instruction.</li>
 <li><I>Listing</I>. Fixed potential infinite loop when editing long comments. (Issue #437)</li>
 <li><I>Listing</I>. Fixed potential ClassCastException in Listing comments.</li>
 <li><I>Listing</I>. Cursor in the listing now stays in the proper column after editing a field. (Issue #702)</li>
-<li><I>Multi-User:Ghidra Server</I>. Added proper Ghidra Server interface binding with new <I>-i</I> option. Corrected <I>-ip</I> option to strictly convey remote access hostname to clients. The updated server will only accept connections from Ghidra 9.1 and later clients due to the registry port now employing TLS. (Issue #101, 645)</li>
+<li><I>Multi-User:Ghidra Server</I>. Added proper Ghidra Server interface binding with new <I>-i</I> option. Corrected <I>-ip</I> option to strictly convey remote access hostname to clients. The updated server will only accept connections from Ghidra 9.1 and later clients due to the registry port now employing TLS. (Issue #101, #645)</li>
 <li><I>PDB</I>. Added char16_t and char32_t to PDB BASIC_TYPE_STRINGS. (Issue #685)</li> 
-<li><I>PDB</I>. Addressed memory leaks and string handling issues in pdb.exe. (Issue #674, 597, 598, 599, 600)</li>
+<li><I>PDB</I>. Addressed memory leaks and string handling issues in pdb.exe. (Issue #674, #597, #598, #599, #600)</li>
 <li><I>PDB</I>. Can now recover stack variables from more recent Visual Studio version PDBs. </li>
 <li><I>Project Manager</I>. Fixed a problem with creating Ghidra projects in Windows root directories (e.g., Z:\)</li>
 <li><I>Project Manager</I>. Fixed a path traversal vulnerability that could occur through loading a malicious project. (Issue #789)</li>


### PR DESCRIPTION
Otherwise links are not generated on the website.
And it was [done before](https://github.com/NationalSecurityAgency/ghidra/blob/cbf4c9d34aa57cbeb49c714d69271bb4790953a4/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html#L275) sometimes, so... consistency!