### PR TITLE
CppExporter: Add missing semi-colon for function prototypes in headers

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
@@ -220,7 +220,7 @@ public class CppExporter extends Exporter {
 			}
 			String headerCode = result.getHeaderCode();
 			if (headerCode != null) {
-				headers.append(headerCode);
+				headers.append(headerCode + ";");
 				headers.append(EOL);
 			}
 


### PR DESCRIPTION
When the CREATE_HEADER_FILE is "true" in the CppExporter, function
prototypes get written to the exported header, but the prototypes lack
the semi-colon, and thus fails a syntax check. This fixes that glitch,
by adding the semi-colon during the function prototype export. The code
should be unchanged for the .c export file, in either case.