### PR TITLE
Add functions for handling repeatable comments to the scripting API

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/script/GhidraScript.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/script/GhidraScript.java
@@ -3697,6 +3697,24 @@ public abstract class GhidraScript extends FlatProgramAPI {
 		return comment;
 	}
 
+	/**
+	 * Returns the repeatable comment at the specified address.  If you want the raw text,
+	 * then you must call {@link #getRepeatableComment(Address)}.  This method returns the text as
+	 * seen in the display.
+	 *
+	 * @param address the address to get the comment
+	 * @return the repeatable comment at the specified address or null if one does not exist
+	 * @see #getRepeatableComment(Address)
+	 */
+	public String getRepeatableCommentAsRendered(Address address) {
+		String comment = currentProgram.getListing().getComment(CodeUnit.REPEATABLE_COMMENT, address);
+		PluginTool tool = state.getTool();
+		if (tool != null) {
+			comment = CommentUtils.getDisplayString(comment, currentProgram);
+		}
+		return comment;
+	}
+
 	private void show(String title, TableService table, Address[] addresses) {
 		PluginTool tool = state.getTool();
 		if (tool == null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/flatapi/FlatProgramAPI.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/flatapi/FlatProgramAPI.java
@@ -499,13 +499,24 @@ public class FlatProgramAPI {
 	}
 
 	/**
-	 * Sets a EOL comment at the specified address
+	 * Sets an EOL comment at the specified address
 	 * @param address the address to set the EOL comment
 	 * @param comment the EOL comment
 	 * @return true if the EOL comment was successfully set
 	 */
 	public final boolean setEOLComment(Address address, String comment) {
 		SetCommentCmd cmd = new SetCommentCmd(address, CodeUnit.EOL_COMMENT, comment);
+		return cmd.applyTo(currentProgram);
+	}
+
+	/**
+	 * Sets a repeatable comment at the specified address
+	 * @param address the address to set the repeatable comment
+	 * @param comment the repeatable comment
+	 * @return true if the repeatable comment was successfully set
+	 */
+	public final boolean setRepeatableComment(Address address, String comment) {
+		SetCommentCmd cmd = new SetCommentCmd(address, CodeUnit.REPEATABLE_COMMENT, comment);
 		return cmd.applyTo(currentProgram);
 	}
 
@@ -562,6 +573,19 @@ public class FlatProgramAPI {
 	 */
 	public final String getEOLComment(Address address) {
 		return currentProgram.getListing().getComment(CodeUnit.EOL_COMMENT, address);
+	}
+
+	/**
+	 * Returns the repeatable comment at the specified address.  The comment returned is the raw text
+	 * of the comment.  Contrastingly, calling {@link #getRepeatableCommentAsRendered(Address)} will
+	 * return the text of the comment as it is rendered in the display.
+	 * @param address the address to get the comment
+	 * @return the repeatable comment at the specified address or null
+	 * if one does not exist
+	 * @see #getRepeatableCommentAsRendered(Address)
+	 */
+	public final String getRepeatableComment(Address address) {
+		return currentProgram.getListing().getComment(CodeUnit.REPEATABLE_COMMENT, address);
 	}
 
 	/**


### PR DESCRIPTION
This is PR adds `setRepeatbleComment`, `getRepeatableComment`, and `getRepeatableCommentAsRendered` to the top level Ghidra scripting environment, for consistency with the other set\*Comment and get\*Comment functions.

Improvement related to question/issue #1245.