### PR TITLE
#1441 Fixed GnuDemanglerParser Conversion Operator

### DIFF
--- a/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerParser.java
+++ b/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerParser.java
@@ -373,9 +373,9 @@ public class GnuDemanglerParser implements DemanglerParser {
 		}
 
 		// this will yield:
-		// fullName: 		NS1::Foo::operator
+		// fullNamespace: 	NS1::Foo::operator
 		// fullReturnType:  std::string
-		String fullName = matcher.group(1);// group 0 is the entire match string
+		String fullNamespace = matcher.group(1);// group 0 is the entire match string
 		String fullReturnType = matcher.group(2);
 
 		boolean isConst = false;
@@ -394,8 +394,8 @@ public class GnuDemanglerParser implements DemanglerParser {
 
 		// 'conversion operator' syntax is operator <name, which is the type>()
 
-		String templatelessName = stripOffTemplates(fullName);
-		setNameAndNamespace(method, templatelessName);
+		String templatelessNamespace = stripOffTemplates(fullNamespace);
+		setNamespace(method, templatelessNamespace);
 
 		// shortReturnType: string
 		String templatelessReturnType = stripOffTemplates(fullReturnType);
@@ -410,7 +410,7 @@ public class GnuDemanglerParser implements DemanglerParser {
 		//
 		method.setName("operator.cast.to." + shortReturnTypeName);
 
-		method.setSignature(fullName + " " + fullReturnType);
+		method.setSignature(fullNamespace + " " + fullReturnType);
 		method.setOverloadedOperator(true);
 
 		return method;
@@ -449,7 +449,7 @@ public class GnuDemanglerParser implements DemanglerParser {
 		method.setReturnType(returnType);
 
 		// 'conversion operator' syntax is operator <name, which is the type>(), where the
-		// operator itself cold be in a class namespace
+		// operator itself could be in a class namespace
 		setNameAndNamespace(method, operatorText);
 
 		List<DemangledDataType> parameters = parseParameters(parametersText);

--- a/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/GnuDemanglerParserTest.java
+++ b/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/GnuDemanglerParserTest.java
@@ -363,6 +363,27 @@ public class GnuDemanglerParserTest extends AbstractGenericTest {
 	}
 
 	@Test
+	public void testOperatorCastTo() throws Exception {
+		//
+		// Mangled: _ZNKSt17integral_constantIbLb0EEcvbEv
+		// 
+		// Demangled: std::integral_constant<bool, false>::operator bool() const
+
+		String mangled = "_ZNKSt17integral_constantIbLb0EEcvbEv";
+
+		String demangled = process.demangle(mangled);
+
+		DemangledObject object = parser.parse(mangled, demangled);
+		assertNotNull(object);
+		assertTrue(object instanceof DemangledFunction);
+
+		String signature = object.getSignature(false);
+		assertEquals(
+			"bool std::integral_constant::operator.cast.to.bool(void)",
+			signature);
+	}
+
+	@Test
 	public void testFunctions() throws Exception {
 		String mangled = "_Z7toFloatidcls";
 


### PR DESCRIPTION
The parseConversionOperator was removing the operator portion from the demangled string and using the namespace to set the name and namespace and then setting the name to operator.cast.to.

Essentially it was flowing like this:
```
demangled = NS1::Foo::operator
fullName = NS1::Foo
demangledNamespace = NS1
demangledName = Foo
demangledName = operator.cast.to
```

It is now:
```
demangled = NS1::Foo::operator
fullNamespace = NS1::Foo
demangledNamespace = NS1::Foo
demangledName = operator.case.to
```

I have also renamed the variables fullName and templatelessName to fullNamespace and templatelessNamespace to make it easier to understand when reviewing in the future.

There is also an unimportant typo fix in the commit.

resolves #1441 