### PR TITLE
6809: extended indirect mode fix

### DIFF
--- a/Ghidra/Processors/6805/data/languages/6x09.sinc
+++ b/Ghidra/Processors/6805/data/languages/6x09.sinc
@@ -215,9 +215,9 @@ EA: "["addr",PCR]" is noOffset5=1 & idxMode=29; simm16 [ addr = inst_next + simm
      eaddr = *:2 eaddr;
      export eaddr; 
 }
-EA: "["addr"]" is imm8=0x9F; simm16 [ addr = inst_next; ] 
+EA: "["imm16"]" is imm8=0x9F; imm16
 {
-     local eaddr:2 = inst_next;
+     local eaddr:2 = imm16;
      eaddr = *:2 eaddr;
      export eaddr; 
 }

--- a/Ghidra/Processors/6805/data/languages/6x09.sinc
+++ b/Ghidra/Processors/6805/data/languages/6x09.sinc
@@ -217,9 +217,7 @@ EA: "["addr",PCR]" is noOffset5=1 & idxMode=29; simm16 [ addr = inst_next + simm
 }
 EA: "["imm16"]" is imm8=0x9F; imm16
 {
-     local eaddr:2 = imm16;
-     eaddr = *:2 eaddr;
-     export eaddr; 
+     export *:2 imm16;
 }
 
 ################################################################


### PR DESCRIPTION
Fixes the effective address calculation in the extended indirect mode with post-byte 0x9F. The current implementation takes PC as EA, whilst it should be a 16-bit address. See ["Indirect Modes"](https://www.6809.org.uk/dragon/6309.txt) table, page 26.
Related to #1201.