### PR TITLE
macOS DYLD support

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldArchitecture.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldArchitecture.java
@@ -33,6 +33,7 @@ public final class DyldArchitecture {
 	// @formatter:off
 	public final static DyldArchitecture X86     = new DyldArchitecture( CpuTypes.CPU_TYPE_X86,     CpuSubTypes.CPU_SUBTYPE_MULTIPLE, "dyld_v1    i386", "i386",    Endian.LITTLE );
 	public final static DyldArchitecture X86_64  = new DyldArchitecture( CpuTypes.CPU_TYPE_X86_64,  CpuSubTypes.CPU_SUBTYPE_MULTIPLE, "dyld_v1  x86_64", "x86_64",  Endian.LITTLE );
+	public final static DyldArchitecture X86_64h = new DyldArchitecture( CpuTypes.CPU_TYPE_X86_64,  CpuSubTypes.CPU_SUBTYPE_MULTIPLE, "dyld_v1 x86_64h", "x86_64",  Endian.LITTLE );
 	public final static DyldArchitecture POWERPC = new DyldArchitecture( CpuTypes.CPU_TYPE_POWERPC, CpuSubTypes.CPU_SUBTYPE_MULTIPLE, "dyld_v1     ppc", "rosetta", Endian.BIG );
 	public final static DyldArchitecture ARMV6   = new DyldArchitecture( CpuTypes.CPU_TYPE_ARM,     CpuSubTypes.CPU_SUBTYPE_ARM_V6,   "dyld_v1   armv6", "armv6",   Endian.LITTLE );
 	public final static DyldArchitecture ARMV7   = new DyldArchitecture( CpuTypes.CPU_TYPE_ARM,     CpuSubTypes.CPU_SUBTYPE_ARM_V7,   "dyld_v1   armv7", "arm7",    Endian.LITTLE );
@@ -43,7 +44,7 @@ public final class DyldArchitecture {
 	public final static DyldArchitecture ARMV8Ae = new DyldArchitecture(CpuTypes.CPU_TYPE_ARM_64,   CpuSubTypes.CPU_SUBTYPE_MULTIPLE, "dyld_v1  arm64e", "AARCH64", Endian.LITTLE);
 
 	
-	public final static DyldArchitecture [] ARCHITECTURES = new DyldArchitecture [] { X86, X86_64, POWERPC, ARMV6, ARMV7, ARMV7F, ARMV7S, ARMV7K, ARMV8A, ARMV8Ae };
+	public final static DyldArchitecture [] ARCHITECTURES = new DyldArchitecture [] { X86, X86_64, X86_64h, POWERPC, ARMV6, ARMV7, ARMV7F, ARMV7S, ARMV7K, ARMV8A, ARMV8Ae };
 	// @formatter:on
 	
 	/**
@@ -114,7 +115,7 @@ public final class DyldArchitecture {
 		if ( this == X86 ) {
             return new LanguageCompilerSpecPair( new LanguageID("x86:LE:32:default"), new CompilerSpecID("gcc") );
 		}
-		else if ( this == X86_64 ) {
+		else if (this == X86_64 || this == X86_64h) {
 			return new LanguageCompilerSpecPair( new LanguageID("x86:LE:64:default"), new CompilerSpecID("gcc") );
 		}
 		else if ( this == POWERPC ) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheHeader.java
@@ -378,6 +378,9 @@ public class DyldCacheHeader implements StructConverter {
 	}
 
 	private void parseImageInfo(MessageLog log, TaskMonitor monitor) throws CancelledException {
+		if (imagesOffset == 0) {
+			return;
+		}
 		monitor.setMessage("Parsing DYLD image info...");
 		monitor.initialize(imagesCount);
 		try {
@@ -395,6 +398,9 @@ public class DyldCacheHeader implements StructConverter {
 	}
 
 	private void parseSlideInfo(MessageLog log, TaskMonitor monitor) throws CancelledException {
+		if (slideInfoOffset == 0) {
+			return;
+		}
 		monitor.setMessage("Parsing DYLD slide info...");
 		monitor.initialize(1);
 		try {
@@ -424,6 +430,9 @@ public class DyldCacheHeader implements StructConverter {
 
 	private void parseLocalSymbolsInfo(MessageLog log, TaskMonitor monitor)
 			throws CancelledException {
+		if (localSymbolsOffset == 0) {
+			return;
+		}
 		monitor.setMessage("Parsing DYLD local symbols info...");
 		monitor.initialize(1);
 		try {
@@ -439,6 +448,9 @@ public class DyldCacheHeader implements StructConverter {
 	}
 
 	private void parseBranchPools(MessageLog log, TaskMonitor monitor) throws CancelledException {
+		if (branchPoolsOffset == 0) {
+			return;
+		}
 		monitor.setMessage("Parsing DYLD branch pool addresses...");
 		monitor.initialize(branchPoolsCount);
 		try {
@@ -455,6 +467,9 @@ public class DyldCacheHeader implements StructConverter {
 	}
 
 	private void parseImageTextInfo(MessageLog log, TaskMonitor monitor) throws CancelledException {
+		if (imagesTextOffset == 0) {
+			return;
+		}
 		monitor.setMessage("Parsing DYLD image text info...");
 		monitor.initialize(imagesTextCount);
 		try {
@@ -473,6 +488,9 @@ public class DyldCacheHeader implements StructConverter {
 
 	private void parseAcceleratorInfo(Program program, AddressSpace space, MessageLog log,
 			TaskMonitor monitor) throws CancelledException {
+		if (accelerateInfoAddr == 0) {
+			return;
+		}
 		monitor.setMessage("Parsing DYLD accelerateor info...");
 		monitor.initialize(imagesTextCount);
 		try {
@@ -605,7 +623,7 @@ public class DyldCacheHeader implements StructConverter {
 		monitor.initialize(branchPoolList.size());
 		try {
 			Address addr = fileOffsetToAddr(branchPoolsOffset, program, space);
-			for (int i = 0; i < branchPoolList.size(); i++) {
+			for (Long element : branchPoolList) {
 				Data d = DataUtilities.createData(program, addr, Pointer64DataType.dataType,
 					Pointer64DataType.dataType.getLength(), false,
 					DataUtilities.ClearDataMode.CHECK_FOR_SPACE);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MachoProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MachoProgramBuilder.java
@@ -41,7 +41,8 @@ import ghidra.program.model.mem.*;
 import ghidra.program.model.reloc.RelocationTable;
 import ghidra.program.model.symbol.*;
 import ghidra.program.model.util.CodeUnitInsertionException;
-import ghidra.util.*;
+import ghidra.util.DataConverter;
+import ghidra.util.Msg;
 import ghidra.util.exception.DuplicateNameException;
 import ghidra.util.exception.InvalidInputException;
 import ghidra.util.task.TaskMonitor;
@@ -296,8 +297,9 @@ public class MachoProgramBuilder {
 			long dataLength, String comment, String source, boolean r, boolean w, boolean x,
 			boolean zeroFill) throws Exception {
 
-		// iOS 12 address fixup
-		if ((start.getOffset() & 0xfff000000000L) != 0) {
+		// iOS 12 chained pointer address fixup (does not apply to x86)
+		if (!program.getLanguageID().getIdAsString().startsWith("x86") &&
+			(start.getOffset() & 0xfff000000000L) != 0) {
 			start = space.getAddress(start.getOffset() | 0xffff000000000000L);
 		}
 

--- a/Ghidra/Processors/x86/data/languages/x86.opinion
+++ b/Ghidra/Processors/x86/data/languages/x86.opinion
@@ -43,6 +43,9 @@
         <constraint primary="7"        processor="x86"     endian="little" size="32" />
         <constraint primary="16777223" processor="x86"     endian="little" size="64" />
     </constraint>
+    <constraint loader="DYLD Cache" compilerSpecID="gcc">
+        <constraint primary="x86_64"   processor="x86"     endian="little" size="64" />
+    </constraint>
     <constraint loader="Common Object File Format (COFF)" compilerSpecID="gcc">
         <constraint primary="332"     processor="x86"          endian="little" size="32" />
         <constraint primary="-31132"  processor="x86"          endian="little" size="64" />


### PR DESCRIPTION
DYLD loader can now load x86_64 DYLD from macOS.  Fixes #1566.  