### PR TITLE
fix movi20 and movi20s  in SuperH architecture

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -91,7 +91,7 @@ define token instr32(32)
     l_rm_20_23 =        (20, 23)
     l_rn_24_27 =        (24, 27)
     l_opcode_28_31 =    (28, 31)
-    l_imm20_00_16 =    (0, 16)
+    l_imm20_00_15 =     (0, 15)
     l_simm20_20_23 =    (20, 23) signed
     l_imm3_20_22 =      (20, 22)
 ;
@@ -499,12 +499,12 @@ disppc2: @(disp,pc) is disp_00_07 & pc
     l_rm_20_23 = zext(*:2 (disp + l_rm_20_23));
 }
 
-simm20: "#"value is l_simm20_20_23 & l_imm20_00_16
-    [ value = ((l_simm20_20_23 << 16) | l_imm20_00_16); ]
+simm20: "#"value is l_simm20_20_23 & l_imm20_00_15
+    [ value = ((l_simm20_20_23 << 16) | l_imm20_00_15); ]
     { export *[const]:4 value; }
 
-simm20s: "#"value is l_simm20_20_23 & l_imm20_00_16
-    [ value = ((l_simm20_20_23 << 16) | l_imm20_00_16) << 8; ]
+simm20s: "#"value is l_simm20_20_23 & l_imm20_00_15
+    [ value = ((l_simm20_20_23 << 16) | l_imm20_00_15) << 8; ]
     { export *[const]:4 value; }
 
 


### PR DESCRIPTION
According to documentation, the lower part of imm20 is 16 bit long

# MOVI20 #imm20, Rn           0000nnnniiii0000 iiiiiiiiiiiiiiii     imm → sign extension → Rn
# MOVI20S #imm20, Rn          0000nnnniiii0001 iiiiiiiiiiiiiiii     imm<<8 → sign extension → Rn

but it was defined with 17 bit long 

l_imm20_00_16 =    (0, 16)

