### PR TITLE
Hack/workaround to support old - pre VS6 - PDBs

### DIFF
--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/PdbParser.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/PdbParser.java
@@ -261,22 +261,26 @@ public class PdbParser {
 		catch (FileNotFoundException e) {
 			throw new PdbException("Unable to find " + PDB_EXE);
 		}
-
-		if (noValidation) {
+		/* ---- HACK - make it work with old PDBs. Uncomment to the end this to remove hack ----
+		
+		if (noValidation) {*/
 			return new String[] { pdbExe, pdbFile.getAbsolutePath() };
-		}
-
+		}/*
+		
 		String pdbAge = programAttributes.getPdbAge();
 		String pdbGuid = programAttributes.getPdbGuid();
 		String pdbSignature = programAttributes.getPdbSignature();
+		
 		if (pdbAge != null && pdbGuid != null) {
 			return new String[] { pdbExe, pdbFile.getAbsolutePath(), pdbGuid, pdbAge };
-		}
+		
 		if (pdbAge != null && pdbSignature != null) {
 			return new String[] { pdbExe, pdbFile.getAbsolutePath(), pdbSignature, pdbAge };
-		}
+		
 		throw new PdbException("Unable to determine PDB GUID/Signature or Age. " +
 			"Please re-import the executable and try again.");
+		*/
+		
 	}
 
 	private void completeDefferedTypeParsing(ApplyDataTypes applyDataTypes,
@@ -1098,12 +1102,13 @@ public class PdbParser {
 		Set<String> guidSubdirPaths = new HashSet<>();
 
 		String guidAgeString = pdbAttributes.getGuidAgeCombo();
+		/* HACK - ignores null to make old PDB work. Uncomment to remove hack
 		if (guidAgeString == null) {
 			throw new PdbException(
 				"Incomplete PDB information (GUID/Signature and/or age) associated with this program.\n" +
 					"Either the program is not a PE, or it was not compiled with debug information.");
 		}
-
+		*/
 		List<String> potentialPdbNames = pdbAttributes.getPotentialPdbFilenames();
 		for (String potentialName : potentialPdbNames) {
 			guidSubdirPaths.add(File.separator + potentialName + File.separator + guidAgeString);


### PR DESCRIPTION
It basically ignores the null signature and age from old format PDB. Works fine. 
TODO in the future: properly implement the old format (version < VS6), documented in Microsoft PDB source code