### PR TITLE
Adding -initScript and -cleanupScript options to headless

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/headless/AnalyzeHeadless.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/headless/AnalyzeHeadless.java
@@ -149,8 +149,10 @@ public class AnalyzeHeadless implements GhidraLaunchable {
 		String keystorePath = null;
 		String serverUID = null;
 		boolean allowPasswordPrompt = false;
-		List<Pair<String, String[]>> preScripts = new LinkedList<>();
-		List<Pair<String, String[]>> postScripts = new LinkedList<>();
+		List<Pair<String, String[]>> preScripts = new ArrayList<>();
+		List<Pair<String, String[]>> postScripts = new ArrayList<>();
+		List<Pair<String, String[]>> initScripts = new ArrayList<>();
+		List<Pair<String, String[]>> cleanupScripts = new ArrayList<>();
 
 		for (int argi = startIndex; argi < args.length; argi++) {
 
@@ -198,6 +200,18 @@ public class AnalyzeHeadless implements GhidraLaunchable {
 				String[] scriptArgs = getSubArguments(args, argi);
 				argi += scriptArgs.length;
 				postScripts.add(new Pair<>(scriptName, scriptArgs));
+			}
+			else if (checkArgument("-initscript", args, argi)) {
+				String scriptName = args[++argi];
+				String[] scriptArgs = getSubArguments(args, argi);
+				argi += scriptArgs.length;
+				initScripts.add(new Pair<>(scriptName, scriptArgs));
+			}
+			else if (checkArgument("-cleanupscript", args, argi)) {
+				String scriptName = args[++argi];
+				String[] scriptArgs = getSubArguments(args, argi);
+				argi += scriptArgs.length;
+				cleanupScripts.add(new Pair<>(scriptName, scriptArgs));
 			}
 			else if (checkArgument("-scriptPath", args, argi)) {
 				options.setScriptDirectories(args[++argi]);
@@ -314,9 +328,11 @@ public class AnalyzeHeadless implements GhidraLaunchable {
 			}
 		}
 
-		// Set up pre and post scripts
+		// Set up scripts
 		options.setPreScriptsWithArgs(preScripts);
 		options.setPostScriptsWithArgs(postScripts);
+		options.setInitScriptsWithArgs(initScripts);
+		options.setCleanupScriptsWithArgs(cleanupScripts);
 
 		// Set loader and loader args
 		options.setLoader(loaderName, loaderArgs);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/headless/HeadlessAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/headless/HeadlessAnalyzer.java
@@ -325,12 +325,25 @@ public class HeadlessAnalyzer {
 				return; // TODO: Should an exception be thrown?
 			}
 
+			// Run init scripts
+			GhidraState scriptState = new GhidraState(null, project, null, null, null, null);
+			HeadlessContinuationOption scriptStatus = runScriptsList(options.initScripts,
+				options.initScriptFileMap, scriptState, HeadlessContinuationOption.CONTINUE);
+			if (scriptStatus == HeadlessContinuationOption.ABORT ||
+				scriptStatus == HeadlessContinuationOption.ABORT_AND_DELETE) {
+				return;
+			}
+
 			if (options.runScriptsNoImport) {
 				processNoImport(folder.getPathname());
 			}
 			else {
 				processWithImport(folder.getPathname(), filesToImport);
 			}
+
+			// Run cleanup scripts
+			runScriptsList(options.cleanupScripts, options.cleanupScriptFileMap, scriptState,
+				scriptStatus);
 		}
 		catch (NotFoundException e) {
 			throw new IOException("Connect to repository folder failed");
@@ -427,12 +440,25 @@ public class HeadlessAnalyzer {
 				return; // TODO: Should an exception be thrown?
 			}
 
+			// Run init scripts
+			GhidraState scriptState = new GhidraState(null, project, null, null, null, null);
+			HeadlessContinuationOption scriptStatus = runScriptsList(options.initScripts,
+				options.initScriptFileMap, scriptState, HeadlessContinuationOption.CONTINUE);
+			if (scriptStatus == HeadlessContinuationOption.ABORT ||
+				scriptStatus == HeadlessContinuationOption.ABORT_AND_DELETE) {
+				return;
+			}
+
 			if (options.runScriptsNoImport) {
 				processNoImport(rootFolderPath);
 			}
 			else {
 				processWithImport(rootFolderPath, filesToImport);
 			}
+
+			// Run cleanup scripts
+			runScriptsList(options.cleanupScripts, options.cleanupScriptFileMap, scriptState,
+				scriptStatus);
 		}
 		finally {
 			project.close();
@@ -820,9 +846,14 @@ public class HeadlessAnalyzer {
 		if (options.preScriptFileMap == null) {
 			options.preScriptFileMap = checkScriptsList(options.preScripts);
 		}
-
 		if (options.postScriptFileMap == null) {
 			options.postScriptFileMap = checkScriptsList(options.postScripts);
+		}
+		if (options.initScriptFileMap == null) {
+			options.initScriptFileMap = checkScriptsList(options.initScripts);
+		}
+		if (options.cleanupScriptFileMap == null) {
+			options.cleanupScriptFileMap = checkScriptsList(options.cleanupScripts);
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/headless/HeadlessOptions.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/headless/HeadlessOptions.java
@@ -50,6 +50,14 @@ public class HeadlessOptions {
 	List<Pair<String, String[]>> postScripts;
 	Map<String, ResourceFile> postScriptFileMap;
 
+	// -initScript
+	List<Pair<String, String[]>> initScripts;
+	Map<String, ResourceFile> initScriptFileMap;
+
+	// -cleanupScript
+	List<Pair<String, String[]>> cleanupScripts;
+	Map<String, ResourceFile> cleanupScriptFileMap;
+
 	// -scriptPath
 	List<String> scriptPaths;
 
@@ -224,6 +232,26 @@ public class HeadlessOptions {
 	public void setPostScriptsWithArgs(List<Pair<String, String[]>> postScripts) {
 		this.postScripts = postScripts;
 		this.postScriptFileMap = null;
+	}
+
+	/**
+	 * Set the ordered list of scripts to execute prior to the import/analysis of ANY programs.
+	 * 
+	 * @param initScripts list of script names/script argument pairs
+	 */
+	public void setInitScriptsWithArgs(List<Pair<String, String[]>> initScripts) {
+		this.initScripts = initScripts;
+		this.initScriptFileMap = null;
+	}
+
+	/**
+	 * Set the ordered list of scripts to execute after ALL programs have been imported/analyzed.
+	 * 
+	 * @param cleanupScripts list of script names/script argument pairs
+	 */
+	public void setCleanupScriptsWithArgs(List<Pair<String, String[]>> cleanupScripts) {
+		this.cleanupScripts = cleanupScripts;
+		this.cleanupScriptFileMap = null;
 	}
 
 	/**

--- a/Ghidra/RuntimeScripts/Common/support/analyzeHeadlessREADME.html
+++ b/Ghidra/RuntimeScripts/Common/support/analyzeHeadlessREADME.html
@@ -112,6 +112,8 @@ The Headless Analyzer uses the command-line parameters discussed below. See <a h
         [[<a href="#import">-import [&lt;directory&gt;|&lt;file&gt;]+</a>] | [<a href="#process">-process [&lt;project_file&gt;]]</a>]
         [<a href="#preScript">-preScript &lt;ScriptName&gt;&nbsp;[&lt;arg&gt;]*</a>]
         [<a href="#postScript">-postScript &lt;ScriptName&gt;&nbsp[&lt;arg&gt;]*</a>]
+        [<a href="#initScript">-initScript &lt;ScriptName&gt;&nbsp[&lt;arg&gt;]*</a>]
+        [<a href="#cleanupScript">-cleanupScript &lt;ScriptName&gt;&nbsp[&lt;arg&gt;]*</a>]
         [<a href="#scriptPath">-scriptPath &quot;&lt;path1&gt;[;&lt;path2&gt;...]&quot;</a>]
         [<a href="#propertiesPath">-propertiesPath &quot;&lt;path1&gt;[;&lt;path2&gt;...]&quot;</a>]
         [<a href="#scriptLog">-scriptlog &lt;path to script log file&gt;</a>]
@@ -306,6 +308,40 @@ The Headless Analyzer uses the command-line parameters discussed below. See <a h
     <br><br>
     This option must be repeated to specify additional scripts. See the <a href="#scripting">Scripting</a> 
     section for a description of advanced scripting capabilities.
+    </LI>
+
+    <br><br>
+    
+    <LI>
+    <a name="initScript"><typewriter>-initScript &lt;ScriptName.ext&gt;&nbsp[&lt;arg&gt;]*</typewriter>
+    </a><br>Identifies the name of a script that will execute before <b>ANY</b> programs are imported/analyzed, 
+    and an optional list of arguments to pass to the script. The script name must include its file 
+    extension (i.e., <typewriter>MyScript.java</typewriter>).
+    <br><br>
+    <B><I>This parameter expects the script name only; do not include the path to the script.</I></B> The
+    Headless Analyzer searches specific default locations for the named script, but additional script 
+    director(ies) may also be specified (see the <a href="#scriptPath"><typewriter>-scriptPath</typewriter>
+    </a> argument for more information).
+    <br><br>
+    This option must be repeated to specify additional scripts. See the <a href="#scripting">Scripting
+    </a> section for a description of advanced scripting capabilities.
+    </LI>
+
+    <br><br>
+    
+    <LI>
+    <a name="cleanupScript"><typewriter>-cleanupScript &lt;ScriptName.ext&gt;&nbsp[&lt;arg&gt;]*</typewriter>
+    </a><br>Identifies the name of a script that will execute after <b>ALL</b> programs are imported/analyzed, 
+    and an optional list of arguments to pass to the script. The script name must include its file 
+    extension (i.e., <typewriter>MyScript.java</typewriter>).
+    <br><br>
+    <B><I>This parameter expects the script name only; do not include the path to the script.</I></B> The
+    Headless Analyzer searches specific default locations for the named script, but additional script 
+    director(ies) may also be specified (see the <a href="#scriptPath"><typewriter>-scriptPath</typewriter>
+    </a> argument for more information).
+    <br><br>
+    This option must be repeated to specify additional scripts. See the <a href="#scripting">Scripting
+    </a> section for a description of advanced scripting capabilities.
     </LI>
 
     <br><br>


### PR DESCRIPTION
Have you ever wanted to easily run one or more headless scripts before **ANY** programs are imported/analyzed?  What about after **ALL** programs are imported/analyzed?  I know, it seems like a fantasy.  Or does it?  Let's turn that fantasy into a reality with these new `-initScript` and `-cleanupScript` headless arguments!