### PR TITLE
Add Gradle Wrapper to exclude from extension build

### DIFF
--- a/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
+++ b/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
@@ -92,6 +92,10 @@ task buildExtension (type: Zip) {
 		exclude '.settings/**'
 		exclude 'developer_scripts'
 		exclude '.antProperties.xml'
+		exclude 'gradlew'
+		exclude 'gradlew.bat'
+		exclude 'gradle/wrapper/gradle-wrapper.jar'
+		exclude 'gradle/wrapper/gradle-wrapper.properties'
 		
 		into pathInZip
 	}


### PR DESCRIPTION
Gradle Wrapper:
https://docs.gradle.org/current/userguide/gradle_wrapper.html

Is "recommended way to execute any Gradle build" so more and more
extensions have the wrapper files in the repository.  They serve no
purpose once built, so ignore it from the zip.