### PR TITLE
Support large (>2^16) offset to exe file NE header

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/EntryTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/EntryTable.java
@@ -36,9 +36,9 @@ public class EntryTable {
      * @param index the index where the entry table begins
      * @param byteCount the length in bytes of the entry table
      */
-    EntryTable(FactoryBundledWithBinaryReader reader, short index, short byteCount) throws IOException {
+    EntryTable(FactoryBundledWithBinaryReader reader, int index, short byteCount) throws IOException {
         long oldIndex = reader.getPointerIndex();
-        reader.setPointerIndex(Conv.shortToInt(index));
+        reader.setPointerIndex(index);
 
         ArrayList<EntryTableBundle> list = new ArrayList<EntryTableBundle>();
         while (true) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ImportedNameTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ImportedNameTable.java
@@ -28,14 +28,14 @@ import ghidra.util.Conv;
  */
 public class ImportedNameTable {
     private FactoryBundledWithBinaryReader reader;
-    private short index;
+    private int index;
 
     /**
      * Constructs a new imported name table.
      * @param reader the binary reader
      * @param index the index where the table begins
      */
-    ImportedNameTable(FactoryBundledWithBinaryReader reader, short index) {
+    ImportedNameTable(FactoryBundledWithBinaryReader reader, int index) {
         this.reader = reader;
         this.index = index;
     }
@@ -50,7 +50,7 @@ public class ImportedNameTable {
      */
     public LengthStringSet getNameAt(short offset) throws IOException {
         long oldIndex = reader.getPointerIndex();
-        int newIndex = Conv.shortToInt(index)+Conv.shortToInt(offset);
+        int newIndex = index + Conv.shortToInt(offset);
         reader.setPointerIndex(newIndex);
         LengthStringSet lss = new LengthStringSet(reader);
         reader.setPointerIndex(oldIndex);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/InformationBlock.java
@@ -195,10 +195,10 @@ public class InformationBlock {
 	private short ne_swaparea;     // Minimum code swap area size
 	private short ne_expver;       // Expected windows version number
 
-	InformationBlock(FactoryBundledWithBinaryReader reader, short index)
+	InformationBlock(FactoryBundledWithBinaryReader reader, int index)
 			throws InvalidWindowsHeaderException, IOException {
 		long oldIndex = reader.getPointerIndex();
-		reader.setPointerIndex(Conv.shortToInt(index));
+		reader.setPointerIndex(index);
 
 		ne_magic = reader.readNextShort();
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ModuleReferenceTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ModuleReferenceTable.java
@@ -38,9 +38,9 @@ public class ModuleReferenceTable {
      * @param count the count of modules referenced
      * @param imp the imported name table
      */
-    ModuleReferenceTable(FactoryBundledWithBinaryReader reader, short index, short count, ImportedNameTable imp) throws IOException {
+    ModuleReferenceTable(FactoryBundledWithBinaryReader reader, int index, short count, ImportedNameTable imp) throws IOException {
         long oldIndex = reader.getPointerIndex();
-        reader.setPointerIndex(Conv.shortToInt(index));
+        reader.setPointerIndex(index);
 
         offsets = new short[Conv.shortToInt(count)];
         for (short i = 0 ; i < count ; ++i) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/NewExecutable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/NewExecutable.java
@@ -47,7 +47,7 @@ public class NewExecutable {
 
         if (dosHeader.isDosSignature()) {
             try {
-				winHeader = new WindowsHeader(reader, baseAddr, (short) dosHeader.e_lfanew());
+				winHeader = new WindowsHeader(reader, baseAddr, dosHeader.e_lfanew());
             }
             catch (InvalidWindowsHeaderException e) {
             }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ResidentNameTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ResidentNameTable.java
@@ -29,9 +29,9 @@ import java.util.ArrayList;
 public class ResidentNameTable {
     private LengthStringOrdinalSet [] names;
 
-    ResidentNameTable(FactoryBundledWithBinaryReader reader, short index) throws IOException {
+    ResidentNameTable(FactoryBundledWithBinaryReader reader, int index) throws IOException {
         long oldIndex = reader.getPointerIndex();
-        reader.setPointerIndex(Conv.shortToInt(index));
+        reader.setPointerIndex(index);
 
         ArrayList<LengthStringOrdinalSet> list = new ArrayList<LengthStringOrdinalSet>();
         while (true) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ResourceTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/ResourceTable.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
  * 
  */
 public class ResourceTable {
-    private short index;
+    private int index;
     private short alignmentShiftCount;
     private ResourceType [] types;
     private ResourceName [] names;
@@ -41,11 +41,11 @@ public class ResourceTable {
      * @param index  the byte index where the Resource Table begins,
      *               (this is relative to the beginning of the file
      */
-    ResourceTable(FactoryBundledWithBinaryReader reader, short index) throws IOException {
+    ResourceTable(FactoryBundledWithBinaryReader reader, int index) throws IOException {
         this.index = index;
 
         long oldIndex = reader.getPointerIndex();
-        reader.setPointerIndex(Conv.shortToInt(index));
+        reader.setPointerIndex(index);
 
         alignmentShiftCount = reader.readNextShort();
 
@@ -100,7 +100,7 @@ public class ResourceTable {
      * relative to the beginning of the file.
      * @return the byte index where the resource table begins
      */
-    public short getIndex() {
+    public int getIndex() {
         return index;
     }
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/SegmentTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/SegmentTable.java
@@ -29,10 +29,10 @@ import ghidra.util.Conv;
 public class SegmentTable {
     private Segment [] segments;
 
-	SegmentTable(FactoryBundledWithBinaryReader reader, SegmentedAddress baseAddr, short index,
+	SegmentTable(FactoryBundledWithBinaryReader reader, SegmentedAddress baseAddr, int index,
 			short segmentCount, short shiftAlignCount) throws IOException {
         long oldIndex = reader.getPointerIndex();
-        reader.setPointerIndex(Conv.shortToInt(index));
+        reader.setPointerIndex(index);
 
         //create a value of the shift count...
         shiftAlignCount = (short)(0x01 << shiftAlignCount);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/WindowsHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/ne/WindowsHeader.java
@@ -49,10 +49,10 @@ public class WindowsHeader {
 	 * @throws IOException for problems reading the header bytes
 	 */
 	public WindowsHeader(FactoryBundledWithBinaryReader reader, SegmentedAddress baseAddr,
-			short index) throws InvalidWindowsHeaderException, IOException {
+			int index) throws InvalidWindowsHeaderException, IOException {
         this.infoBlock = new InformationBlock(reader, index);
 
-        short segTableIndex = (short)(infoBlock.getSegmentTableOffset() + index);
+        int segTableIndex = infoBlock.getSegmentTableOffset() + index;
         this.segTable = new SegmentTable(reader,
 			baseAddr, segTableIndex, infoBlock.getSegmentCount(),
 			infoBlock.getSegmentAlignmentShiftCount());
@@ -60,22 +60,22 @@ public class WindowsHeader {
         //if resource table offset == resident name table offset, then
         //we do not have any resources...
         if (infoBlock.getResourceTableOffset() != infoBlock.getResidentNameTableOffset()) {
-            short rsrcTableIndex = (short)(infoBlock.getResourceTableOffset() + index);
+            int rsrcTableIndex = infoBlock.getResourceTableOffset() + index;
             this.rsrcTable = new ResourceTable(reader, rsrcTableIndex);
         }
 
-        short resNameTableIndex = (short)(infoBlock.getResidentNameTableOffset() + index);
+        int resNameTableIndex = infoBlock.getResidentNameTableOffset() + index;
         this.resNameTable = new ResidentNameTable(reader, resNameTableIndex);
 
-        short impNameTableIndex = (short)(infoBlock.getImportedNamesTableOffset() + index);
+        int impNameTableIndex = infoBlock.getImportedNamesTableOffset() + index;
         this.impNameTable = new ImportedNameTable(reader, impNameTableIndex);
 
-        short modRefTableIndex = (short)(infoBlock.getModuleReferenceTableOffset() + index);
+        int modRefTableIndex = infoBlock.getModuleReferenceTableOffset() + index;
         this.modRefTable = new ModuleReferenceTable(reader, modRefTableIndex,
                                         infoBlock.getModuleReferenceTableCount(),
                                         impNameTable);
 
-        short entryTableIndex = (short)(infoBlock.getEntryTableOffset() + index);
+        int entryTableIndex = infoBlock.getEntryTableOffset() + index;
         this.entryTable = new EntryTable(reader, entryTableIndex, infoBlock.getEntryTableSize());
 
         this.nonResNameTable = new NonResidentNameTable(reader,


### PR DESCRIPTION
NE style EXE files have a `DWORD` offset to the NE header, but Ghidra currently casts this down to a `short` for no clear reason.  For most NEs which only have the tiny Windows or OS/2 stub program before the NE header, this works fine, but some programs have the NE header further into the file.

Specifically, programs using the _Phar Lap 286|DOS-Extender_ have the extender code before the NE header, or >200kb.  Examples that use this extender are the Origin systems games _Ultima 8_ and _Crusader: No Remorse_.  Currently for these the NE header is not found and Ghidra falls back to treating them as plain MZ exes - so the relocation and DLL resolution do not happen.

Removing the casts and treating the offset as `int` moslty fixes the problem, and I'm able to decompile these EXEs (there is still some issues resolving import ordinals, but I'll fix that in a separate PR).