### PR TITLE
Fix loading PEs with ImageBase == 0 that need relocations

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/BaseRelocationDataDirectory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/BaseRelocationDataDirectory.java
@@ -110,7 +110,8 @@ public class BaseRelocationDataDirectory extends DataDirectory implements ByteAr
             BaseRelocation br = BaseRelocation.createBaseRelocation(reader, addr);
 
             // Sanity check to make sure the data looks OK.
-            if (br.getVirtualAddress() == 0)
+            // VA of 0 is normal for example for SMM drivers.
+            if (br.getVirtualAddress() < 0)
                 break;
             if (br.getSizeOfBlock() < BaseRelocation.IMAGE_SIZEOF_BASE_RELOCATION)
                 break;


### PR DESCRIPTION
SMM Drivers usually (and other PEs, I'm sure) have an ImageBase of 0 but have relocations, so they could be rebased and relocated.

There are two problems here:

1. The PE loader rebases a PE with ImageBase == 0, which isn't necessary, but not a problem in itself
2. Relocations aren't applied when VA == 0, so the PE is first rebased but then flagged as non-relocatable

In combination, this of course causes erroneous loading of the PE and additionally, there is no error message pointing out this problematic combination.

Rebasing PEs with an ImageBase of 0 is debateable, but of course, relocations have to work correctly, if rebasing is done.