### PR TITLE
Fix Windows NE flag parsing error

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
@@ -536,9 +536,6 @@ public class InformationBlock {
         if ((ne_flags_app & FLAGS_APP_NONCONFORMING_PROG) != 0) {
             buffer.append(TAB+"Nonconforming"+"\n");
         }
-        if ((ne_flags_app & FLAGS_APP_OS2) != 0) {
-            buffer.append(TAB+"OS/2"+"\n");
-        }
         return buffer.toString();
     }
     /**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
@@ -100,10 +100,9 @@ public class InformationBlock {
      */
     public final static byte FLAGS_APP_WINDOWS_PM            = (byte) 0x03;
     /**
-     * Is application designed for OS/2?
+     * Does the first segment contain code that loads the application?
      */
-    public final static byte FLAGS_APP_OS2                   = (byte) 0x08;
-    public final static byte FLAGS_APP_LOAD_CODE             = (byte) 0x10;
+    public final static byte FLAGS_APP_LOAD_CODE             = (byte) 0x08;
     public final static byte FLAGS_APP_LINK_ERRS             = (byte) 0x20;
     public final static byte FLAGS_APP_NONCONFORMING_PROG    = (byte) 0x40;
     public final static byte FLAGS_APP_LIBRARY_MODULE        = (byte) 0x80;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
@@ -102,10 +102,10 @@ public class InformationBlock {
     /**
      * Is application designed for OS/2?
      */
-    public final static byte FLAGS_APP_OS2                   = (byte) 0x04;
-    public final static byte FLAGS_APP_LOAD_CODE             = (byte) 0x08;
-    public final static byte FLAGS_APP_LINK_ERRS             = (byte) 0x10;
-    public final static byte FLAGS_APP_NONCONFORMING_PROG    = (byte) 0x20;
+    public final static byte FLAGS_APP_OS2                   = (byte) 0x08;
+    public final static byte FLAGS_APP_LOAD_CODE             = (byte) 0x10;
+    public final static byte FLAGS_APP_LINK_ERRS             = (byte) 0x20;
+    public final static byte FLAGS_APP_NONCONFORMING_PROG    = (byte) 0x40;
     public final static byte FLAGS_APP_LIBRARY_MODULE        = (byte) 0x80;
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
@@ -516,9 +516,15 @@ public class InformationBlock {
      */
     public String getApplicationFlagsAsString() {
         StringBuffer buffer = new StringBuffer();
-        if ((ne_flags_app & FLAGS_APP_FULL_SCREEN) != 0) {
+        byte application_type = ne_flags_app & 0x03;
+        if (application_type == FLAGS_APP_FULL_SCREEN) {
             buffer.append(TAB+"Full Screen"+"\n");
+        } else if (application_type == FLAGS_APP_WIN_PM_COMPATIBLE) {
+            buffer.append(TAB+"Windows P.M. API Compatible"+"\n");
+        } else if (application_type == FLAGS_APP_WINDOWS_PM) {
+            buffer.append(TAB+"Windows P.M. API"+"\n");
         }
+
         if ((ne_flags_app & FLAGS_APP_LIBRARY_MODULE) != 0) {
             buffer.append(TAB+"Library Module"+"\n");
         }
@@ -533,12 +539,6 @@ public class InformationBlock {
         }
         if ((ne_flags_app & FLAGS_APP_OS2) != 0) {
             buffer.append(TAB+"OS/2"+"\n");
-        }
-        if ((ne_flags_app & FLAGS_APP_WINDOWS_PM) != 0) {
-            buffer.append(TAB+"Windows P.M. API"+"\n");
-        }
-        if ((ne_flags_app & FLAGS_APP_WIN_PM_COMPATIBLE) != 0) {
-            buffer.append(TAB+"Windows P.M. API Compatible"+"\n");
         }
         return buffer.toString();
     }


### PR DESCRIPTION
`FLAGS_APP_FULL_SCREEN`, `FLAGS_APP_WIN_PM_COMPATIBLE`, and `FLAGS_APP_WINDOWS_PM` are numbers, not bit flags. The function should check if the low-order two bits equal to any of these, rather than if any bit is set.

Also, the bit field definition of the application flags in Ghidra is different from [1]. I don't know which one is correct, since I guess the doc in fileformat.info isn't official. But at least `FLAGS_APP_NONCONFORMING_PROG` should be 0x40, since it's documented by Microsoft in [2].

Reference: 
[1] https://www.fileformat.info/format/exe/corion-ne.htm
[2] https://www.pcjs.org/pubs/pc/reference/microsoft/mspl13/msdos/encyclopedia/appendix-k/