### PR TITLE
Fix export from IDA Pro unicode comments

### DIFF
--- a/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
+++ b/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
@@ -632,7 +632,7 @@ class XmlExporter(IdaXml):
         # tag_remove seems to be losing last character
         # work around is to add a space
         cmt_text = ida_lines.tag_remove(cmt + ' ')
-        self.write_text(cmt_text)
+        self.write_text(cmt_text.decode('utf-8'))
         self.end_element(COMMENT, False)
 
 


### PR DESCRIPTION
Current script make 1 character for each byte in comment line. So it`s cause double length and incorrect chars in international comments from IDA in Ghidra. This small patch fix it.

IDA Pro:
![image](https://user-images.githubusercontent.com/4955678/82805800-49906a80-9e8d-11ea-80e7-6081adb6d619.png)

Before patch:
![image](https://user-images.githubusercontent.com/4955678/82805823-54e39600-9e8d-11ea-8e19-93c22ef49224.png)

After patch:
![image](https://user-images.githubusercontent.com/4955678/82805855-62008500-9e8d-11ea-93d3-610af885baf6.png)
