### PR TITLE
[pcode] Fix renaming global variable

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighFunctionDBUtil.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighFunctionDBUtil.java
@@ -599,7 +599,7 @@ public class HighFunctionDBUtil {
 
 			if (name != null) {
 				try {
-					setGlobalName(highSymbol, highSymbol.getName(), source);
+					setGlobalName(highSymbol, name, source);
 				}
 				catch (DuplicateNameException e) {
 					if (isRename) {


### PR DESCRIPTION
Set a name for global variable in `updateDBVariable` from the `name` parameter but not from the high symbol.