### PR TITLE
Fix typo in the README file for the IDA scripts version 7XX

### DIFF
--- a/GhidraBuild/IDAPro/Python/7xx/README.html
+++ b/GhidraBuild/IDAPro/Python/7xx/README.html
@@ -11,7 +11,7 @@
     <h1>XML Exporter for IDA version 7</h1>
     <p>
       The 7XX versions of the XML Exporter, Importer, and Loader can only be used
-      with IDA version 7.0 are greater.
+      with IDA version 7.0 and greater.
     </p>
     <p>
       <filename>xml_exporter.py</filename> is a plugin to export an IDA database as an XML file.


### PR DESCRIPTION
This commit fixes a typo in the README file for the IDA scripts version 7XX ("are" in place of "and").