### PR TITLE
Handle undefined directives in preprocessor

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/sleigh/grammar/SleighPreprocessor.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/sleigh/grammar/SleighPreprocessor.java
@@ -411,6 +411,9 @@ public class SleighPreprocessor implements ExpressionEnvironment {
 
 	@Override
 	public void reportError(String msg) {
+		if (isInif()) {
+			return;
+		}
 		errorCount += 1;
 		Location location = new Location(file.getName(),lineno);
 		Msg.error(this, location + ": " + msg);


### PR DESCRIPTION
Tokenizing undefined directives currently generates an error as
the lookup fails.  Using undefined directives should be valid
code as directives are meant to be defined or undefined.

If inside an `if`, errors are ignored

fixes #1834 1834