### PR TITLE
GhidraDev 2.1.1 updates

### DIFF
--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevFeature/category.xml
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevFeature/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/ghidra.ghidradev_2.1.0.qualifier.jar" id="ghidra.ghidradev" version="2.1.0.qualifier">
+   <feature url="features/ghidra.ghidradev_2.1.1.qualifier.jar" id="ghidra.ghidradev" version="2.1.1.qualifier">
       <category name="ghidra.ghidradev"/>
    </feature>
    <category-def name="ghidra.ghidradev" label="Ghidra"/>

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevFeature/feature.xml
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevFeature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ghidra.ghidradev"
       label="GhidraDev"
-      version="2.1.0.qualifier"
+      version="2.1.1.qualifier"
       provider-name="Ghidra">
 
    <description>

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/GhidraDev_README.html
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/GhidraDev_README.html
@@ -53,8 +53,16 @@ change with future releases.</p>
 </ul>
 
 <h2><a name="ChangeHistory"></a>Change History</h2>
-<p><u><b>2.1.1</b>:</u> Python debugging now works when PyDev is installed via the Eclipse "dropins"
-directory.</p>
+<p><u><b>2.1.1</b>:</u> 
+<ul>
+  <li>
+    Python debugging now works when PyDev is installed via the Eclipse "dropins" directory.
+  </li>
+  <li>
+    Fixed a bug in the check that prevents Ghidra projects from being created within the Ghidra 
+    installation directory.
+  </li>
+</ul>
 <p><u><b>2.1.0</b>:</u> 
 <ul>
   <li>

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/GhidraDev_README.html
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/GhidraDev_README.html
@@ -19,7 +19,7 @@
 <h1>GhidraDev README</h1>
 <p>GhidraDev provides support for developing and debugging Ghidra scripts and modules in Eclipse.
 </p>
-<p>The information provided in this document is effective as of GhidraDev 2.1.0 and is subject to
+<p>The information provided in this document is effective as of GhidraDev 2.1.1 and is subject to
 change with future releases.</p>
 
 <ul>
@@ -53,6 +53,8 @@ change with future releases.</p>
 </ul>
 
 <h2><a name="ChangeHistory"></a>Change History</h2>
+<p><u><b>2.1.1</b>:</u> Python debugging now works when PyDev is installed via the Eclipse "dropins"
+directory.</p>
 <p><u><b>2.1.0</b>:</u> 
 <ul>
   <li>

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/META-INF/MANIFEST.MF
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GhidraDev
 Bundle-SymbolicName: ghidra.ghidradev;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.1.1.qualifier
 Bundle-Activator: ghidradev.Activator
 Require-Bundle: org.eclipse.ant.core;bundle-version="3.5.200",
  org.eclipse.buildship.core;bundle-version="3.0.0",

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/utils/PyDevUtils.java
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/utils/PyDevUtils.java
@@ -16,13 +16,21 @@
 package ghidradev.ghidraprojectcreator.utils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.naming.OperationNotSupportedException;
 
 import org.eclipse.core.runtime.*;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
+
+import ghidradev.Activator;
 
 /**
  * Utility methods for interacting with PyDev.
@@ -142,21 +150,31 @@ public class PyDevUtils {
 	 * Gets The PyDev source directory.
 	 * 
 	 * @return The PyDev source directory, or null if it was not found.
+	 * @throws CoreException if there was a problem searching for the PyDev source directory.
 	 */
-	public static File getPyDevSrcDir() {
+	public static File getPyDevSrcDir() throws CoreException {
 		String eclipsePath = Platform.getInstallLocation().getURL().getFile();
 		File pluginsDir = new File(eclipsePath, "plugins");
-		File[] pluginSubDirs = pluginsDir.listFiles(File::isDirectory);
-		if (pluginSubDirs != null) {
-			for (File dir : pluginSubDirs) {
-				if (dir.getName().startsWith("org.python.pydev")) {
-					File pysrcDir = new File(dir, "pysrc");
-					if (pysrcDir.isDirectory()) {
-						return pysrcDir;
-					}
+		File dropinsDir = new File(eclipsePath, "dropins");
+		
+		for (File searchRoot : List.of(pluginsDir, dropinsDir)) {
+			try (Stream<Path> paths = Files.walk(Paths.get(searchRoot.toURI()))) {
+				Optional<File> pysrcDir = paths.filter(
+					Files::isDirectory)
+						.filter(p -> p.endsWith("pysrc"))
+						.map(p -> p.toFile())
+						.filter(f -> f.getParentFile().getName().startsWith("org.python.pydev"))
+						.findFirst();
+				if (pysrcDir.isPresent()) {
+					return pysrcDir.get();
 				}
 			}
+			catch (IOException e) {
+				throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID,
+					IStatus.ERROR, "Problem searching for PyDev source directory", e));
+			}
 		}
+		
 		return null;
 	}
 }

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/utils/PyDevUtils.java
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/utils/PyDevUtils.java
@@ -20,13 +20,18 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.naming.OperationNotSupportedException;
 
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 
@@ -154,10 +159,12 @@ public class PyDevUtils {
 	 */
 	public static File getPyDevSrcDir() throws CoreException {
 		String eclipsePath = Platform.getInstallLocation().getURL().getFile();
-		File pluginsDir = new File(eclipsePath, "plugins");
-		File dropinsDir = new File(eclipsePath, "dropins");
 		
-		for (File searchRoot : List.of(pluginsDir, dropinsDir)) {
+		List<File> searchDirs = new ArrayList<>();
+		searchDirs.add(new File(eclipsePath, "plugins"));
+		searchDirs.add(new File(eclipsePath, "dropins"));
+		
+		for (File searchRoot : searchDirs) {
 			try (Stream<Path> paths = Files.walk(Paths.get(searchRoot.toURI()))) {
 				Optional<File> pysrcDir = paths.filter(
 					Files::isDirectory)

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/CreateGhidraModuleProjectWizard.java
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/CreateGhidraModuleProjectWizard.java
@@ -37,6 +37,7 @@ import ghidradev.EclipseMessageUtils;
 import ghidradev.ghidraprojectcreator.utils.GhidraModuleUtils;
 import ghidradev.ghidraprojectcreator.utils.GhidraModuleUtils.ModuleTemplateType;
 import ghidradev.ghidraprojectcreator.wizards.pages.*;
+import utilities.util.FileUtilities;
 
 /**
  * Wizard to create a new Ghidra module project.
@@ -160,10 +161,10 @@ public class CreateGhidraModuleProjectWizard extends Wizard implements INewWizar
 	 * @return True if the data returned from the wizard pages are valid; otherwise, false
 	 */
 	private boolean validate() {
-		if (projectPage.getProjectDir().getAbsolutePath().startsWith(
-			ghidraInstallationPage.getGhidraInstallDir().getAbsolutePath())) {
+		if (FileUtilities.isPathContainedWithin(ghidraInstallationPage.getGhidraInstallDir(),
+				projectPage.getProjectDir())) {
 			EclipseMessageUtils.showErrorDialog("Invalid Project Root Directory",
-				"Project root directory cannot reside inside of the selected Ghidra installation directory.");
+					"Project root directory cannot reside inside of the selected Ghidra installation directory.");
 			return false;
 		}
 		return true;


### PR DESCRIPTION
A branch for my contributions to the next version of GhidraDev:

- Python debugging now works when PyDev is installed via the Eclipse dropins directory (fixes #1707)
- Improved check that prevents Eclipse projects from being created within the Ghidra installation directory (fixes #2298)