### PR TITLE
Load jar modules/extensions in development mode

### DIFF
--- a/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraLauncher.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraLauncher.java
@@ -62,8 +62,9 @@ public class GhidraLauncher {
 		}
 		else {
 			addPatchPaths(classpathList, layout.getPatchDir());
-			addModuleJarPaths(classpathList, modules);
 		}
+		addModuleJarPaths(classpathList, modules);
+		
 		classpathList = orderClasspath(classpathList, modules);
 
 		// Add the classpath to the class loader


### PR DESCRIPTION
**Describe the bug**

If in development mode (SystemUtilities.isInDevelopmentMode()) aka launched from eclipse, Ghidra will only load plugins from the Extensions/[extname]/bin/main/[...]/*.class files. Plugins in .jar-Format aren't loaded correctly (They are shown in the Extension explorer, but not loaded).

fixes #1615