### PR TITLE
Fix paths in Gradle task descriptions

### DIFF
--- a/gradle/processorProject.gradle
+++ b/gradle/processorProject.gradle
@@ -95,7 +95,7 @@ rootProject.assembleDistribution {
  *****************************************************************************************/
 task sleighCompile (type: JavaExec) {
 	group = rootProject.GHIDRA_GROUP
-	description "  Compiles all the sleigh languages.    [processorUtils.gradle]\n"
+	description "  Compiles all the sleigh languages.    [gradle/processorProject.gradle]\n"
 	 
 	// define standard parameters for JavaExec
 	classpath configurations.sleighConfig
@@ -128,7 +128,7 @@ rootProject.allSleighCompile.dependsOn saveSleighArgs
  *****************************************************************************************/
 task cleanSleigh  {
 	group rootProject.GHIDRA_GROUP
-	description "Removes all the compile sleigh language files (*.sla).   [gradle/processProject.gradle]\n"
+	description "Removes all the compile sleigh language files (*.sla).   [gradle/processorProject.gradle]\n"
  	doLast {
 		def deleteTree = fileTree(dir: "data/languages", include: "*.sla")
 		deleteTree.each { File file ->

--- a/gradle/root/svg.gradle
+++ b/gradle/root/svg.gradle
@@ -16,7 +16,7 @@
  *********************************************************************************/
 task rasterizeSvg(type: JavaExec) {
 	group rootProject.GHIDRA_GROUP
-	description "   Converts .svg files to .png files.  [gradle/root/distribution.gradle]\n"
+	description "   Converts .svg files to .png files.  [gradle/root/svg.gradle]\n"
 				
 	subprojects { p ->
 	

--- a/gradle/support/extensionCommon.gradle
+++ b/gradle/support/extensionCommon.gradle
@@ -4,7 +4,7 @@ task zipExtensions (type: Zip) {
 	def p = this.project
 	
 	it.group 'private'
-	it.description "Creates a zip file for an extension module.  [gradle/support/distribution.gradle]"
+	it.description "Creates a zip file for an extension module.  [gradle/support/extensionCommon.gradle]"
 	it.archiveName "${rootProject.ext.ZIP_NAME_PREFIX}_${p.name}.zip"
 	it.destinationDir rootProject.ext.DISTRIBUTION_DIR
 	


### PR DESCRIPTION
These paths was likely not changed during refatoring of Gradle scripts.
I make them correspond to actual location of files where their definitions originates.