### PR TITLE
Adding ExitProcess to PEFunctionsThatDoNotReturn

### DIFF
--- a/Ghidra/Features/Base/data/PEFunctionsThatDoNotReturn
+++ b/Ghidra/Features/Base/data/PEFunctionsThatDoNotReturn
@@ -2,5 +2,6 @@ CxxThrowException
 CxxThrowException@8
 CxxFrameHandler3
 crtExitProcess
+ExitProcess
 exit
 longjmp


### PR DESCRIPTION
[ExitProcess](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitprocess) from kernel32.dll should be added to the list of PE functions that are known to not return:

Here is a very basic program I created to illustrate the problem:
[ExitProcess.zip](https://github.com/NationalSecurityAgency/ghidra/files/4551826/ExitProcess.zip)

**Before**:
<img width="924" alt="before" src="https://user-images.githubusercontent.com/5378554/80599433-eaa81480-89f8-11ea-8ead-5767058165f2.PNG">

**After**:
<img width="860" alt="after" src="https://user-images.githubusercontent.com/5378554/80599442-eda30500-89f8-11ea-8d40-ca188a973b6b.PNG">
