### PR TITLE
Use JDK's default TLS protocol

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/net/SSLContextInitializer.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/net/SSLContextInitializer.java
@@ -36,7 +36,7 @@ import ghidra.util.Msg;
  */
 public class SSLContextInitializer implements ModuleInitializer {
 
-	private static final String DEFAULT_TLS_PROTOCOL = "TLSv1.2";
+	private static final String DEFAULT_TLS_PROTOCOL = "TLS";  // use Java's default enabled TLS protocols
 
 	private static final String PROTOCOL_PROPERTY = "ghidra.net.ssl.protocol";
 


### PR DESCRIPTION
The SSLContextInitializer used hard-coded "TLSv1.2" as the default TLS protocol. This means TLS 1.3 wouldn't be used even in Java 11 or later, which support TLS 1.3 by default. This patch changes DEFAULT_TLS_PROTOCOL to "TLS", which uses the JDK's default enabled TLS protocols.