### PR TITLE
Additions to pcodetest

### DIFF
--- a/Ghidra/Extensions/SleighDevTools/pcodetest/build
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/build
@@ -52,6 +52,9 @@ pcodetest_group.add_argument('--variants', default=json.dumps(PCodeTest.defaults
 sys.argv.pop(0)
 args = parser.parse_args(sys.argv)
 
+PCodeTest.defaults.toolchain_root = args.toolchain_root
+PCodeTest.defaults.build_root = args.build_root
+PCodeTest.defaults.gcc_version = args.gcc_version
 PCodeTest.defaults.skip_files = args.skip_files
 PCodeTest.defaults.pcodetest_root = args.pcodetest_root
 PCodeTest.defaults.pcodetest_src = args.pcodetest_src

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_DOUBLE.test
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_DOUBLE.test
@@ -17,6 +17,19 @@ TEST f8_greaterThan_Main()
 #endif
 
 #ifdef HAS_DOUBLE
+TEST f8_compareLogic_Main()
+{
+	extern f8 f8_compareLogic(f8 lhs, f8 rhs);
+	ASSERTF8(f8_compareLogic(0x1, 0x1), 21);
+	ASSERTF8(f8_compareLogic(0x1, 0x2), 21);
+	ASSERTF8(f8_compareLogic(0x2, 0x1), 22);
+	ASSERTF8(f8_compareLogic(-0x1, -0x1), 21);
+	ASSERTF8(f8_compareLogic(-0x1, -0x2), 21);
+	ASSERTF8(f8_compareLogic(-0x2, -0x1), 24);
+}
+#endif
+
+#ifdef HAS_DOUBLE
 TEST f8_greaterThanEquals_Main()
 {
 	extern f8 f8_greaterThanEquals(f8 lhs, f8 rhs);

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_DOUBLE_BODY.c
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_DOUBLE_BODY.c
@@ -25,6 +25,19 @@ f8 f8_greaterThan(f8 lhs, f8 rhs)
 	return z;
 }
 
+f8 f8_compareLogic(f8 lhs, f8 rhs)
+{
+	if (lhs < 0)
+		lhs += 2;
+	if (lhs > 0)
+		lhs += 4;
+	if (lhs == 0)
+		lhs += 8;
+	if (lhs != rhs)
+		lhs += 16;
+	return lhs;
+}
+
 f8 f8_greaterThanEquals(f8 lhs, f8 rhs)
 {
 	f8 z;

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_FLOAT.test
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_FLOAT.test
@@ -13,19 +13,6 @@ TEST f4_compareLogic_Main()
 }
 #endif
 
-#ifdef HAS_DOUBLE
-TEST f8_compareLogic_Main()
-{
-	extern f8 f8_compareLogic(f8 lhs, f8 rhs);
-	ASSERTF8(f8_compareLogic(0x1, 0x1), 21);
-	ASSERTF8(f8_compareLogic(0x1, 0x2), 21);
-	ASSERTF8(f8_compareLogic(0x2, 0x1), 22);
-	ASSERTF8(f8_compareLogic(-0x1, -0x1), 21);
-	ASSERTF8(f8_compareLogic(-0x1, -0x2), 21);
-	ASSERTF8(f8_compareLogic(-0x2, -0x1), 24);
-}
-#endif
-
 /* Comparison operators */
 #ifdef HAS_FLOAT
 TEST f4_greaterThan_Main()

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_FLOAT_BODY.c
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/BIOPS_FLOAT_BODY.c
@@ -29,19 +29,6 @@ f4 f4_compareLogic(f4 lhs, f4 rhs)
 	return lhs;
 }
 
-f8 f8_compareLogic(f8 lhs, f8 rhs)
-{
-	if (lhs < 0)
-		lhs += 2;
-	if (lhs > 0)
-		lhs += 4;
-	if (lhs == 0)
-		lhs += 8;
-	if (lhs != rhs)
-		lhs += 16;
-	return lhs;
-}
-
 /* Comparison operators */
 f4 f4_greaterThan(f4 lhs, f4 rhs)
 {

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT.test
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT.test
@@ -1,0 +1,339 @@
+#include "pcode_test.h"
+
+TEST pcode_i1_to_i1_convert_Main()
+{	extern i1 pcode_i1_to_i1_convert(i1 a);
+	ASSERTI1(pcode_i1_to_i1_convert(0), 0);
+	ASSERTI1(pcode_i1_to_i1_convert(-1), -1);
+	ASSERTI1(pcode_i1_to_i1_convert(2), 2);
+	ASSERTI1(pcode_i1_to_i1_convert(I1_MAX), I1_MAX);
+	ASSERTI1(pcode_i1_to_i1_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_i1_to_i2_convert_Main()
+{	extern i2 pcode_i1_to_i2_convert(i1 a);
+	ASSERTI2(pcode_i1_to_i2_convert(0), 0);
+	ASSERTI2(pcode_i1_to_i2_convert(-1), -1);
+	ASSERTI2(pcode_i1_to_i2_convert(2), 2);
+	ASSERTI2(pcode_i1_to_i2_convert(I1_MAX), I1_MAX);
+	ASSERTI2(pcode_i1_to_i2_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_i1_to_i4_convert_Main()
+{	extern i4 pcode_i1_to_i4_convert(i1 a);
+	ASSERTI4(pcode_i1_to_i4_convert(0), 0);
+	ASSERTI4(pcode_i1_to_i4_convert(-1), -1);
+	ASSERTI4(pcode_i1_to_i4_convert(2), 2);
+	ASSERTI4(pcode_i1_to_i4_convert(I1_MAX), I1_MAX);
+	ASSERTI4(pcode_i1_to_i4_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_i1_to_u1_convert_Main()
+{	extern u1 pcode_i1_to_u1_convert(i1 a);
+	ASSERTU1(pcode_i1_to_u1_convert(0), 0);
+	ASSERTU1(pcode_i1_to_u1_convert(-1), -1);
+	ASSERTU1(pcode_i1_to_u1_convert(2), 2);
+	ASSERTU1(pcode_i1_to_u1_convert(I1_MAX), I1_MAX);
+	ASSERTU1(pcode_i1_to_u1_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_i1_to_u2_convert_Main()
+{	extern u2 pcode_i1_to_u2_convert(i1 a);
+	ASSERTU2(pcode_i1_to_u2_convert(0), 0);
+	ASSERTU2(pcode_i1_to_u2_convert(-1), -1);
+	ASSERTU2(pcode_i1_to_u2_convert(2), 2);
+	ASSERTU2(pcode_i1_to_u2_convert(I1_MAX), I1_MAX);
+	ASSERTU2(pcode_i1_to_u2_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_i1_to_u4_convert_Main()
+{	extern u4 pcode_i1_to_u4_convert(i1 a);
+	ASSERTU4(pcode_i1_to_u4_convert(0), 0);
+	ASSERTU4(pcode_i1_to_u4_convert(-1), -1);
+	ASSERTU4(pcode_i1_to_u4_convert(2), 2);
+	ASSERTU4(pcode_i1_to_u4_convert(I1_MAX), I1_MAX);
+	ASSERTU4(pcode_i1_to_u4_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_i2_to_i1_convert_Main()
+{	extern i1 pcode_i2_to_i1_convert(i2 a);
+	ASSERTI1(pcode_i2_to_i1_convert(0), 0);
+	ASSERTI1(pcode_i2_to_i1_convert(-1), -1);
+	ASSERTI1(pcode_i2_to_i1_convert(2), 2);
+	ASSERTI1(pcode_i2_to_i1_convert(I2_MAX), -1);
+	ASSERTI1(pcode_i2_to_i1_convert(I2_MIN), 0);
+}
+
+TEST pcode_i2_to_i2_convert_Main()
+{	extern i2 pcode_i2_to_i2_convert(i2 a);
+	ASSERTI2(pcode_i2_to_i2_convert(0), 0);
+	ASSERTI2(pcode_i2_to_i2_convert(-1), -1);
+	ASSERTI2(pcode_i2_to_i2_convert(2), 2);
+	ASSERTI2(pcode_i2_to_i2_convert(I2_MAX), I2_MAX);
+	ASSERTI2(pcode_i2_to_i2_convert(I2_MIN), I2_MIN);
+}
+
+TEST pcode_i2_to_i4_convert_Main()
+{	extern i4 pcode_i2_to_i4_convert(i2 a);
+	ASSERTI4(pcode_i2_to_i4_convert(0), 0);
+	ASSERTI4(pcode_i2_to_i4_convert(-1), -1);
+	ASSERTI4(pcode_i2_to_i4_convert(2), 2);
+	ASSERTI4(pcode_i2_to_i4_convert(I2_MAX), I2_MAX);
+	ASSERTI4(pcode_i2_to_i4_convert(I2_MIN), I2_MIN);
+}
+
+TEST pcode_i2_to_u1_convert_Main()
+{	extern u1 pcode_i2_to_u1_convert(i2 a);
+	ASSERTU1(pcode_i2_to_u1_convert(0), 0);
+	ASSERTU1(pcode_i2_to_u1_convert(-1), -1);
+	ASSERTU1(pcode_i2_to_u1_convert(2), 2);
+	ASSERTU1(pcode_i2_to_u1_convert(I2_MAX), U1_MAX);
+	ASSERTU1(pcode_i2_to_u1_convert(I2_MIN), 0);
+}
+
+TEST pcode_i2_to_u2_convert_Main()
+{	extern u2 pcode_i2_to_u2_convert(i2 a);
+	ASSERTU2(pcode_i2_to_u2_convert(0), 0);
+	ASSERTU2(pcode_i2_to_u2_convert(-1), -1);
+	ASSERTU2(pcode_i2_to_u2_convert(2), 2);
+	ASSERTU2(pcode_i2_to_u2_convert(I2_MAX), I2_MAX);
+	ASSERTU2(pcode_i2_to_u2_convert(I2_MIN), I2_MIN);
+}
+
+TEST pcode_i2_to_u4_convert_Main()
+{	extern u4 pcode_i2_to_u4_convert(i2 a);
+	ASSERTU4(pcode_i2_to_u4_convert(0), 0);
+	ASSERTU4(pcode_i2_to_u4_convert(-1), -1);
+	ASSERTU4(pcode_i2_to_u4_convert(2), 2);
+	ASSERTU4(pcode_i2_to_u4_convert(I2_MAX), I2_MAX);
+	ASSERTU4(pcode_i2_to_u4_convert(I2_MIN), I2_MIN);
+}
+
+TEST pcode_i4_to_i1_convert_Main()
+{	extern i1 pcode_i4_to_i1_convert(i4 a);
+	ASSERTI1(pcode_i4_to_i1_convert(0), 0);
+	ASSERTI1(pcode_i4_to_i1_convert(-1), -1);
+	ASSERTI1(pcode_i4_to_i1_convert(2), 2);
+	ASSERTI1(pcode_i4_to_i1_convert(I1_MAX), I1_MAX);
+	ASSERTI1(pcode_i4_to_i1_convert(I1_MAX), I1_MAX);
+	ASSERTI1(pcode_i4_to_i1_convert(I4_MAX), -1);
+	ASSERTI1(pcode_i4_to_i1_convert(I4_MIN), 0);
+}
+
+TEST pcode_i4_to_i2_convert_Main()
+{	extern i2 pcode_i4_to_i2_convert(i4 a);
+	ASSERTI2(pcode_i4_to_i2_convert(0), 0);
+	ASSERTI2(pcode_i4_to_i2_convert(-1), -1);
+	ASSERTI2(pcode_i4_to_i2_convert(2), 2);
+	ASSERTI2(pcode_i4_to_i2_convert(0xffff0000), 0);
+	ASSERTI2(pcode_i4_to_i2_convert(I2_MIN), I2_MIN);
+	ASSERTI2(pcode_i4_to_i2_convert(I2_MAX), I2_MAX);
+	ASSERTI2(pcode_i4_to_i2_convert(U2_MAX), -1);
+	ASSERTI2(pcode_i4_to_i2_convert(I4_MAX), -1);
+	ASSERTI2(pcode_i4_to_i2_convert(I4_MIN), 0);
+}
+
+TEST pcode_i4_to_i4_convert_Main()
+{	extern i4 pcode_i4_to_i4_convert(i4 a);
+	ASSERTI4(pcode_i4_to_i4_convert(0), 0);
+	ASSERTI4(pcode_i4_to_i4_convert(-1), -1);
+	ASSERTI4(pcode_i4_to_i4_convert(2), 2);
+	ASSERTI4(pcode_i4_to_i4_convert(I4_MAX), I4_MAX);
+	ASSERTI4(pcode_i4_to_i4_convert(I4_MIN), I4_MIN);
+}
+
+TEST pcode_i4_to_u1_convert_Main()
+{	extern u1 pcode_i4_to_u1_convert(i4 a);
+	ASSERTU1(pcode_i4_to_u1_convert(0), 0);
+	ASSERTU1(pcode_i4_to_u1_convert(-1), U1_MAX);
+	ASSERTU1(pcode_i4_to_u1_convert(2), 2);
+	ASSERTU1(pcode_i4_to_u1_convert(I4_MAX), U1_MAX);
+	ASSERTU1(pcode_i4_to_u1_convert(I4_MIN), 0);
+}
+
+TEST pcode_i4_to_u2_convert_Main()
+{	extern u2 pcode_i4_to_u2_convert(i4 a);
+	ASSERTU2(pcode_i4_to_u2_convert(0), 0);
+	ASSERTU2(pcode_i4_to_u2_convert(-1), U2_MAX);
+	ASSERTU2(pcode_i4_to_u2_convert(2), 2);
+	ASSERTU2(pcode_i4_to_u2_convert(I4_MAX), U2_MAX);
+	ASSERTU2(pcode_i4_to_u2_convert(I4_MIN), 0);
+}
+
+TEST pcode_i4_to_u4_convert_Main()
+{	extern u4 pcode_i4_to_u4_convert(i4 a);
+	ASSERTU4(pcode_i4_to_u4_convert(0), 0);
+	ASSERTU4(pcode_i4_to_u4_convert(-1), U4_MAX);
+	ASSERTU4(pcode_i4_to_u4_convert(2), 2);
+	ASSERTU4(pcode_i4_to_u4_convert(I4_MAX), I4_MAX);
+	ASSERTU4(pcode_i4_to_u4_convert(I4_MIN), I4_MIN);
+}
+
+TEST pcode_u1_to_i1_convert_Main()
+{	extern i1 pcode_u1_to_i1_convert(u1 a);
+	ASSERTI1(pcode_u1_to_i1_convert(0), 0);
+	ASSERTI1(pcode_u1_to_i1_convert(U1_MAX), -1);
+	ASSERTI1(pcode_u1_to_i1_convert(2), 2);
+	ASSERTI1(pcode_u1_to_i1_convert(I1_MIN), I1_MIN);
+	ASSERTI1(pcode_u1_to_i1_convert(I1_MAX), I1_MAX);
+}
+
+TEST pcode_u1_to_i2_convert_Main()
+{	extern i2 pcode_u1_to_i2_convert(u1 a);
+	ASSERTI2(pcode_u1_to_i2_convert(0), 0);
+	ASSERTI2(pcode_u1_to_i2_convert(U1_MAX), U1_MAX);
+	ASSERTI2(pcode_u1_to_i2_convert(2), 2);
+	ASSERTI2(pcode_u1_to_i2_convert(I1_MIN), 0x80);
+	ASSERTI2(pcode_u1_to_i2_convert(I1_MAX), I1_MAX);
+}
+
+TEST pcode_u1_to_i4_convert_Main()
+{	extern i4 pcode_u1_to_i4_convert(u1 a);
+	ASSERTI4(pcode_u1_to_i4_convert(0), 0);
+	ASSERTI4(pcode_u1_to_i4_convert(U1_MAX), U1_MAX);
+	ASSERTI4(pcode_u1_to_i4_convert(2), 2);
+	ASSERTI4(pcode_u1_to_i4_convert(I1_MIN), 0x80);
+	ASSERTI4(pcode_u1_to_i4_convert(I1_MAX), I1_MAX);
+}
+
+TEST pcode_u1_to_u1_convert_Main()
+{	extern u1 pcode_u1_to_u1_convert(u1 a);
+	ASSERTU1(pcode_u1_to_u1_convert(0), 0);
+	ASSERTU1(pcode_u1_to_u1_convert(2), 2);
+	ASSERTU1(pcode_u1_to_u1_convert(U1_MAX), U1_MAX);
+	ASSERTU1(pcode_u1_to_u1_convert(I1_MAX), I1_MAX);
+	ASSERTU1(pcode_u1_to_u1_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_u1_to_u2_convert_Main()
+{	extern u2 pcode_u1_to_u2_convert(u1 a);
+	ASSERTU2(pcode_u1_to_u2_convert(0), 0);
+	ASSERTU2(pcode_u1_to_u2_convert(2), 2);
+	ASSERTU2(pcode_u1_to_u2_convert(U1_MAX), U1_MAX);
+	ASSERTU2(pcode_u1_to_u2_convert(I1_MAX), I1_MAX);
+	ASSERTU2(pcode_u1_to_u2_convert(I1_MIN), 0x80);
+}
+
+TEST pcode_u1_to_u4_convert_Main()
+{	extern u4 pcode_u1_to_u4_convert(u1 a);
+	ASSERTU4(pcode_u1_to_u4_convert(0), 0);
+	ASSERTU4(pcode_u1_to_u4_convert(2), 2);
+	ASSERTU4(pcode_u1_to_u4_convert(U1_MAX), U1_MAX);
+	ASSERTU4(pcode_u1_to_u4_convert(I1_MAX), I1_MAX);
+	ASSERTU4(pcode_u1_to_u4_convert(I1_MIN), 0x80);
+}
+
+TEST pcode_u2_to_i1_convert_Main()
+{	extern i1 pcode_u2_to_i1_convert(u2 a);
+	ASSERTI1(pcode_u2_to_i1_convert(0), 0);
+	ASSERTI1(pcode_u2_to_i1_convert(2), 2);
+	ASSERTI1(pcode_u2_to_i1_convert(U2_MAX), -1);
+	ASSERTI1(pcode_u2_to_i1_convert(I2_MAX), -1);
+	ASSERTI1(pcode_u2_to_i1_convert(I2_MIN), 0);
+}
+
+TEST pcode_u2_to_i2_convert_Main()
+{	extern i2 pcode_u2_to_i2_convert(u2 a);
+	ASSERTI2(pcode_u2_to_i2_convert(0), 0);
+	ASSERTI2(pcode_u2_to_i2_convert(2), 2);
+	ASSERTI2(pcode_u2_to_i2_convert(U2_MAX), -1);
+	ASSERTI2(pcode_u2_to_i2_convert(I2_MAX), I2_MAX);
+	ASSERTI2(pcode_u2_to_i2_convert(I2_MIN), I2_MIN);
+}
+
+TEST pcode_u2_to_i4_convert_Main()
+{	extern i4 pcode_u2_to_i4_convert(u2 a);
+	ASSERTI4(pcode_u2_to_i4_convert(0), 0);
+	ASSERTI4(pcode_u2_to_i4_convert(2), 2);
+	ASSERTI4(pcode_u2_to_i4_convert(U2_MAX), U2_MAX);
+	ASSERTI4(pcode_u2_to_i4_convert(I2_MAX), I2_MAX);
+	ASSERTI4(pcode_u2_to_i4_convert(I2_MIN), 0x8000);
+}
+
+TEST pcode_u2_to_u1_convert_Main()
+{	extern u1 pcode_u2_to_u1_convert(u2 a);
+	ASSERTU1(pcode_u2_to_u1_convert(0), 0);
+	ASSERTU1(pcode_u2_to_u1_convert(2), 2);
+	ASSERTU1(pcode_u2_to_u1_convert(U2_MAX), U1_MAX);
+	ASSERTU1(pcode_u2_to_u1_convert(I2_MAX), U1_MAX);
+	ASSERTU1(pcode_u2_to_u1_convert(I2_MIN), 0);
+}
+
+TEST pcode_u2_to_u2_convert_Main()
+{	extern u2 pcode_u2_to_u2_convert(u2 a);
+	ASSERTU2(pcode_u2_to_u2_convert(0), 0);
+	ASSERTU2(pcode_u2_to_u2_convert(2), 2);
+	ASSERTU2(pcode_u2_to_u2_convert(U2_MAX), U2_MAX);
+	ASSERTU2(pcode_u2_to_u2_convert(I2_MIN), I2_MIN);
+	ASSERTU2(pcode_u2_to_u2_convert(I2_MAX), I2_MAX);
+}
+
+TEST pcode_u2_to_u4_convert_Main()
+{	extern u4 pcode_u2_to_u4_convert(u2 a);
+	ASSERTU4(pcode_u2_to_u4_convert(0), 0);
+	ASSERTU4(pcode_u2_to_u2_convert(2), 2);
+	ASSERTU4(pcode_u2_to_u4_convert(U2_MAX), U2_MAX);
+	ASSERTU4(pcode_u2_to_u4_convert(I2_MIN), 0x8000);
+	ASSERTU4(pcode_u2_to_u4_convert(I2_MAX), I2_MAX);
+}
+
+TEST pcode_u4_to_i1_convert_Main()
+{	extern i1 pcode_u4_to_i1_convert(u4 a);
+	ASSERTI1(pcode_u4_to_i1_convert(0), 0);
+	ASSERTI1(pcode_u4_to_i1_convert(2), 2);
+	ASSERTI1(pcode_u4_to_i1_convert(U4_MAX), -1);
+	ASSERTI1(pcode_u4_to_i1_convert(U1_MAX), -1);
+	ASSERTI1(pcode_u4_to_i1_convert(I4_MAX), -1);
+	ASSERTI1(pcode_u4_to_i1_convert(I4_MIN), 0);
+	ASSERTI1(pcode_u4_to_i1_convert(I1_MAX), I1_MAX);
+	ASSERTI1(pcode_u4_to_i1_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_u4_to_i2_convert_Main()
+{	extern i2 pcode_u4_to_i2_convert(u4 a);
+	ASSERTI2(pcode_u4_to_i2_convert(0), 0);
+	ASSERTI2(pcode_u4_to_i2_convert(2), 2);
+	ASSERTI2(pcode_u4_to_i2_convert(U4_MAX), -1);
+	ASSERTI2(pcode_u4_to_i2_convert(U2_MAX), -1);
+	ASSERTI2(pcode_u4_to_i2_convert(I4_MAX), -1);
+	ASSERTI2(pcode_u4_to_i2_convert(I4_MIN), 0);
+	ASSERTI2(pcode_u4_to_i2_convert(I2_MAX), I2_MAX);
+	ASSERTI2(pcode_u4_to_i2_convert(I2_MIN), I2_MIN);
+}
+
+TEST pcode_u4_to_i4_convert_Main()
+{	extern i4 pcode_u4_to_i4_convert(u4 a);
+	ASSERTI4(pcode_u4_to_i4_convert(0), 0);
+	ASSERTI4(pcode_u4_to_i4_convert(2), 2);
+	ASSERTI4(pcode_u4_to_i4_convert(U4_MAX), -1);
+	ASSERTI4(pcode_u4_to_i4_convert(I4_MAX), I4_MAX);
+	ASSERTI4(pcode_u4_to_i4_convert(I4_MIN), I4_MIN);
+}
+
+TEST pcode_u4_to_u1_convert_Main()
+{	extern u1 pcode_u4_to_u1_convert(u4 a);
+	ASSERTU1(pcode_u4_to_u1_convert(0), 0);
+	ASSERTU1(pcode_u4_to_u1_convert(2), 2);
+	ASSERTU1(pcode_u4_to_u1_convert(U4_MAX), U1_MAX);
+	ASSERTU1(pcode_u4_to_u1_convert(I4_MAX), U1_MAX);
+	ASSERTU1(pcode_u4_to_u1_convert(I4_MIN), 0);
+}
+
+TEST pcode_u4_to_u2_convert_Main()
+{	extern u2 pcode_u4_to_u2_convert(u4 a);
+	ASSERTU2(pcode_u4_to_u2_convert(0), 0);
+	ASSERTU2(pcode_u4_to_u2_convert(2), 2);
+	ASSERTU2(pcode_u4_to_u2_convert(U4_MAX), U2_MAX);
+	ASSERTU2(pcode_u4_to_u2_convert(I4_MAX), U2_MAX);
+	ASSERTU2(pcode_u4_to_u2_convert(I4_MIN), 0);
+}
+
+TEST pcode_u4_to_u4_convert_Main()
+{	extern u4 pcode_u4_to_u4_convert(u4 a);
+	ASSERTU4(pcode_u4_to_u4_convert(0), 0);
+	ASSERTU4(pcode_u4_to_u4_convert(2), 2);
+	ASSERTU4(pcode_u4_to_u4_convert(U4_MAX), U4_MAX);
+	ASSERTU4(pcode_u4_to_u4_convert(I4_MIN), I4_MIN);
+	ASSERTU4(pcode_u4_to_u4_convert(I4_MAX), I4_MAX);
+}
+
+MAIN CONVERT_main() { }

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_BODY.c
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_BODY.c
@@ -1,0 +1,159 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "pcode_test.h"
+
+
+#define PCODE_CONVERT(typ, typ0)			\
+  typ0 pcode_##typ##_to_##typ0##_convert(typ a) {	\
+    return (typ0)a;					\
+  }
+
+PCODE_CONVERT(i1, i1);
+PCODE_CONVERT(i1, i2);
+PCODE_CONVERT(i1, i4);
+PCODE_CONVERT(i1, u1);
+PCODE_CONVERT(i1, u2);
+PCODE_CONVERT(i1, u4);
+
+PCODE_CONVERT(i2, i1);
+PCODE_CONVERT(i2, i2);
+PCODE_CONVERT(i2, i4);
+PCODE_CONVERT(i2, u1);
+PCODE_CONVERT(i2, u2);
+PCODE_CONVERT(i2, u4);
+
+PCODE_CONVERT(i4, i1);
+PCODE_CONVERT(i4, i2);
+PCODE_CONVERT(i4, i4);
+PCODE_CONVERT(i4, u1);
+PCODE_CONVERT(i4, u2);
+PCODE_CONVERT(i4, u4);
+
+PCODE_CONVERT(u1, i1);
+PCODE_CONVERT(u1, i2);
+PCODE_CONVERT(u1, i4);
+PCODE_CONVERT(u1, u1);
+PCODE_CONVERT(u1, u2);
+PCODE_CONVERT(u1, u4);
+
+PCODE_CONVERT(u2, i1);
+PCODE_CONVERT(u2, i2);
+PCODE_CONVERT(u2, i4);
+PCODE_CONVERT(u2, u1);
+PCODE_CONVERT(u2, u2);
+PCODE_CONVERT(u2, u4);
+
+PCODE_CONVERT(u4, i1);
+PCODE_CONVERT(u4, i2);
+PCODE_CONVERT(u4, i4);
+PCODE_CONVERT(u4, u1);
+PCODE_CONVERT(u4, u2);
+PCODE_CONVERT(u4, u4);
+
+#if defined(HAS_LONGLONG)
+
+PCODE_CONVERT(i8, i1);
+PCODE_CONVERT(i8, i2);
+PCODE_CONVERT(i8, i4);
+PCODE_CONVERT(i8, i8);
+PCODE_CONVERT(i8, u1);
+PCODE_CONVERT(i8, u2);
+PCODE_CONVERT(i8, u4);
+PCODE_CONVERT(i8, u8);
+
+PCODE_CONVERT(u8, i1);
+PCODE_CONVERT(u8, i2);
+PCODE_CONVERT(u8, i4);
+PCODE_CONVERT(u8, i8);
+PCODE_CONVERT(u8, u1);
+PCODE_CONVERT(u8, u2);
+PCODE_CONVERT(u8, u4);
+PCODE_CONVERT(u8, u8);
+
+PCODE_CONVERT(i1, i8);
+PCODE_CONVERT(i2, i8);
+PCODE_CONVERT(i4, i8);
+PCODE_CONVERT(u1, i8);
+PCODE_CONVERT(u2, i8);
+PCODE_CONVERT(u4, i8);
+
+PCODE_CONVERT(i1, u8);
+PCODE_CONVERT(i2, u8);
+PCODE_CONVERT(i4, u8);
+PCODE_CONVERT(u1, u8);
+PCODE_CONVERT(u2, u8);
+PCODE_CONVERT(u4, u8);
+
+#endif // HAS_LONGLONG
+
+
+#if defined(HAS_FLOAT)
+
+PCODE_CONVERT(f4, i1);
+PCODE_CONVERT(f4, i2);
+PCODE_CONVERT(f4, i4);
+PCODE_CONVERT(f4, f4);
+PCODE_CONVERT(f4, u1);
+PCODE_CONVERT(f4, u2);
+PCODE_CONVERT(f4, u4);
+
+PCODE_CONVERT(i1, f4);
+PCODE_CONVERT(i2, f4);
+PCODE_CONVERT(i4, f4);
+PCODE_CONVERT(u1, f4);
+PCODE_CONVERT(u2, f4);
+PCODE_CONVERT(u4, f4);
+
+#if defined(HAS_LONGLONG)
+PCODE_CONVERT(f4, u8);
+PCODE_CONVERT(f4, i8);
+PCODE_CONVERT(u8, f4);
+PCODE_CONVERT(i8, f4);
+#endif // HAS_LONGLONG
+
+#endif // HAS_FLOAT
+
+
+#if defined(HAS_DOUBLE)
+
+PCODE_CONVERT(f8, i1);
+PCODE_CONVERT(f8, i2);
+PCODE_CONVERT(f8, i4);
+PCODE_CONVERT(f8, f8);
+PCODE_CONVERT(f8, u1);
+PCODE_CONVERT(f8, u2);
+PCODE_CONVERT(f8, u4);
+
+PCODE_CONVERT(i1, f8);
+PCODE_CONVERT(i2, f8);
+PCODE_CONVERT(i4, f8);
+PCODE_CONVERT(u1, f8);
+PCODE_CONVERT(u2, f8);
+PCODE_CONVERT(u4, f8);
+
+#if defined(HAS_FLOAT)
+PCODE_CONVERT(f8, f4);
+PCODE_CONVERT(f4, f8);
+#endif // HAS_FLOAT
+
+#if defined(HAS_LONGLONG)
+PCODE_CONVERT(f8, u8);
+PCODE_CONVERT(f8, i8);
+PCODE_CONVERT(u8, f8);
+PCODE_CONVERT(i8, f8);
+#endif // HAS_LONGLONG
+
+#endif // HAS_DOUBLE

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_DOUBLE.test
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_DOUBLE.test
@@ -1,0 +1,106 @@
+#include "pcode_test.h"
+
+TEST pcode_i1_to_f8_convert_main()
+{	extern f8 pcode_i1_to_f8_convert(i1 a);
+	ASSERTF8(pcode_i1_to_f8_convert(0), 0);
+}
+
+TEST pcode_i2_to_f8_convert_main()
+{	extern f8 pcode_i2_to_f8_convert(i2 a);
+	ASSERTF8(pcode_i2_to_f8_convert(0), 0);
+}
+
+TEST pcode_i4_to_f8_convert_main()
+{	extern f8 pcode_i4_to_f8_convert(i4 a);
+	ASSERTF8(pcode_i4_to_f8_convert(0), 0);
+}
+
+TEST pcode_u1_to_f8_convert_main()
+{	extern f8 pcode_u1_to_f8_convert(u1 a);
+	ASSERTF8(pcode_u1_to_f8_convert(0), 0);
+}
+
+TEST pcode_u2_to_f8_convert_main()
+{	extern f8 pcode_u2_to_f8_convert(u2 a);
+	ASSERTF8(pcode_u2_to_f8_convert(0), 0);
+}
+
+TEST pcode_u4_to_f8_convert_main()
+{	extern f8 pcode_u4_to_f8_convert(u4 a);
+	ASSERTF8(pcode_u4_to_f8_convert(0), 0);
+}
+
+TEST pcode_f8_to_i1_convert_main()
+{	extern i1 pcode_f8_to_i1_convert(f8 a);
+	ASSERTI1(pcode_f8_to_i1_convert(0), 0);
+}
+
+TEST pcode_f8_to_i2_convert_main()
+{	extern i2 pcode_f8_to_i2_convert(f8 a);
+	ASSERTI2(pcode_f8_to_i2_convert(0), 0);
+}
+
+TEST pcode_f8_to_i4_convert_main()
+{	extern i4 pcode_f8_to_i4_convert(f8 a);
+	ASSERTI4(pcode_f8_to_i4_convert(0), 0);
+}
+
+TEST pcode_f8_to_u1_convert_main()
+{	extern u1 pcode_f8_to_u1_convert(f8 a);
+	ASSERTU1(pcode_f8_to_u1_convert(0), 0);
+}
+
+TEST pcode_f8_to_u2_convert_main()
+{	extern u2 pcode_f8_to_u2_convert(f8 a);
+	ASSERTU2(pcode_f8_to_u2_convert(0), 0);
+}
+
+TEST pcode_f8_to_u4_convert_main()
+{	extern u4 pcode_f8_to_u4_convert(f8 a);
+	ASSERTU4(pcode_f8_to_u4_convert(0), 0);
+}
+
+TEST pcode_f8_to_f8_convert_main()
+{	extern f8 pcode_f8_to_f8_convert(f8 a);
+	ASSERTF8(pcode_f8_to_f8_convert(0), 0);
+}
+
+#ifdef HAS_LONGLONG
+
+TEST pcode_f8_to_i8_convert_main()
+{	extern i8 pcode_f8_to_i8_convert(f8 a);
+	ASSERTI8(pcode_f8_to_i8_convert(0), 0);
+}
+
+TEST pcode_f8_to_u8_convert_main()
+{	extern u8 pcode_f8_to_u8_convert(f8 a);
+	ASSERTU8(pcode_f8_to_u8_convert(0), 0);
+}
+
+TEST pcode_u8_to_f8_convert_main()
+{	extern f8 pcode_u8_to_f8_convert(u8 a);
+	ASSERTF8(pcode_u8_to_f8_convert(0), 0);
+}
+
+TEST pcode_i8_to_f8_convert_main()
+{	extern f8 pcode_i8_to_f8_convert(i8 a);
+	ASSERTF8(pcode_i8_to_f8_convert(0), 0);
+}
+
+#endif // HAS_LONGLONG
+
+#ifdef HAS_FLOAT
+
+TEST pcode_f8_to_f4_convert_main()
+{	extern f4 pcode_f8_to_f4_convert(f8 a);
+	ASSERTF4(pcode_f8_to_f4_convert(0), 0);
+}
+
+TEST pcode_f4_to_f8_convert_main()
+{	extern f8 pcode_f4_to_f8_convert(f4 a);
+	ASSERTF8(pcode_f4_to_f8_convert(0), 0);
+}
+
+#endif // HAS_FLOAT
+
+MAIN CONVERT_DOUBLE_main() { }

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_FLOAT.test
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_FLOAT.test
@@ -1,0 +1,92 @@
+#include "pcode_test.h"
+
+TEST pcode_i1_to_f4_convert_main()
+{	extern f4 pcode_i1_to_f4_convert(i1 a);
+	ASSERTF4(pcode_i1_to_f4_convert(0), 0);
+}
+
+TEST pcode_i2_to_f4_convert_main()
+{	extern f4 pcode_i2_to_f4_convert(i2 a);
+	ASSERTF4(pcode_i2_to_f4_convert(0), 0);
+}
+
+TEST pcode_i4_to_f4_convert_main()
+{	extern f4 pcode_i4_to_f4_convert(i4 a);
+	ASSERTF4(pcode_i4_to_f4_convert(0), 0);
+}
+
+TEST pcode_u1_to_f4_convert_main()
+{	extern f4 pcode_u1_to_f4_convert(u1 a);
+	ASSERTF4(pcode_u1_to_f4_convert(0), 0);
+}
+
+TEST pcode_u2_to_f4_convert_main()
+{	extern f4 pcode_u2_to_f4_convert(u2 a);
+	ASSERTF4(pcode_u2_to_f4_convert(0), 0);
+}
+
+TEST pcode_u4_to_f4_convert_main()
+{	extern f4 pcode_u4_to_f4_convert(u4 a);
+	ASSERTF4(pcode_u4_to_f4_convert(0), 0);
+}
+
+TEST pcode_f4_to_i1_convert_main()
+{	extern i1 pcode_f4_to_i1_convert(f4 a);
+	ASSERTI1(pcode_f4_to_i1_convert(0), 0);
+}
+
+TEST pcode_f4_to_i2_convert_main()
+{	extern i2 pcode_f4_to_i2_convert(f4 a);
+	ASSERTI2(pcode_f4_to_i2_convert(0), 0);
+}
+
+TEST pcode_f4_to_i4_convert_main()
+{	extern i4 pcode_f4_to_i4_convert(f4 a);
+	ASSERTI4(pcode_f4_to_i4_convert(0), 0);
+}
+
+TEST pcode_f4_to_i8_convert_main()
+{	extern i8 pcode_f4_to_i8_convert(f4 a);
+	ASSERTI8(pcode_f4_to_i8_convert(0), 0);
+}
+
+TEST pcode_f4_to_u1_convert_main()
+{	extern u1 pcode_f4_to_u1_convert(f4 a);
+	ASSERTU1(pcode_f4_to_u1_convert(0), 0);
+}
+
+TEST pcode_f4_to_u2_convert_main()
+{	extern u2 pcode_f4_to_u2_convert(f4 a);
+	ASSERTU2(pcode_f4_to_u2_convert(0), 0);
+}
+
+TEST pcode_f4_to_u4_convert_main()
+{	extern u4 pcode_f4_to_u4_convert(f4 a);
+	ASSERTU4(pcode_f4_to_u4_convert(0), 0);
+}
+
+TEST pcode_f4_to_u8_convert_main()
+{	extern u8 pcode_f4_to_u8_convert(f4 a);
+	ASSERTU8(pcode_f4_to_u8_convert(0), 0);
+}
+
+TEST pcode_f4_to_f4_convert_main()
+{	extern f4 pcode_f4_to_f4_convert(f4 a);
+	ASSERTF4(pcode_f4_to_f4_convert(0), 0);
+}
+
+#ifdef HAS_LONGLONG
+
+TEST pcode_u8_to_f4_convert_main()
+{	extern f4 pcode_u8_to_f4_convert(u8 a);
+	ASSERTF4(pcode_u8_to_f4_convert(0), 0);
+}
+
+TEST pcode_i8_to_f4_convert_main()
+{	extern f4 pcode_i8_to_f4_convert(i8 a);
+	ASSERTF4(pcode_i8_to_f4_convert(0), 0);
+}
+
+#endif // HAS_LONGLONG
+
+MAIN CONVERT_FLOAT_main() { }

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_LONGLONG.test
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/CONVERT_LONGLONG.test
@@ -1,0 +1,283 @@
+#include "pcode_test.h"
+
+TEST pcode_i1_to_i8_convert_main()
+{	extern i8 pcode_i1_to_i8_convert(i1 a);
+	ASSERTI8(pcode_i1_to_i8_convert(0), 0);
+	ASSERTI8(pcode_i1_to_i8_convert(-1), -1);
+	ASSERTI8(pcode_i1_to_i8_convert(2), 2);
+	ASSERTI8(pcode_i1_to_i8_convert(U1_MAX), -1);
+	ASSERTI8(pcode_i1_to_i8_convert(I1_MIN), I1_MIN);
+	ASSERTI8(pcode_i1_to_i8_convert(I1_MAX), I1_MAX);
+}
+
+TEST pcode_i1_to_u8_convert_main()
+{	extern u8 pcode_i1_to_u8_convert(i1 a);
+	ASSERTU8(pcode_i1_to_u8_convert(0), 0);
+	ASSERTU8(pcode_i1_to_u8_convert(-1), -1);
+	ASSERTU8(pcode_i1_to_u8_convert(2), 2);
+	ASSERTU8(pcode_i1_to_u8_convert(I1_MIN), I1_MIN);
+	ASSERTU8(pcode_i1_to_u8_convert(I1_MAX), I1_MAX);
+}
+
+TEST pcode_i2_to_i8_convert_main()
+{	extern i8 pcode_i2_to_i8_convert(i2 a);
+	ASSERTI8(pcode_i2_to_i8_convert(0), 0);
+	ASSERTI8(pcode_i2_to_i8_convert(-1), -1);
+	ASSERTI8(pcode_i2_to_i8_convert(2), 2);
+	ASSERTI8(pcode_i2_to_i8_convert(U2_MAX), -1);
+	ASSERTI8(pcode_i2_to_i8_convert(I2_MIN), I2_MIN);
+	ASSERTI8(pcode_i2_to_i8_convert(I2_MAX), I2_MAX);
+}
+
+TEST pcode_i2_to_u8_convert_main()
+{	extern u8 pcode_i2_to_u8_convert(i2 a);
+	ASSERTU8(pcode_i2_to_u8_convert(0), 0);
+	ASSERTU8(pcode_i2_to_u8_convert(-1), -1);
+	ASSERTU8(pcode_i2_to_u8_convert(2), 2);
+	ASSERTU8(pcode_i2_to_u8_convert(I2_MIN), I2_MIN);
+	ASSERTU8(pcode_i2_to_u8_convert(I2_MAX), I2_MAX);
+}
+
+TEST pcode_i4_to_i8_convert_main()
+{	extern i8 pcode_i4_to_i8_convert(i4 a);
+	ASSERTI8(pcode_i4_to_i8_convert(0), 0);
+	ASSERTI8(pcode_i4_to_i8_convert(-1), -1);
+	ASSERTI8(pcode_i4_to_i8_convert(2), 2);
+	ASSERTI8(pcode_i4_to_i8_convert(U4_MAX), -1);
+	ASSERTI8(pcode_i4_to_i8_convert(I4_MAX), I4_MAX);
+	ASSERTI8(pcode_i4_to_i8_convert(I4_MIN), I4_MIN);
+}
+
+TEST pcode_i4_to_u8_convert_main()
+{	extern u8 pcode_i4_to_u8_convert(i4 a);
+	ASSERTU8(pcode_i4_to_u8_convert(0), 0);
+	ASSERTU8(pcode_i4_to_u8_convert(-1), -1);
+	ASSERTU8(pcode_i4_to_u8_convert(2), 2);
+	ASSERTU8(pcode_i4_to_u8_convert(I4_MAX), I4_MAX);
+	ASSERTU8(pcode_i4_to_u8_convert(I4_MIN), I4_MIN);
+}
+
+TEST pcode_u1_to_i8_convert_main()
+{	extern i8 pcode_u1_to_i8_convert(u1 a);
+	ASSERTI8(pcode_u1_to_i8_convert(0), 0);
+	ASSERTI8(pcode_u1_to_i8_convert(2), 2);
+	ASSERTI8(pcode_u1_to_i8_convert(U1_MAX), U1_MAX);
+	ASSERTI8(pcode_u1_to_i8_convert(I1_MIN), 0x80);
+	ASSERTI8(pcode_u1_to_i8_convert(I1_MAX), I1_MAX);
+}
+
+TEST pcode_u1_to_u8_convert_main()
+{	extern u8 pcode_u1_to_u8_convert(u1 a);
+	ASSERTU8(pcode_u1_to_u8_convert(0), 0);
+	ASSERTU8(pcode_u1_to_u8_convert(2), 2);
+	ASSERTU8(pcode_u1_to_u8_convert(U1_MAX), U1_MAX);
+	ASSERTU8(pcode_u1_to_u8_convert(I1_MIN), 0x80);
+	ASSERTU8(pcode_u1_to_u8_convert(I1_MAX), I1_MAX);
+}
+
+TEST pcode_u2_to_i8_convert_main()
+{	extern i8 pcode_u2_to_i8_convert(u2 a);
+	ASSERTI8(pcode_u2_to_i8_convert(0), 0);
+	ASSERTI8(pcode_u2_to_i8_convert(2), 2);
+	ASSERTI8(pcode_u2_to_i8_convert(U2_MAX), U2_MAX);
+	ASSERTI8(pcode_u2_to_i8_convert(I2_MIN), 0x8000);
+	ASSERTI8(pcode_u2_to_i8_convert(I2_MAX), I2_MAX);
+}
+
+TEST pcode_u2_to_u8_convert_main()
+{	extern u8 pcode_u2_to_u8_convert(u2 a);
+	ASSERTU8(pcode_u2_to_u8_convert(0), 0);
+	ASSERTU8(pcode_u2_to_u8_convert(2), 2);
+	ASSERTU8(pcode_u2_to_u8_convert(U2_MAX), U2_MAX);
+	ASSERTU8(pcode_u2_to_u8_convert(I2_MIN), 0x8000);
+	ASSERTU8(pcode_u2_to_u8_convert(I2_MAX), I2_MAX);
+}
+
+TEST pcode_u4_to_i8_convert_main()
+{	extern i8 pcode_u4_to_i8_convert(u4 a);
+	ASSERTI8(pcode_u4_to_i8_convert(0), 0);
+	ASSERTI8(pcode_u4_to_i8_convert(-1), -1);
+	ASSERTI8(pcode_u4_to_i8_convert(2), 2);
+	ASSERTI8(pcode_u4_to_i8_convert(I4_MIN), I4_MIN);
+	ASSERTI8(pcode_u4_to_i8_convert(I4_MAX), I4_MAX);
+}
+
+TEST pcode_u4_to_u8_convert_main()
+{	extern u8 pcode_u4_to_u8_convert(u4 a);
+	ASSERTU8(pcode_u4_to_u8_convert(0), 0);
+	ASSERTU8(pcode_u4_to_u8_convert(2), 2);
+	ASSERTU8(pcode_u4_to_u8_convert(U4_MAX), U4_MAX);
+	ASSERTU8(pcode_u4_to_u8_convert(I4_MIN), 0x80000000);
+	ASSERTU8(pcode_u4_to_u8_convert(I4_MAX), I4_MAX);
+}
+
+TEST pcode_i8_to_i1_convert_main()
+{	extern i1 pcode_i8_to_i1_convert(i8 a);
+	ASSERTI1(pcode_i8_to_i1_convert(0), 0);
+	ASSERTI1(pcode_i8_to_i1_convert(-1), -1);
+	ASSERTI1(pcode_i8_to_i1_convert(2), 2);
+	ASSERTI1(pcode_i8_to_i1_convert(I8_MIN), 0);
+	ASSERTI1(pcode_i8_to_i1_convert(I8_MAX), U1_MAX);
+	ASSERTI1(pcode_i8_to_i1_convert(U8_MAX), -1);
+	ASSERTI1(pcode_i8_to_i1_convert(I1_MAX), I1_MAX);
+	ASSERTI1(pcode_i8_to_i1_convert(I1_MIN), I1_MIN);
+	ASSERTI1(pcode_i8_to_i1_convert(U1_MAX), U1_MAX);
+}
+
+TEST pcode_i8_to_i2_convert_main()
+{	extern i2 pcode_i8_to_i2_convert(i8 a);
+	ASSERTI2(pcode_i8_to_i2_convert(0), 0);
+	ASSERTI2(pcode_i8_to_i2_convert(-1), -1);
+	ASSERTI2(pcode_i8_to_i2_convert(2), 2);
+	ASSERTI2(pcode_i8_to_i2_convert(I8_MIN), 0);
+	ASSERTI2(pcode_i8_to_i2_convert(I8_MAX), U2_MAX);
+	ASSERTI2(pcode_i8_to_i2_convert(U8_MAX), -1);
+	ASSERTI2(pcode_i8_to_i2_convert(I2_MAX), I2_MAX);
+	ASSERTI2(pcode_i8_to_i2_convert(I2_MIN), I2_MIN);
+	ASSERTI2(pcode_i8_to_i2_convert(U2_MAX), U2_MAX);
+}
+
+TEST pcode_i8_to_i4_convert_main()
+{	extern i4 pcode_i8_to_i4_convert(i8 a);
+	ASSERTI4(pcode_i8_to_i4_convert(0), 0);
+	ASSERTI4(pcode_i8_to_i4_convert(-1), -1);
+	ASSERTI4(pcode_i8_to_i4_convert(2), 2);
+	ASSERTI4(pcode_i8_to_i4_convert(I8_MIN), 0);
+	ASSERTI4(pcode_i8_to_i4_convert(I8_MAX), U4_MAX);
+	ASSERTI4(pcode_i8_to_i4_convert(U8_MAX), -1);
+	ASSERTI4(pcode_i8_to_i4_convert(I4_MAX), I4_MAX);
+	ASSERTI4(pcode_i8_to_i4_convert(I4_MIN), I4_MIN);
+	ASSERTI4(pcode_i8_to_i4_convert(U4_MAX), U4_MAX);
+}
+
+TEST pcode_i8_to_i8_convert_main()
+{	extern i8 pcode_i8_to_i8_convert(i8 a);
+	ASSERTI8(pcode_i8_to_i8_convert(0), 0);
+	ASSERTI8(pcode_i8_to_i8_convert(-1), -1);
+	ASSERTI8(pcode_i8_to_i8_convert(2), 2);
+	ASSERTI8(pcode_i8_to_i8_convert(I8_MAX), I8_MAX);
+	ASSERTI8(pcode_i8_to_i8_convert(I8_MIN), I8_MIN);
+}
+
+TEST pcode_i8_to_u1_convert_main()
+{	extern u1 pcode_i8_to_u1_convert(i8 a);
+	ASSERTU1(pcode_i8_to_u1_convert(0), 0);
+	ASSERTU1(pcode_i8_to_u1_convert(-1), U1_MAX);
+	ASSERTU1(pcode_i8_to_u1_convert(2), 2);
+	ASSERTU1(pcode_i8_to_u1_convert(I8_MAX), U1_MAX);
+	ASSERTU1(pcode_i8_to_u1_convert(I8_MIN), 0);
+	ASSERTU1(pcode_i8_to_u1_convert(U8_MAX), U1_MAX);
+}
+
+TEST pcode_i8_to_u2_convert_main()
+{	extern u2 pcode_i8_to_u2_convert(i8 a);
+	ASSERTU2(pcode_i8_to_u2_convert(0), 0);
+	ASSERTU2(pcode_i8_to_u2_convert(-1), U2_MAX);
+	ASSERTU2(pcode_i8_to_u2_convert(2), 2);
+	ASSERTU2(pcode_i8_to_u2_convert(I8_MAX), U2_MAX);
+	ASSERTU2(pcode_i8_to_u2_convert(I8_MIN), 0);
+	ASSERTU2(pcode_i8_to_u2_convert(U8_MAX), U2_MAX);
+}
+
+TEST pcode_i8_to_u4_convert_main()
+{	extern u4 pcode_i8_to_u4_convert(i8 a);
+	ASSERTU4(pcode_i8_to_u4_convert(0), 0);
+	ASSERTU4(pcode_i8_to_u4_convert(-1), U4_MAX);
+	ASSERTU4(pcode_i8_to_u4_convert(2), 2);
+	ASSERTU4(pcode_i8_to_u4_convert(I8_MAX), U4_MAX);
+	ASSERTU4(pcode_i8_to_u4_convert(I8_MIN), 0);
+	ASSERTU4(pcode_i8_to_u4_convert(U8_MAX), U4_MAX);
+}
+
+TEST pcode_i8_to_u8_convert_main()
+{	extern u8 pcode_i8_to_u8_convert(i8 a);
+	ASSERTU8(pcode_i8_to_u8_convert(0), 0);
+	ASSERTU8(pcode_i8_to_u8_convert(-1), U8_MAX);
+	ASSERTU8(pcode_i8_to_u8_convert(2), 2);
+	ASSERTU4(pcode_i8_to_u4_convert(I8_MAX), I8_MAX);
+	ASSERTU4(pcode_i8_to_u4_convert(I8_MIN), I8_MIN);
+	ASSERTU4(pcode_i8_to_u4_convert(U8_MAX), U8_MAX);
+}
+
+TEST pcode_u8_to_i1_convert_main()
+{	extern i1 pcode_u8_to_i1_convert(u8 a);
+	ASSERTI1(pcode_u8_to_i1_convert(0), 0);
+	ASSERTI1(pcode_u8_to_i1_convert(2), 2);
+	ASSERTI1(pcode_u8_to_i1_convert(U8_MAX), -1);
+	ASSERTI1(pcode_u8_to_i1_convert(U1_MAX), -1);
+	ASSERTI1(pcode_u8_to_i1_convert(I8_MAX), -1);
+	ASSERTI1(pcode_u8_to_i1_convert(I8_MIN), 0);
+	ASSERTI1(pcode_u8_to_i1_convert(I1_MAX), I1_MAX);
+	ASSERTI1(pcode_u8_to_i1_convert(I1_MIN), I1_MIN);
+}
+
+TEST pcode_u8_to_i2_convert_main()
+{	extern i2 pcode_u8_to_i2_convert(u8 a);
+	ASSERTI2(pcode_u8_to_i2_convert(0), 0);
+	ASSERTI2(pcode_u8_to_i2_convert(2), 2);
+	ASSERTI2(pcode_u8_to_i2_convert(U8_MAX), -1);
+	ASSERTI2(pcode_u8_to_i2_convert(U2_MAX), -1);
+	ASSERTI2(pcode_u8_to_i2_convert(I8_MAX), -1);
+	ASSERTI2(pcode_u8_to_i2_convert(I8_MIN), 0);
+	ASSERTI2(pcode_u8_to_i2_convert(I2_MAX), I2_MAX);
+	ASSERTI2(pcode_u8_to_i2_convert(I2_MIN), I2_MIN);
+}
+
+TEST pcode_u8_to_i4_convert_main()
+{	extern i4 pcode_u8_to_i4_convert(u8 a);
+	ASSERTI4(pcode_u8_to_i4_convert(0), 0);
+	ASSERTI4(pcode_u8_to_i4_convert(2), 2);
+	ASSERTI4(pcode_u8_to_i4_convert(U8_MAX), -1);
+	ASSERTI4(pcode_u8_to_i4_convert(U4_MAX), -1);
+	ASSERTI4(pcode_u8_to_i4_convert(I8_MAX), -1);
+	ASSERTI4(pcode_u8_to_i4_convert(I8_MIN), 0);
+	ASSERTI4(pcode_u8_to_i4_convert(I4_MAX), I4_MAX);
+	ASSERTI4(pcode_u8_to_i4_convert(I4_MIN), I4_MIN);
+}
+
+TEST pcode_u8_to_i8_convert_main()
+{	extern i8 pcode_u8_to_i8_convert(u8 a);
+	ASSERTI8(pcode_u8_to_i8_convert(0), 0);
+	ASSERTI8(pcode_u8_to_i8_convert(2), 2);
+	ASSERTI8(pcode_u8_to_i8_convert(U8_MAX), -1);
+	ASSERTI8(pcode_u8_to_i8_convert(I8_MIN), I8_MIN);
+	ASSERTI8(pcode_u8_to_i8_convert(I8_MAX), I8_MAX);
+}
+
+TEST pcode_u8_to_u1_convert_main()
+{	extern u1 pcode_u8_to_u1_convert(u8 a);
+	ASSERTU1(pcode_u8_to_u1_convert(0), 0);
+	ASSERTU1(pcode_u8_to_u1_convert(2), 2);
+	ASSERTU1(pcode_u8_to_u1_convert(U8_MAX), U1_MAX);
+	ASSERTU1(pcode_u8_to_u1_convert(I8_MAX), U1_MAX);
+	ASSERTU1(pcode_u8_to_u1_convert(I8_MIN), 0);
+}
+
+TEST pcode_u8_to_u2_convert_main()
+{	extern u2 pcode_u8_to_u2_convert(u8 a);
+	ASSERTU2(pcode_u8_to_u2_convert(0), 0);
+	ASSERTU2(pcode_u8_to_u2_convert(2), 2);
+	ASSERTU2(pcode_u8_to_u2_convert(U8_MAX), U2_MAX);
+	ASSERTU2(pcode_u8_to_u2_convert(I8_MAX), U2_MAX);
+	ASSERTU2(pcode_u8_to_u2_convert(I8_MIN), 0);
+}
+
+TEST pcode_u8_to_u4_convert_main()
+{	extern u4 pcode_u8_to_u4_convert(u8 a);
+	ASSERTU4(pcode_u8_to_u4_convert(0), 0);
+	ASSERTU4(pcode_u8_to_u4_convert(2), 2);
+	ASSERTU4(pcode_u8_to_u4_convert(U8_MAX), U4_MAX);
+	ASSERTU4(pcode_u8_to_u4_convert(I8_MAX), U4_MAX);
+	ASSERTU4(pcode_u8_to_u4_convert(I8_MIN), 0);
+}
+
+TEST pcode_u8_to_u8_convert_main()
+{	extern u8 pcode_u8_to_u8_convert(u8 a);
+	ASSERTU8(pcode_u8_to_u8_convert(0), 0);
+	ASSERTU8(pcode_u8_to_u8_convert(2), 2);
+	ASSERTU8(pcode_u8_to_u8_convert(U8_MAX), U8_MAX);
+	ASSERTU8(pcode_u8_to_u8_convert(I8_MIN), I8_MIN);
+	ASSERTU8(pcode_u8_to_u8_convert(I8_MAX), I8_MAX);
+}
+
+MAIN CONVERT_LONGLONG_main() { }

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/pcode_defs.py
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/pcode_defs.py
@@ -629,3 +629,75 @@ PCodeTest({
     'has_double': 0,
     'has_longlong': 0,
 })
+
+PCodeTest({
+    'name': 'RV64GC',
+    'build_all': 1,
+    'toolchain': 'RISCV/riscv64-elf',
+    'language_id': 'RISCV:LE:64:RV64GC',
+    'architecture_test': 'RISCV',
+    'ccflags': '-lgcc -march=rv64gc -mabi=lp64d',
+    'has_float': 1,
+    'has_double': 1,
+    'has_longlong': 1,
+})
+
+PCodeTest({
+    'name': 'RV64G',
+    'build_all': 1,
+    'toolchain': 'RISCV/riscv64-elf',
+    'language_id': 'RISCV:LE:64:RV64G',
+    'architecture_test': 'RISCV',
+    'ccflags': '-lgcc -march=rv64g -mabi=lp64d',
+    'has_float': 1,
+    'has_double': 1,
+    'has_longlong': 1,
+})
+
+PCodeTest({
+    'name': 'RV32G',
+    'build_all': 1,
+    'toolchain': 'RISCV/riscv-elf',
+    'language_id': 'RISCV:LE:32:RV32G',
+    'architecture_test': 'RISCV',
+    'ccflags': '-lgcc -march=rv32g -mabi=ilp32d',
+    'has_float': 1,
+    'has_double': 1,
+    'has_longlong': 1,
+})
+
+PCodeTest({
+    'name': 'RV32GC',
+    'build_all': 1,
+    'toolchain': 'RISCV/riscv-elf',
+    'language_id': 'RISCV:LE:32:RV32GC',
+    'architecture_test': 'RISCV',
+    'ccflags': '-lgcc -march=rv32gc -mabi=ilp32d',
+    'has_float': 1,
+    'has_double': 1,
+    'has_longlong': 1,
+})
+
+PCodeTest({
+    'name': 'RV32IMC',
+    'build_all': 1,
+    'toolchain': 'RISCV/riscv-elf',
+    'language_id': 'RISCV:LE:32:RV32IMC',
+    'architecture_test': 'RISCV',
+    'ccflags': '-lgcc -march=rv32imc -mabi=ilp32',
+    'has_float': 0,
+    'has_double': 0,
+    'has_longlong': 0,
+})
+
+PCodeTest({
+    'name': 'RV32IM',
+    'build_all': 1,
+    'toolchain': 'RISCV/riscv-elf',
+    'language_id': 'RISCV:LE:32:RV32IM',
+    'architecture_test': 'RISCV',
+    'ccflags': '-lgcc -march=rv32im -mabi=ilp32',
+    'has_float': 0,
+    'has_double': 0,
+    'has_longlong': 0,
+})

--- a/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/ProcessorEmulatorTestAdapter.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/ProcessorEmulatorTestAdapter.java
@@ -2221,5 +2221,20 @@ public abstract class ProcessorEmulatorTestAdapter extends TestCase implements E
 	public final void test_StructUnionManipulation() {
 		// stub
 	}
+	
+	public final void test_CONVERT() {
+		// stub
+	}
 
+	public final void test_CONVERT_DOUBLE() {
+		// stub
+	}
+	
+	public final void test_CONVERT_FLOAT() {
+		// stub
+	}
+	
+	public final void test_CONVERT_LONGLONG() {
+		// stub
+	}
 }


### PR DESCRIPTION
- adding tests for casting between types
- added RISC-V pcode def
- small build fix for f8 in f4 files
- added missing command line args to default


Adding a bunch of very simple tests that cast between 2 types:
`[u1,i1,u2,i2,u4,i4,u8,i8,f4,f8] * [u1,i1,u2,i2,u4,i4,u8,i8,f4,f8]`


Opening now as a draft to see if there is any feedback with the current approach or any suggestions for similar tests to add in this sort of category.