### PR TITLE
Unlock Ghidra GUI when resetting Python

### DIFF
--- a/Ghidra/Features/Python/src/main/java/ghidra/python/PythonPlugin.java
+++ b/Ghidra/Features/Python/src/main/java/ghidra/python/PythonPlugin.java
@@ -177,7 +177,7 @@ public class PythonPlugin extends ProgramPlugin
 	 */
 	private void resetInterpreter() {
 
-		TaskLauncher.launchModal("Resetting Python...", () -> {
+		TaskLauncher.launchNonModal("Resetting Python...", (TaskMonitor monitor) -> {
 			resetInterpreterInBackground();
 		});
 	}


### PR DESCRIPTION
Made the PythonPlugin reset interpreter task a non modal task. The user is now free to use Ghidra while the interpreter is resetting.

Resolves #1773