### PR TITLE
updates for 'layout busy' dialog

### DIFF
--- a/Ghidra/Features/GraphServices/Module.manifest
+++ b/Ghidra/Features/GraphServices/Module.manifest
@@ -4,5 +4,7 @@ MODULE FILE LICENSE: lib/jungrapht-visualization-1.0-RC8.jar BSD
 MODULE FILE LICENSE: lib/jgrapht-core-1.4.0.jar LGPL 2.1
 MODULE FILE LICENSE: lib/jgrapht-io-1.4.0.jar LGPL 2.1
 MODULE FILE LICENSE: lib/jheaps-0.11.jar Apache License 2.0
+MODULE FILE LICENSE: lib/log4j-slf4j-impl-2.12.1.jar Apache License 2.0
 MODULE FILE LICENSE: lib/slf4j-api-1.7.25.jar MIT
 MODULE FILE LICENSE: lib/slf4j-nop-1.7.25.jar MIT
+

--- a/Ghidra/Features/GraphServices/build.gradle
+++ b/Ghidra/Features/GraphServices/build.gradle
@@ -11,13 +11,16 @@ eclipse.project.name = 'Features Graph Services'
 dependencies {
 	compile project(":Base")
 
-	compile "com.github.tomnelson:jungrapht-visualization:1.0-RC8"
+	compile "com.github.tomnelson:jungrapht-visualization:1.0-SNAPSHOT"
 	compile "org.jgrapht:jgrapht-core:1.4.0"
 	
 	// not using jgrapht-io code that depends on antlr, so exclude antlr
 	compile ("org.jgrapht:jgrapht-io:1.4.0") { exclude group: "org.antlr", module: "antlr4-runtime" }
 	runtime "org.slf4j:slf4j-api:1.7.25"
-	runtime "org.slf4j:slf4j-nop:1.7.25"
+	// use this if you want no slf4j log messages
+	//runtime "org.slf4j:slf4j-nop:1.7.25"
+	// use this if you want slf4j log messages sent to log4j
+	runtime "org.apache.logging.log4j:log4j-slf4j-impl:2.12.1"
 	runtime "org.jheaps:jheaps:0.11"
       
 	helpPath project(path: ":Base", configuration: 'helpPath')

--- a/Ghidra/Features/GraphServices/src/main/help/help/topics/GraphServices/GraphDisplay.htm
+++ b/Ghidra/Features/GraphServices/src/main/help/help/topics/GraphServices/GraphDisplay.htm
@@ -27,6 +27,8 @@
     <ul>
       <li>MouseButton1+drag will translate the display in the x and y axis</li>
       <li>Mouse Wheel will zoom in and out</li>
+      <li>CTRL+Mouse Wheel will zoom in and out in the X-Axis only</li>
+      <li>ALT+Mouse Wheel will zoom in and out in the Y-Axis only</li>
       <li>Ctrl+MouseButton1 will select a vertex or edge</li>
       <ul>
         <li>Shift+Ctrl+MouseButton1 over an unselected vertex will add that vertex to the selection</li>
@@ -45,7 +47,7 @@
         <li>MouseButton1 click-drag on the lens center circle to move the magnifier lens</li>
         <li>MouseButton1 click-draw on a lens edge diamond to resize the magnifier lens </li>
         <li>MouseButton1 click on the upper-right circle-cross to dispose of the magnifier lens</li>
-        <li>Ctrl-MouseWheel to change the magnification of the lens</li>
+        <li>MouseWheel will change the magnification of the lens</li>
       </ul>
       <li>The <IMG src="images/view-filter.png"> button will open a Filter dialog. Select buttons in the dialog to hide specific vertices or edges in the display</li>
       <ul>

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplay.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplay.java
@@ -130,6 +130,19 @@ public class DefaultGraphDisplay implements GraphDisplay {
 		this.pluginTool = graphDisplayProvider.getPluginTool();
 		this.viewer = createViewer();
 
+		this.viewer.getVisualizationModel().getLayoutModel()
+				.getLayoutStateChangeSupport().addLayoutStateChangeListener(
+						evt -> {
+							if (evt.active) {
+								// could show a 'Layout Busy' Dialog here
+								log.info("LayoutAlgorithm started");
+							} else {
+								// could close 'Layout Busy' dialog
+								log.info("LayoutAlgorithm has finished");
+							}
+						}
+		);
+
 		buildHighlighers();
 
 		componentProvider = new DefaultGraphDisplayComponentProvider(this, pluginTool);

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplay.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplay.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 
+import docking.widgets.PopupWindow;
 import org.jgrapht.Graph;
 import org.jungrapht.visualization.*;
 import org.jungrapht.visualization.annotations.MultiSelectedVertexPaintable;
@@ -54,6 +55,7 @@ import ghidra.service.graph.*;
 import ghidra.util.Msg;
 import ghidra.util.Swing;
 import ghidra.util.task.TaskMonitor;
+import org.jungrapht.visualization.util.GraphImage;
 import resources.Icons;
 import util.CollectionUtils;
 
@@ -118,6 +120,7 @@ public class DefaultGraphDisplay implements GraphDisplay {
 	private SingleSelectedVertexPaintable<AttributedVertex, AttributedEdge> singleSelectedVertexPaintable;
 	private MultiSelectedVertexPaintable<AttributedVertex, AttributedEdge> multiSelectedVertexPaintable;
 	private DefaultGraphDisplayProvider graphDisplayProvider;
+	private JDialog layoutWorkingWindow;
 
 	/**
 	 * Create the initial display, the graph-less visualization viewer, and its controls
@@ -130,18 +133,20 @@ public class DefaultGraphDisplay implements GraphDisplay {
 		this.pluginTool = graphDisplayProvider.getPluginTool();
 		this.viewer = createViewer();
 
-		this.viewer.getVisualizationModel().getLayoutModel()
-				.getLayoutStateChangeSupport().addLayoutStateChangeListener(
-						evt -> {
-							if (evt.active) {
-								// could show a 'Layout Busy' Dialog here
-								log.info("LayoutAlgorithm started");
-							} else {
-								// could close 'Layout Busy' dialog
-								log.info("LayoutAlgorithm has finished");
-							}
-						}
-		);
+//		this.viewer.getVisualizationModel().getLayoutModel()
+//				.getLayoutStateChangeSupport().addLayoutStateChangeListener(
+//						evt -> {
+//							if (evt.active) {
+//								// could show a 'Layout Busy' Dialog here
+//								showLayoutWorking();
+//								log.info("LayoutAlgorithm started");
+//							} else {
+//								// could close 'Layout Busy' dialog
+//								hideLayoutWorking();
+//								log.info("LayoutAlgorithm has finished");
+//							}
+//						}
+//		);
 
 		buildHighlighers();
 
@@ -171,6 +176,32 @@ public class DefaultGraphDisplay implements GraphDisplay {
 		JComponent component = viewer.getComponent();
 		component.setFocusable(true);
 		return component;
+	}
+
+	protected void showLayoutWorking() {
+		if (this.layoutWorkingWindow != null) {
+			this.layoutWorkingWindow.dispose();
+		}
+			Window win = SwingUtilities.getWindowAncestor(viewer.getComponent());
+			JProgressBar progressBar = new JProgressBar();
+			progressBar.setIndeterminate(true);
+			JPanel panel = new JPanel(new BorderLayout());
+			panel.add(progressBar, BorderLayout.CENTER);
+			panel.add(new JLabel("Please wait......."), BorderLayout.PAGE_START);
+			this.layoutWorkingWindow = new JDialog(win, "Dialog", Dialog.ModalityType.MODELESS);
+			this.layoutWorkingWindow.add(panel);
+			this.layoutWorkingWindow.setTitle("Layout Algorithm");
+			this.layoutWorkingWindow.pack();
+//		}
+		this.layoutWorkingWindow.setLocationRelativeTo(win);
+		this.layoutWorkingWindow.setVisible(true);
+	}
+
+	protected void hideLayoutWorking() {
+//		JOptionPane.getRootFrame().dispose();
+		if (this.layoutWorkingWindow != null) {
+			this.layoutWorkingWindow.setVisible(false);
+		}
 	}
 
 	int getId() {

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/GhidraIconCache.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/GhidraIconCache.java
@@ -34,7 +34,7 @@ public class GhidraIconCache {
 	private static final int DEFAULT_FONT_SIZE = 12;
 	private static final String DEFAULT_FONT_NAME = "Dialog";
 	private static final int DEFAULT_MARGIN_BORDER_SIZE = 4;
-	private static final float LABEL_TO_ICON_PROPORTION_WAG = 1.4f;
+	private static final float LABEL_TO_ICON_PROPORTION_WAG = 1.1f;
 	private static final double SQRT_2 = Math.sqrt(2.0);
 	private JLabel rendererLabel = new JLabel();
 	private Map<RenderingHints.Key, Object> renderingHints = new HashMap<>();
@@ -128,7 +128,7 @@ public class GhidraIconCache {
 			case DIAMOND:
 			default: // ELLIPSE
 				scalex =
-					labelSize.getWidth() / vertexShape.getBounds().getWidth() * SQRT_2;
+					labelSize.getWidth() / vertexShape.getBounds().getWidth() * 1.1;
 				scaley = labelSize.getHeight() / vertexShape.getBounds().getHeight() * 2;
 				vertexShape = AffineTransform.getScaleInstance(scalex, scaley)
 					.createTransformedShape(vertexShape);

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutFunction.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutFunction.java
@@ -46,17 +46,20 @@ class LayoutFunction
 	static final String MULTI_ROW_EDGE_AWARE_TREE = "Hierarchical MultiRow";
 	static final String EDGE_AWARE_TREE = "Hierarchical";
 	static final String EDGE_AWARE_RADIAL = "Radial";
+	static final String GEM = "Gem (Graph Embedder)";
 
 	public String[] getNames() {
 		return new String[] { EDGE_AWARE_TREE, MULTI_ROW_EDGE_AWARE_TREE, TIDIER_TREE,
 				MIN_CROSS_TOP_DOWN, MIN_CROSS_LONGEST_PATH, MIN_CROSS_NETWORK_SIMPLEX,
 				MIN_CROSS_COFFMAN_GRAHAM, CIRCLE_MINCROSS, KAMADA_KAWAI, FRUCTERMAN_REINGOLD,
-				EDGE_AWARE_RADIAL };
+				EDGE_AWARE_RADIAL, GEM };
 	}
 
 	@Override
 	public LayoutAlgorithm.Builder<AttributedVertex, ?, ?> apply(String name) {
 		switch(name) {
+			case GEM:
+				return GEMLayoutAlgorithm.edgeAwareBuilder();
 			case KAMADA_KAWAI:
 				return KKLayoutAlgorithm.<AttributedVertex> builder().preRelaxDuration(1000);
 			case FRUCTERMAN_REINGOLD:

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutFunction.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutFunction.java
@@ -67,7 +67,7 @@ class LayoutFunction
 						.preRelaxDuration(1000);
 			case FRUCTERMAN_REINGOLD:
 				return FRLayoutAlgorithm.<AttributedVertex> builder()
-					.repulsionContractBuilder(BarnesHutFRRepulsion.barnesHutBuilder())
+					.repulsionContractBuilder(BarnesHutFRRepulsion.builder())
 					.executor(Executors.newSingleThreadExecutor());
 			case CIRCLE_MINCROSS:
 				return CircleLayoutAlgorithm.<AttributedVertex> builder()

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutFunction.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutFunction.java
@@ -15,6 +15,7 @@
  */
 package ghidra.graph.visualization;
 
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 import org.jungrapht.visualization.layout.algorithms.*;
@@ -61,30 +62,38 @@ class LayoutFunction
 			case GEM:
 				return GEMLayoutAlgorithm.edgeAwareBuilder();
 			case KAMADA_KAWAI:
-				return KKLayoutAlgorithm.<AttributedVertex> builder().preRelaxDuration(1000);
+				return KKLayoutAlgorithm.<AttributedVertex> builder()
+						.executor(Executors.newSingleThreadExecutor())
+						.preRelaxDuration(1000);
 			case FRUCTERMAN_REINGOLD:
 				return FRLayoutAlgorithm.<AttributedVertex> builder()
-					.repulsionContractBuilder(BarnesHutFRRepulsion.barnesHutBuilder());
+					.repulsionContractBuilder(BarnesHutFRRepulsion.barnesHutBuilder())
+					.executor(Executors.newSingleThreadExecutor());
 			case CIRCLE_MINCROSS:
 				return CircleLayoutAlgorithm.<AttributedVertex> builder()
+						.executor(Executors.newSingleThreadExecutor())
 					.reduceEdgeCrossing(true);
 			case TIDIER_TREE:
 				return TidierTreeLayoutAlgorithm.<AttributedVertex, AttributedEdge> edgeAwareBuilder();
 			case MIN_CROSS_TOP_DOWN:
 				return HierarchicalMinCrossLayoutAlgorithm
 					.<AttributedVertex, AttributedEdge> edgeAwareBuilder()
+						.executor(Executors.newSingleThreadExecutor())
 						.layering(Layering.TOP_DOWN);
 			case MIN_CROSS_LONGEST_PATH:
 				return EiglspergerLayoutAlgorithm
 						.<AttributedVertex, AttributedEdge> edgeAwareBuilder()
+						.executor(Executors.newSingleThreadExecutor())
 						.layering(Layering.LONGEST_PATH);
 			case MIN_CROSS_NETWORK_SIMPLEX:
 				return EiglspergerLayoutAlgorithm
 						.<AttributedVertex, AttributedEdge> edgeAwareBuilder()
+						.executor(Executors.newSingleThreadExecutor())
 						.layering(Layering.NETWORK_SIMPLEX);
 			case MIN_CROSS_COFFMAN_GRAHAM:
 				return EiglspergerLayoutAlgorithm
 						.<AttributedVertex, AttributedEdge> edgeAwareBuilder()
+						.executor(Executors.newSingleThreadExecutor())
 						.layering(Layering.COFFMAN_GRAHAM);
 			case MULTI_ROW_EDGE_AWARE_TREE:
 				return MultiRowEdgeAwareTreeLayoutAlgorithm

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutTransitionManager.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutTransitionManager.java
@@ -122,11 +122,7 @@ class LayoutTransitionManager {
 		visualizationServer.getRenderContext().getMultiLayerTransformer().setToIdentity();
 		LayoutAlgorithm<AttributedVertex> layoutAlgorithm = builder.build();
 
-		if (layoutAlgorithm instanceof RenderContextAware) {
-			((RenderContextAware<AttributedVertex, AttributedEdge>) layoutAlgorithm)
-				.setRenderContext(visualizationServer.getRenderContext());
-		}
-		else {
+		if (!(layoutAlgorithm instanceof EdgeShapeFunctionSupplier)) {
 			visualizationServer.getRenderContext().setEdgeShapeFunction(originalEdgeShapeFunction);
 		}
 		if (layoutAlgorithm instanceof VertexShapeAware) {
@@ -148,10 +144,6 @@ class LayoutTransitionManager {
 			int preferredWidth = layoutModel.getPreferredWidth();
 			int preferredHeight = layoutModel.getPreferredHeight();
 			layoutModel.setSize(preferredWidth, preferredHeight);
-		}
-		if (layoutAlgorithm instanceof RenderContextAware) {
-			((RenderContextAware<AttributedVertex, AttributedEdge>) layoutAlgorithm)
-				.setRenderContext(renderContext);
 		}
 		if (layoutAlgorithm instanceof AfterRunnable) {
 			((AfterRunnable) layoutAlgorithm).setAfter(visualizationServer::scaleToLayout);

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutTransitionManager.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/LayoutTransitionManager.java
@@ -119,22 +119,15 @@ class LayoutTransitionManager {
 		this.vertexShapeFunction = visualizationServer.getRenderContext().getVertexShapeFunction();
 		this.originalEdgeShapeFunction =
 			visualizationServer.getRenderContext().getEdgeShapeFunction();
-		this.pool = GThreadPool.getSharedThreadPool("LayoutAlgorithms");
+		this.pool = GThreadPool.getPrivateThreadPool("LayoutAlgorithms");
 
 		visualizationServer.getVisualizationModel().getLayoutModel()
 				.getLayoutStateChangeSupport().addLayoutStateChangeListener(
 				evt -> {
 					if (evt.active) {
 						showLayoutWorking(currentExecutor);
-						// could show a 'Layout Busy' Dialog here
-//						log.info("LayoutAlgorithm started");
 					} else {
-						// could close 'Layout Busy' dialog
-//						if (currentExecutor != null) {
-//							if (currentExecutor instanceof )
-//						}
 						hideLayoutWorking();
-//						log.info("LayoutAlgorithm has finished");
 					}
 				}
 		);
@@ -154,6 +147,7 @@ class LayoutTransitionManager {
 		cancel.addActionListener(evt -> {
 			((ThreadPoolExecutor) executor).shutdownNow();
 			layoutWorkingWindow.setVisible(false);
+			pool = GThreadPool.getPrivateThreadPool("LayoutAlgorithms");
 		});
 		panel.add(cancel);
 		this.layoutWorkingWindow = new JDialog(win, "Dialog", Dialog.ModalityType.MODELESS);
@@ -186,9 +180,9 @@ class LayoutTransitionManager {
 		visualizationServer.getRenderContext().getMultiLayerTransformer().setToIdentity();
 		LayoutAlgorithm<AttributedVertex> layoutAlgorithm = builder.build();
 
-		if (layoutAlgorithm instanceof Threaded) {
+		if (layoutAlgorithm instanceof ExecutorConsumer) {
 			currentExecutor = pool.getExecutor();
-			((Threaded)layoutAlgorithm).setExecutor(currentExecutor);
+			((ExecutorConsumer)layoutAlgorithm).setExecutor(currentExecutor);
 		}
 		if (!(layoutAlgorithm instanceof EdgeShapeFunctionSupplier)) {
 			visualizationServer.getRenderContext().setEdgeShapeFunction(originalEdgeShapeFunction);

--- a/Ghidra/Features/GraphServices/src/main/resources/jungrapht.properties
+++ b/Ghidra/Features/GraphServices/src/main/resources/jungrapht.properties
@@ -12,8 +12,8 @@ jungrapht.modalRendererTimerSleep=30
 jungrapht.satelliteBackgroundTransparent=false
 
 # default spacing for tree layouts
-jungrapht.treeLayoutHorizontalSpacing=400
-jungrapht.treeLayoutVerticalSpacing=300
+jungrapht.treeLayoutHorizontalSpacing=50
+jungrapht.treeLayoutVerticalSpacing=50
 
 # default area of pick footprint (item is picked when footprint intersects item shape)
 jungrapht.pickAreaSize=20

--- a/Ghidra/Framework/Generic/src/main/resources/generic.log4jdev.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/generic.log4jdev.xml
@@ -72,7 +72,8 @@
 		<logger name="ghidra.app.util.importer" level="DEBUG" />
 		<logger name="ghidra.app.util.opinion" level="DEBUG" />
 		<logger name="ghidra.util.classfinder" level="DEBUG" />			
-		<logger name="ghidra.util.task" level="DEBUG" />		
+		<logger name="ghidra.util.task" level="DEBUG" />
+		<logger name="org.jungrapht.visualization" level="INFO" />
 
 		<Root level="ALL">
 			<AppenderRef ref="console" level="DEBUG"/>      

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ if (file("flatRepo").isDirectory()) {
 	allprojects {
 		repositories {
 			mavenLocal()
+			maven {
+				url "https://oss.sonatype.org/content/repositories/snapshots"
+			}
 			mavenCentral()
 			jcenter()
 			flatDir name: "flat", dirs:["$rootProject.projectDir/flatRepo"]


### PR DESCRIPTION
Added insertion points for showing a 'busy' dialog while layout algorithm is running.
Added GEM (Graph Embedder) layout algorithm.
Added jar(s) so that logging of jungrapht-visualization can go to Ghidra log4j output.
Reverted to SNAPSHOT release for jungrapt-visualization.