### PR TITLE
ARM: Fix sleigh description of teq in Thumb mode

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -4768,7 +4768,7 @@ Pcrel: [cloc,Rm0003]  is Rm0003 & thc0404=1 [ cloc = inst_next; ]
 {
    build ItCond;
   build ThumbExpandImm12;
-  local tmp = Rn0003 | ThumbExpandImm12;
+  local tmp = Rn0003 ^ ThumbExpandImm12;
   resflags(tmp);
   th_affectflags();
 }
@@ -4777,7 +4777,7 @@ Pcrel: [cloc,Rm0003]  is Rm0003 & thc0404=1 [ cloc = inst_next; ]
 {
    build ItCond;
   build thshift2;
-  local tmp = Rn0003 | thshift2;
+  local tmp = Rn0003 ^ thshift2;
   resflags(tmp);
   th_affectflags();
 }


### PR DESCRIPTION
teq performs a bitwise EXCLUSIVE or, not an inclusive or. (See section A8.8.238 of the ARMv7 reference manual.)