### PR TITLE
Fix a bug when parsing the ELF SHT_MIPS_OPTIONS section

### DIFF
--- a/Ghidra/Processors/MIPS/src/main/java/ghidra/app/util/bin/format/elf/extend/MIPS_ElfExtension.java
+++ b/Ghidra/Processors/MIPS/src/main/java/ghidra/app/util/bin/format/elf/extend/MIPS_ElfExtension.java
@@ -580,9 +580,11 @@ public class MIPS_ElfExtension extends ElfExtension {
 						break;
 
 					default:
-						// consume unprocessed option description bytes
-						elfLoadHelper.createData(nextOptionAddr,
-							new ArrayDataType(ByteDataType.dataType, optionDataSize, 1));
+						if (optionDataSize > 0) {
+							// consume unprocessed option description bytes
+							elfLoadHelper.createData(nextOptionAddr,
+								new ArrayDataType(ByteDataType.dataType, optionDataSize, 1));
+						}
 				}
 
 				limit -= odkHeader.getLength() + optionDataSize;


### PR DESCRIPTION
This pull request fixes an issue where Ghidra throws an error when opening a MIPS binary that contains option entries with a size of 8 in the `SHT_MIPS_OPTIONS` section