### PR TITLE
Added root .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.java]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
The added .editorconfig aids in viewing source code from a web browser. GitHub's internal editor will parse this. AFAIK Eclipse won't parse the file without an additional plugin so I don't think its addition should be an issue.

At the moment it just changes the tab size from 8 to 4 in java files.