### PR TITLE
Handle errors in PDB parsing

### DIFF
--- a/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/iterate.cpp
@@ -20,7 +20,8 @@ static void iterateEnumMembers(IDiaSymbol& symbol) {
 	DWORD celt = 0;
 	CComPtr<IDiaEnumSymbols> pEnum;
 	CComPtr<IDiaSymbol> pMember;
-	symbol.findChildren(SymTagNull, NULL, nsNone, &pEnum);
+	HRESULT res = symbol.findChildren(SymTagNull, NULL, nsNone, &pEnum);
+	handleFindChildrenError(res);
 	if (pEnum == NULL) {
 		return;
 	}
@@ -42,7 +43,8 @@ void iterateEnums(PDBApiContext& ctx) {
 	DWORD celt = 0;
 	CComPtr<IDiaEnumSymbols> pEnum;
 	CComPtr<IDiaSymbol> pSymbol;
-	ctx.Global().findChildren(SymTagEnum, NULL, nsNone, &pEnum);
+	HRESULT res = ctx.Global().findChildren(SymTagEnum, NULL, nsNone, &pEnum);
+	handleFindChildrenError(res);
 	if (pEnum == NULL) {
 		return;
 	}
@@ -73,7 +75,8 @@ void iterateEnums(PDBApiContext& ctx) {
 static void iterateMembers(IDiaSymbol& symbol) {
 	DWORD celt = 0;
 	CComPtr<IDiaEnumSymbols> pEnum;
-	symbol.findChildren(SymTagNull, NULL, nsNone, &pEnum);
+	HRESULT res = symbol.findChildren(SymTagNull, NULL, nsNone, &pEnum);
+	handleFindChildrenError(res);
 	if (pEnum == NULL) {
 		return;
 	}
@@ -99,7 +102,8 @@ static void iterateMembers(IDiaSymbol& symbol) {
 void iterateDataTypes(PDBApiContext& ctx) {
 	DWORD celt = 0;
 	CComPtr<IDiaEnumSymbols> pEnum;
-	ctx.Global().findChildren(SymTagUDT, NULL, nsNone/*nsfCaseInsensitive|nsfUndecoratedName*/, &pEnum);
+	HRESULT res = ctx.Global().findChildren(SymTagUDT, NULL, nsNone/*nsfCaseInsensitive|nsfUndecoratedName*/, &pEnum);
+	handleFindChildrenError(res);
 	if (pEnum == NULL) {
 		return;
 	}
@@ -141,7 +145,8 @@ void iterateDataTypes(PDBApiContext& ctx) {
 void iterateTypedefs(PDBApiContext& ctx) {
 	DWORD celt = 0;
 	CComPtr<IDiaEnumSymbols> pEnum;
-	ctx.Global().findChildren(SymTagTypedef, NULL, nsNone/*nsfCaseInsensitive|nsfUndecoratedName*/, &pEnum);
+	HRESULT res = ctx.Global().findChildren(SymTagTypedef, NULL, nsNone/*nsfCaseInsensitive|nsfUndecoratedName*/, &pEnum);
+	handleFindChildrenError(res);
 	if (pEnum == NULL) {
 		return;
 	}
@@ -168,7 +173,8 @@ void iterateTypedefs(PDBApiContext& ctx) {
 void iterateClasses(PDBApiContext& ctx) {
 	DWORD celt = 0;
 	CComPtr<IDiaEnumSymbols> pEnum;
-	ctx.Global().findChildren(SymTagUDT, NULL, nsNone/*nsfCaseInsensitive|nsfUndecoratedName*/, &pEnum);
+	HRESULT res = ctx.Global().findChildren(SymTagUDT, NULL, nsNone/*nsfCaseInsensitive|nsfUndecoratedName*/, &pEnum);
+	handleFindChildrenError(res);
 	if (pEnum == NULL) {
 		return;
 	}
@@ -332,7 +338,8 @@ void iterateFunctions(PDBApiContext& ctx) {
 	DWORD celt = 0;
 	CComPtr<IDiaEnumSymbols> pEnum;
 	CComPtr<IDiaSymbol> pSymbol;
-	ctx.Global().findChildren(SymTagFunction, NULL, nsNone, &pEnum);
+	HRESULT res = ctx.Global().findChildren(SymTagNull, NULL, nsNone, &pEnum);
+	handleFindChildrenError(res);
 	if (pEnum == NULL) {
 		return;
 	}

--- a/Ghidra/Features/PDB/src/pdb/cpp/pdb.cpp
+++ b/Ghidra/Features/PDB/src/pdb/cpp/pdb.cpp
@@ -117,4 +117,13 @@ int PDBApiContext::init(const std::wstring& szFilename, const std::wstring& szSi
 	return hr;
 }
 
+void handleFindChildrenError(HRESULT res) {
+	if (!FAILED(res)) {
+		return;
+	}
 
+	if (res == E_NOTIMPL) {
+		fatal("findChilren() returned E_NOTIMPL. Maybe the input file is an unsupported partial PDB\n");
+	}
+	fatal("findChildren() failed\n");
+}

--- a/Ghidra/Features/PDB/src/pdb/headers/pdb.h
+++ b/Ghidra/Features/PDB/src/pdb/headers/pdb.h
@@ -66,4 +66,6 @@ private:
 	CComPtr<IDiaDataSource>   pSource;
 };
 
+void handleFindChildrenError(HRESULT res);
+
 #endif


### PR DESCRIPTION
Microsoft's DIA API doesn't handle so-called partial PDBs, which are created by default from VS 2017 onward (see [MS blog post](https://devblogs.microsoft.com/cppblog/faster-c-build-cycle-in-vs-15-with-debugfastlink/)). Currently Ghidra's pdb.exe just silently doesn't output the expected information for these PDBs. This patch handles errors from findChildren and points the user at the probable cause of the problem.