### PR TITLE
Make cabextract build incremental.

### DIFF
--- a/GPL/CabExtract/build.gradle
+++ b/GPL/CabExtract/build.gradle
@@ -15,44 +15,6 @@ eclipse.project.name = 'GPL CabExtract'
 project.ext.cabextract = "cabextract-1.6"
 
 /*********************************************************************************
- * CabExtract extraction task
- *
- * Unpacks the cabextract tar file that's needed for the symbol server.  This
- * is only unpacked for building the tool; once it's built, this unzipped 
- * archive is removed.
- *********************************************************************************/
-task unpackCabExtract (type: Copy) {
- 
-	from tarTree(file("data/${cabextract}.tar.gz"))
-	into 'build/unpack'
-	
-	// Force the task to be executed every time by setting to false.
-	// This is done since configure changes the contents for a platform
-	// NOTE: this can cause the 'build/unpack' to be deleted prior to an unpack
-	outputs.upToDateWhen { false }
-	
-	doLast {
- 		// Force all unpacked files to have the same timestamp
- 		ant.touch() {
- 			fileset(dir: file("build/unpack/${cabextract}"))
-	    }
- 	}
-}
-
-/*********************************************************************************
- * CabExtract configure task
- *
- * Performs configure on a newly unpacked cabextract tar file prior to
- * performing make.
- *********************************************************************************/
-task configureCabExtract (type: Exec) {
-	group "private"
-	workingDir "build/unpack/${cabextract}"
-	executable "./configure"
-	dependsOn unpackCabExtract
-}
-
-/*********************************************************************************
  * CabExtract platform specific tasks
  *
  * The cabextract tool requires that its 'configure' script is called before make.
@@ -66,12 +28,27 @@ if (['linux64', 'osx64'].contains(currentPlatform)) {
 		group "private"
 		workingDir "build/unpack/${cabextract}"
 		executable "make"
-		dependsOn configureCabExtract
-		doLast {
+		inputs.file("data/${cabextract}.tar.gz")
+		outputs.file("build/os/${currentPlatform}/cabextract")
+		// Extract archive and ./configure
+		doFirst {
 			copy {
-				from "build/unpack/${cabextract}/cabextract"
-				into "build/os/${currentPlatform}"
+				from tarTree(file("data/${cabextract}.tar.gz"))
+				into 'build/unpack'
 			}
+			// Force all unpacked files to have the same timestamp
+			ant.touch() {
+				fileset(dir: file("build/unpack/${cabextract}"))
+			}
+			exec {
+				workingDir "build/unpack/${cabextract}"
+				executable "./configure"
+			}
+		}
+		// Move out the built cabextract and delete the extracted files
+		doLast {
+			ant.move file: "build/unpack/${cabextract}/cabextract",
+				todir: "build/os/${currentPlatform}"
 			delete file("build/unpack/${cabextract}")
 		}
 	}


### PR DESCRIPTION
cabextract was being rebuilt every time, so this sets its build task's inputs and outputs so it's only built when stale. The extract and configure tasks were put into doFirst because they can't have proper inputs/outputs dependencies when the extracted archive is always deleted after being built. I have never used gradle before so if something is bizarre it's not on purpose.