### PR TITLE
Documentation: Removed non-existing link

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/action/builder/AbstractActionBuilder.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/action/builder/AbstractActionBuilder.java
@@ -227,7 +227,7 @@ public abstract class AbstractActionBuilder<T extends DockingActionIf, B extends
 	 * Configure whether this {@code DockingAction} is enabled.
 	 * 
 	 * <p><b>Note: most clients do not need to use this method.  Enablement is controlled by 
-	 * {@link #validContextWhen(Predicate)} or {@link #validGlobalContextWhen(Predicate)}.
+	 * {@link #validContextWhen(Predicate)}.
 	 * </b>
 	 * 
 	 * @param b {@code true} if enabled


### PR DESCRIPTION
Removed the link to validGlobalContextWhen which was removed in 5dc7df71b3927bae7e7eed312f4ff30a1d385f16