### PR TITLE
Target Java 11 for extensions

### DIFF
--- a/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
+++ b/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
@@ -27,6 +27,11 @@ artifacts {
 	helpPath jar
 }
 
+compileJava {
+    sourceCompatibility = ghidraProps.getProperty('application.java.compiler')
+    targetCompatibility = ghidraProps.getProperty('application.java.compiler')
+}
+
 dependencies {
 	compile fileTree(dir: 'lib', include: "*.jar")
 	compile fileTree(dir: ghidraDir + '/Framework', include: "**/*.jar")


### PR DESCRIPTION
This sets the source and target compatibility to 11 in the buildExtension.gradle script. This will help extension developers from unknowingly targeting a different version than what ghidra is targeting.