### PR TITLE
Remove not needed dependency

### DIFF
--- a/gradle/root/distribution.gradle
+++ b/gradle/root/distribution.gradle
@@ -382,7 +382,6 @@ task createInstallationZip(type: Zip) { t ->
 		dependsOn ":assembleDistribution_win64"
 		dependsOn ":assembleDistribution_linux64"
 		dependsOn ":assembleDistribution_osx64"
-		dependsOn ":assembleSource"
 	}
 
 	if (project.hasProperty("allPlatforms")) {


### PR DESCRIPTION
This is either cleanup or just silly question which arise when I play with #1239.
It seems that `assemblySource` task is added two times. I not that familiar with Gradle, but for me that seems as duplication, just using different syntax.