### PR TITLE
Provide a basic .desktop file for Linux

### DIFF
--- a/Ghidra/RuntimeScripts/Linux/ghidra.desktop
+++ b/Ghidra/RuntimeScripts/Linux/ghidra.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Ghidra
+Comment=The Ghidra Software Reverse Engineering (SRE) Suite
+Exec=ghidraRun
+Icon=ghidra
+Terminal=false

--- a/Ghidra/RuntimeScripts/build.gradle
+++ b/Ghidra/RuntimeScripts/build.gradle
@@ -25,6 +25,7 @@ rootProject.OS_NAMES.each { platform ->
 				into "server"
 			}
 			t.from (p.file("Linux/ghidraRun")) 
+			t.from (p.file("Linux/ghidra.desktop"))
 		}
 
 		if (isWindows(platform)) {

--- a/Ghidra/RuntimeScripts/certification.manifest
+++ b/Ghidra/RuntimeScripts/certification.manifest
@@ -10,6 +10,7 @@ Common/support/buildGhidraJarREADME.txt||GHIDRA||||END|
 Common/support/debug.log4j.xml||GHIDRA||||END|
 Common/support/launch.properties||GHIDRA||||END|
 Linux/ghidraRun||GHIDRA||||END|
+Linux/ghidra.desktop||GHIDRA||||END|
 Linux/server/ghidraSvr||GHIDRA||||END|
 Linux/server/svrAdmin||GHIDRA||||END|
 Linux/server/svrInstall||GHIDRA||||END|


### PR DESCRIPTION
Some distributions started to adopt Ghidra into their package repositories, but won't include a .desktop file due to upstream not providing one.

Since Ghidra doesn't have a set default installation location, this .desktop file needs either modification on the users end (to include the full path) or the `ghidraRun` script has to be present in the search PATH (in addition to the icon being present in one of the icon search directories/providing a full path to that as well).