### PR TITLE
Fix writev syscall number

### DIFF
--- a/Ghidra/Features/Base/data/x64_linux_syscall_numbers
+++ b/Ghidra/Features/Base/data/x64_linux_syscall_numbers
@@ -18,7 +18,7 @@
 17 pread64
 18 pwrite64
 19 readv
-2 writev
+20 writev
 21 access
 22 pipe
 23 select


### PR DESCRIPTION
Looks like there's a typo in x64_linux_syscall_numbers