### PR TITLE
Escaping source_file names in pdb.exe

### DIFF
--- a/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
@@ -323,8 +323,9 @@ void dumpFunctionLines( IDiaSymbol& symbol, IDiaSession& session )
 		DWORD end = 0;
 		pLine->get_lineNumberEnd( &end );
 
+		std::wstring escapedSourceFileName = escapeXmlEntities(std::wstring(sourceFileName.GetBSTR(), sourceFileName.length()));
 		printf("%S<line_number source_file=\"%ws\" start=\"%d\" end=\"%d\" addr=\"0x%x\" /> \n",
-					indent(12).c_str(), sourceFileName.GetBSTR(), start, end, addr);
+					indent(12).c_str(), escapedSourceFileName.c_str(), start, end, addr);
 	}
 }
 
@@ -401,7 +402,8 @@ void iterateSourceFiles(IDiaEnumSourceFiles * pSourceFiles) {
 		bstr_t name;
 		DWORD id = 0;
 		if( (pSourceFile->get_fileName( name.GetAddress() ) == S_OK) && (pSourceFile->get_uniqueId( &id ) == S_OK) ) {
-			printf("%S<source_file name=\"%ws\" id=\"0x%x\" /> \n", indent(12).c_str(), name.GetBSTR(), id);
+			std::wstring escapedName = escapeXmlEntities(std::wstring(name.GetBSTR(), name.length()));
+			printf("%S<source_file name=\"%ws\" id=\"0x%x\" /> \n", indent(12).c_str(), escapedName.c_str(), id);
 		}
 		pSourceFile = NULL;
 	}


### PR DESCRIPTION
Escaping the source_file name in iterate.cpp, to fix a SAXParseException when parsing rust pdbs. 

**The bugged output**
Prior to this fix Pdb.exe would create lines like this in the output xml: 
<line_number source_file="<::core::macros::panic macros>" start="2" end="2" addr="0x5283" />

This would cause the following error when Ghidra went to parse it:
"Problem parsing or applying PDB information: org.xml.sax.SAXParseException; lineNumber: 6927; columnNumber: 39; The value of attribute "source_file" associated with an element type "line_number" must not contain the '<' character."

**The correct output**
After this fix the above line becomes the one below, and is able to fully parse a basic rust pdb:
<line_number source_file="\&lt;::core::macros::panic macros\&gt;" start="2" end="2" addr="0x5283" />