### PR TITLE
Fixes crash in pdb.exe on rust pdb's

### DIFF
--- a/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
@@ -324,7 +324,7 @@ void dumpFunctionLines( IDiaSymbol& symbol, IDiaSession& session )
 		pLine->get_lineNumberEnd( &end );
 
 		printf("%S<line_number source_file=\"%ws\" start=\"%d\" end=\"%d\" addr=\"0x%x\" /> \n",
-					indent(12).c_str(), sourceFileName.GetBSTR(), start, end, addr);
+					indent(12).c_str(), escapeXmlEntities(sourceFileName.GetBSTR()).data(), start, end, addr);
 	}
 }
 
@@ -401,7 +401,7 @@ void iterateSourceFiles(IDiaEnumSourceFiles * pSourceFiles) {
 		bstr_t name;
 		DWORD id = 0;
 		if( (pSourceFile->get_fileName( name.GetAddress() ) == S_OK) && (pSourceFile->get_uniqueId( &id ) == S_OK) ) {
-			printf("%S<source_file name=\"%ws\" id=\"0x%x\" /> \n", indent(12).c_str(), name.GetBSTR(), id);
+			printf("%S<source_file name=\"%ws\" id=\"0x%x\" /> \n", indent(12).c_str(), escapeXmlEntities(name.GetBSTR()).data(), id);
 		}
 		pSourceFile = NULL;
 	}

--- a/Ghidra/Features/PDB/src/pdb/cpp/print.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/print.cpp
@@ -150,18 +150,9 @@ std::wstring printType( IDiaSymbol * pType, const std::wstring& suffix ) {
 		if ( pBaseType == NULL ) {
 			return L"";
 		}
-		ULONGLONG lenArray = getLength( *pType );
-		ULONGLONG lenElem  = getLength( *pBaseType );
-		ULONGLONG sz;
-		if (lenElem == 0) {
-			sz = 1;//prevent divide by zero...
-		}
-		else {
-			sz = lenArray / lenElem;
-		}
 		const size_t strLen = suffix.length() + 64 + 3;	// length of suffix + wag_for_numeric_value + "[]\0" 
 		std::vector<wchar_t> str(strLen);
-		swprintf_s(str.data(), strLen, L"%s[%I64d]", suffix.c_str(), sz);
+		swprintf_s(str.data(), strLen, L"%s[%d]", suffix.c_str(), getCount( *pType ));
 		return printType(pBaseType, str.data());
 	} 
 

--- a/Ghidra/Features/PDB/src/pdb/cpp/print.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/print.cpp
@@ -154,7 +154,7 @@ std::wstring printType( IDiaSymbol * pType, const std::wstring& suffix ) {
 		ULONGLONG lenElem  = getLength( *pBaseType );
 		ULONGLONG sz;
 		if (lenElem == 0) {
-			sz = 0;//prevent divide by zero...
+			sz = 1;//prevent divide by zero...
 		}
 		else {
 			sz = lenArray / lenElem;

--- a/Ghidra/Features/PDB/src/pdb/cpp/print.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/print.cpp
@@ -152,12 +152,16 @@ std::wstring printType( IDiaSymbol * pType, const std::wstring& suffix ) {
 		}
 		ULONGLONG lenArray = getLength( *pType );
 		ULONGLONG lenElem  = getLength( *pBaseType );
-		if (lenElem == 0) {//prevent divide by zero...
-			lenElem = lenArray;
+		ULONGLONG sz;
+		if (lenElem == 0) {
+			sz = 0;//prevent divide by zero...
+		}
+		else {
+			sz = lenArray / lenElem;
 		}
 		const size_t strLen = suffix.length() + 64 + 3;	// length of suffix + wag_for_numeric_value + "[]\0" 
 		std::vector<wchar_t> str(strLen);
-		swprintf_s(str.data(), strLen, L"%s[%I64d]", suffix.c_str(), lenArray / lenElem);
+		swprintf_s(str.data(), strLen, L"%s[%I64d]", suffix.c_str(), sz);
 		return printType(pBaseType, str.data());
 	} 
 

--- a/Ghidra/Features/PDB/src/pdb/cpp/symbol.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/symbol.cpp
@@ -231,6 +231,11 @@ ULONGLONG getLength(IDiaSymbol& symbol) {
 	symbol.get_length( &len );
 	return len;
 }
+DWORD getCount(IDiaSymbol &symbol) {
+	DWORD count = 0;
+	symbol.get_count( &count );
+	return count;
+}
 DWORD getTag(IDiaSymbol& symbol) {
 	DWORD tag = 0;
 	symbol.get_symTag( &tag );

--- a/Ghidra/Features/PDB/src/pdb/headers/symbol.h
+++ b/Ghidra/Features/PDB/src/pdb/headers/symbol.h
@@ -27,6 +27,7 @@ std::wstring   getName(IDiaSymbol& pSymbol);
 std::wstring   getUndecoratedName(IDiaSymbol& pSymbol);
 DWORD          getRVA(IDiaSymbol& pSymbol);
 ULONGLONG      getLength(IDiaSymbol& pSymbol);
+DWORD          getCount(IDiaSymbol& pSymbol);
 DWORD          getTag(IDiaSymbol& pSymbol);
 std::wstring   getTagAsString(IDiaSymbol& pSymbol);
 DWORD          getKind(IDiaSymbol& pSymbol);


### PR DESCRIPTION
Fixes crash in pdb.exe caused when processing an array of length 0

Also escapes filenames as there's at least one instance of a bad
filename in the provided pdb: <::core::macros::panic macros>

Fixes  #1804 