### PR TITLE
#433 Corrected Sleigh documentation on 'attach names'

### DIFF
--- a/GhidraDocs/languages/html/sleigh_tokens.html
+++ b/GhidraDocs/languages/html/sleigh_tokens.html
@@ -196,9 +196,7 @@ The <span class="emphasis"><em>stringlist</em></span> is assigned to each of the
 in the same manner as the <span class="bold"><strong>attach
 variables</strong></span> and <span class="bold"><strong>attach
 values</strong></span> statements. A specific encoding of the field now
-displays as the string in the list at that integer position. Field
-values greater than the size of the list are interpreted as invalid
-encodings.
+displays as the string in the list at that integer position. Field values that are not equal to the size of the list are interpreted as invalid encodings.
 </p>
 </div>
 </div>


### PR DESCRIPTION
#433 I looked through the code and I found where the mentioned error gets triggered. It seems that if the size of the stringlist is not equal to the maximum value of the pattern value of one of the fields, the program will throw an error saying that the field is a mismatch for the stringlist.

if (patval.maxValue() + 1 != names.size()) {
	reportError(location, "Attach name '" + sym + "' is wrong size for list: " + names);
}

So I believe the above statement should be corrected to: "Field values that are not equal to the size of the list are interpreted as invalid encodings".