### PR TITLE
Fix instruction display with literal operands

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/databasesearcher/InstructionMnemonicOperandFieldSearcher.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/databasesearcher/InstructionMnemonicOperandFieldSearcher.java
@@ -169,10 +169,12 @@ public class InstructionMnemonicOperandFieldSearcher extends ProgramDatabaseFiel
 			}
 		}
 		// check for separator before first operand
-		if (nOperands > 0) {
-			String separator = instruction.getSeparator(0);
-			if (separator != null) {
+		String separator = instruction.getSeparator(0);
+		if (separator != null) {
+			if (nOperands > 0) {
 				opStrings[0] = separator + opStrings[0];
+			} else {
+				return new String[] {separator};
 			}
 		}
 		return opStrings;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/OperandFieldHelper.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/OperandFieldHelper.java
@@ -391,19 +391,28 @@ abstract class OperandFieldHelper extends FieldFactory {
 
 	private ListingField getFieldForInstruction(Instruction inst, ProxyObj<?> proxy, int varWidth) {
 		int numOperands = inst.getNumOperands();
+
+		List<FieldElement> elements = new ArrayList<>();
 		if (numOperands == 0) {
-			return null;
-		}
-
-		List<OperandFieldElement> elements = new ArrayList<>();
-		int characterOffset = createSeparatorFieldElement(inst, 0, 0, 0, 0, elements);
-
-		for (int opIndex = 0; opIndex < numOperands; opIndex++) {
-			OperandRepresentationList operandRepresentationList =
-				codeUnitFormat.getOperandRepresentationList(inst, opIndex);
-			characterOffset = addElementsForOperand(inst, elements, opIndex,
-				operandRepresentationList, characterOffset);
-			characterOffset = 0;
+			String separator = inst.getSeparator(0);
+			if (separator == null) {
+				return null;
+			}
+	
+			AttributedString as = new AttributedString(separator, separatorAttributes.colorAttribute,
+				getMetrics(separatorAttributes.styleAttribute));
+			FieldElement fieldElement = new TextFieldElement(as, 0, 0);
+			elements.add(fieldElement);
+		} else {
+			int characterOffset = createSeparatorFieldElement(inst, 0, 0, 0, 0, elements);
+	
+			for (int opIndex = 0; opIndex < numOperands; opIndex++) {
+				OperandRepresentationList operandRepresentationList =
+					codeUnitFormat.getOperandRepresentationList(inst, opIndex);
+				characterOffset = addElementsForOperand(inst, elements, opIndex,
+					operandRepresentationList, characterOffset);
+				characterOffset = 0;
+			}
 		}
 
 		// There may be operands with no representation objects, so we don't want to create a composite field element.
@@ -414,7 +423,7 @@ abstract class OperandFieldHelper extends FieldFactory {
 			new CompositeFieldElement(elements), startX + varWidth, width, hlProvider);
 	}
 
-	private int addElementsForOperand(Instruction inst, List<OperandFieldElement> elements,
+	private int addElementsForOperand(Instruction inst, List<FieldElement> elements,
 			int opIndex, OperandRepresentationList opRepList, int characterOffset) {
 		int subOpIndex = 0;
 		if (opRepList == null || opRepList.hasError()) {
@@ -437,7 +446,7 @@ abstract class OperandFieldHelper extends FieldFactory {
 			characterOffset, elements);
 	}
 
-	private int addElements(Instruction inst, List<OperandFieldElement> elements, List<?> objList,
+	private int addElements(Instruction inst, List<FieldElement> elements, List<?> objList,
 			int opIndex, int subOpIndex, boolean underline, int characterOffset) {
 		for (int i = 0; i < objList.size(); i++) {
 			characterOffset = addElement(inst, elements, objList.get(i), underline, opIndex,
@@ -446,7 +455,7 @@ abstract class OperandFieldHelper extends FieldFactory {
 		return characterOffset;
 	}
 
-	private int addElement(Instruction inst, List<OperandFieldElement> elements, Object opElem,
+	private int addElement(Instruction inst, List<FieldElement> elements, Object opElem,
 			boolean underline, int opIndex, int subOpIndex, int characterOffset) {
 
 		if (opElem instanceof VariableOffset) {
@@ -468,7 +477,7 @@ abstract class OperandFieldHelper extends FieldFactory {
 	}
 
 	private int createSeparatorFieldElement(Instruction instruction, int separatorIndex,
-			int opIndex, int subOpIndex, int characterOffset, List<OperandFieldElement> elements) {
+			int opIndex, int subOpIndex, int characterOffset, List<FieldElement> elements) {
 		String separator = instruction.getSeparator(separatorIndex);
 		if (separator == null) {
 			return characterOffset;

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/model/listing/CodeUnitFormat.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/model/listing/CodeUnitFormat.java
@@ -116,17 +116,19 @@ public class CodeUnitFormat {
 		if (cu instanceof Instruction) {
 			Instruction instr = (Instruction) cu;
 			int n = instr.getNumOperands();
+			String separator = instr.getSeparator(0);
+			if (separator != null || n != 0) {
+				stringBuffer.append(" ");
+			}
+			if (separator != null) {
+				stringBuffer.append(separator);
+			}
 			for (int i = 0; i < n; i++) {
-				if (i == 0) {
-					stringBuffer.append(" ");
-				}
-				else {
-					String separator = instr.getSeparator(i);
-					if (separator != null && separator.length() != 0) {
-						stringBuffer.append(separator);
-					}
-				}
 				stringBuffer.append(getOperandRepresentationString(cu, i));
+				separator = instr.getSeparator(i + 1);
+				if (separator != null) {
+					stringBuffer.append(separator);
+				}
 			}
 		}
 		else { // data always has one operand


### PR DESCRIPTION
For instructions which only have literal string operands (such as the Z80 IM 0/IM 1/IM2 instructions), previously the operand was missing in the assembly view and in the search result view, and could also not be found by search.

You can reproduce the bug by creating a file with the 2 bytes `ED 56`, opening it in Ghidra with the Z80 language, and looking at the disassembly. Without the fix, it only displays `IM`, after it correctly display `IM 1`.

In [PseudoInstruction](https://github.com/NationalSecurityAgency/ghidra/blob/eaf6ab250df63652cd455f0c051ce7e03f4f641b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoInstruction.java#L454-L473), the correct code is already there, I copied the approach to CodeUnitFormat.

I'm not 100% sure that the fix in InstructionMnemonicOperandFieldSearcher doesn't introduce further bugs (as it will create a OperandFieldLocation for operand 0 which doesn't exist). But when testing it, it didn't seem to cause issues.

This fixes bug #550.