### PR TITLE
Allow setting arbitrary font sizes from 6-32.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/options/OptionsGui.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/options/OptionsGui.java
@@ -22,6 +22,7 @@ import java.beans.PropertyChangeListener;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import javax.swing.*;
 import javax.swing.border.Border;
@@ -130,9 +131,6 @@ public class OptionsGui extends JPanel {
 		MNEMONIC_OVERRIDE, PARAMETER_CUSTOM, PARAMETER_DYNAMIC, REGISTERS, SEPARATOR, UNDERLINE,
 		VARIABLE, VERSION_TRAK, XREF, XREF_OFFCUT, XREF_READ, XREF_WRITE, XREF_OTHER };
 
-	private String[] fontSizes = { "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
-		"17", "18", "20", "22", "24", "30" };
-
 	private Map<Integer, FontMetrics> metricsMap = new HashMap<>();
 
 	private JList<ScreenElement> namesList;
@@ -142,7 +140,7 @@ public class OptionsGui extends JPanel {
 	private JCheckBox boldCheckbox;
 	private JCheckBox italicsCheckbox;
 	private JCheckBox customCheckbox;
-	private JComboBox<String> fontSizeField;
+	private JComboBox<Integer> fontSizeField;
 	private JComboBox<String> fontNameField;
 	private JPanel colorPanel;
 	private int selectedIndex;
@@ -174,7 +172,7 @@ public class OptionsGui extends JPanel {
 		});
 
 		setSelectedFontName(baseFont.getName());
-		fontSizeField.setSelectedItem(Integer.toString(baseFont.getSize()));
+		fontSizeField.setSelectedItem(baseFont.getSize());
 
 		namesList.setSelectedIndex(0);
 		namesList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -346,7 +344,7 @@ public class OptionsGui extends JPanel {
 		fontNameField.setRenderer(new FontRenderer());
 		panel1.add(fontNameField);
 
-		fontSizeField = new GComboBox<>(fontSizes);
+		fontSizeField = new GComboBox<>(IntStream.rangeClosed(6, 32).boxed().toArray(Integer[]::new));
 		fontSizeField.setBackground(Color.white);
 		panel1.add(fontSizeField);
 		panel.add(panel1, BorderLayout.NORTH);
@@ -774,7 +772,7 @@ public class OptionsGui extends JPanel {
 		String name = (String) fontNameField.getSelectedItem();
 		int size = baseFont.getSize();
 		try {
-			size = Integer.parseInt((String) fontSizeField.getSelectedItem());
+			size = (Integer) fontSizeField.getSelectedItem();
 		}
 		catch (Exception e) {
 		}

--- a/Ghidra/Framework/Docking/src/main/java/docking/options/editor/FontPropertyEditor.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/options/editor/FontPropertyEditor.java
@@ -22,6 +22,7 @@ import java.beans.PropertyEditorSupport;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import javax.swing.*;
 
@@ -103,7 +104,7 @@ public class FontPropertyEditor extends PropertyEditorSupport {
 		JLabel fontLabel, sizeLabel, styleLabel;
 		JLabel fontStringLabel;
 		JComboBox<FontWrapper> fonts;
-		JComboBox<String> sizes;
+		JComboBox<Integer> sizes;
 		JComboBox<String> styles;
 		int styleChoice;
 		int sizeChoice;
@@ -170,12 +171,11 @@ public class FontPropertyEditor extends PropertyEditorSupport {
 			fontPanel.add(fonts);
 			fonts.setSelectedItem(fontWrapper);
 
-			sizes = new GComboBox<>(
-				new String[] { "8", "10", "12", "14", "16", "18", "24", "28", "32" });
+			sizes = new GComboBox<>(IntStream.rangeClosed(6, 32).boxed().toArray(Integer[]::new));
 			sizes.setMaximumRowCount(9);
 			sizePanel.add(sizes);
 			sizeChoice = font.getSize();
-			sizes.setSelectedItem("" + sizeChoice);
+			sizes.setSelectedItem(sizeChoice);
 			sizes.setMaximumRowCount(9);
 
 			styles = new GComboBox<>(new String[] { "PLAIN", "BOLD", "ITALIC", "BOLD & ITALIC" });
@@ -203,8 +203,7 @@ public class FontPropertyEditor extends PropertyEditorSupport {
 				styleChoice = styles.getSelectedIndex();
 			}
 			else {
-				String sizeStr = (String) sizes.getSelectedItem();
-				sizeChoice = Integer.parseInt(sizeStr);
+				sizeChoice = (Integer) sizes.getSelectedItem();
 			}
 
 			font = new Font(fontNameChoice, styleChoice, sizeChoice);


### PR DESCRIPTION
Previously, font selection dialogs only allowed setting some font sizes
between 6-32. Moreover, the font selection dialog for listings allowed a
different set of font sizes compared to the font selection dialog used
everywhere else. Make both of these allow all font sizes from 6-32.

Closes #160.