### PR TITLE
Fix potential buffer over-read in getTagAsString

### DIFF
--- a/Ghidra/Features/PDB/src/pdb/cpp/symbol.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/symbol.cpp
@@ -239,7 +239,7 @@ DWORD getTag(IDiaSymbol& symbol) {
 
 std::wstring getTagAsString(IDiaSymbol& symbol) {
 	const DWORD tag = getTag(symbol);
-	if (tag > _countof(SYMBOL_TAG_STRINGS))	{
+	if (tag > _countof(SYMBOL_TAG_STRINGS) - 1)	{
 		return L"";
 	}
 	return SYMBOL_TAG_STRINGS[tag];


### PR DESCRIPTION
If `tag` equals `_countof(SYMBOL_TAG_STRINGS)`, then this function will read one element beyond the boundary of SYMBOL_TAG_STRINGS array.