### PR TITLE
Make "Override Signature" work for tail-call-optimized calls.

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/OverridePrototypeAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/OverridePrototypeAction.java
@@ -108,7 +108,8 @@ public class OverridePrototypeAction extends AbstractDecompilerAction {
 		if (instr == null) {
 			return null;
 		}
-		if (!instr.getFlowType().isCall()) {
+		if (!instr.getFlowType().isCall() &&
+			!instr.getFlowType().isJump()) {
 			return null;
 		}
 		ClangFunction cfunc = tokenAtCursor.getClangFunction();


### PR DESCRIPTION
For jump instructions that aren't optimized calls, the function should still return null because it won't find a CALL/CALLIND pcode op.