### PR TITLE
Use the proper length for string types in listing.

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AbstractIntegerDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AbstractIntegerDataType.java
@@ -18,13 +18,13 @@ package ghidra.program.model.data;
 import java.math.BigInteger;
 
 import ghidra.docking.settings.*;
+import ghidra.program.model.data.RenderUnicodeSettingsDefinition.RENDER_ENUM;
 import ghidra.program.model.mem.ByteMemBufferImpl;
 import ghidra.program.model.mem.MemBuffer;
 import ghidra.program.model.scalar.Scalar;
 import ghidra.util.BigEndianDataConverter;
 import ghidra.util.LittleEndianDataConverter;
 import ghidra.util.StringFormat;
-import ghidra.util.StringUtilities;
 
 /**
  * Base type for integer data types such as {@link CharDataType chars}, {@link IntegerDataType ints},
@@ -281,17 +281,10 @@ public abstract class AbstractIntegerDataType extends BuiltIn implements ArraySt
 			}
 
 			MemBuffer memBuf = new ByteMemBufferImpl(null, bytes, true);
-			StringDataInstance instance = new StringDataInstance(this, settings, memBuf, nominalLen);
-			if (bytes.length == 1) {
-				return instance.getCharRepresentation();
-			}
-
-			String stringRepresentation = instance.getStringRepresentation();
-			if (stringRepresentation.length() != nominalLen) {
-				stringRepresentation = StringUtilities.toQuotedString(bytes);
-			}
-
-			return stringRepresentation;
+			StringDataInstance instance = new StringDataInstance(this, settings, memBuf,
+					nominalLen, RENDER_ENUM.ESC_SEQ);
+			return bytes.length == 1 ? instance.getCharRepresentation() :
+				instance.getStringRepresentation();
 		}
 
 		String valStr;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StringDataInstance.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StringDataInstance.java
@@ -201,6 +201,37 @@ public class StringDataInstance {
 		this.length = length;
 	}
 
+	/**
+	 * Creates a string instance using the data in the {@link MemBuffer} and the settings
+	 * pulled from the {@link AbstractStringDataType string data type} but using the given
+	 * {@link RenderUnicodeSettingsDefinition.RENDER_ENUM rendering setting}.
+	 *
+	 * @param stringDataType {@link AbstractStringDataType} common string base data type.
+	 * @param settings {@link Settings} attached to the data location.
+	 * @param buf {@link MemBuffer} containing the data.
+	 * @param length Length passed from the caller to the datatype.  -1 indicates a 'probe'
+	 * trying to detect the length of an unknown string, otherwise it will be the length
+	 * of the containing field of the data instance.
+	 * @param renderSettings How to render the instance contents.
+	 */
+	public StringDataInstance(DataType dataType, Settings settings, MemBuffer buf, int length,
+			RenderUnicodeSettingsDefinition.RENDER_ENUM renderSettings) {
+		settings = (settings == null) ? SettingsImpl.NO_SETTINGS : settings;
+		this.buf = buf;
+		this.charsetName = getCharsetNameFromDataTypeOrSettings(dataType, settings);
+		this.charSize = CharsetInfo.getInstance().getCharsetCharSize(charsetName);
+		// NOTE: for now only handle padding for charSize == 1
+		this.paddedCharSize =
+			charSize == 1 ? getDataOrganization(dataType).getCharSize() : charSize;
+		this.stringLayout = getLayoutFromDataType(dataType);
+		this.showTranslation = TRANSLATION.isShowTranslated(settings);
+		this.translatedValue = TRANSLATION.getTranslatedValue(settings);
+		this.renderSetting = renderSettings;
+		this.endianSetting = ENDIAN.getEndianess(settings, null);
+
+		this.length = length;
+	}
+
 	private StringDataInstance(StringDataInstance copyFrom, StringLayoutEnum newLayout,
 			MemBuffer newBuf, int newLen) {
 		this.charSize = copyFrom.charSize;
@@ -229,6 +260,9 @@ public class StringDataInstance {
 	private static StringLayoutEnum getLayoutFromDataType(DataType dataType) {
 		if (dataType instanceof AbstractStringDataType) {
 			return ((AbstractStringDataType) dataType).getStringLayout();
+		}
+		if (dataType instanceof AbstractIntegerDataType) {
+			return StringLayoutEnum.FIXED_LEN;
 		}
 		return StringLayoutEnum.NULL_TERMINATED_BOUNDED;
 	}


### PR DESCRIPTION
Character sequences were univocally rendered as a single character regardless of their length.  This patch attempts to correct the issue, by allowing multi-char sequences to be represented as strings if possible.

Right now this won't convert unicode code points into characters, but neither does the convert to char sequence menu action.  I'm not fully sure if falling back to `StringUtilities.toQuotedString` if the string representation length differs from the nominal length is the right thing to do, but it seems to work for a bunch of edge cases I threw at it.

This is supposed to fix issue #1209