### PR TITLE
Fix spelling

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/Snapshots/Snapshots.html
+++ b/Ghidra/Features/Base/src/main/help/help/topics/Snapshots/Snapshots.html
@@ -65,7 +65,7 @@ snapshot view.<br>
 <blockquote>
   <p>Snapshot views can be docked with normal views or they can live in
 their own windows.&nbsp; Global menu and toolbar actions have been
-changed to accomodate snapshot views.&nbsp; Global actions now operate
+changed to accommodate snapshot views.&nbsp; Global actions now operate
 on whatever component has focus (the component whose header bar is
 colored blue).&nbsp; For example, if you have the connected <span
  style="font-style: italic;">Listing View</span> and a snapshot <span

--- a/Ghidra/Framework/DB/src/main/java/db/VarKeyInteriorNode.java
+++ b/Ghidra/Framework/DB/src/main/java/db/VarKeyInteriorNode.java
@@ -357,7 +357,7 @@ class VarKeyInteriorNode extends VarKeyNode {
 
 	/**
 	 * Update the child key associated with the specified key index.
-	 * Other entries are shifted as necessary to accomodate the new key length for 
+	 * Other entries are shifted as necessary to accommodate the new key length for 
 	 * the updated entry.
 	 * @param index child key index
 	 * @param updateKey updated child node key

--- a/Ghidra/Processors/Atmel/src/main/java/ghidra/app/util/bin/format/elf/relocation/AVR32_ElfRelocationHandler.java
+++ b/Ghidra/Processors/Atmel/src/main/java/ghidra/app/util/bin/format/elf/relocation/AVR32_ElfRelocationHandler.java
@@ -249,7 +249,7 @@ public class AVR32_ElfRelocationHandler extends ElfRelocationHandler {
 				    memory.setInt(relocationAddress, newValue);
 				    System.out.println("  HANDLED AVR relocation: R_AVR32_21S at "+relocationAddress + ", New = " + newValue);
 				    break;
-				case AVR32_ElfRelocationConstants.R_AVR32_16U: //Use long to accomodate the Unsignedness...
+				case AVR32_ElfRelocationConstants.R_AVR32_16U: //Use long to accommodate the Unsignedness...
 				    long newValueLong = ((symbolValue + addend) & 0x0000ffff);
 				    memory.setLong(relocationAddress, newValueLong);
 				    System.out.println("  HANDLED AVR relocation: R_AVR32_16U at "+relocationAddress + ", NewLong = " + newValueLong);


### PR DESCRIPTION
This PR fixes the occurrences of the misspelling of the English word "accommodate" (misspelled as "accomodate").