### PR TITLE
68000: Fix MOVE USP,x and MOVE x,USP opcodes

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -1084,8 +1084,8 @@ macro shiftCXFlags(cntreg) {
 :move eaw,"CCR"			is (opbig=0x44 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ unpackflags(eaw); }
 :move SR,eaw			is SR; (opbig=0x40 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ packflags(SR); eaw = SR; }
 :move eaw,SR			is SR; (opbig=0x46 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ SR = eaw; unpackflags(SR); }
-:move "USP",regan		is opbig=0x4e & op37=13 & regan				{ regan = SP; }
-:move regan,"USP"		is opbig=0x4e & op37=12 & regan				{ SP = regan; }
+:move USP,regan			is opbig=0x4e & op37=13 & regan & USP			{ regan = USP; }
+:move regan,USP			is opbig=0x4e & op37=12 & regan & USP			{ USP = regan; }
  
 :movea.w eaw,reg9an		is (op=3 & reg9an & mode2=1)... & eaw				{ reg9an = sext(eaw); }
 :movea.l eal,reg9an		is (op=2 & reg9an & mode2=1)... & eal				{ reg9an = eal; }

--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -1084,8 +1084,8 @@ macro shiftCXFlags(cntreg) {
 :move eaw,"CCR"			is (opbig=0x44 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ unpackflags(eaw); }
 :move SR,eaw			is SR; (opbig=0x40 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ packflags(SR); eaw = SR; }
 :move eaw,SR			is SR; (opbig=0x46 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ SR = eaw; unpackflags(SR); }
-:move SP,regan			is SP; opbig=0x4e & op37=13 & regan				{ regan = SP; }
-:move regan,SP			is SP; opbig=0x4e & op37=12 & regan				{ SP = regan; }
+:move "USP",regan		is opbig=0x4e & op37=13 & regan				{ regan = SP; }
+:move regan,"USP"		is opbig=0x4e & op37=12 & regan				{ SP = regan; }
  
 :movea.w eaw,reg9an		is (op=3 & reg9an & mode2=1)... & eaw				{ reg9an = sext(eaw); }
 :movea.l eal,reg9an		is (op=2 & reg9an & mode2=1)... & eal				{ reg9an = eal; }


### PR DESCRIPTION
On the MC680x0 processor, the opcodes 0x4E6_x_ are disassembled as `MOVE SP,x` or `MOVE x,SP` even though their correct designation is `MOVE USP,x` or `MOVE x,USP`, where `USP` is the "user stack pointer". See this excerpt from the _Programmer's Reference Manual_:
![move-usp](https://user-images.githubusercontent.com/9830685/75815965-9a179080-5d94-11ea-981a-e7ace73c9455.png)

This becomes particularly confusing when the source or destination register is `A7` (the stack pointer), because in this case a `MOVE SP,SP` is disassembled.

This pull request fixes the disassembly to use `USP` instead. Please note that this is my first modification of a Ghidra SLA specification, so please mention any subtleties that I might have overlooked.
