### PR TITLE
Change reuse/append display to 'showing' display

### DIFF
--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplayProvider.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplayProvider.java
@@ -51,7 +51,7 @@ public class DefaultGraphDisplayProvider implements GraphDisplayProvider {
 			TaskMonitor monitor) {
 
 		if (reuseGraph && !displays.isEmpty()) {
-			return getExistingGraph();
+			return getVisibleGraph();
 		}
 
 		DefaultGraphDisplay display =
@@ -66,9 +66,16 @@ public class DefaultGraphDisplayProvider implements GraphDisplayProvider {
 		this.options = graphOptions;
 	}
 
-	private GraphDisplay getExistingGraph() {
-		DefaultGraphDisplay display = displays.iterator().next();
-		return display;
+	/**
+	 * Get a {@code GraphDisplay} that is 'showing', assuming that is the one the user
+	 * wishes to append to.
+	 * Called only when displays is not empty. If there are no 'showing' displays,
+	 * return one from the Set via its iterator
+	 * @return a display that is showing
+	 */
+	private GraphDisplay getVisibleGraph() {
+		return displays.stream().filter(d -> d.getComponent().isShowing())
+				.findAny().orElse(displays.iterator().next());
 	}
 
 	@Override


### PR DESCRIPTION
When reuse/append is selected, the current approach appends to the 'first' GraphDisplay using an Iterator on the Set. If the user has opened multiple graph displays (by default added as new tabs in a tabbed pane), then the appended-to GraphDisplay will likely not be the one that is currently showing.
The assumption is that the user wants to append to the display they are looking at.
Limitations: If the user has docked GraphDisplays in other windows, and more than one GraphDisplay is 'showing', then this approach may not select the one the user wanted.