### PR TITLE
Sleigh token fields bounds

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/antlr/ghidra/sleigh/grammar/SleighCompiler.g
+++ b/Ghidra/Framework/SoftwareModeling/src/main/antlr/ghidra/sleigh/grammar/SleighCompiler.g
@@ -212,7 +212,11 @@ fielddef
 		} fieldmods) {
 			if ($fielddef.size() > 0 && $fielddef::fieldQuality != null) {
 				if ($tokendef.size() > 0 && $tokendef::tokenSymbol != null) {
-					sc.addTokenField(find(n), $tokendef::tokenSymbol, $fielddef::fieldQuality);
+					if ($tokendef::tokenSymbol.getToken().getSize()*8 <= $fielddef::fieldQuality.high) {
+						reportError(find($t), "field high must be less than token size");
+					} else {
+						sc.addTokenField(find(n), $tokendef::tokenSymbol, $fielddef::fieldQuality);
+					}
 				} else if ($contextdef.size() > 0 && $contextdef::varnode != null) {
 					if (!sc.addContextField($contextdef::varnode, $fielddef::fieldQuality)) {
 						reportError(find($t), "all context definitions must come before constructors");


### PR DESCRIPTION
A token field should be bound by the size of the token.  Avoid invalid fields, most likely off-by-one errors.

This will make sleigh compile error out with a message: "field high must be less than token size" if the high value of the field is greater than or equal to the byte aligned size of the token.