### PR TITLE
Add more known symbol server URLs

### DIFF
--- a/Ghidra/Configurations/Public_Release/data/PDB_SYMBOL_SERVER_URLS.pdburl
+++ b/Ghidra/Configurations/Public_Release/data/PDB_SYMBOL_SERVER_URLS.pdburl
@@ -1,1 +1,3 @@
 Internet,https://msdl.microsoft.com/download/symbols
+Internet,https://symbols.mozilla.org/
+Internet,https://chromium-browser-symsrv.commondatastorage.googleapis.com/


### PR DESCRIPTION
Add two more public symbol servers:
1. Mozilla: https://symbols.mozilla.org/
2. Google Chrome: https://chromium-browser-symsrv.commondatastorage.googleapis.com

References:
1. https://www.chromium.org/developers/how-tos/debugging-on-windows
2. https://developer.mozilla.org/en-US/docs/Mozilla/Using_the_Mozilla_symbol_server