### PR TITLE
Properly model 6502's BRK opcode.

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -194,7 +194,8 @@ ADDRI:  imm16   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 	B = 1;
 	pushSR();
 	I = 1;
-	goto 0xFFFE;
+	local target:2 = 0xFFFE;
+	goto [*:2 target];
 }
 
 :BVC  REL			is op=0x50; REL

--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -189,7 +189,12 @@ ADDRI:  imm16   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 
 :BRK   is op=0x00
 {
-	goto inst_start;
+	*:2 (SP - 1) = inst_next;
+	SP = SP - 2;
+	B = 1;
+	pushSR();
+	I = 1;
+	goto 0xFFFE;
 }
 
 :BVC  REL			is op=0x50; REL


### PR DESCRIPTION
Model 6502's BRK opcode by following the sequence defined in the MCS6500 programming manual, as in:

1. The next instruction is pushed to the stack.
2. The B flag is set to 1.
3. The status flag byte is pushed to the stack.
4. The I flag is set to 1.
5. PC jumps to the IRQ vector.