### PR TITLE
[decompiler] History navigation by mouse buttons

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/GhidraOptions.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/GhidraOptions.java
@@ -175,13 +175,27 @@ public interface GhidraOptions {
 	final String CURSOR_HIGHLIGHT_GROUP = "Cursor Text Highlight";
 
 	final String CURSOR_HIGHLIGHT_BUTTON_NAME =
-		CURSOR_HIGHLIGHT_GROUP + Options.DELIMITER + "Mouse Button To Activate";
+			CURSOR_HIGHLIGHT_GROUP + Options.DELIMITER + "Mouse Button To Activate";
 
 	final String HIGHLIGHT_COLOR_NAME =
-		CURSOR_HIGHLIGHT_GROUP + Options.DELIMITER + "Highlight Color";
+			CURSOR_HIGHLIGHT_GROUP + Options.DELIMITER + "Highlight Color";
+
+	//
+	// mouse next/prev history
+	//
+
+	String MOUSE_NEXT_PREV_ADDR_GROUP = "Mouse Next/Previous Address";
+
+	String MOUSE_NEXT_ADDR_BUTTON_NAME =
+			MOUSE_NEXT_PREV_ADDR_GROUP + Options.DELIMITER + "Mouse Button Next Address";
+
+	String MOUSE_PREV_ADDR_BUTTON_NAME =
+			MOUSE_NEXT_PREV_ADDR_GROUP + Options.DELIMITER + "Mouse Button Previous Address";
 
 	public static enum CURSOR_MOUSE_BUTTON_NAMES {
-		LEFT(MouseEvent.BUTTON1), MIDDLE(MouseEvent.BUTTON2), RIGHT(MouseEvent.BUTTON3);
+		LEFT(MouseEvent.BUTTON1), MIDDLE(MouseEvent.BUTTON2), RIGHT(MouseEvent.BUTTON3), FOURTH(4),
+		FIFTH(5), SIXTH(6), SEVENTH(7), EIGHTH(8),
+		NINTH(9), TENTH(10);
 		private int mouseEventID;
 
 		CURSOR_MOUSE_BUTTON_NAMES(int mouseEventID) {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java
@@ -265,6 +265,9 @@ public class DecompileOptions {
 	private Color middleMouseHighlightColor;
 	private int middleMouseHighlightButton = MouseEvent.BUTTON2;
 
+	private int mouseNextAddressButton = CURSOR_MOUSE_BUTTON_NAMES.SEVENTH.getMouseEventID();
+	private int mousePrevAddressButton = CURSOR_MOUSE_BUTTON_NAMES.SIXTH.getMouseEventID();
+
 	private final static String HIGHLIGHT_CURRENT_VARIABLE_MSG =
 		"Display.Color for Current Variable Highlight";
 	private final static Color HIGHLIGHT_CURRENT_VARIABLE_DEF = new Color(255, 255, 0, 128);
@@ -446,14 +449,22 @@ public class DecompileOptions {
 		}
 
 		PluginTool tool = ownerPlugin.getTool();
-		Options toolOptions = tool.getOptions(CATEGORY_BROWSER_FIELDS);
+		Options toolBrowserFieldsOptions = tool.getOptions(CATEGORY_BROWSER_FIELDS);
+		Options toolDecompilerOptions = tool.getOptions("Decompiler");
 
 		middleMouseHighlightColor =
-			toolOptions.getColor(HIGHLIGHT_COLOR_NAME, HIGHLIGHT_MIDDLE_MOUSE_DEF);
+				toolBrowserFieldsOptions.getColor(HIGHLIGHT_COLOR_NAME, HIGHLIGHT_MIDDLE_MOUSE_DEF);
 
-		CURSOR_MOUSE_BUTTON_NAMES mouseEvent =
-			toolOptions.getEnum(CURSOR_HIGHLIGHT_BUTTON_NAME, CURSOR_MOUSE_BUTTON_NAMES.MIDDLE);
-		middleMouseHighlightButton = mouseEvent.getMouseEventID();
+		CURSOR_MOUSE_BUTTON_NAMES mouseHighlightEvent = toolBrowserFieldsOptions
+				.getEnum(CURSOR_HIGHLIGHT_BUTTON_NAME, CURSOR_MOUSE_BUTTON_NAMES.MIDDLE);
+		CURSOR_MOUSE_BUTTON_NAMES mouseNextAddressEvent = toolDecompilerOptions
+				.getEnum(MOUSE_NEXT_ADDR_BUTTON_NAME, CURSOR_MOUSE_BUTTON_NAMES.SIXTH);
+		CURSOR_MOUSE_BUTTON_NAMES mousePrevAddressEvent = toolDecompilerOptions
+				.getEnum(MOUSE_PREV_ADDR_BUTTON_NAME, CURSOR_MOUSE_BUTTON_NAMES.FIFTH);
+
+		middleMouseHighlightButton = mouseHighlightEvent.getMouseEventID();
+		mouseNextAddressButton = mouseNextAddressEvent.getMouseEventID();
+		mousePrevAddressButton = mousePrevAddressEvent.getMouseEventID();
 	}
 
 	/**
@@ -721,6 +732,14 @@ public class DecompileOptions {
 
 	public int getMiddleMouseHighlightButton() {
 		return middleMouseHighlightButton;
+	}
+
+	public int getMouseNextAddressButton() {
+		return mouseNextAddressButton;
+	}
+
+	public int getMousePrevAddressButton() {
+		return mousePrevAddressButton;
 	}
 
 	public boolean isPRECommentIncluded() {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/CDisplayPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/CDisplayPanel.java
@@ -141,6 +141,11 @@ public class CDisplayPanel extends JPanel implements DecompilerCallbackHandler {
 	}
 
 	@Override
+	public void goToNextPrevAddress(boolean isNext) {
+		// stub
+	}
+
+	@Override
 	public void locationChanged(ProgramLocation programLocation) {
 		if (locationListener == null) {
 			return;

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerCallbackHandler.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerCallbackHandler.java
@@ -46,5 +46,7 @@ public interface DecompilerCallbackHandler {
 
 	void goToFunction(Function function, boolean newWindow);
 
+	void goToNextPrevAddress(boolean isNext);
+
 	void doWheNotBusy(Callback c);
 }

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerController.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerController.java
@@ -272,6 +272,10 @@ public class DecompilerController {
 		callbackHandler.goToFunction(function, newWindow);
 	}
 
+	void goToNextPrevAddress(boolean isNext) {
+		callbackHandler.goToNextPrevAddress(isNext);
+	}
+
 	void goToLabel(String labelName, boolean newWindow) {
 		callbackHandler.goToLabel(labelName, newWindow);
 	}

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
@@ -88,6 +88,9 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 	private Color searchHighlightColor;
 	private SearchLocation currentSearchLocation;
 
+	private int mouseNextAddressButton;
+	private int mousePrevAddressButton;
+
 	private DecompileData decompileData = new EmptyDecompileData("No Function");
 	private final DecompilerClipboardProvider clipboard;
 
@@ -123,6 +126,8 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		currentVariableHighlightColor = options.getCurrentVariableHighlightColor();
 		middleMouseHighlightColor = options.getMiddleMouseHighlightColor();
 		middleMouseHighlightButton = options.getMiddleMouseHighlightButton();
+		mouseNextAddressButton = options.getMouseNextAddressButton();
+		mousePrevAddressButton = options.getMousePrevAddressButton();
 
 		setLayout(new BorderLayout());
 		add(scroller);
@@ -571,6 +576,14 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 			}
 		}
 
+		if (buttonState == mouseNextAddressButton && clickCount == 1) {
+			controller.goToNextPrevAddress(true);
+		}
+
+		if (buttonState == mousePrevAddressButton && clickCount == 1) {
+			controller.goToNextPrevAddress(false);
+		}
+
 		if (buttonState == middleMouseHighlightButton && clickCount == 1) {
 			togglePrimaryHighlight(location, field, middleMouseHighlightColor);
 		}
@@ -993,6 +1006,9 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		middleMouseHighlightColor = decompilerOptions.getMiddleMouseHighlightColor();
 		middleMouseHighlightButton = decompilerOptions.getMiddleMouseHighlightButton();
 		searchHighlightColor = decompilerOptions.getSearchHighlightColor();
+
+		mouseNextAddressButton = decompilerOptions.getMouseNextAddressButton();
+		mousePrevAddressButton = decompilerOptions.getMousePrevAddressButton();
 
 		highlightController.setHighlightColor(currentVariableHighlightColor);
 	}

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
@@ -640,6 +640,25 @@ public class DecompilerProvider extends NavigatableComponentProviderAdapter
 	}
 
 	@Override
+	public void goToNextPrevAddress(boolean isNext) {
+		NavigationHistoryService historyService = tool.getService(NavigationHistoryService.class);
+		if (historyService == null) {
+			return;
+		}
+
+		Navigatable navigatable = null;
+		GoToService service = tool.getService(GoToService.class);
+		if (service != null) {
+			navigatable = service.getDefaultNavigatable();
+		}
+		if (isNext) {
+			historyService.next(navigatable);
+		} else {
+			historyService.previous(navigatable);
+		}
+	}
+
+	@Override
 	public void doWheNotBusy(Callback c) {
 		followUpWork.offer(c);
 		followUpWorkUpdater.update();

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/fieldpanel/FieldPanel.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/fieldpanel/FieldPanel.java
@@ -1304,7 +1304,9 @@ public class FieldPanel extends JPanel
 		public void mousePressed(MouseEvent e) {
 			hoverHandler.stopHover();
 			mouseHandler.mousePressed(e);
-			cursorHandler.setCursorPos(e.getX(), e.getY(), EventTrigger.GUI_ACTION);
+			if (e.getButton() <= MouseEvent.BUTTON3) {
+				cursorHandler.setCursorPos(e.getX(), e.getY(), EventTrigger.GUI_ACTION);
+			}
 		}
 
 		@Override


### PR DESCRIPTION
Works only in Decompiler window (context) and only for my mouse (button number 6 for previous address in the history and button number 7 for next address in the history), but everyone can change buttons in the decompiler's settings. Maybe it's incorrect PR, but it can be used by other users and can be fundament for other changes.