### PR TITLE
Control Flow Guard: Create proper CFG table/array and provide Analyzer

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/LoadConfigDirectory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/LoadConfigDirectory.java
@@ -253,6 +253,26 @@ public class LoadConfigDirectory implements StructConverter {
 	public long getCfgFunctionCount() {
 		return guardCfFunctionCount;
 	}
+	
+	/**
+	 * Gets the ControlFlowGuard IAT table pointer address.
+	 * 
+	 * @return The ControlFlowGuard IAT table function pointer address.  
+	 *   Could be 0 if ControlFlowGuard is not being used or the target is not a driver.
+	 */
+	public long getGuardAdressIatTableTablePointer() {
+		return guardAddressTakenIatEntryTable;
+	}
+
+	/**
+	 * Gets the ControlFlowGuard IAT entries count.
+	 * 
+	 * @return The ControlFlowGuard IAT entries count.  Could be 0 if ControlFlowGuard is 
+	 *   not being used or if the target is not a driver.
+	 */
+	public long getGuardAdressIatTableCount() {
+		return guardAddressTakenIatEntryCount;
+	}
 
 	/**
 	 * Gets the ReturnFlowGuard failure routine address.

--- a/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/CfgAnalyzer.java
+++ b/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/CfgAnalyzer.java
@@ -14,6 +14,7 @@ import ghidra.framework.cmd.Command;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.listing.Data;
+import ghidra.program.model.listing.FunctionManager;
 import ghidra.program.model.listing.Listing;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.mem.Memory;
@@ -65,8 +66,13 @@ public class CfgAnalyzer extends AbstractAnalyzer {
 			return true;
 		}
 
+		FunctionManager funcMgr = program.getFunctionManager();
 		Command cmd = null;
 		for (Address target : getFunctionAddressesFromTable(program, tableData)) {
+			if (funcMgr.getFunctionAt(target) != null) {
+				// if there already is a function, just bail...
+				continue;
+			}
 			cmd = new DisassembleCommand(target, null, true);
 			cmd.applyTo(program);
 

--- a/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/CfgAnalyzer.java
+++ b/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/CfgAnalyzer.java
@@ -1,3 +1,18 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ghidra.app.plugin.prototype.MicrosoftCodeAnalyzerPlugin;
 
 import java.util.ArrayList;
@@ -69,15 +84,14 @@ public class CfgAnalyzer extends AbstractAnalyzer {
 		FunctionManager funcMgr = program.getFunctionManager();
 		Command cmd = null;
 		for (Address target : getFunctionAddressesFromTable(program, tableData)) {
-			if (funcMgr.getFunctionAt(target) != null) {
-				// if there already is a function, just bail...
-				continue;
+			if (listing.getInstructionAt(target) == null) {
+				cmd = new DisassembleCommand(target, null, true);
+				cmd.applyTo(program);
 			}
-			cmd = new DisassembleCommand(target, null, true);
-			cmd.applyTo(program);
-
-			cmd = new CreateFunctionCmd(target);
-			cmd.applyTo(program);
+			if (funcMgr.getFunctionAt(target) == null) {
+				cmd = new CreateFunctionCmd(target);
+				cmd.applyTo(program);
+			}
 		}
 
 		return true;

--- a/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/CfgAnalyzer.java
+++ b/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/CfgAnalyzer.java
@@ -1,0 +1,109 @@
+package ghidra.app.plugin.prototype.MicrosoftCodeAnalyzerPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ghidra.app.cmd.disassemble.DisassembleCommand;
+import ghidra.app.cmd.function.CreateFunctionCmd;
+import ghidra.app.services.AbstractAnalyzer;
+import ghidra.app.services.AnalysisPriority;
+import ghidra.app.services.AnalyzerType;
+import ghidra.app.util.bin.format.pe.ControlFlowGuard;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.framework.cmd.Command;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.listing.Data;
+import ghidra.program.model.listing.Listing;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.mem.MemoryAccessException;
+import ghidra.program.model.symbol.SourceType;
+import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.symbol.SymbolTable;
+import ghidra.program.model.symbol.SymbolType;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.task.TaskMonitor;
+
+/**
+ * Finds Control Flow Guard data structures (annotated by the Importer) within a Windows program. 
+ * It disassembles and creates functions from the CFG Tables.
+ */
+public class CfgAnalyzer extends AbstractAnalyzer {
+	private static final String NAME = "Control Flow Guard Analyzer";
+	private static final String DESCRIPTION =
+			"Creates functions from GuardCFFunctionTable if present.";
+	private Address cfgTableAddr = null;
+
+	public CfgAnalyzer() {
+		super(NAME, DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
+		setSupportsOneTimeAnalysis();
+		// TODO(marpie): the perfect time to run would be after the PDB importer, but 
+		//                how could that be specified? For now, just use the same as the RTTI Analyzer.
+		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.before().before());
+		setDefaultEnablement(true);
+	}
+
+	@Override
+	public boolean canAnalyze(Program program) {
+		return checkCfgPresence(program);
+	}
+
+	@Override
+	public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
+			throws CancelledException {
+		if (cfgTableAddr == null) {
+			log.appendMsg(this.getName(), "Couldn't find Control Flow Guard tables.");
+			return true;
+		}
+
+		Listing listing = program.getListing();
+
+		Data tableData = listing.getDataAt(cfgTableAddr);
+		if (!tableData.isArray() || (tableData.getNumComponents() < 1)) {
+			log.appendMsg(this.getName(), "Control Flow Guard table seems to be empty.");
+			return true;
+		}
+
+		Command cmd = null;
+		for (Address target : getFunctionAddressesFromTable(program, tableData)) {
+			cmd = new DisassembleCommand(target, null, true);
+			cmd.applyTo(program);
+
+			cmd = new CreateFunctionCmd(target);
+			cmd.applyTo(program);
+		}
+
+		return true;
+	}
+
+	private boolean checkCfgPresence(Program program) {
+		SymbolTable table = program.getSymbolTable();
+		for (Symbol symbol : table.getSymbols(ControlFlowGuard.GuardCFFunctionTableName)) {
+			if ((symbol.getSymbolType() == SymbolType.LABEL) && (symbol.getSource() == SourceType.IMPORTED)) {
+				cfgTableAddr = symbol.getAddress();
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private List<Address> getFunctionAddressesFromTable(Program program, Data table) {
+		List<Address> list = new ArrayList<Address>();
+
+		Address imageBase = program.getImageBase();
+		Memory mem = program.getMemory();
+		long offset = 0;
+		for (int i = 0; i < table.getNumComponents(); i++) {
+			Data entry = table.getComponent(i);
+			try {
+				offset = mem.getInt(entry.getAddress());
+			} catch (MemoryAccessException e) {
+				// just assume everything else will also fail and bail here
+				break;
+			}
+			list.add(imageBase.add(offset));
+		}
+		return list;
+	}
+}


### PR DESCRIPTION
As described in #1547 the functions in `GuardCFFunctionTable` are not used in later stages to create functions from them. The table is a ideal candidate to identify valid functions so it should be utilized. 

This PR changes the `ControlFlowGuard` class to create a proper table by creating a structure for every function entry (including the possible padding), then creating an array at `GuardCFFunctionTable`.

This enables a later Analyzer to pick up that array, iterate it to disassemble the instructions and create proper functions.

**Open Issues**

  * The Analyzer should optimally run after a possible PDB Analyzer that created the correct function-lables / functions.
  * I don't know how to properly use the Structure I created in the analyzer. Ideally I would like to iterate the array, get the structure and use entry.Offset or something to get the offset. In the current state I simply assume that the start of the entry points to the ibo32 and read that.
