### PR TITLE
SuperH - Fixes the lvalue for movu.b and movu.w

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -488,7 +488,7 @@ disppc2: @(disp,pc) is disp_00_07 & pc
 :movu.b @(l_disp_00_11, l_rm_20_23), l_rn_24_27
     is l_opcode_28_31=0b0011 & l_rn_24_27 & l_rm_20_23 & l_opcode_16_19=0b0001 & l_opcode_12_15=0b1000 & l_disp_00_11
 {
-    l_rm_20_23 = zext(*:1 (l_disp_00_11 + l_rm_20_23));
+    l_rn_24_27 = zext(*:1 (l_disp_00_11 + l_rm_20_23));
 }
 
 # MOVU.W @(disp12,Rm), Rn 0011nnnnmmmm0001 1001dddddddddddd (disp×2+Rm) → zero extension → Rn
@@ -496,7 +496,7 @@ disppc2: @(disp,pc) is disp_00_07 & pc
     is l_opcode_28_31=0b0011 & l_rn_24_27 & l_rm_20_23 & l_opcode_16_19=0b0001 & l_opcode_12_15=0b1001 & l_disp_00_11
     [ disp = l_disp_00_11 * 2; ]
 {
-    l_rm_20_23 = zext(*:2 (disp + l_rm_20_23));
+    l_rn_24_27 = zext(*:2 (disp + l_rm_20_23));
 }
 
 simm20: "#"value is l_simm20_20_23 & l_imm20_00_15


### PR DESCRIPTION
As with all other mov instructions, the second address is the lvalue, the one to receive the data.
For movu.b and movu.w the first address was receiving its own data.