### PR TITLE
#1495 AARCH64 Platform

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Architecture.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Architecture.java
@@ -21,6 +21,7 @@ public enum Architecture {
 	X86_64("x86_64", "amd64"),
 	POWERPC("ppc"),
 	POWERPC_64("ppc64"),
+	AARCH64("aarch64"),
 	UNKNOWN("Unknown Architecture");
 
 	/**

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
@@ -1,5 +1,6 @@
 /* ###
  * IP: GHIDRA
+ * REVIEWED: NO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +39,7 @@ public enum Platform {
 	/**
 	 * Identifies a Windows OS, the architecture for which we do not know or have not encountered
 	 */
-	WIN_UNKOWN(OperatingSystem.WINDOWS, Architecture.UNKNOWN, "win32", ".dll", ".exe"),
+	WIN_UNKOWN(OperatingSystem.WINDOWS, Architecture.UNKNOWN, "win64", ".dll", ".exe"),
 
 	/**
 	 * Identifies a Linux OS.
@@ -46,14 +47,19 @@ public enum Platform {
 	LINUX(OperatingSystem.LINUX, Architecture.X86, "linux32", ".so", ""),
 
 	/**
-	 * Identifies a Linux OS.
+	 * Identifies a Linux OS x86-64.
 	 */
 	LINUX_64(OperatingSystem.LINUX, Architecture.X86_64, "linux64", ".so", ""),
 
 	/**
+	 * Identifies a Linux OS x86-64.
+	 */
+	LINUX_AARCH64(OperatingSystem.LINUX, Architecture.AARCH64, "linux64", ".so", ""),
+
+	/**
 	 * Identifies a Linux OS, the architecture for which we do not know or have not encountered
 	 */
-	LINUX_UKNOWN(OperatingSystem.LINUX, Architecture.UNKNOWN, "linux32", ".so", ""),
+	LINUX_UKNOWN(OperatingSystem.LINUX, Architecture.UNKNOWN, "linux64", ".so", ""),
 
 	/**
 	 * Identifies a Mac OS X for the Intel x86 32-bit platform.


### PR DESCRIPTION
AARCH64 was added to the Architecture enum.
All UNKNOWN Platform variants now default to 64 bit since 32 bit platforms are no longer supported.

Might resolve #1495. Needs confirmation that the distributed executables can run on an aarch64 machine running linux. I'm not sure if it's automatically emulated or not.