### PR TITLE
Fixed pointer to array dereferencing

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
@@ -1893,6 +1893,8 @@ Datatype *TypeFactory::downChain(Datatype *ptrtype,uintb &off)
   pt = pt->getSubType(off,&off);
   if (pt == (Datatype *)0)
     return (Datatype *)0;
+  if (pt->metatype == TYPE_ARRAY)
+    return getTypePointerAbsolute(ptype->size, pt, ptype->getWordSize());
   return getTypePointer(ptype->size,pt,ptype->getWordSize());
 }
 


### PR DESCRIPTION
This is part of the issue seen in #1180. It's still not perfect but it's at least a bit better than it was.

Here is the new output vs the [previous output](https://github.com/NationalSecurityAgency/ghidra/issues/1180#issuecomment-549082508).

<pre>
float addMatrix(float (*m1) [4] [4],float (*m2) [4] [4],float (*result) [4] [4])

{
  int j;
  int i;
  
  i = 0;
  while (i < 4) {
    j = 0;
    while (j < 4) {
      (*result)[(long)j + <b>(long)i * 4</b>] = (*m2)[(long)j + (long)i * 4] + (*m1)[(long)j + <b>(long)i * 4</b>]
      ;
      j += 1;
    }
    i += 1;
  }
  return (*result + 1)[1];
}
</pre>

I couldn't figure out how to make it display `(*result)[1][1]` instead of `(*result + 1)[1]`

Multiplying (or left shifting equivalent) by the size of the array (as seen in bold) should be a hint to the decompiler that the array itself is being indexed. I couldn't figure out how to get that to work and it's difficult to debug the decompiler because I can't see what's going on. I got this one by setting breakpoints and praying I'd find it.