### PR TITLE
ARM: Correct Sleigh constructors for VNMLA/VNMLS/VNMUL

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -3129,26 +3129,26 @@ define pcodeop FloatVectorNeg;
 @if defined(VFPv2) || defined(VFPv3)
 
 
-:vnmls.f64 Dd,Dn,Dm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=1 & c0811=11 & c0606=1 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=11 & thv_c0606=1 & thv_c0404=0) ) & Dm & Dn & Dd 
+:vnmla^COND^".f64" Dd,Dn,Dm is ( ($(AMODE) & COND & c2327=0x1c & c2021=1 & c0811=11 & c0606=1 & c0404=0) |
+                                 ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=11 & thv_c0606=1 & thv_c0404=0) ) & Dm & Dn & Dd
 {
-	product:8 = Dn f* Dm;
-	Dd = 0 f- product f- Dd;
+    product:8 = Dn f* Dm;
+    Dd = (0 f- Dd) f+ (0 f- product);
 }
 
-:vnmls.f32 Sd,Sn,Sm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=1 & c0811=10 & c0606=1 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=10 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd 
+:vnmla^COND^".f32" Sd,Sn,Sm is ( ($(AMODE) & COND & c2327=0x1c & c2021=1 & c0811=10 & c0606=1 & c0404=0) |
+                                 ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=10 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd
 {
-	product:4 = Sn f* Sm;
-	Sd = 0 f- product f- Sd;
+    product:4 = Sn f* Sm;
+    Sd = (0 f- Sd) f+ (0 f- product);
 }
 
-:vnmls.f16 Sd,Sn,Sm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=1 & c0811=9 & c0606=1 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=9 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd 
+:vnmla.f16 Sd,Sn,Sm         is ( ($(AMODE) & cond=0xe & c2327=0x1c & c2021=1 & c0811=9 & c0606=1 & c0404=0) |
+                                 ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=9 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd
 {
-	product:2 = Sn:2 f* Sm:2;
-	product = 0:2 f- product f- Sd:2;
-	Sd = zext(product);
+    product:2 = Sn:2 f* Sm:2;
+    product = (0:2 f- Sd:2) f+ (0:2 f- product);
+    Sd = zext(product);
 }
 
 :vnmls^COND^".f64" Dd,Dn,Dm  is ( ($(AMODE) & COND & c2327=0x1c & c2021=1 & c0811=11 & c0606=0 & c0404=0) |

--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -3151,26 +3151,26 @@ define pcodeop FloatVectorNeg;
 	Sd = zext(product);
 }
 
-:vnmls.f64 Dd,Dn,Dm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=1 & c0811=11 & c0606=0 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=11 & thv_c0606=0 & thv_c0404=0) ) & Dm & Dn & Dd 
+:vnmls^COND^".f64" Dd,Dn,Dm  is ( ($(AMODE) & COND & c2327=0x1c & c2021=1 & c0811=11 & c0606=0 & c0404=0) |
+                                  ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=11 & thv_c0606=0 & thv_c0404=0) ) & Dm & Dn & Dd
 {
-	product:8 = Dn f* Dm;
-	Dd = product f- Dd;
+    product:8 = Dn f* Dm;
+    Dd = product f- Dd;
 }
 
-:vnmls.f32 Sd,Sn,Sm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=1 & c0811=10 & c0606=0 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=10 & thv_c0606=0 & thv_c0404=0) ) & Sm & Sn & Sd 
+:vnmls^COND^".f32" Sd,Sn,Sm  is ( ($(AMODE) & COND & c2327=0x1c & c2021=1 & c0811=10 & c0606=0 & c0404=0) |
+                                  ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=10 & thv_c0606=0 & thv_c0404=0) ) & Sm & Sn & Sd
 {
-	product:4 = Sn f* Sm;
-	Sd = product f- Sd;
+    product:4 = Sn f* Sm;
+    Sd = product f- Sd;
 }
 
-:vnmls.f16 Sd,Sn,Sm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=1 & c0811=9 & c0606=0 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=9 & thv_c0606=0 & thv_c0404=0) ) & Sm & Sn & Sd 
+:vnmls.f16 Sd,Sn,Sm          is ( ($(AMODE) & cond=0xe & c2327=0x1c & c2021=1 & c0811=9 & c0606=0 & c0404=0) |
+                                  ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=1 & thv_c0811=9 & thv_c0606=0 & thv_c0404=0) ) & Sm & Sn & Sd 
 {
-	product:2 = Sn:2 f* Sm:2;
-	product = product f- Sd:2;
-	Sd = zext(product);
+    product:2 = Sn:2 f* Sm:2;
+    product = product f- Sd:2;
+    Sd = zext(product);
 }
 
 :vnmul^COND^".f64" Dd,Dn,Dm is ( ($(AMODE) & COND & c2327=0x1c & c2021=2 & c0811=11 & c0606=1 & c0404=0) |

--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -3173,26 +3173,26 @@ define pcodeop FloatVectorNeg;
 	Sd = zext(product);
 }
 
-:vnmul.f64 Dd,Dn,Dm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=2 & c0811=11 & c0606=1 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=11 & thv_c0606=1 & thv_c0404=0) ) & Dm & Dn & Dd 
+:vnmul^COND^".f64" Dd,Dn,Dm is ( ($(AMODE) & COND & c2327=0x1c & c2021=2 & c0811=11 & c0606=1 & c0404=0) |
+                                 ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=11 & thv_c0606=1 & thv_c0404=0) ) & Dm & Dn & Dd
 {
-	product:8 = Dn f* Dm;
-	Dd = 0 f- product;
+    product:8 = Dn f* Dm;
+    Dd = 0 f- product;
 }
 
-:vnmul.f32 Sd,Sn,Sm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=2 & c0811=10 & c0606=1 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=10 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd 
+:vnmul^COND^".f32" Sd,Sn,Sm is ( ($(AMODE) & COND & c2327=0x1c & c2021=2 & c0811=10 & c0606=1 & c0404=0) |
+                                 ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=10 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd
 {
-	product:4 = Sn f* Sm;
-	Sd = 0 f- product;
+    product:4 = Sn f* Sm;
+    Sd = 0 f- product;
 }
 
-:vnmul.f16 Sd,Sn,Sm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=2 & c0811=9 & c0606=1 & c0404=0) |
-                                    ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=9 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd 
+:vnmul.f16 Sd,Sn,Sm         is ( ($(AMODE) & cond=0xe & c2327=0x1c & c2021=2 & c0811=9 & c0606=1 & c0404=0) |
+                                 ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=9 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd
 {
-	product:2 = Sn:2 f* Sm:2;
-	product = 0 f- product;
-	Sd = zext(product);
+    product:2 = Sn:2 f* Sm:2;
+    product = 0 f- product;
+    Sd = zext(product);
 }
 
 :vneg^COND^".f32" Sd,Sm		is ( ( $(AMODE) & COND &     c2327=0x1d &     c1621=0x31 &     c0611=0x29 &     c0404=0 ) |


### PR DESCRIPTION
This change amends the Sleigh constructors such that these instructions now disassemble properly, rather than as CDP instructions.

The ARM encodings for these instructions allow a condition code to be specified for them, but these constructors were treating them as if they were unconditional instructions, meaning any conditional variants would decode as if they were a CDP instruction.

The half-precision variants were amended to also assume a condition code of `14` (`0xE`), rather than `15` (`0xF`), as the ARMv8 architectural reference (see sections: F6.1.146, F6.1.147, and F6.1.148 respectively for each instruction) that if a half-precision instruction contains a condition code other than `0xE`, its behavior is considered `CONSTRAINED UNPREDICTABLE`. 

This was my first time working with Sleigh, so if anything looks incorrect, feel free to point it out.