### PR TITLE
Fixed DemangledDataType long long and long double

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/demangler/DemangledDataType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/demangler/DemangledDataType.java
@@ -59,7 +59,7 @@ public class DemangledDataType extends DemangledType {
 	public final static String INT = "int";
 	public final static String INT0_T = "int0_t";//TODO
 	public final static String LONG = "long";
-	public final static String LONG_LONG = "long long";
+	public final static String LONG_LONG = "long_long";
 	public final static String FLOAT = "float";
 	public final static String DOUBLE = "double";
 	public final static String INT8 = "__int8";
@@ -68,7 +68,7 @@ public class DemangledDataType extends DemangledType {
 	public final static String INT64 = "__int64";
 	public final static String INT128 = "__int128";//TODO
 	public final static String FLOAT128 = "__float128";//TODO
-	public final static String LONG_DOUBLE = "long double";
+	public final static String LONG_DOUBLE = "long_double";
 	public final static String PTR64 = "__ptr64";
 	public final static String STRING = "string";
 	public final static String UNDEFINED = "undefined";


### PR DESCRIPTION
I'm not sure how this went unnoticed until now, but the following changes are necessary due to the following:
https://github.com/NationalSecurityAgency/ghidra/blob/b0609a1cb32c5d6351ce766e86b48e3da13c7f62/Ghidra/Features/Base/src/main/java/ghidra/app/util/demangler/DemangledType.java#L114-L121

Because of the replace(' ', '_') passing "long long" or "long double" results in setting the name to "long_long" or "long_double" respectively and then calling getDataType would return null.