### PR TITLE
Escape XML chars for PDB parsing

### DIFF
--- a/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
@@ -314,6 +314,7 @@ void dumpFunctionLines( IDiaSymbol& symbol, IDiaSession& session )
 
 		bstr_t sourceFileName;
 		pSrc->get_fileName(sourceFileName.GetAddress());
+		std::wstring wsSourceFileName(sourceFileName.GetBSTR(), SysStringLen(sourceFileName));
 
 		DWORD addr = 0;
 		pLine->get_relativeVirtualAddress( &addr );
@@ -324,7 +325,7 @@ void dumpFunctionLines( IDiaSymbol& symbol, IDiaSession& session )
 		pLine->get_lineNumberEnd( &end );
 
 		printf("%S<line_number source_file=\"%ws\" start=\"%d\" end=\"%d\" addr=\"0x%x\" /> \n",
-					indent(12).c_str(), sourceFileName.GetBSTR(), start, end, addr);
+					indent(12).c_str(), escapeXmlEntities(wsSourceFileName).c_str(), start, end, addr);
 	}
 }
 
@@ -401,7 +402,8 @@ void iterateSourceFiles(IDiaEnumSourceFiles * pSourceFiles) {
 		bstr_t name;
 		DWORD id = 0;
 		if( (pSourceFile->get_fileName( name.GetAddress() ) == S_OK) && (pSourceFile->get_uniqueId( &id ) == S_OK) ) {
-			printf("%S<source_file name=\"%ws\" id=\"0x%x\" /> \n", indent(12).c_str(), name.GetBSTR(), id);
+			std::wstring wsName(name.GetBSTR(), SysStringLen(name));
+			printf("%S<source_file name=\"%ws\" id=\"0x%x\" /> \n", indent(12).c_str(), escapeXmlEntities(wsName).c_str(), id);
 		}
 		pSourceFile = NULL;
 	}
@@ -491,9 +493,11 @@ void iterateInjectedSource(IDiaEnumInjectedSources * pInjectedSrcs) {
 
 		bstr_t filename;
 		pInjectedSrc->get_filename(filename.GetAddress());
+		std::wstring wsFileName(filename.GetBSTR(), SysStringLen(filename));
 
 		bstr_t objectname;
 		pInjectedSrc->get_objectFilename(objectname.GetAddress());
+		std::wstring wsObjectname(objectname.GetBSTR(), SysStringLen(objectname));
 
 		DWORD crc;
 		pInjectedSrc->get_crc(&crc);
@@ -503,8 +507,8 @@ void iterateInjectedSource(IDiaEnumInjectedSources * pInjectedSrcs) {
 
 		printf("%S<injected_source filename=\"%ws\" objectname=\"%ws\" crc=\"0x%x\" length=\"0x%I64x\" />\n",
 					indent(8).c_str(),
-					filename.GetBSTR(),
-					objectname.GetBSTR(),
+					escapeXmlEntities(wsFileName).c_str(),
+					escapeXmlEntities(wsObjectname).c_str(),
 					crc,
 					length);
 

--- a/Ghidra/Features/PDB/src/pdb/cpp/pdb.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/pdb.cpp
@@ -17,6 +17,7 @@
 #include "find.h"
 #include "print.h"
 #include "symbol.h"
+#include "xml.h"
 #include <stdlib.h>
 
 PDBApiContext::PDBApiContext(const std::wstring& szFilename, const std::wstring& szSignature, const std::wstring& szAge)
@@ -112,7 +113,7 @@ int PDBApiContext::init(const std::wstring& szFilename, const std::wstring& szSi
 		fatal("Unable to get GUID\n");
 	}
 
-	printf("<pdb file=\"%S\" exe=\"%S\" guid=\"%S\" age=\"%ld\">\n", szFilename.c_str(), exename.c_str(), guidStr.c_str(), currAge);
+	printf("<pdb file=\"%S\" exe=\"%S\" guid=\"%S\" age=\"%ld\">\n", escapeXmlEntities(szFilename).c_str(), escapeXmlEntities(exename).c_str(), escapeXmlEntities(guidStr).c_str(), currAge);
 
 	return hr;
 }


### PR DESCRIPTION
Was trying to load a PDB located in a directory path that contained an '&' (ampersand) symbol. Realized that XML special chars were not escaped for PDB filename or exe name.

szFilename, exename, and guidStr are now escaped properly.

Also added fixes in iterate.cpp for strings returned by get_fileName() and get_objectFilename().