### PR TITLE
COFF i960

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/CoffBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/CoffBinaryAnalysisCommand.java
@@ -145,7 +145,7 @@ public class CoffBinaryAnalysisCommand extends FlatProgramAPI
 	private void processStrings(CoffFileHeader header) throws Exception {
 		monitor.setMessage("Processing strings...");
 		Address start = toAddr(header.getSymbolTablePointer() +
-			(header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF));
+			(header.getSymbolTableEntries() * header.getSectionSize()));
 		Address address = start;
 		createData(address, new DWordDataType());
 		createLabel(address, "Number_of_strings", true);
@@ -163,7 +163,7 @@ public class CoffBinaryAnalysisCommand extends FlatProgramAPI
 	private void processSymbols(CoffFileHeader header) throws Exception {
 		monitor.setMessage("Processing symbols...");
 		Address start = toAddr(header.getSymbolTablePointer());
-		long length = header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF;
+		long length = header.getSymbolTableEntries() * header.getSectionSize();
 		Address address = start;
 		List<CoffSymbol> symbols = header.getSymbols();
 		for (int i = 0; i < symbols.size(); ++i) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/CoffBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/CoffBinaryAnalysisCommand.java
@@ -145,7 +145,7 @@ public class CoffBinaryAnalysisCommand extends FlatProgramAPI
 	private void processStrings(CoffFileHeader header) throws Exception {
 		monitor.setMessage("Processing strings...");
 		Address start = toAddr(header.getSymbolTablePointer() +
-			(header.getSymbolTableEntries() * header.getSectionSize()));
+			(header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF));
 		Address address = start;
 		createData(address, new DWordDataType());
 		createLabel(address, "Number_of_strings", true);
@@ -163,7 +163,7 @@ public class CoffBinaryAnalysisCommand extends FlatProgramAPI
 	private void processSymbols(CoffFileHeader header) throws Exception {
 		monitor.setMessage("Processing symbols...");
 		Address start = toAddr(header.getSymbolTablePointer());
-		long length = header.getSymbolTableEntries() * header.getSectionSize();
+		long length = header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF;
 		Address address = start;
 		List<CoffSymbol> symbols = header.getSymbols();
 		for (int i = 0; i < symbols.size(); ++i) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/CoffBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/CoffBinaryAnalysisCommand.java
@@ -145,7 +145,7 @@ public class CoffBinaryAnalysisCommand extends FlatProgramAPI
 	private void processStrings(CoffFileHeader header) throws Exception {
 		monitor.setMessage("Processing strings...");
 		Address start = toAddr(header.getSymbolTablePointer() +
-			(header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF));
+			header.getSymbolTableLength());
 		Address address = start;
 		createData(address, new DWordDataType());
 		createLabel(address, "Number_of_strings", true);
@@ -163,7 +163,7 @@ public class CoffBinaryAnalysisCommand extends FlatProgramAPI
 	private void processSymbols(CoffFileHeader header) throws Exception {
 		monitor.setMessage("Processing symbols...");
 		Address start = toAddr(header.getSymbolTablePointer());
-		long length = header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF;
+		long length = header.getSymbolTableLength();
 		Address address = start;
 		List<CoffSymbol> symbols = header.getSymbols();
 		for (int i = 0; i < symbols.size(); ++i) {
@@ -224,7 +224,7 @@ public class CoffBinaryAnalysisCommand extends FlatProgramAPI
 			return;
 		}
 		Address start = toAddr(section.getPointerToLineNumbers());
-		long length = section.getLineNumberCount() * CoffLineNumber.SIZEOF;
+		long length = section.getLineNumberLength();
 		Address address = start;
 		List<CoffLineNumber> lineNumbers = section.getLineNumbers();
 		for (CoffLineNumber lineNumber : lineNumbers) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffConstants.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffConstants.java
@@ -27,6 +27,10 @@ public class CoffConstants {
 	 */
 	public final static int SYMBOL_NAME_LENGTH          =   8;
 	/**
+	 * Length (in bytes) of a symbol data structure.
+	 */
+	public final static int SYMBOL_SIZEOF               =  18;
+	/**
 	 * Max-length (in bytes) of a file name.
 	 */
 	public final static int FILE_NAME_LENGTH            =  14;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffConstants.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffConstants.java
@@ -38,4 +38,8 @@ public class CoffConstants {
 	 * Number of dimensions of a symbol's auxiliary array.
 	 */
 	public final static int AUXILIARY_ARRAY_DIMENSION   =  4;
+	/**
+	 * Length (in bytes0 of a Line Number
+	 */
+	public final static int LINENO_SIZEOF = 6;
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffConstants.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffConstants.java
@@ -27,10 +27,6 @@ public class CoffConstants {
 	 */
 	public final static int SYMBOL_NAME_LENGTH          =   8;
 	/**
-	 * Length (in bytes) of a symbol data structure.
-	 */
-	public final static int SYMBOL_SIZEOF               =  18;
-	/**
 	 * Max-length (in bytes) of a file name.
 	 */
 	public final static int FILE_NAME_LENGTH            =  14;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffFileHeader.java
@@ -80,21 +80,6 @@ public class CoffFileHeader implements StructConverter {
 	public short getSectionCount() {
 		return f_nscns;
 	}
-	
-	/**
-	 * Returns the size of the section header in this COFF file.
-	 * @return the size of the section header in this COFF file
-	 */
-	public int getSectionSize() {
-		if ((f_magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC) ||
-				(f_magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC)) {
-			// i960 is aligned and padded differently
-			return 24;
-		}
-		else {
-			return 18;
-		}
-	}
 
 	/**
 	 * Returns the time stamp of when this file was created.

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffFileHeader.java
@@ -80,6 +80,21 @@ public class CoffFileHeader implements StructConverter {
 	public short getSectionCount() {
 		return f_nscns;
 	}
+	
+	/**
+	 * Returns the size of the section header in this COFF file.
+	 * @return the size of the section header in this COFF file
+	 */
+	public int getSectionSize() {
+		if ((f_magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC) ||
+				(f_magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC)) {
+			// i960 is aligned and padded differently
+			return 24;
+		}
+		else {
+			return 18;
+		}
+	}
 
 	/**
 	 * Returns the time stamp of when this file was created.

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffFileHeader.java
@@ -104,6 +104,14 @@ public class CoffFileHeader implements StructConverter {
 	public int getSymbolTableEntries() {
 		return f_nsyms;
 	}
+	
+	/**
+	 * Returns the length of symbols in the symbol table.
+	 * @return the length of symbols in the symbol table
+	 */
+	public int getSymbolTableLength() {
+		return f_nsyms * CoffConstants.SYMBOL_SIZEOF;
+	}
 
 	/**
 	 * Returns the size in bytes of the optional header.

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffLineNumber.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffLineNumber.java
@@ -23,10 +23,12 @@ import ghidra.util.exception.DuplicateNameException;
 import java.io.IOException;
 
 public class CoffLineNumber implements StructConverter {
-	public final static int SIZEOF = 4 + 2;
 
-	private int   l_addr; // address of line number
-	private short l_lnno; // line number
+	protected int   l_addr; // address of line number
+	protected short l_lnno; // line number
+	
+	protected CoffLineNumber() {		
+	}
 
 	CoffLineNumber(BinaryReader reader) throws IOException {
 		l_addr = reader.readNextInt();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSectionHeader.java
@@ -208,6 +208,14 @@ public class CoffSectionHeader implements StructConverter {
 	public int getLineNumberCount() {
 		return s_nlnno;
 	}
+	
+	/**
+	 * Returns the length of line number entries for this section.
+	 * @return the length of line number entries for this section
+	 */
+	public int getLineNumberLength() {
+		return s_nlnno * CoffConstants.LINENO_SIZEOF;
+	}
 
 	/**
 	 * Returns the flags for this section.

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSectionHeader.java
@@ -80,7 +80,7 @@ public class CoffSectionHeader implements StructConverter {
 					: BigEndianDataConverter.INSTANCE;
 			int nameIndex = dc.getInt(nameBytes, 4);//string table index
 			int stringTableIndex = _header.getSymbolTablePointer() +
-				(_header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF);
+				(_header.getSymbolTableEntries() * _header.getSectionSize());
 			s_name = reader.readAsciiString(stringTableIndex + nameIndex);
 		}
 		else {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSectionHeader.java
@@ -80,7 +80,7 @@ public class CoffSectionHeader implements StructConverter {
 					: BigEndianDataConverter.INSTANCE;
 			int nameIndex = dc.getInt(nameBytes, 4);//string table index
 			int stringTableIndex = _header.getSymbolTablePointer() +
-				(_header.getSymbolTableEntries() * _header.getSectionSize());
+				(_header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF);
 			s_name = reader.readAsciiString(stringTableIndex + nameIndex);
 		}
 		else {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbol.java
@@ -27,12 +27,9 @@ public class CoffSymbol implements StructConverter {
 	private String e_name;
 	private int e_value;
 	private short e_scnum;
-	private int e_type;
-	private short e_flags;
+	private short e_type;
 	private byte e_sclass;
 	private byte e_numaux;
-	private short f_magic;
-	private byte [] unused;
 
 	private List<CoffSymbolAux> _auxiliarySymbols = new ArrayList<CoffSymbolAux>();
 
@@ -43,33 +40,19 @@ public class CoffSymbol implements StructConverter {
 			int nameIndex = reader.readNextInt();//string table index
 			int stringTableIndex =
 				header.getSymbolTablePointer() +
-					(header.getSymbolTableEntries() * header.getSectionSize());
+					(header.getSymbolTableEntries() * CoffConstants.SYMBOL_SIZEOF);
 			e_name = reader.readAsciiString(stringTableIndex + nameIndex);
 		}
 		else {
 			e_name = reader.readNextAsciiString(CoffConstants.SYMBOL_NAME_LENGTH);
 		}
 
-		if (header.getMagic() == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				header.getMagic() == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			e_value = reader.readNextInt();
-			e_scnum = reader.readNextShort();
-			e_flags = reader.readNextShort();
-			e_type = reader.readNextInt();
-			e_sclass = reader.readNextByte();
-			e_numaux = reader.readNextByte();
-			f_magic = header.getMagic();
-			unused = reader.readNextByteArray(2);
-		} else {
-			e_value = reader.readNextInt();
-			e_scnum = reader.readNextShort();
-			e_flags = 0;
-			e_type = reader.readNextShort();
-			e_sclass = reader.readNextByte();
-			e_numaux = reader.readNextByte();
-			f_magic = header.getMagic();
-			unused = reader.readNextByteArray(0);
-		}
+		e_value = reader.readNextInt();
+		e_scnum = reader.readNextShort();
+		e_type = reader.readNextShort();
+		e_sclass = reader.readNextByte();
+		e_numaux = reader.readNextByte();
+
 		for (int i = 0; i < e_numaux; ++i) {
 			_auxiliarySymbols.add(CoffSymbolAuxFactory.read(reader, this));
 		}
@@ -79,10 +62,6 @@ public class CoffSymbol implements StructConverter {
 //		w.println(e_name + ", " + e_type + ", " + e_scnum + ", " + e_sclass + ", 0x" + Integer.toHexString(e_value) + ", " + e_numaux );
 //	}
 
-	public short getFileHeaderMagic() {
-		return f_magic;
-	}
-	
 	public String getName() {
 		return e_name;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbol.java
@@ -24,14 +24,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CoffSymbol implements StructConverter {
-	private String e_name;
-	private int e_value;
-	private short e_scnum;
-	private short e_type;
-	private byte e_sclass;
-	private byte e_numaux;
+	protected String e_name;
+	protected int e_value;
+	protected short e_scnum;
+	protected int e_type;
+	protected byte e_sclass;
+	protected byte e_numaux;
 
-	private List<CoffSymbolAux> _auxiliarySymbols = new ArrayList<CoffSymbolAux>();
+	protected List<CoffSymbolAux> _auxiliarySymbols = new ArrayList<CoffSymbolAux>();
+
+	protected CoffSymbol() {	
+	}
 
 	CoffSymbol(BinaryReader reader, CoffFileHeader header) throws IOException {
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxArray.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxArray.java
@@ -34,7 +34,7 @@ public class CoffSymbolAuxArray implements CoffSymbolAux {
 	private short   fourthDimension;
 	private byte [] unused;
 
-	CoffSymbolAuxArray(BinaryReader reader) throws IOException {
+	CoffSymbolAuxArray(BinaryReader reader, short magic) throws IOException {
 		tagIndex        = reader.readNextInt();
 		lineNumber      = reader.readNextShort();
 		arraySize       = reader.readNextShort();
@@ -42,7 +42,12 @@ public class CoffSymbolAuxArray implements CoffSymbolAux {
 		secondDimension = reader.readNextShort();
 		thirdDimension  = reader.readNextShort();
 		fourthDimension = reader.readNextShort();
-		unused          = reader.readNextByteArray(2);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused          = reader.readNextByteArray(8);
+		} else {
+			unused          = reader.readNextByteArray(2);
+		}
 	}
 
 	public int getTagIndex() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxArray.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxArray.java
@@ -25,14 +25,17 @@ import java.io.IOException;
 
 public class CoffSymbolAuxArray implements CoffSymbolAux {
 
-	private int     tagIndex;
-	private short   lineNumber;
-	private short   arraySize;
-	private short   firstDimension;
-	private short   secondDimension;
-	private short   thirdDimension;
-	private short   fourthDimension;
-	private byte [] unused;
+	protected int     tagIndex;
+	protected short   lineNumber;
+	protected short   arraySize;
+	protected short   firstDimension;
+	protected short   secondDimension;
+	protected short   thirdDimension;
+	protected short   fourthDimension;
+	protected byte [] unused;
+
+	protected CoffSymbolAuxArray() {		
+	}
 
 	CoffSymbolAuxArray(BinaryReader reader) throws IOException {
 		tagIndex        = reader.readNextInt();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxArray.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxArray.java
@@ -34,7 +34,7 @@ public class CoffSymbolAuxArray implements CoffSymbolAux {
 	private short   fourthDimension;
 	private byte [] unused;
 
-	CoffSymbolAuxArray(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxArray(BinaryReader reader) throws IOException {
 		tagIndex        = reader.readNextInt();
 		lineNumber      = reader.readNextShort();
 		arraySize       = reader.readNextShort();
@@ -42,12 +42,7 @@ public class CoffSymbolAuxArray implements CoffSymbolAux {
 		secondDimension = reader.readNextShort();
 		thirdDimension  = reader.readNextShort();
 		fourthDimension = reader.readNextShort();
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused          = reader.readNextByteArray(8);
-		} else {
-			unused          = reader.readNextByteArray(2);
-		}
+		unused          = reader.readNextByteArray(2);
 	}
 
 	public int getTagIndex() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxBeginningOfBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxBeginningOfBlock.java
@@ -31,12 +31,17 @@ public class CoffSymbolAuxBeginningOfBlock implements CoffSymbolAux {
 	private int     nextEntryIndex;
 	private byte [] unused3;
 
-	CoffSymbolAuxBeginningOfBlock(BinaryReader reader) throws IOException {
+	CoffSymbolAuxBeginningOfBlock(BinaryReader reader, short magic) throws IOException {
 		unused1          = reader.readNextByteArray(4);
 		sourceLineNumber = reader.readNextShort();
 		unused2          = reader.readNextByteArray(5);
 		nextEntryIndex   = reader.readNextInt();
-		unused3          = reader.readNextByteArray(2);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused3          = reader.readNextByteArray(8);
+		} else {
+			unused3          = reader.readNextByteArray(2);
+		}
 	}
 
 	public byte[] getUnused1() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxBeginningOfBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxBeginningOfBlock.java
@@ -25,12 +25,15 @@ import java.io.IOException;
 
 public class CoffSymbolAuxBeginningOfBlock implements CoffSymbolAux {
 
-	private byte [] unused1;
-	private short   sourceLineNumber;
-	private byte [] unused2;
-	private int     nextEntryIndex;
-	private byte [] unused3;
+	protected byte [] unused1;
+	protected short   sourceLineNumber;
+	protected byte [] unused2;
+	protected int     nextEntryIndex;
+	protected byte [] unused3;
 
+	protected CoffSymbolAuxBeginningOfBlock() {
+	}
+	
 	CoffSymbolAuxBeginningOfBlock(BinaryReader reader) throws IOException {
 		unused1          = reader.readNextByteArray(4);
 		sourceLineNumber = reader.readNextShort();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxBeginningOfBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxBeginningOfBlock.java
@@ -31,17 +31,12 @@ public class CoffSymbolAuxBeginningOfBlock implements CoffSymbolAux {
 	private int     nextEntryIndex;
 	private byte [] unused3;
 
-	CoffSymbolAuxBeginningOfBlock(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxBeginningOfBlock(BinaryReader reader) throws IOException {
 		unused1          = reader.readNextByteArray(4);
 		sourceLineNumber = reader.readNextShort();
 		unused2          = reader.readNextByteArray(5);
 		nextEntryIndex   = reader.readNextInt();
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused3          = reader.readNextByteArray(8);
-		} else {
-			unused3          = reader.readNextByteArray(2);
-		}
+		unused3          = reader.readNextByteArray(2);
 	}
 
 	public byte[] getUnused1() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxDefault.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxDefault.java
@@ -27,13 +27,8 @@ class CoffSymbolAuxDefault implements CoffSymbolAux {
 
 	private byte [] bytes;
 
-	CoffSymbolAuxDefault(BinaryReader reader, short magic) throws IOException {
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			bytes = reader.readNextByteArray(24);
-		} else {
-			bytes = reader.readNextByteArray(18);
-		}
+	CoffSymbolAuxDefault(BinaryReader reader) throws IOException {
+		bytes = reader.readNextByteArray(CoffConstants.SYMBOL_SIZEOF);
 	}
 
 	public byte [] getBytes() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxDefault.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxDefault.java
@@ -25,7 +25,10 @@ import java.io.IOException;
 
 class CoffSymbolAuxDefault implements CoffSymbolAux {
 
-	private byte [] bytes;
+	protected byte [] bytes;
+
+	protected CoffSymbolAuxDefault() {
+	}
 
 	CoffSymbolAuxDefault(BinaryReader reader) throws IOException {
 		bytes = reader.readNextByteArray(CoffConstants.SYMBOL_SIZEOF);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxDefault.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxDefault.java
@@ -27,8 +27,13 @@ class CoffSymbolAuxDefault implements CoffSymbolAux {
 
 	private byte [] bytes;
 
-	CoffSymbolAuxDefault(BinaryReader reader) throws IOException {
-		bytes = reader.readNextByteArray(CoffConstants.SYMBOL_SIZEOF);
+	CoffSymbolAuxDefault(BinaryReader reader, short magic) throws IOException {
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			bytes = reader.readNextByteArray(24);
+		} else {
+			bytes = reader.readNextByteArray(18);
+		}
 	}
 
 	public byte [] getBytes() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfBlock.java
@@ -25,9 +25,12 @@ import java.io.IOException;
 
 public class CoffSymbolAuxEndOfBlock implements CoffSymbolAux {
 
-	private byte [] unused1;
-	private short   sourceLineNumber;
-	private byte [] unused2;
+	protected byte [] unused1;
+	protected short   sourceLineNumber;
+	protected byte [] unused2;
+
+	protected CoffSymbolAuxEndOfBlock() {		
+	}
 
 	CoffSymbolAuxEndOfBlock(BinaryReader reader) throws IOException {
 		unused1          = reader.readNextByteArray(4);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfBlock.java
@@ -29,16 +29,10 @@ public class CoffSymbolAuxEndOfBlock implements CoffSymbolAux {
 	private short   sourceLineNumber;
 	private byte [] unused2;
 
-	CoffSymbolAuxEndOfBlock(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxEndOfBlock(BinaryReader reader) throws IOException {
 		unused1          = reader.readNextByteArray(4);
 		sourceLineNumber = reader.readNextShort();
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused2          = reader.readNextByteArray(18);
-		}
-		else {
-			unused2          = reader.readNextByteArray(12);
-		}
+		unused2          = reader.readNextByteArray(12);
 	}
 
 	public byte[] getUnused1() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfBlock.java
@@ -29,10 +29,16 @@ public class CoffSymbolAuxEndOfBlock implements CoffSymbolAux {
 	private short   sourceLineNumber;
 	private byte [] unused2;
 
-	CoffSymbolAuxEndOfBlock(BinaryReader reader) throws IOException {
+	CoffSymbolAuxEndOfBlock(BinaryReader reader, short magic) throws IOException {
 		unused1          = reader.readNextByteArray(4);
 		sourceLineNumber = reader.readNextShort();
-		unused2          = reader.readNextByteArray(12);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused2          = reader.readNextByteArray(18);
+		}
+		else {
+			unused2          = reader.readNextByteArray(12);
+		}
 	}
 
 	public byte[] getUnused1() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfStruct.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfStruct.java
@@ -25,10 +25,13 @@ import java.io.IOException;
 
 public class CoffSymbolAuxEndOfStruct implements CoffSymbolAux {
 
-	private int     tagIndex;
-	private byte [] unused1;
-	private short   size; //of structure, union, or enumeration
-	private byte [] unused2;
+	protected int     tagIndex;
+	protected byte [] unused1;
+	protected short   size; //of structure, union, or enumeration
+	protected byte [] unused2;
+
+	protected CoffSymbolAuxEndOfStruct() {		
+	}
 
 	CoffSymbolAuxEndOfStruct(BinaryReader reader) throws IOException {
 		tagIndex = reader.readNextInt();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfStruct.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfStruct.java
@@ -30,11 +30,16 @@ public class CoffSymbolAuxEndOfStruct implements CoffSymbolAux {
 	private short   size; //of structure, union, or enumeration
 	private byte [] unused2;
 
-	CoffSymbolAuxEndOfStruct(BinaryReader reader) throws IOException {
+	CoffSymbolAuxEndOfStruct(BinaryReader reader, short magic) throws IOException {
 		tagIndex = reader.readNextInt();
 		unused1  = reader.readNextByteArray(2);
 		size     = reader.readNextShort();
-		unused2  = reader.readNextByteArray(10);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused2  = reader.readNextByteArray(16);
+		} else {
+			unused2  = reader.readNextByteArray(10);
+		}
 	}
 
 	public int getTagIndex() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfStruct.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxEndOfStruct.java
@@ -30,16 +30,11 @@ public class CoffSymbolAuxEndOfStruct implements CoffSymbolAux {
 	private short   size; //of structure, union, or enumeration
 	private byte [] unused2;
 
-	CoffSymbolAuxEndOfStruct(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxEndOfStruct(BinaryReader reader) throws IOException {
 		tagIndex = reader.readNextInt();
 		unused1  = reader.readNextByteArray(2);
 		size     = reader.readNextShort();
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused2  = reader.readNextByteArray(16);
-		} else {
-			unused2  = reader.readNextByteArray(10);
-		}
+		unused2  = reader.readNextByteArray(10);
 	}
 
 	public int getTagIndex() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFactory.java
@@ -27,33 +27,33 @@ final class CoffSymbolAuxFactory {
 		if (symbol.getDerivedType(1) == CoffSymbolType.DT_NON && symbol.getBasicType() == CoffSymbolType.T_NULL) {
 
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_FILE) {
-				return new CoffSymbolAuxFilename(reader);
+				return new CoffSymbolAuxFilename(reader, symbol.getFileHeaderMagic());
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_STAT) {
-				return new CoffSymbolAuxSection(reader);
+				return new CoffSymbolAuxSection(reader, symbol.getFileHeaderMagic());
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_STRTAG ||
 				symbol.getStorageClass() == CoffSymbolStorageClass.C_UNTAG ||
 				symbol.getStorageClass() == CoffSymbolStorageClass.C_ENTAG) {
-				return new CoffSymbolAuxTagName(reader);
+				return new CoffSymbolAuxTagName(reader, symbol.getFileHeaderMagic());
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_EOS) {
-				return new CoffSymbolAuxEndOfStruct(reader);
+				return new CoffSymbolAuxEndOfStruct(reader, symbol.getFileHeaderMagic());
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_BLOCK) {
-				return new CoffSymbolAuxBeginningOfBlock(reader);
+				return new CoffSymbolAuxBeginningOfBlock(reader, symbol.getFileHeaderMagic());
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_FCN) {
-				return new CoffSymbolAuxFunction(reader);
+				return new CoffSymbolAuxFunction(reader, symbol.getFileHeaderMagic());
 			}
 		}
 
 		if (symbol.getDerivedType(1) == CoffSymbolType.DT_FCN) {
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_EXT) {
-				return new CoffSymbolAuxFunction(reader);
+				return new CoffSymbolAuxFunction(reader, symbol.getFileHeaderMagic());
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_STAT) {
-				return new CoffSymbolAuxFunction(reader);
+				return new CoffSymbolAuxFunction(reader, symbol.getFileHeaderMagic());
 			}
 		}
 
@@ -64,11 +64,11 @@ final class CoffSymbolAuxFactory {
 				case CoffSymbolStorageClass.C_MOS:
 				case CoffSymbolStorageClass.C_MOU:
 				case CoffSymbolStorageClass.C_TPDEF:
-					return new CoffSymbolAuxArray(reader);
+					return new CoffSymbolAuxArray(reader, symbol.getFileHeaderMagic());
 			}
 		}
 
-		return new CoffSymbolAuxDefault(reader);
+		return new CoffSymbolAuxDefault(reader, symbol.getFileHeaderMagic());
 	}
 	
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFactory.java
@@ -27,33 +27,33 @@ final class CoffSymbolAuxFactory {
 		if (symbol.getDerivedType(1) == CoffSymbolType.DT_NON && symbol.getBasicType() == CoffSymbolType.T_NULL) {
 
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_FILE) {
-				return new CoffSymbolAuxFilename(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxFilename(reader);
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_STAT) {
-				return new CoffSymbolAuxSection(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxSection(reader);
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_STRTAG ||
 				symbol.getStorageClass() == CoffSymbolStorageClass.C_UNTAG ||
 				symbol.getStorageClass() == CoffSymbolStorageClass.C_ENTAG) {
-				return new CoffSymbolAuxTagName(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxTagName(reader);
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_EOS) {
-				return new CoffSymbolAuxEndOfStruct(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxEndOfStruct(reader);
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_BLOCK) {
-				return new CoffSymbolAuxBeginningOfBlock(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxBeginningOfBlock(reader);
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_FCN) {
-				return new CoffSymbolAuxFunction(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxFunction(reader);
 			}
 		}
 
 		if (symbol.getDerivedType(1) == CoffSymbolType.DT_FCN) {
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_EXT) {
-				return new CoffSymbolAuxFunction(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxFunction(reader);
 			}
 			if (symbol.getStorageClass() == CoffSymbolStorageClass.C_STAT) {
-				return new CoffSymbolAuxFunction(reader, symbol.getFileHeaderMagic());
+				return new CoffSymbolAuxFunction(reader);
 			}
 		}
 
@@ -64,11 +64,11 @@ final class CoffSymbolAuxFactory {
 				case CoffSymbolStorageClass.C_MOS:
 				case CoffSymbolStorageClass.C_MOU:
 				case CoffSymbolStorageClass.C_TPDEF:
-					return new CoffSymbolAuxArray(reader, symbol.getFileHeaderMagic());
+					return new CoffSymbolAuxArray(reader);
 			}
 		}
 
-		return new CoffSymbolAuxDefault(reader, symbol.getFileHeaderMagic());
+		return new CoffSymbolAuxDefault(reader);
 	}
 	
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFilename.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFilename.java
@@ -28,9 +28,14 @@ public class CoffSymbolAuxFilename implements CoffSymbolAux {
 	private byte [] filename;
 	private byte [] unused;
 
-	CoffSymbolAuxFilename(BinaryReader reader) throws IOException {
+	CoffSymbolAuxFilename(BinaryReader reader, short magic) throws IOException {
 		filename = reader.readNextByteArray(CoffConstants.FILE_NAME_LENGTH);
-		unused   = reader.readNextByteArray(4);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused   = reader.readNextByteArray(10);
+		} else {
+			unused   = reader.readNextByteArray(4);
+		}
 	}
 
 	public String getFilename() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFilename.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFilename.java
@@ -28,14 +28,9 @@ public class CoffSymbolAuxFilename implements CoffSymbolAux {
 	private byte [] filename;
 	private byte [] unused;
 
-	CoffSymbolAuxFilename(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxFilename(BinaryReader reader) throws IOException {
 		filename = reader.readNextByteArray(CoffConstants.FILE_NAME_LENGTH);
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused   = reader.readNextByteArray(10);
-		} else {
-			unused   = reader.readNextByteArray(4);
-		}
+		unused   = reader.readNextByteArray(4);
 	}
 
 	public String getFilename() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFilename.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFilename.java
@@ -25,9 +25,12 @@ import ghidra.util.exception.DuplicateNameException;
 
 public class CoffSymbolAuxFilename implements CoffSymbolAux {
 
-	private byte [] filename;
-	private byte [] unused;
+	protected byte [] filename;
+	protected byte [] unused;
 
+	protected CoffSymbolAuxFilename() {
+	}
+	
 	CoffSymbolAuxFilename(BinaryReader reader) throws IOException {
 		filename = reader.readNextByteArray(CoffConstants.FILE_NAME_LENGTH);
 		unused   = reader.readNextByteArray(4);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFunction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFunction.java
@@ -25,11 +25,14 @@ import java.io.IOException;
 
 public class CoffSymbolAuxFunction implements CoffSymbolAux {
 
-	private int     tagIndex;
-	private int     size;
-	private int     filePointerToLineNumber;
-	private int     nextEntryIndex;
-	private byte [] unused;
+	protected int     tagIndex;
+	protected int     size;
+	protected int     filePointerToLineNumber;
+	protected int     nextEntryIndex;
+	protected byte [] unused;
+
+	protected CoffSymbolAuxFunction() {		
+	}
 
 	CoffSymbolAuxFunction(BinaryReader reader) throws IOException {
 		tagIndex                = reader.readNextInt();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFunction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFunction.java
@@ -31,12 +31,17 @@ public class CoffSymbolAuxFunction implements CoffSymbolAux {
 	private int     nextEntryIndex;
 	private byte [] unused;
 
-	CoffSymbolAuxFunction(BinaryReader reader) throws IOException {
+	CoffSymbolAuxFunction(BinaryReader reader, short magic) throws IOException {
 		tagIndex                = reader.readNextInt();
 		size                    = reader.readNextInt();
 		filePointerToLineNumber = reader.readNextInt();
 		nextEntryIndex          = reader.readNextInt();
-		unused                  = reader.readNextByteArray(2);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused                  = reader.readNextByteArray(8);
+		} else {
+			unused                  = reader.readNextByteArray(2);
+		}
 	}
 
 	public int getTagIndex() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFunction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxFunction.java
@@ -31,17 +31,12 @@ public class CoffSymbolAuxFunction implements CoffSymbolAux {
 	private int     nextEntryIndex;
 	private byte [] unused;
 
-	CoffSymbolAuxFunction(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxFunction(BinaryReader reader) throws IOException {
 		tagIndex                = reader.readNextInt();
 		size                    = reader.readNextInt();
 		filePointerToLineNumber = reader.readNextInt();
 		nextEntryIndex          = reader.readNextInt();
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused                  = reader.readNextByteArray(8);
-		} else {
-			unused                  = reader.readNextByteArray(2);
-		}
+		unused                  = reader.readNextByteArray(2);
 	}
 
 	public int getTagIndex() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxName.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxName.java
@@ -25,10 +25,13 @@ import java.io.IOException;
 
 public class CoffSymbolAuxName implements CoffSymbolAux {
 
-	private int     tagIndex;
-	private byte [] unused1;
-	private short   size;
-	private byte [] unused2;
+	protected int     tagIndex;
+	protected byte [] unused1;
+	protected short   size;
+	protected byte [] unused2;
+
+	protected CoffSymbolAuxName() {		
+	}
 
 	CoffSymbolAuxName(BinaryReader reader) throws IOException {
 		tagIndex   = reader.readNextInt();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxSection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxSection.java
@@ -25,10 +25,13 @@ import java.io.IOException;
 
 public class CoffSymbolAuxSection implements CoffSymbolAux {
 
-	private int      sectionLength;
-	private short    relocationCount;
-	private short    lineNumberCount;
-	private byte []  unused;
+	protected int      sectionLength;
+	protected short    relocationCount;
+	protected short    lineNumberCount;
+	protected byte []  unused;
+
+	protected CoffSymbolAuxSection() {		
+	}
 
 	CoffSymbolAuxSection(BinaryReader reader) throws IOException {
 		sectionLength     = reader.readNextInt();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxSection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxSection.java
@@ -30,11 +30,16 @@ public class CoffSymbolAuxSection implements CoffSymbolAux {
 	private short    lineNumberCount;
 	private byte []  unused;
 
-	CoffSymbolAuxSection(BinaryReader reader) throws IOException {
+	CoffSymbolAuxSection(BinaryReader reader, short magic) throws IOException {
 		sectionLength     = reader.readNextInt();
 		relocationCount   = reader.readNextShort();
 		lineNumberCount   = reader.readNextShort();
-		unused            = reader.readNextByteArray(10);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused        = reader.readNextByteArray(16);
+		} else {
+			unused        = reader.readNextByteArray(10);
+		}
 	}
 
 	public int getSectionLength() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxSection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxSection.java
@@ -30,16 +30,11 @@ public class CoffSymbolAuxSection implements CoffSymbolAux {
 	private short    lineNumberCount;
 	private byte []  unused;
 
-	CoffSymbolAuxSection(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxSection(BinaryReader reader) throws IOException {
 		sectionLength     = reader.readNextInt();
 		relocationCount   = reader.readNextShort();
 		lineNumberCount   = reader.readNextShort();
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused        = reader.readNextByteArray(16);
-		} else {
-			unused        = reader.readNextByteArray(10);
-		}
+		unused            = reader.readNextByteArray(10);
 	}
 
 	public int getSectionLength() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxTagName.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxTagName.java
@@ -25,11 +25,14 @@ import java.io.IOException;
 
 public class CoffSymbolAuxTagName implements CoffSymbolAux {
 
-	private byte []  unused1;
-	private short    size;
-	private byte []  unused2;
-	private int      nextEntryIndex;
-	private byte []  unused3;
+	protected byte []  unused1;
+	protected short    size;
+	protected byte []  unused2;
+	protected int      nextEntryIndex;
+	protected byte []  unused3;
+
+	protected CoffSymbolAuxTagName() {		
+	}
 
 	CoffSymbolAuxTagName(BinaryReader reader) throws IOException {
 		unused1         = reader.readNextByteArray(6);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxTagName.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxTagName.java
@@ -31,12 +31,17 @@ public class CoffSymbolAuxTagName implements CoffSymbolAux {
 	private int      nextEntryIndex;
 	private byte []  unused3;
 
-	CoffSymbolAuxTagName(BinaryReader reader) throws IOException {
+	CoffSymbolAuxTagName(BinaryReader reader, short magic) throws IOException {
 		unused1         = reader.readNextByteArray(6);
 		size            = reader.readNextShort();
 		unused2         = reader.readNextByteArray(4);
 		nextEntryIndex  = reader.readNextInt();
-		unused3         = reader.readNextByteArray(2);
+		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
+				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
+			unused3         = reader.readNextByteArray(8);
+		} else {
+			unused3         = reader.readNextByteArray(8);
+		}
 	}
 
 	public byte [] getUnused1() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxTagName.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/CoffSymbolAuxTagName.java
@@ -31,17 +31,12 @@ public class CoffSymbolAuxTagName implements CoffSymbolAux {
 	private int      nextEntryIndex;
 	private byte []  unused3;
 
-	CoffSymbolAuxTagName(BinaryReader reader, short magic) throws IOException {
+	CoffSymbolAuxTagName(BinaryReader reader) throws IOException {
 		unused1         = reader.readNextByteArray(6);
 		size            = reader.readNextShort();
 		unused2         = reader.readNextByteArray(4);
 		nextEntryIndex  = reader.readNextInt();
-		if (magic == CoffMachineType.IMAGE_FILE_MACHINE_I960ROMAGIC ||
-				magic == CoffMachineType.IMAGE_FILE_MACHINE_I960RWMAGIC) {
-			unused3         = reader.readNextByteArray(8);
-		} else {
-			unused3         = reader.readNextByteArray(8);
-		}
+		unused3         = reader.readNextByteArray(2);
 	}
 
 	public byte [] getUnused1() {


### PR DESCRIPTION
COFF structs can be different based on the f_magic.  This PR implements the COFF for i960

(see https://github.com/NationalSecurityAgency/ghidra/commit/ca21388e65dee7b6b1287c00bf01c153b9b80cd4 and #1336)