### PR TITLE
Don't escape menupath separator in plugin details.

### DIFF
--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/PluginDetailsPanel.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/PluginDetailsPanel.java
@@ -224,7 +224,7 @@ class PluginDetailsPanel extends AbstractDetailsPanel {
 		for (int i = 0; i < path.length; i++) {
 			buffy.append(path[i].replaceAll("\\&", ""));  // strip off the mnemonic identifier '&'
 			if (i != path.length - 1) {
-				buffy.append("-&gt;");
+				buffy.append("->");
 			}
 		}
 		return buffy.toString();

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/PluginDetailsPanel.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/PluginDetailsPanel.java
@@ -220,7 +220,7 @@ class PluginDetailsPanel extends AbstractDetailsPanel {
 			return null;
 		}
 
-		StringBuffer buffy = new StringBuffer();
+		StringBuilder buffy = new StringBuilder();
 		for (int i = 0; i < path.length; i++) {
 			buffy.append(path[i].replaceAll("\\&", ""));  // strip off the mnemonic identifier '&'
 			if (i != path.length - 1) {


### PR DESCRIPTION
The menu path separator string doesn't need to escape the `>` HTML entity as it will shown as intended.  The optimal way to sort this out would be to use `&rarr;` instead of `->` but that would mean changing a bit too many things for a minor fix like this.