### PR TITLE
tricore CFSR wrong space

### DIFF
--- a/Ghidra/Processors/tricore/data/languages/tricore.sinc
+++ b/Ghidra/Processors/tricore/data/languages/tricore.sinc
@@ -5042,13 +5042,13 @@ macro multiply_u_u(mres0, rega, regb, n) {
 # MFCR D[c], const16 (RLC)
 :mfcr Rd2831,const1227Z is PCPMode=0 & ( op0007=0x4d & op0811=0x0 ; Rd2831 ) & const1227Z
 {
-	Rd2831 = *[register]:4 const1227Z;
+	Rd2831 = *[ram]:4 const1227Z;
 }
 
 @if defined(TRICORE_V2)
 :mffr Rd2831,Rd0811 is PCPMode=0 & Rd0811 & op0007=0x4b & op1215=0x0 ; Rd2831 & op1627=0x1d1
 {
-	Rd2831 = *[register]:4 Rd0811;
+	Rd2831 = *[ram]:4 Rd0811;
 }
 @endif
 
@@ -6364,13 +6364,13 @@ macro multiply_u_u(mres0, rega, regb, n) {
 # MTCR const16, D[a] (RLC)
 :mtcr const1227Z,Rd0811 is PCPMode=0 & ( Rd0811 & op0007=0xcd ; op2831=0x0 ) & const1227Z
 {
-	*[register]:4 const1227Z = Rd0811;
+	*[ram]:4 const1227Z = Rd0811;
 }
 
 @if defined(TRICORE_V2)
 :mtfr Rd0811,Rd1215 is PCPMode=0 & Rd0811 & Rd1215 & op0007=0x4b ; op1631=0x1c1
 {
-	*[register]:4 Rd1215 = Rd0811;
+	*[ram]:4 Rd1215 = Rd0811;
 }
 @endif
 


### PR DESCRIPTION
CFSR access was using the register address space instead of the ram address space.  

This fixes 4 instructions: to and from using a const or a register.  These were the only 4 to use `[register]`, probably an artifact that didn't get fixed when I was still figuring out the memory mapped registers.

reported (w/ fix) by @ABratovic  fixes #1630