### PR TITLE
Inherit file archive data organization from program

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/archive/DataTypeManagerHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/archive/DataTypeManagerHandler.java
@@ -627,6 +627,11 @@ public class DataTypeManagerHandler {
 		newManager.addDataTypeManagerListener(listenerDelegate);
 		dataTypeIndexer.removeDataTypeManager(oldManager);
 		dataTypeIndexer.addDataTypeManager(newManager);
+		
+		if (newManager instanceof FileDataTypeManager) {
+			((FileDataTypeManager)newManager).setDataOrganization(plugin.getProgram().getCompilerSpec().getDataOrganization());
+		}
+		
 		fireDataTypeManagerChanged(archive);
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/FileDataTypeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/FileDataTypeManager.java
@@ -192,6 +192,15 @@ public class FileDataTypeManager extends StandAloneDataTypeManager
 		fname = fname + SUFFIX;
 		return new File(file.getParentFile(), fname);
 	}
+	
+	/**
+	 * Set the data organization used by this data type manager.
+	 * 
+	 * @param org the new data organization
+	 */
+	public void setDataOrganization(DataOrganization org) {
+		dataOrganization = org;
+	}
 
 	private void updateRootCategoryName(ResourceFile newFile, Category root) {
 		String newName = getRootName(newFile.getName());


### PR DESCRIPTION
DataTypeManagerDB's default implementation of getDataOrganization() uses ``DataOrganizationImpl.getDefaultOrganization()`` to set ``dataOrganization`` to its initial value. This is inherited by the data type manager for file archives, forcing all archives to use the default values for type sizes as specified in``DataOrganizationImpl``. These sizes are used regardless of the specification used by the program:

	private int pointerShift = 0;
	private int pointerSize = 4;
	private int charSize = 1;
	private int wideCharSize = 2;
	private int shortSize = 2;
	private int integerSize = 4;
	private int longSize = 4;
	private int longLongSize = 8;
	private int floatSize = 4;
	private int doubleSize = 8;
	private int longDoubleSize = 8;

This PR updates the file archive data organization to match the program's data organization. This is akin to what ``ProgramDataTypeManager`` does in ``setProgram()``.

There may be a better place to put these changes, but this seemed the simplest to me.