### PR TITLE
#464 fix: Add GNU extended asm support; remove broken asm support

### DIFF
--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
@@ -700,6 +700,7 @@ public class CParser {
             System.out.println("C Parser:  Java program parsed successfully.");
         } catch (ParseException e) {
             System.out.println("C Parser:  Encountered errors during parse.");
+            System.out.println(e);
         }
     }
     
@@ -2288,43 +2289,53 @@ void AsmStatement() :
   (
     <ASM> [TypeQualifier(dec)]
     (
-//      ("(" AsmLine() ")" )
-//    |
-//      ("{" AsmLine() "}" )
-//    |
-      ( AsmLine() )
+      ("(" GnuAsm() ")" )
     )
   )
 }
 
-void AsmLine() :
+// TODO:
+// Microsoft asm as per https://docs.microsoft.com/en-us/cpp/assembler/inline/asm?view=vs-2019
+// with MASM syntax taken from:
+// https://docs.microsoft.com/en-us/cpp/assembler/masm/directives-reference?view=vs-2019
+// https://docs.microsoft.com/en-us/cpp/assembler/masm/symbols-reference?view=vs-2019
+// https://docs.microsoft.com/en-us/cpp/assembler/masm/operators-reference?view=vs-2019
+// NOTE:
+// This synatx is highly irregular(?), e.g. the "__asm int 3  __asm ret" style would require huge changes in the parses ... possibly CPP.jj as well
+// Also "__asm {int 3; ret }" will require large changes as "int", "3" and "ret" are already tokens so we can't do:
+// ( "{" ( ~ "}" ) * "}" )
+
+// GNU Asm as per https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#OutputOperands
+void GnuAsm() : {}
 {
-	Declaration dec = new Declaration();
+    ( <STRING_LITERAL> )+
+    [ ":" [ GnuAsmOperandList() ]
+	    [ ":" [ GnuAsmOperandList() ]
+    		[ ":" [ GnuAsmClobberList() ] ] ] ]
 }
+
+void GnuAsmOperandList() : {}
 {
-  (<IDENTIFIER> | <STRING_LITERAL> | <INTEGER_LITERAL> | <ATTRIBUTE> | BuiltInTypeSpecifier(dec) | "#" | "+" | "-" | "," | ":" | ("[" AsmLine() "]") | ( "(" AsmLine() ")" ) | ( "{" AsmLine() "}" ) )+
+	(
+		GnuAsmOperand() ( ","  GnuAsmOperand() )*
+	)
 }
 
+void GnuAsmOperand() : {}
+{
+	(
+		// in output operands the Expression() should be LValue()
+		// but Expression is more permissive so we can use GnuAsmOperand() for both input and ouput operands
+		[ "[" <IDENTIFIER> "]" ] ( <STRING_LITERAL> )+  "(" Expression() ")"
+	)
+}
 
-//void AsmStatement() : {}
-//{
-//	( <ASM> (
-//	    ( "{" SubAsm() "}" )
-//	    |
-//	    ( "(" SubAsm() ")" )
-//	    |
-//	    ( <IDENTIFIER> | "," | "[" | "]" | "(" | ")" | "%" | <INTEGER_LITERAL> | <CHARACTER_LITERAL> )+ ("\r" | "\n)+
-//	  )
-//	)
-//}
-
-//void SubAsm() : {}
-//{
-//    ( "(" SubAsm() ")" ) |
-//    ( <IDENTIFIER> | "," | "[" | "]" | "%" | <INTEGER_LITERAL> | <CHARACTER_LITERAL> )+
-//         ( [ "(" SubAsm() ")" ] [ SubAsm() ] ) 
-//    )
-//}
+void GnuAsmClobberList() : {}
+{
+	(
+		<STRING_LITERAL> ( "," <STRING_LITERAL> )*
+	)
+}
 
 
 void SelectionStatement() : {}


### PR DESCRIPTION
This fixes issue #464.
I added GNU extended Asm support (as described in https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html).
This also supports:
- ISO C standard (n1570 draft of C2011): J.5.10 The asm keyword
- C++ standard (n3376 draft of the C++11 standard): 7.4 The asm declaration [dcl.asm]

It does not support Microsoft Asm (as described in https://docs.microsoft.com/en-us/cpp/assembler/inline/asm?view=vs-2019).

However, Microsoft Asm never worked in the first place. I tested via:
```
/**/
void test1()
{
	// taken from https://docs.microsoft.com/en-us/cpp/assembler/inline/asm?view=vs-2019#grammar
	__asm int 3 // without patch ERROR: ghidra.app.util.cparser.C.ParseException: Encountered " <INTEGER_LITERAL> "3 "" at line 5, column 19.
}
/**/
/**/
void test2() // parses OK with patch
{
	// taken from https://docs.microsoft.com/en-us/cpp/assembler/inline/asm?view=vs-2019#grammar
	__asm int 3; // without patch ERROR: ghidra.app.util.cparser.C.ParseException: Encountered " <INTEGER_LITERAL> "3 "" at line 12, column 19.
}
/**/
/**/
void test3()
{
	// taken from https://docs.microsoft.com/en-us/cpp/assembler/inline/asm?view=vs-2019#grammar
	__asm {
		int 3; // without patch ERROR: ghidra.app.util.cparser.C.ParseException: Encountered " "{" "{ "" at line 17, column 1.
	};
}
/**/
```
And none of the simple tests worked **before** patching. Also none work after testing.

However, even very advanced GNU Asm works. Tested with:
```
/**/

// GNU asm works perfectly with patch. Everything after this comment works find:

typedef int size_t;

void simple_gnu_asm()
{
	asm(".intel_syntax noprefix");
	asm ("call .L1         \n\t"
	     ".L1:             \n\t"
	     "addw [esp],6     \n\t"
	     "ret              \n\t"
	);
	asm("ret":::);
	asm(".att_syntax noprefix");
}

unsigned long __readfsdword(unsigned long Offset)
{
	unsigned long ret;
	__asm__ (
		"mov{" "l" " %%" "fs" ":%[offset], %[ret] | %[ret], %%" "fs" ":%[offset]}"
		: [ret] "=r" (ret)
		: [offset] "m" ((int)Offset)
	);
	return ret;
}

unsigned long __readfsdword(unsigned long Offset) { unsigned long ret; __asm__ ("mov{" "l" " %%" "fs" ":%[offset], %[ret] | %[ret], %%" "fs" ":%[offset]}" : [ret] "=r" (ret) : [offset] "m" ((*(unsigned long *) (size_t) Offset))); return ret; }

unsigned char _interlockedbittestandset(long *Base, long Offset)
{
	unsigned char old;
	__asm__  (
		"lock bts{l %[Offset],%[Base] | %[Base],%[Offset]} ; setc %[old]"
		: [old] "=qm" (old), [Base] "+m" (*Base)
		: [Offset] "I" "r" "w" (Offset)
		: "memory", "cc"
	);
	return old;
}

unsigned char _interlockedbittestandset(long *Base, long Offset) { unsigned char old; __asm__ __volatile__ ("lock bts{l %[Offset],%[Base] | %[Base],%[Offset]} ; setc %[old]" : [old] "=qm" (old), [Base] "+m" (*Base) : [Offset] "I" "r" (Offset) : "memory", "cc"); return old; }
/**/

/*
Patch also handles:
C++ standard (n3376 draft of the C++11 standard): 7.4 The asm declaration [dcl.asm]
ISO C standard (n1570 draft of C2011): J.5.10 The asm keyword
*/
```
I tried to add MS asm support, but failed, because it would require extensive changes to the parser (see source code comments).

---

Because this only parses after `asm` keywords, this should not break anything.

Any comments welcome.