### PR TITLE
PE: Fix NTHeader name

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/NTHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/NTHeader.java
@@ -44,10 +44,6 @@ import ghidra.util.task.TaskMonitorAdapter;
  */
 public class NTHeader implements StructConverter, OffsetValidator {
 	/**
-	 * The name to use when converting into a structure data type.
-	 */
-	public final static String NAME = "IMAGE_NT_HEADERS32";
-	/**
 	 * The size of the NT header signature.
 	 */
 	public final static int SIZEOF_SIGNATURE = BinaryReader.SIZEOF_INT;
@@ -98,6 +94,14 @@ public class NTHeader implements StructConverter, OffsetValidator {
 		parse();
 	}
 
+	/**
+	 * Returns the name to use when converting into a structure data type.
+	 * @return the name to use when converting into a structure data type
+	 */
+	public String getName() {
+		return "IMAGE_NT_HEADERS" + (optionalHeader.is64bit() ? "64" : "32");
+	}
+
 	public boolean isRVAResoltionSectionAligned() {
 		return layout == SectionLayout.MEMORY;
 	}
@@ -123,7 +127,7 @@ public class NTHeader implements StructConverter, OffsetValidator {
 	 */
 	@Override
 	public DataType toDataType() throws DuplicateNameException, IOException {
-		StructureDataType struct = new StructureDataType(NAME, 0);
+		StructureDataType struct = new StructureDataType(getName(), 0);
 
 		struct.add(new ArrayDataType(ASCII, 4, 1), "Signature", null);
 		struct.add(fileHeader.toDataType(), "FileHeader", null);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeDataType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeDataType.java
@@ -86,7 +86,7 @@ public class PeDataType extends FactoryStructureDataType {
 				return;
 			}
 
-			addComponent(struct, ntHeader.toDataType(), NTHeader.NAME);
+			addComponent(struct, ntHeader.toDataType(), ntHeader.getName());
 
 			SectionHeader[] sections = ntHeader.getFileHeader().getSectionHeaders();
 			for (SectionHeader section : sections) {


### PR DESCRIPTION
The NT Header name of a PE file should be `IMAGE_NT_HEADERS32` for 32-bit file or `IMAGE_NT_HEADERS64` for 64-bit file. This name shouldn't be hardcoded to `IMAGE_NT_HEADERS32`.

Before:
![wrong IMAGE_NT_HEADERS name](https://user-images.githubusercontent.com/16713498/70390956-d5f7bf80-1a0a-11ea-9e20-752204ff0389.png)

After:
![correct name](https://user-images.githubusercontent.com/16713498/70390959-d8f2b000-1a0a-11ea-9556-301c602cd0a7.png)
