### PR TITLE
68000: add m68k/SVR4 DWARF register mappings

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.dwarf
+++ b/Ghidra/Processors/68000/data/languages/68000.dwarf
@@ -1,0 +1,10 @@
+<dwarf>
+	<register_mappings>
+		<register_mapping dwarf="0" ghidra="D0" auto_count="8"/> <!-- D0..D7 -->
+
+		<register_mapping dwarf="8" ghidra="A0" auto_count="7"/> <!-- A0..A6 -->
+		<register_mapping dwarf="15" ghidra="SP" stackpointer="true"/>
+
+		<register_mapping dwarf="16" ghidra="FP0" auto_count="8"/> <!-- FP0..FP7 -->
+	</register_mappings>
+</dwarf>

--- a/Ghidra/Processors/68000/data/languages/68000.ldefs
+++ b/Ghidra/Processors/68000/data/languages/68000.ldefs
@@ -16,6 +16,7 @@
     <external_name tool="IDA-PRO" name="68000"/>
     <external_name tool="IDA-PRO" name="68040"/>
     <external_name tool="IDA-PRO" name="68K"/>
+    <external_name tool="DWARF.register.mapping.file" name="68000.dwarf"/>
   </language>
   <language processor="68000"
             endian="big"
@@ -30,6 +31,7 @@
     <compiler name="default" spec="68000.cspec" id="default"/>
     <external_name tool="gnu" name="m68k:68030"/>
     <external_name tool="IDA-PRO" name="68030"/>
+    <external_name tool="DWARF.register.mapping.file" name="68000.dwarf"/>
   </language>
   <language processor="68000"
             endian="big"
@@ -46,6 +48,7 @@
     <external_name tool="IDA-PRO" name="68010"/>
     <external_name tool="IDA-PRO" name="68020"/>
     <external_name tool="IDA-PRO" name="68020EX"/>
+    <external_name tool="DWARF.register.mapping.file" name="68000.dwarf"/>
   </language>
   <language processor="68000"
             endian="big"
@@ -59,5 +62,6 @@
     <description>Motorola 32-bit Coldfire</description>
     <compiler name="default" spec="68000.cspec" id="default"/>
     <external_name tool="IDA-PRO" name="colfire"/>
+    <external_name tool="DWARF.register.mapping.file" name="68000.dwarf"/>
   </language>
 </language_definitions>


### PR DESCRIPTION
When performing analysis on a Coldfire ELF binary, the error `No DWARF to Ghidra register mappings found for this program's language [68000:BE:32:Coldfire], unable to import functions` is emitted, because no mapping file exists for 68000.

This commit adds such a mapping, based on [what gcc says should be used for m68k/SVR4](https://github.com/gcc-mirror/gcc/blob/releases/gcc-9.2.0/gcc/config/m68k/m68kelf.h#L98); D0-D7, followed by A0-A6 and A7/SP, followed by FP0-FP7.