### PR TITLE
Fix typos in error messages (fixes #1114)

### DIFF
--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/ExtensionTableModel.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/ExtensionTableModel.java
@@ -126,7 +126,7 @@ class ExtensionTableModel extends ThreadedTableModel<ExtensionDetails, List<Exte
 		ResourceFile installDir = Application.getApplicationLayout().getExtensionInstallationDir();
 		if (!installDir.canWrite()) {
 			Msg.showError(this, null, "Permissions Error",
-				"Cannot install/uninstall extensions: Invalid write permissions on installion directory.\n" +
+				"Cannot install/uninstall extensions: Invalid write permissions on installation directory.\n" +
 					"See the \"Ghidra Extension Notes\" section of the Ghidra Installation Guide for more information.");
 			return;
 		}

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/ExtensionTableProvider.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/ExtensionTableProvider.java
@@ -126,7 +126,7 @@ public class ExtensionTableProvider extends DialogComponentProvider {
 					Application.getApplicationLayout().getExtensionInstallationDir();
 				if (!installDir.canWrite()) {
 					Msg.showError(this, null, "Permissions Error",
-						"Cannot install/uninstall extensions: Invalid write permissions on installion directory.\n" +
+						"Cannot install/uninstall extensions: Invalid write permissions on installation directory.\n" +
 							"See the \"Ghidra Extension Notes\" section of the Ghidra Installation Guide for more information.");
 					return;
 				}


### PR DESCRIPTION
This PR fixes issue #1114 reported by @hadess. Correct typos: change "installion" to "installation".
Fixes #1114