### PR TITLE
Fix missing progressbar in TaskDialog. Close #1819

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/task/WrappingTaskMonitor.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/task/WrappingTaskMonitor.java
@@ -68,7 +68,7 @@ public class WrappingTaskMonitor implements TaskMonitor {
 			delegate.removeCancelledListener(l);
 		}
 
-		newDelegate.setMaximum(delegate.getMaximum());
+		newDelegate.initialize(delegate.getMaximum());
 		newDelegate.setProgress(delegate.getProgress());
 		newDelegate.setMessage(delegate.getMessage());
 		newDelegate.setIndeterminate(delegate.isIndeterminate());


### PR DESCRIPTION
Not completely sure if this is fine, but calling `initialize` here instead of `setMaximum` gives the task dialog a chance to call `installProgressMonitor` even if the delegate was changed too late and `TaskDialog` missed the `initialize` call.

I also tried to write a test for this but I couldn't really get it to work (not really familiar with the codebase yet)