### PR TITLE
Use the virtual size to determine the section a RVA belongs to in PE files

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/NTHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/NTHeader.java
@@ -154,7 +154,7 @@ public class NTHeader implements StructConverter, OffsetValidator {
 		SectionHeader[] sections = fileHeader.getSectionHeaders();
 		for (SectionHeader section : sections) {
 			long sectionVA = section.getVirtualAddress() & Conv.INT_MASK;
-			long rawSize = section.getSizeOfRawData() & Conv.INT_MASK;
+			long vSize = section.getVirtualSize() & Conv.INT_MASK;
 			long rawPtr = section.getPointerToRawData() & Conv.INT_MASK;
 
 			switch (layout) {
@@ -162,7 +162,7 @@ public class NTHeader implements StructConverter, OffsetValidator {
 					return rva;
 				case FILE:
 				default:
-					if (rva >= sectionVA && rva < sectionVA + rawSize) {
+					if (rva >= sectionVA && rva < sectionVA + vSize) {
 						return rva + rawPtr - sectionVA;
 					}
 					break;


### PR DESCRIPTION
This was fine for most sane PE binaries because the raw size usually matches the virtual size, but with some packed binaries this is not always the case.

The [specification](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers) allows any combination of virtual size and raw size.