### PR TITLE
switch from md5 to sha256 to check dependencies integrity

### DIFF
--- a/gradle/support/fetchDependencies.gradle
+++ b/gradle/support/fetchDependencies.gradle
@@ -56,13 +56,13 @@ ext.YAJSW_ZIP = 'https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable
 ext.PYDEV_ZIP = 'https://sourceforge.net/projects/pydev/files/pydev/PyDev%206.3.1/PyDev%206.3.1.zip'
 ext.CDT_ZIP = 'http://www.eclipse.org/downloads/download.php?r=1&protocol=https&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
 
-// The MD5s for each of the dependencies
-ext.DEX_MD5 = '032456b9db9e6059376611553aecf31f'
-ext.AXML_MD5 = '55d70be9862c2b456cc91a933c197934'
-ext.HFS_MD5 = 'cc1713d634d2cd1fd7f21e18ae4d5d5c'
-ext.YAJSW_MD5 = 'e490ea92554f0238d74d4ef6161cb2c7'
-ext.PYDEV_MD5 = '06263bdef4917c49d8d977d12c2d5073'
-ext.CDT_MD5 = '8e9438a6e3947d614af98e1b58e945a2'
+// The SHA-256s for each of the dependencies
+ext.DEX_SHA_256 = '7907eb4d6e9280b6e17ddce7ee0507eae2ef161ee29f70a10dbc6944fdca75bc'
+ext.AXML_SHA_256 = '00ed038eb6abaf6ddec8d202a3ed7a81b521458f4cd459948115cfd02ff59d6d'
+ext.HFS_SHA_256 = '90c9b54798abca5b12f4a678db7d0a4c970f4702cb153c11919536d0014dedbf'
+ext.YAJSW_SHA_256 = '1398fcb1e93abb19992c4fa06d7fe5758aabb4c45781d7ef306c6f57ca7a7321'
+ext.PYDEV_SHA_256 = '4d81fe9d8afe7665b8ea20844d3f5107f446742927c59973eade4f29809b0699'
+ext.CDT_SHA_256 = '81b7d19d57c4a3009f4761699a72e8d642b5e1d9251d2bb98df438b1e28f8ba9'
 
 // Number of times to try and establish a connection when downloading files before
 // failing
@@ -109,7 +109,7 @@ def createDirs() {
  *
  * Note: We do not validate that the number of bytes downloaded matches the
  *       expected total here; any discrepencies will be caught when checking
- *       the MD5s later on.
+ *       the SHA-256s later on.
  *
  * @param url the file to download
  * @param filename the local file to create for the download
@@ -206,39 +206,39 @@ def populateFlatRepo() {
    // 1. Download all the dependencies and verify their checksums. If the dependency has already
    //    been download, do NOT download again.
    File file = new File(DOWNLOADS_DIR, 'dex-tools-2.0.zip')
-   if (!DEX_MD5.equals(generateChecksum(file))) {
+   if (!DEX_SHA_256.equals(generateChecksum(file))) {
       download (DEX_ZIP, file.path)
-      validateChecksum(generateChecksum(file), DEX_MD5);
+      validateChecksum(generateChecksum(file), DEX_SHA_256);
    }
   
    file = new File(DOWNLOADS_DIR, 'AXMLPrinter2.jar')
-   if (!AXML_MD5.equals(generateChecksum(file))) {
+   if (!AXML_SHA_256.equals(generateChecksum(file))) {
       download (AXML_ZIP, file.path)
-      validateChecksum(generateChecksum(file), AXML_MD5);
+      validateChecksum(generateChecksum(file), AXML_SHA_256);
    }
    
    file = new File(DOWNLOADS_DIR, 'hfsexplorer-0_21-bin.zip')
-   if (!HFS_MD5.equals(generateChecksum(file))) {
+   if (!HFS_SHA_256.equals(generateChecksum(file))) {
       download (HFS_ZIP, file.path)
-      validateChecksum(generateChecksum(file), HFS_MD5);
+      validateChecksum(generateChecksum(file), HFS_SHA_256);
    }
    
    file = new File(DOWNLOADS_DIR, 'yajsw-stable-12.12.zip')
-   if (!YAJSW_MD5.equals(generateChecksum(file))) {
+   if (!YAJSW_SHA_256.equals(generateChecksum(file))) {
       download (YAJSW_ZIP, file.path)
-      validateChecksum(generateChecksum(file), YAJSW_MD5);
+      validateChecksum(generateChecksum(file), YAJSW_SHA_256);
    }
    
    file = new File(DOWNLOADS_DIR, 'PyDev 6.3.1.zip')
-   if (!PYDEV_MD5.equals(generateChecksum(file))) {
+   if (!PYDEV_SHA_256.equals(generateChecksum(file))) {
       download (PYDEV_ZIP, file.path)
-      validateChecksum(generateChecksum(file), PYDEV_MD5);
+      validateChecksum(generateChecksum(file), PYDEV_SHA_256);
    }
    
    file = new File(DOWNLOADS_DIR, 'cdt-8.6.0.zip')
-   if (!CDT_MD5.equals(generateChecksum(file))) {
+   if (!CDT_SHA_256.equals(generateChecksum(file))) {
       download (CDT_ZIP, file.path)
-      validateChecksum(generateChecksum(file), CDT_MD5);
+      validateChecksum(generateChecksum(file), CDT_SHA_256);
    }
    
    // 2. Unzip the dependencies
@@ -256,7 +256,7 @@ def populateFlatRepo() {
 }
 
 /**
- * Generates the md5 for the given file
+ * Generates the SHA-256 for the given file
  *
  * @param file the file to generate the checksum for
  * @return the generated checksum
@@ -265,7 +265,7 @@ def generateChecksum(file) {
    if (!file.exists()) {
       return null
    }
-   MessageDigest md = MessageDigest.getInstance("MD5");
+   MessageDigest md = MessageDigest.getInstance("SHA-256");
    md.update(Files.readAllBytes(Paths.get(file.path)));
    byte[] digest = md.digest();
    StringBuilder sb = new StringBuilder();
@@ -279,11 +279,11 @@ def generateChecksum(file) {
 /**
  * Compares two checksums and generates an assert failure if they do not match
  *
- * @param sourceMd5 the checksum to validate
- * @param expectedMd5 the expected checksum
+ * @param sourceSha256 the checksum to validate
+ * @param expectedSha256 the expected checksum
  */
-def validateChecksum(sourceMd5, expectedMd5) {
-   	assert(sourceMd5.equals(expectedMd5));    
+def validateChecksum(sourceSha256, expectedSha256) {
+   	assert(sourceSha256.equals(expectedSha256));    
 }
 
 /**


### PR DESCRIPTION
By modern standards it's not acceptable to use MD5 to verify the integrity of dependencies downloaded over the network, especially the cdt zip which is downloaded on http, not HTTPS

I switched to sha256 in the gradle script to fetch the deps