### PR TITLE
Fix xlmexp.py exporting comments of stack variable in functions

### DIFF
--- a/GhidraBuild/IDAPro/Python/6xx/plugins/xmlexp.py
+++ b/GhidraBuild/IDAPro/Python/6xx/plugins/xmlexp.py
@@ -1683,9 +1683,9 @@ class XmlExporter:
             regcmt = idaapi.get_member_cmt(member.id, False)
             rptcmt = idaapi.get_member_cmt(member.id, True)
             if regcmt != None:
-                regcmt  = idaapi.tag_remove(regcmt + " ", 0)
+                regcmt  = idaapi.tag_remove(regcmt + " ")
             if rptcmt != None:
-                rptrcmt = idaapi.tag_remove(rptcmt + " ", 0)
+                rptrcmt = idaapi.tag_remove(rptcmt + " ")
             has_regcmt = regcmt != None and len(regcmt) > 0
             has_rptcmt = rptcmt != None and len(rptcmt) > 0
             has_content = has_regcmt or has_rptcmt


### PR DESCRIPTION
Issue #1917 remove the non-existent parameter, so exporting functions that have stack variable with a comment on the is possible.