### PR TITLE
Generalize 6502 processor spec file.

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.pspec
+++ b/Ghidra/Processors/6502/data/languages/6502.pspec
@@ -3,44 +3,14 @@
 <processor_spec>
   <programcounter register="PC"/>
   
-  <volatile outputop="write" inputop="read">
-    <range space="RAM" first="0x0" last="0x20"/>
-  </volatile>
-  
   <default_symbols>
-    <symbol name="PORTA" address="0"/>
-    <symbol name="PORTB" address="1"/>
-    <symbol name="PORTC" address="2"/>
-    <symbol name="PORTD" address="3"/>
-    <symbol name="DDRA" address="4"/>
-    <symbol name="DDRB" address="5"/>
-    <symbol name="DDRC" address="6"/>
-    <symbol name="DDRD" address="7"/>
-    <symbol name="SPCR" address="A"/>
-    <symbol name="SPSR" address="B"/>
-    <symbol name="SPDR" address="C"/>
-    <symbol name="BAUD" address="D"/>
-    <symbol name="SCCR1" address="E"/>
-    <symbol name="SCCR2" address="F"/>
-    <symbol name="SCSR" address="10"/>
-    <symbol name="SCDAT" address="11"/>
-    <symbol name="TCR" address="12"/>
-    <symbol name="TSR" address="13"/>
-    <symbol name="ICHR" address="14"/>
-    <symbol name="ICLR" address="15"/>
-    <symbol name="OCHR" address="16"/>
-    <symbol name="OCLR" address="17"/>
-    <symbol name="CHR" address="18"/>
-    <symbol name="CLR" address="19"/>
-    <symbol name="ACHR" address="1A"/>
-    <symbol name="ACLR" address="1B"/>
     <symbol name="NMI" address="FFFA" entry="true" type="code_ptr"/>
     <symbol name="RES" address="FFFC" entry="true" type="code_ptr"/>
     <symbol name="IRQ" address="FFFE" entry="true" type="code_ptr"/>
   </default_symbols>
   
   <default_memory_blocks>
-    <memory_block name="LOW_RAM" start_address="0x0000" length="0x0100" initialized="false"/>
+    <memory_block name="ZERO_PAGE" start_address="0x0000" length="0x0100" initialized="false"/>
     <memory_block name="STACK" start_address="0x0100" length="0x0100" initialized="false"/>
   </default_memory_blocks>
 </processor_spec>


### PR DESCRIPTION
I've checked a few 6502 datasheets from a few vendors and I wasn't able to find the zero page symbols defined in the processor spec supplied with Ghidra, so I removed those (while leaving the standard three vectors at the very top of the RAM area).  Also, `LOW_RAM` has been renamed to `ZERO_PAGE` which is the commonly known name for the $00-$FF memory range on 6502 processors.