### PR TITLE
Removed sleighCompile dependency from assembleDistribution

### DIFF
--- a/gradle/processorProject.gradle
+++ b/gradle/processorProject.gradle
@@ -167,10 +167,6 @@ task sleighCompile (type: JavaExec) {
 	jvmArgs '-Xmx2048M'	
 }
 
-// The task that copies the common files to the distribution folder must depend on
-// the sleigh tasks before executing.
-rootProject.assembleDistribution.dependsOn sleighCompile
-
 // Add in this projects sleighCompile to the allSleighCompile task
 rootProject.allSleighCompile.dependsOn sleighCompile
 


### PR DESCRIPTION
This is no longer needed since ghidra automatically recompiles the sleigh files when loading them depending on their timestamp. Removes about 10-15 minutes from the buildGhidra task.