### PR TITLE
[x86] Change operand size to 2 (64bit) for 67H prefix

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -1477,7 +1477,7 @@ macro fucompe(val1, val2) {
 
 # TODO I don't think the following line can really happen because the 66 67 prefix must come before REX prefix
 :^instruction is instrPhase=0 & over=0x66 & opsize=2; instruction   [ opsize=0; mandover=mandover $xor 1; ] {} # Operand size override
-:^instruction is instrPhase=0 & over=0x67 & addrsize=2; instruction [ addrsize=1; ] {} # Address size override
+:^instruction is instrPhase=0 & over=0x67 & addrsize=2; instruction [ addrsize=1; opsize=2; ] {} # Address size override
 
 :^instruction is instrPhase=0 & addrsize=2 &            row=0x4 & rexw=0 & rexr & rexx & rexb;  instruction [ instrPhase=1; rexprefix=1; opsize=1; rexWprefix=0; rexRprefix=rexr; rexXprefix=rexx; rexBprefix=rexb; ] {}
 :^instruction is instrPhase=0 & addrsize=2 &            row=0x4 & rexw=1 & rexr & rexx & rexb;  instruction [ instrPhase=1; rexprefix=1; opsize=2; rexWprefix=1; rexRprefix=rexr; rexXprefix=rexx; rexBprefix=rexb; ] {}
@@ -2052,6 +2052,7 @@ Suffix3D: imm8        is imm8 [ suffix3D=imm8; ] { }
 :CALL rel32     is vexMode=0 & addrsize=0 & opsize=1 & byte=0xe8; rel32     { push24(&:4 inst_next); call rel32; }
 :CALL rel32     is vexMode=0 & addrsize=1 & opsize=1 & byte=0xe8; rel32     { push44(&:4 inst_next); call rel32; }
 @ifdef IA64
+:CALL rel32     is vexMode=0 & addrsize=1 & opsize=2 & byte=0xe8; rel32     { push88(&:8 inst_next); call rel32; }
 :CALL rel32     is vexMode=0 & addrsize=2 & (opsize=1 | opsize=2) & byte=0xe8; rel32     { push88(&:8 inst_next); call rel32; }
 @endif
 #  When is a call a Jump, when it jumps right after.  Not always the case but...


### PR DESCRIPTION
CALL (67 E8 ...) interprets as call near with address size override prefix (address size will be
32-bit) but with default operand size. Default operand size for x86-64 is 64-bit:

> 2.2.1.7 Default 64-Bit Operand Size
> In 64-bit mode, two groups of instructions have a default operand size of 64 bits (do not need a
> REX prefix for this operand size). These are:
> - Near branches.
> - All instructions, except far branches, that implicitly reference the RSP.

But operand size for x86-64 by default is 32-bit (`opsize=1`) (see sleigh specification).

The commit fix operand size for 67H prefix and also fix near call (E8).

I tried to make a minimum of changes, but I don't know how many mnemonics depend on the 67H prefix. This work well for me, but I will create PR, if found some new issues.