### PR TITLE
Fix importing of function's signature from IDA

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CreateFunctionCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CreateFunctionCmd.java
@@ -213,7 +213,6 @@ public class CreateFunctionCmd extends BackgroundCommand {
 					if (functionModel == null) {
 						functionModel = new PartitionCodeSubModel(program);
 					}
-// TODO: What if function already exists ??
 					if (createFunction(monitor, funcName, functionModel, nameSpace, origEntry,
 						origBody, tmpSource)) {
 						functionsCreated++;
@@ -281,7 +280,8 @@ public class CreateFunctionCmd extends BackgroundCommand {
 				if (!recreateFunction) {
 					long bodySize = functionContaining.getBody().getNumAddresses();
 					if (bodySize != 1) {
-						return false;
+						newFunc = functionContaining;
+						return true;
 					}
 				}
 
@@ -474,7 +474,8 @@ public class CreateFunctionCmd extends BackgroundCommand {
 		if (bodySize > 1) {
 			if (!recreateFunction) {
 				// Function at entry already exists and recreateFunction not enabled
-				return false;
+				newFunc = existingFunction;
+				return true;
 			}
 			// if it is a thunk, then we're done
 			if (resolveThunk(entry, null, monitor)) {

--- a/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
+++ b/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
@@ -1008,7 +1008,7 @@ class XmlExporter(IdaXml):
             demangled = ida_name.get_demangled_name(addr,
                                             DEMANGLED_TYPEINFO,
                                             self.inf.demnames, True)
-            if demangled != None and demangled == "'string'":
+            if demangled != None and (demangled == "'string'" or '(' not in demangled):
                 demangled = None
             outbuf = ''
             outbuf = idaapi.print_type(addr, False)

--- a/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
+++ b/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
@@ -777,6 +777,7 @@ class XmlExporter(IdaXml):
         self.start_element(DATATYPES, True)
         self.export_structures()
         self.export_enums()
+        self.export_hexrays_types()
         self.end_element(DATATYPES)
         self.display_cpu_time(timer)
 
@@ -2184,6 +2185,120 @@ class XmlExporter(IdaXml):
         xml_declaration += "\n<?program_dtd version=\"1\"?>\n"
         self.write_to_xmlfile(xml_declaration)
 
+    def export_hexrays_types(self):
+        """
+        Exports information about standard HexRays datatypes.
+        It's needed for parsing of function's signatures.
+        """
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_BOOL1")
+        self.write_attribute(DATATYPE, "bool")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_BOOL2")
+        self.write_attribute(DATATYPE, "undefined2")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_BOOL4")
+        self.write_attribute(DATATYPE, "undefined4")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "__int8")
+        self.write_attribute(DATATYPE, "sbyte")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "__int16")
+        self.write_attribute(DATATYPE, "sword")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "__int32")
+        self.write_attribute(DATATYPE, "sdword")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "__int64")
+        self.write_attribute(DATATYPE, "sqword")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "__int128")
+        self.write_attribute(DATATYPE, "int16")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_BYTE")
+        self.write_attribute(DATATYPE, "undefined1")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_WORD")
+        self.write_attribute(DATATYPE, "undefined2")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_DWORD")
+        self.write_attribute(DATATYPE, "undefined4")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_QWORD")
+        self.write_attribute(DATATYPE, "undefined8")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_OWORD")
+        self.write_attribute(DATATYPE, "int16")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_TBYTE")
+        self.write_attribute(DATATYPE, "float10")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_UNKNOWN")
+        self.write_attribute(DATATYPE, "undefined")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "BYTE")
+        self.write_attribute(DATATYPE, "undefined1")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "WORD")
+        self.write_attribute(DATATYPE, "undefined2")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "DWORD")
+        self.write_attribute(DATATYPE, "undefined4")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "LONG")
+        self.write_attribute(DATATYPE, "undefined4")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "_QWORD")
+        self.write_attribute(DATATYPE, "undefined8")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "__ptr32")
+        self.write_attribute(DATATYPE, "pointer32")
+        self.close_tag()
+
+        self.start_element(TYPE_DEF)
+        self.write_attribute(NAME, "__ptr64")
+        self.write_attribute(DATATYPE, "pointer64")
+        self.close_tag()
 
 class XmlImporter(IdaXml):
     """


### PR DESCRIPTION
cfce5fa fix problem of exporting thunked function:
```
ERROR (FunctionsXmlMgr) Failed to create function at 00004294: Unable to create function at 00004294
```
The commit may be regressive, but I used Ghidra with merged the PR for a month and there were no problems.

Sadly Ghidra don't support parsing of many calling convention (see `TODO` in the code). I don't change CParser, because it will be very massive for the PR.

Fixes #1492.