### PR TITLE
GhidraFileChooser unnecessary ellipses ....

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/DirectoryList.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/DirectoryList.java
@@ -37,7 +37,7 @@ import ghidra.util.exception.AssertException;
 
 class DirectoryList extends GList<File> implements GhidraFileChooserDirectoryModelIf {
 	private static final int DEFAULT_ICON_SIZE = 16;
-	private static final int WIDTH_PADDING = 14;
+	private static final int WIDTH_PADDING = 20;
 	private static final int HEIGHT_PADDING = 5;
 
 	private GhidraFileChooser chooser;


### PR DESCRIPTION
Fixes #1862

I just increased `DirectoryList.WIDTH_PADDING` from `14` to `20`, which was the minimum increase needed to fix all the poorly places ellipses I was seeing.  Tested on both Nimbus and Windows LaF's