### PR TITLE
cdt-8.6.0.zip checksum isn't downloaded over HTTPS

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -177,7 +177,7 @@ Download `cdt-8.6.0.zip` from The Eclipse Foundation, and place it in:
 ```bash
 cd ~/Downloads   # Or wherever
 curl -OL 'http://www.eclipse.org/downloads/download.php?r=1&protocol=https&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
-curl -o 'cdt-8.6.0.zip.sha512' -L --retry 3 'http://www.eclipse.org/downloads/sums.php?type=sha512&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
+curl -o 'cdt-8.6.0.zip.sha512' -L --retry 3 'https://www.eclipse.org/downloads/sums.php?type=sha512&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
 shasum -a 512 -c 'cdt-8.6.0.zip.sha512'
 mkdir -p ~/git/ghidra/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/build/
 cp ~/Downloads/cdt-8.6.0.zip ~/git/ghidra/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/build/


### PR DESCRIPTION
The file cdt-8.6.0.zip itself isn't available over HTTPS, so it is important that we download the checksum over HTTPS. Otherwise, the MITM can modify both the file and its SHA512 to match the malicious zip file.