### PR TITLE
Add missing quotes in launch.bat

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/support/launch.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/launch.bat
@@ -36,7 +36,7 @@ for /f "tokens=2" %%# in ("%cmdcmdline%") do if /i "%%#" equ "/c" set DOUBLE_CLI
 :: '% ~' dereferences the value in param 0
 :: 'd' - drive
 :: 'p' - path (without filename)
-set SUPPORT_DIR=%~dp0
+set "SUPPORT_DIR=%~dp0"
 
 ::
 :: Parse arguments
@@ -63,20 +63,20 @@ goto showUsage
 ::
 :: Production Environment
 ::
-set INSTALL_DIR=%SUPPORT_DIR%..\
-set CPATH=%INSTALL_DIR%Ghidra\Framework\Utility\lib\Utility.jar
-set LS_CPATH=%SUPPORT_DIR%LaunchSupport.jar
-set DEBUG_LOG4J=%SUPPORT_DIR%debug.log4j.xml
+set "INSTALL_DIR=%SUPPORT_DIR%..\"
+set "CPATH=%INSTALL_DIR%Ghidra\Framework\Utility\lib\Utility.jar"
+set "LS_CPATH=%SUPPORT_DIR%LaunchSupport.jar"
+set "DEBUG_LOG4J=%SUPPORT_DIR%debug.log4j.xml"
 
 if exist "%INSTALL_DIR%Ghidra" goto continue2
 
 ::
 :: Development Environment
 ::
-set INSTALL_DIR=%INSTALL_DIR%..\..\..\
-set CPATH=%INSTALL_DIR%Ghidra\Framework\Utility\bin\main
-set LS_CPATH=%INSTALL_DIR%GhidraBuild\LaunchSupport\bin\main
-set DEBUG_LOG4J=%INSTALL_DIR%Ghidra\RuntimeScripts\Common\support\debug.log4j.xml
+set "INSTALL_DIR=%INSTALL_DIR%..\..\..\"
+set "CPATH=%INSTALL_DIR%Ghidra\Framework\Utility\bin\main"
+set "LS_CPATH=%INSTALL_DIR%GhidraBuild\LaunchSupport\bin\main"
+set "DEBUG_LOG4J=%INSTALL_DIR%Ghidra\RuntimeScripts\Common\support\debug.log4j.xml"
 
 :continue2
 

--- a/Ghidra/RuntimeScripts/Windows/support/launch.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/launch.bat
@@ -108,7 +108,7 @@ if "%JAVA_HOME%" == "" (
 		goto exit1
 	)
 )
-set JAVA_CMD=%JAVA_HOME%\bin\java
+set "JAVA_CMD=%JAVA_HOME%\bin\java"
 
 :: Get the configurable VM arguments from the launch properties
 for /f "delims=*" %%i in ('java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%\" -vmargs') do set VMARG_LIST=%VMARG_LIST% %%i


### PR DESCRIPTION
When set Windows environment variables, they need to be quoted if special characters like & exists in path.

Fixes #1726