### PR TITLE
Fix ELF header component ordinals bug

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -1707,7 +1707,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	 * @return e_entry component ordinal 
 	 */
 	public int getEntryComponentOrdinal() {
-		return 9;
+		return 11;
 	}
 
 	/**
@@ -1716,7 +1716,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	 * @return e_phoff component ordinal 
 	 */
 	public int getPhoffComponentOrdinal() {
-		return 10;
+		return 12;
 	}
 
 	/**
@@ -1725,7 +1725,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	 * @return e_shoff component ordinal 
 	 */
 	public int getShoffComponentOrdinal() {
-		return 11;
+		return 13;
 	}
 
 	private void addSection(ElfSectionHeader newSection) {


### PR DESCRIPTION
There was a bug introduced by my last PR that added `e_ident_osabi` and `e_ident_abiversion`. I hadn't noticed that ordinals were being used to create references for `e_entry`, `e_phoff`, and `e_shoff`. This fix updates those ordinals so that references are created for the correct fields in the ELF header.

Current (master):
![image](https://user-images.githubusercontent.com/12718188/77558436-ef712a00-6e88-11ea-92fa-6ddcfc83217e.png)

Fixed:
![image](https://user-images.githubusercontent.com/12718188/77557960-5fcb7b80-6e88-11ea-804f-c764ae6293d4.png)
