### PR TITLE
Fix an issue with ELFExternalSymbolResolver

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/ELFExternalSymbolResolver.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/ELFExternalSymbolResolver.java
@@ -148,7 +148,12 @@ public class ELFExternalSymbolResolver {
 				continue;
 			}
 			try {
-				s.setNamespace(extLibrary);
+				Symbol parent_symbol = s.getParentSymbol();
+				if (parent_symbol != null && parent_symbol.isExternal()) {
+					parent_symbol.setNamespace(extLibrary);
+				} else {
+					s.setNamespace(extLibrary);
+				}
 				idIterator.remove();
 				libResolvedCount++;
 				Msg.debug(ELFExternalSymbolResolver.class, "External symbol " + extLoc.getLabel() +
@@ -180,13 +185,9 @@ public class ELFExternalSymbolResolver {
 
 	private static Collection<Long> getUnresolvedExternalFunctionIds(Program program) {
 		List<Long> symbolIds = new ArrayList<>();
-		ExternalManager externalManager = program.getExternalManager();
-		Library library = externalManager.getExternalLibrary(Library.UNKNOWN);
-		if (library != null) {
-			for (Symbol s : program.getSymbolTable().getSymbols(library)) {
-				if (s.getSymbolType() == SymbolType.FUNCTION) {
-					symbolIds.add(s.getID());
-				}
+		for (Symbol s : program.getSymbolTable().getExternalSymbols()) {
+			if (s.getSymbolType() == SymbolType.FUNCTION) {
+				symbolIds.add(s.getID());
 			}
 		}
 		return symbolIds;


### PR DESCRIPTION
The ELFExternalSymbolResolver is used to resolve symbols to external libraries.
This PR fixes an issue where it fails to resolve symbols that don't directly live in the \<EXTERNAL\> namespace, but are instead nested under a class namespace within \<EXTERNAL\> .

Tested:
Built Ghidra and ran the FixupELFExternalSymbolsScript.java script. It successfully moved symbols (and the class they were nested under) from the unknown <EXTERNAL> imports bucket to the correct external library.