### PR TITLE
Add instructionEndian to generated .ldefs files.

### DIFF
--- a/GhidraBuild/Skeleton/data/languages/skel.ldefs
+++ b/GhidraBuild/Skeleton/data/languages/skel.ldefs
@@ -7,6 +7,7 @@
 <!-- 
    <language processor="Skel"
             endian="little"
+            instructionEndian="little"
             size="16"
             variant="default"
             version="1.0"


### PR DESCRIPTION
As per the discussion in #1422, the `instructionEndian` attribute is now present in generated language definition files by the Ghidra Eclipse plugin. 