### PR TITLE
Fix row filter bytes for ADAM7 interlacing

### DIFF
--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/CrushedPNGUtil.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/CrushedPNGUtil.java
@@ -207,8 +207,9 @@ public class CrushedPNGUtil {
 			throws PNGFormatException {
 		int width;
 		int height;
-		if (ihdrChunk.getInterlaceMethod() == 1) {
+		if (ihdrChunk.getInterlaceMethod() == CrushedPNGConstants.ADAM7_INTERLACE) {
 			//Msg.debug(this, "Checking Adam7 unpacking");
+			int y = 0;
 			for (int pass = 0; pass < CrushedPNGConstants.STARTING_COL.length; pass++) {
 				width =
 					(ihdrChunk.getImgWidth() - CrushedPNGConstants.STARTING_COL[pass] +
@@ -220,7 +221,6 @@ public class CrushedPNGUtil {
 						CrushedPNGConstants.ROW_INCREMENT[pass];
 
 				int row = 0;
-				int y = 0;
 				while (row < height) {
 					if (decompressedResult[y] > 4) {
 						throw new PNGFormatException("Unknown row filter type " +
@@ -236,7 +236,7 @@ public class CrushedPNGUtil {
 				}
 			}
 
-			int y = 0;
+			y = 0;
 			for (int pass = 0; pass < CrushedPNGConstants.STARTING_COL.length; pass++) {
 
 				//Formula taken from pngcheck

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/IHDRChunk.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/IHDRChunk.java
@@ -138,8 +138,9 @@ public class IHDRChunk {
 				rowFilterBytes += height;
 			}
 
+		} else {
+			rowFilterBytes = imgHeight;
 		}
-		rowFilterBytes = imgHeight;
 	}
 
 	public int getImgWidth() {

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/IHDRChunk.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/IHDRChunk.java
@@ -133,7 +133,7 @@ public class IHDRChunk {
 
 			for (int pass = 0; pass < CrushedPNGConstants.STARTING_ROW.length; pass++) {
 				int height =
-					(imgHeight - CrushedPNGConstants.STARTING_ROW[pass] + CrushedPNGConstants.ROW_INCREMENT[pass - 1]) /
+					(imgHeight - CrushedPNGConstants.STARTING_ROW[pass] + CrushedPNGConstants.ROW_INCREMENT[pass] - 1) /
 						CrushedPNGConstants.ROW_INCREMENT[pass];
 				rowFilterBytes += height;
 			}


### PR DESCRIPTION
The previous code calculated the correct value, but then overwrote it unconditionally.