### PR TITLE
Handle all PCLATH modification cases.

### DIFF
--- a/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic17c7xxAnalyzer.java
+++ b/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic17c7xxAnalyzer.java
@@ -1073,7 +1073,7 @@ public class Pic17c7xxAnalyzer extends AbstractAnalyzer {
 				Msg.warn(this, "Unhandled PCLATH change at: " + instr.getMinAddress());
 			}
 		}
-		else if (REG_MODIFICATION_MNEMONICS.contains(mnemonic)) {
+		else if (REG_S_MODIFICATION_MNEMONICS.contains(mnemonic)) {
 			pclathContext.setValueUnknown();
 			Msg.warn(this, "Unhandled PCLATH change at: " + instr.getMinAddress());
 		}


### PR DESCRIPTION
PCLATH modification analysis for PIC17C7xx microprocessors would handle a certain subset of opcodes twice (`REG_MODIFICATION_MNEMONICS`) in an if-else chain, shadowing the second instance of the analysis code.