### PR TITLE
Don't scan 3rd party jars for ExtensionPoints in dev mode

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/classfinder/ClassJar.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/classfinder/ClassJar.java
@@ -96,7 +96,8 @@ class ClassJar extends ClassLocation {
 		//
 		// Dev Mode - don't scan 3rd-party jar files
 		// 
-		if (pathName.contains("ExternalLibraries")) {
+		if (pathName.contains("ExternalLibraries") || pathName.contains("caches") ||
+			pathName.contains("flatrepo")) {
 			return true;
 		}
 


### PR DESCRIPTION
There is some code in `ClassJar.ignoreJar()` that attempts to prevent the ClassSearcher from digging into 3rd party jars in various setups.  The setup where you are running Ghidra in development mode from the "flatrepo" environment isn't accounted for.  I noticed this because the new Jython 2.7.2 jar has a lot of classes that end in "Loader" and exceptions are thrown when we try to load some of them.