### PR TITLE
Set repeatable comment for function in XML import

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/FunctionsXmlMgr.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/FunctionsXmlMgr.java
@@ -545,6 +545,7 @@ class FunctionsXmlMgr {
 		writeReturnType(writer, func);
 		writeAddressRange(writer, func);
 		writeRegularComment(writer, func.getComment());
+		writeRepeatableComment(writer, func.getRepeatableComment());
 		if (func.getSignatureSource() != SourceType.DEFAULT) {
 			writeTypeInfoComment(writer, func);
 		}
@@ -611,6 +612,12 @@ class FunctionsXmlMgr {
 	private void writeRegularComment(XmlWriter writer, String comment) {
 		if (comment != null && comment.length() > 0) {
 			writer.writeElement("REGULAR_CMT", null, comment);
+		}
+	}
+
+	private void writeRepeatableComment(XmlWriter writer, String comment) {
+		if (comment != null && comment.length() > 0) {
+			writer.writeElement("REPEATABLE_CMT", null, comment);
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/FunctionsXmlMgr.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/FunctionsXmlMgr.java
@@ -167,7 +167,8 @@ class FunctionsXmlMgr {
 
 					String regularComment = getElementText(parser, "REGULAR_CMT");
 					func.setComment(regularComment);
-					getElementText(parser, "REPEATABLE_CMT");
+					String repeatableComment = getElementText(parser, "REPEATABLE_CMT");
+					func.setRepeatableComment(repeatableComment);
 					String typeInfoComment = getElementText(parser, "TYPEINFO_CMT");
 					List<Variable> stackParams = new ArrayList<>();
 					List<Variable> stackVariables = new ArrayList<>();


### PR DESCRIPTION
XML importer don't import repeatable comment for functions.