### PR TITLE
Sleighexample fixes

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
@@ -278,7 +278,7 @@ libdecomp.a:	$(LIBDECOMP_OPT_OBJS)
 	ar qc libdecomp.a $(LIBDECOMP_OPT_OBJS)
 	ranlib libdecomp.a
 
-sleighexamp_dir:
+sleighexamp_dir: slghscan.cc
 	rm -rf $(SLEIGHVERSION)
 	mkdir $(SLEIGHVERSION)
 	mkdir $(SLEIGHVERSION)/src $(SLEIGHVERSION)/specfiles

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleighexample.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleighexample.cc
@@ -346,10 +346,13 @@ int main(int argc,char **argv)
 --
 --LNK=src/libsla.a
 --
+--libsla.a:
+--	$(MAKE) -C src/ $@
+--
 --sleighexample.o:	sleighexample.cc
 --	$(CXX) -c $(DBG_CXXFLAGS) $(INCLUDES) $< -o $@
 --
---sleighexample:	sleighexample.o
+--sleighexample:	sleighexample.o libsla.a
 --	$(CXX) $(DBG_CXXFLAGS) -o sleighexample sleighexample.o $(LNK)
 --
 --clean:


### PR DESCRIPTION
I was trying to experiment with `libsla` and I discovered the `sleighexample` binary and the `sleighexamp_dir`. It seems that the target is currently broken, and this PR is my proposal to fix it.

Using this PR, it is possible to compile and test `sleighexample`  by typing:
```
make sleighexamp_dir
cd sleigh-*/
make sleighexample
./sleighexample disassemble
```