### PR TITLE
Android relocation support

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/AndroidPackedRelocationTableDataType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/AndroidPackedRelocationTableDataType.java
@@ -1,0 +1,96 @@
+package ghidra.app.util.bin.format.elf;
+
+import java.util.Formatter;
+
+import ghidra.docking.settings.Settings;
+import ghidra.program.model.data.BuiltIn;
+import ghidra.program.model.data.ByteDataType;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.DataTypeManager;
+import ghidra.program.model.data.Dynamic;
+import ghidra.program.model.mem.MemBuffer;
+
+public class AndroidPackedRelocationTableDataType extends BuiltIn implements Dynamic {
+
+	private ElfRelocation[] relocs;
+	private int size;
+
+	public AndroidPackedRelocationTableDataType() {
+		this(new ElfRelocation[0], -1);
+	}
+
+	public AndroidPackedRelocationTableDataType(ElfRelocation[] relocs, int length) {
+		this(relocs, length, null);
+	}
+	
+	public AndroidPackedRelocationTableDataType(ElfRelocation[] relocs, int length, DataTypeManager dtm) {
+		super(null, "AndroidPackedRelocationTable", dtm);
+		this.relocs = relocs;
+		this.size = length;		
+	}
+
+	@Override
+	public DataType clone(DataTypeManager dtm) {
+		if (dtm == getDataTypeManager()) {
+			return this;
+		}
+		return new AndroidPackedRelocationTableDataType(relocs, size, dtm);
+	}
+
+	@Override
+	public String getDescription() {
+		return "Android Packed Relocation Table";
+	}
+
+	@Override
+	public String getDefaultLabelPrefix() {
+		return "AndroidPackedRelocationTable";
+	}	
+
+	@Override
+	public String getRepresentation(MemBuffer buf, Settings settings, int length) {
+		//TODO I think we need to reparse the data here, as the relocs data is not populated 
+		
+		if (relocs.length > 0) {
+			Formatter formatter = new Formatter();
+			
+			for(ElfRelocation reloc : relocs) {
+				formatter.format("%d,%d,%d \n", reloc.getOffset(), reloc.getRelocationInfo(), reloc.getAddend());
+			}
+					
+			return formatter.toString();
+		} else {
+			return "No relocs present";
+		}
+	}
+
+	@Override
+	public int getLength() {
+		return -1;
+	}
+
+	@Override
+	public Object getValue(MemBuffer buf, Settings settings, int length) {
+		return"Value";
+	}
+
+	@Override
+	public int getLength(MemBuffer buf, int maxLength) {
+		return size;
+	}
+
+	@Override
+	public boolean canSpecifyLength() {
+		return false;
+	}
+
+	@Override
+	public boolean isDynamicallySized() {
+		return true;
+	}
+
+	@Override
+	public DataType getReplacementBaseType() {
+		return ByteDataType.dataType;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicType.java
@@ -100,6 +100,16 @@ public class ElfDynamicType {
 		"DT_PREINIT_ARRAYSZ", "Size in bytes of DT_PREINIT_ARRAY", ElfDynamicValueType.VALUE);
 
 	// OS-specific range: 0x6000000d - 0x6ffff000
+	
+	public static ElfDynamicType DT_ANDROID_REL =
+		addDefaultDynamicType(0x6000000F, "DT_ANDROID_REL", "Address of Rel relocs", ElfDynamicValueType.ADDRESS);
+	public static ElfDynamicType DT_ANDROID_RELSZ = addDefaultDynamicType(0x60000010, "DT_ANDROID_RELSZ",
+		"Total size of Rel relocs", ElfDynamicValueType.VALUE);
+
+	public static ElfDynamicType DT_ANDROID_RELA =
+		addDefaultDynamicType(0x60000011, "DT_ANDROID_RELA", "Address of Rela relocs", ElfDynamicValueType.ADDRESS);
+	public static ElfDynamicType DT_ANDROID_RELASZ = addDefaultDynamicType(0x60000012, "DT_ANDROID_RELASZ",
+		"Total size of Rela relocs", ElfDynamicValueType.VALUE);		
 
 	// Value Range (??): 0x6ffffd00 - 0x6ffffdff
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -399,7 +399,7 @@ public class ElfHeader implements StructConverter, Writeable {
 					section, section.getOffset(), section.getAddress(), section.getSize(),
 					section.getEntrySize(), addendTypeReloc, symbolTable, sectionToBeRelocated));
 			} 
-			else if (sectionHeaderType == ElfSectionHeaderConstants.SHT_ANDROID_RELA ||
+			else if (sectionHeaderType == ElfSectionHeaderConstants.SHT_ANDROID_REL ||
 					   sectionHeaderType == ElfSectionHeaderConstants.SHT_ANDROID_RELA) {
 
 				for (ElfRelocationTable relocTable : relocationTableList) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocation.java
@@ -123,6 +123,28 @@ public class ElfRelocation implements ByteArrayConverter, StructConverter {
 		return elfRelocation;
 	}
 
+	/**
+	 * GenericFactory construction and initialization method for a ELF relocation entry 
+	 * @param reader binary reader positioned at start of relocation entry.
+	 * @param elfHeader ELF header
+	 * @param relocationIndex index of entry in relocation table
+	 * @param withAddend true if if RELA entry with addend, else false
+	 * @param r_offset The offset for the entry
+	 * @param r_info The info value for the entry
+	 * @param r_addend The addend for the entry
+	 * @return ELF relocation object
+	 * @throws IOException
+	 */
+	static ElfRelocation createElfRelocation(FactoryBundledWithBinaryReader reader,
+			ElfHeader elfHeader, int relocationIndex, boolean withAddend, long r_offset, long r_info, long r_addend) throws IOException {
+
+		Class<? extends ElfRelocation> elfRelocationClass = getElfRelocationClass(elfHeader);
+		ElfRelocation elfRelocation =
+			(ElfRelocation) reader.getFactory().create(elfRelocationClass);
+		elfRelocation.initElfRelocation(elfHeader, relocationIndex, withAddend, r_offset, r_info, r_addend);
+		return elfRelocation;
+	}
+
 	private static Class<? extends ElfRelocation> getElfRelocationClass(ElfHeader elfHeader) {
 		Class<? extends ElfRelocation> elfRelocationClass = null;
 		ElfLoadAdapter loadAdapter = elfHeader.getLoadAdapter();
@@ -158,6 +180,38 @@ public class ElfRelocation implements ByteArrayConverter, StructConverter {
 		this.hasAddend = withAddend;
 		if (reader != null) {
 			readEntryData(reader);
+		}
+	}
+
+	/**
+	 * Initialize ELF relocation entry using data provided via the parameters.
+	 * @param elfHeader ELF header
+	 * @param relocationTableIndex index of relocation within relocation table
+	 * @param withAddend true if if RELA entry with addend, else false
+	 * @param r_offset The offset for the entry
+	 * @param r_info The info value for the entry
+	 * @param r_addend The addend for the entry
+	 * @throws IOException
+	 */
+	protected void initElfRelocation(ElfHeader elfHeader, int relocationTableIndex, 
+			boolean withAddend, long r_offset, long r_info, long r_addend) throws IOException {
+		this.is32bit = elfHeader.is32Bit();
+		this.relocationIndex = relocationTableIndex;
+		this.hasAddend = withAddend;
+		
+		if (is32bit) {
+			this.r_offset = r_offset & Conv.INT_MASK;
+			this.r_info = r_info & Conv.INT_MASK;
+			if (hasAddend) {
+				this.r_addend = r_addend & Conv.INT_MASK;
+			}
+		}
+		else {
+			this.r_offset = r_offset;
+			this.r_info = r_info;
+			if (hasAddend) {
+				this.r_addend = r_addend;
+			}
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderConstants.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderConstants.java
@@ -111,6 +111,11 @@ public class ElfSectionHeaderConstants {
 
 	// OS Specific Section Types
 
+	/**Android relocation entries w/o explicit addends*/
+	public static final int SHT_ANDROID_REL = 0x60000001;
+	/**Android relocation entries with explicit addends*/
+	public static final int SHT_ANDROID_RELA = 0x60000002;
+
 	/**Object attributes */
 	public static final int SHT_GNU_ATTRIBUTES = 0x6ffffff5;
 	/**GNU-style hash table */

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderType.java
@@ -68,6 +68,11 @@ public class ElfSectionHeaderType {
 		ElfSectionHeaderConstants.SHT_SYMTAB_SHNDX, "SHT_SYMTAB_SHNDX", "Extended section indeces");
 
 	// OS-specific range: 0x60000000 - 0x6fffffff
+	
+	public static ElfSectionHeaderType SHT_ANDROID_REL = addDefaultSectionHeaderType(
+		ElfSectionHeaderConstants.SHT_ANDROID_REL, "SHT_ANDROID_REL", "Android relocation entries w/o explicit addends");
+	public static ElfSectionHeaderType SHT_ANDROID_RELA = addDefaultSectionHeaderType(
+		ElfSectionHeaderConstants.SHT_ANDROID_RELA, "SHT_ANDROID_RELA", "Android relocation entries with explicit addends");
 
 	public static ElfSectionHeaderType SHT_GNU_ATTRIBUTES = addDefaultSectionHeaderType(
 		ElfSectionHeaderConstants.SHT_GNU_ATTRIBUTES, "SHT_GNU_ATTRIBUTES", "Object attributes");


### PR DESCRIPTION
Added support for unpacking Android relocation sections, as discussed in [this issue](https://github.com/NationalSecurityAgency/ghidra/issues/1171)

This is based on the implementation in LLVM, as can be seen in these diffs for the [packer](https://reviews.llvm.org/D39152) and [unpacker](https://reviews.llvm.org/D39272).