### PR TITLE
1937 Adds an indentation preference to the decompiler output

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/options.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/options.cc
@@ -70,6 +70,7 @@ OptionDatabase::OptionDatabase(Architecture *g)
   registerOption(new OptionIndentIncrement());
   registerOption(new OptionCommentIndent());
   registerOption(new OptionCommentStyle());
+  registerOption(new OptionIndentationStyle());
   registerOption(new OptionCommentHeader());
   registerOption(new OptionCommentInstruction());
   registerOption(new OptionIntegerFormat());
@@ -472,6 +473,18 @@ string OptionCommentStyle::apply(Architecture *glb,const string &p1,const string
 {
   glb->print->setCommentStyle(p1);
   return "Comment style set to "+p1;
+}
+
+/// \class OptionIndentationStyle
+/// \brief Set the style of indentation emitted by the decompiler
+///
+/// The first parameter is either "allman", or "kr", other styles could be
+/// supported in the future 
+string OptionIndentationStyle::apply(Architecture *glb,const string &p1,const string &p2,const string &p3) const
+
+{
+	glb->print->setIndentationStyle(p1);
+	return "Indentation style set to "+p1;
 }
 
 /// \class OptionCommentHeader

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/options.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/options.hh
@@ -174,6 +174,12 @@ public:
   virtual string apply(Architecture *glb,const string &p1,const string &p2,const string &p3) const;
 };
 
+class OptionIndentationStyle : public ArchOption {
+public:
+  OptionIndentationStyle(void) { name = "indentationstyle"; }	///< Constructor
+  virtual string apply(Architecture *glb,const string &p1,const string &p2,const string &p3) const;
+};
+
 class OptionCommentHeader : public ArchOption {
 public:
   OptionCommentHeader(void) { name = "commentheader"; }	///< Constructor

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
@@ -62,6 +62,11 @@ struct PartialSymbolEntry {
 ///  - etc.
 class PrintC : public PrintLanguage {
 protected:
+  /// \brief Possible types of indentation style
+  enum indentation_style {
+    indentation_style_kr = 0,		/// K&R style indentation
+    indentation_style_allman = 1    /// Allman styles indentation
+  };
   static OpToken hidden;		///< Hidden functional (that may force parentheses)
   static OpToken scope;			///< The sub-scope/namespace operator
   static OpToken object_member;		///< The \e member operator
@@ -118,6 +123,7 @@ protected:
   bool option_nocasts;		///< Don't print a cast if \b true
   bool option_unplaced;		///< Set to \b true if we should display unplaced comments
   bool option_hide_exts;	///< Set to \b true if we should hide implied extension operations
+  indentation_style option_indentationStyle;  ///< Set to the prefered type of indentation style
   string nullToken;		///< Token to use for 'null'
   CommentSorter commsorter;	///< Container/organizer for comments in the current function
 
@@ -202,6 +208,7 @@ public:
   virtual ~PrintC(void) {}
   virtual void adjustTypeOperators(void);
   virtual void setCommentStyle(const string &nm);
+  virtual void setIndentationStyle(const string &nm);
   virtual bool isCharacterConstant(const uint1 *buf,int4 size,int4 charsize) const;
   virtual void docTypeDefinitions(const TypeFactory *typegrp);
   virtual void docAllGlobals(void);
@@ -219,6 +226,7 @@ public:
   virtual void emitBlockDoWhile(const BlockDoWhile *bl);
   virtual void emitBlockInfLoop(const BlockInfLoop *bl);
   virtual void emitBlockSwitch(const BlockSwitch *bl);
+  virtual int4 emitFormatedStartBrace(int4 indent);
 
   virtual void opCopy(const PcodeOp *op);
   virtual void opLoad(const PcodeOp *op);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
@@ -431,6 +431,11 @@ public:
   /// \param nm is the configuration description
   virtual void setCommentStyle(const string &nm)=0;
 
+  /// \brief Set the indentation style used in the decompiler output
+  ///
+  /// \param nm is the configuration description
+  virtual void setIndentationStyle(const string &nm)=0;
+
   /// \brief Decide is the given byte array looks like a character string
   ///
   /// This looks for encodings and/or a terminator that is appropriate for the high-level language

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java
@@ -189,6 +189,28 @@ public class DecompileOptions {
 
 	private final static CommentStyleEnum COMMENTSTYLE_OPTIONDEFAULT = CommentStyleEnum.CStyle;
 	private CommentStyleEnum commentStyle;
+	
+	private final static String INDENTATIONSTYLE_OPTIONSTRING = "Display.Indentation style";
+	private final static String INDENTATIONSTYLE_OPTIONDESCRIPTION = "The indentation style to be used";
+	
+	public enum IndentationStyleEnum {
+		
+		KR("K&R style"), Allman("Allman style");
+		
+		private String label;
+		
+		private IndentationStyleEnum(String label) {
+			this.label = label;
+		}
+		
+		@Override
+		public String toString() {
+			return label;
+		}
+	}	
+
+	private final static IndentationStyleEnum INDENTATIONSTYLE_OPTIONDEFAULT = IndentationStyleEnum.KR;
+	private IndentationStyleEnum indentationStyle;
 
 	private final static String COMMENTPRE_OPTIONSTRING = "Display.Display PRE comments";
 	private final static String COMMENTPRE_OPTIONDESCRIPTION =
@@ -355,6 +377,7 @@ public class DecompileOptions {
 		commentWARNInclude = COMMENTWARN_OPTIONDEFAULT;
 		commentHeadInclude = COMMENTHEAD_OPTIONDEFAULT;
 		integerFormat = INTEGERFORMAT_OPTIONDEFAULT;
+		indentationStyle = INDENTATIONSTYLE_OPTIONDEFAULT;
 		keywordColor = HIGHLIGHT_KEYWORD_DEF;
 		functionColor = HIGHLIGHT_FUNCTION_DEF;
 		commentColor = HIGHLIGHT_COMMENT_DEF;
@@ -373,6 +396,7 @@ public class DecompileOptions {
 		decompileTimeoutSeconds = SUGGESTED_DECOMPILE_TIMEOUT_SECS;
 		payloadLimitMBytes = SUGGESTED_MAX_PAYLOAD_BYTES;
 		cachedResultsSize = SUGGESTED_CACHED_RESULTS_SIZE;
+		
 	}
 
 	/**
@@ -408,6 +432,7 @@ public class DecompileOptions {
 		indentwidth = opt.getInt(INDENTWIDTH_OPTIONSTRING, INDENTWIDTH_OPTIONDEFAULT);
 		commentindent = opt.getInt(COMMENTINDENT_OPTIONSTRING, COMMENTINDENT_OPTIONDEFAULT);
 		commentStyle = opt.getEnum(COMMENTSTYLE_OPTIONSTRING, COMMENTSTYLE_OPTIONDEFAULT);
+		indentationStyle = opt.getEnum(INDENTATIONSTYLE_OPTIONSTRING, INDENTATIONSTYLE_OPTIONDEFAULT);
 		commentEOLInclude = opt.getBoolean(COMMENTEOL_OPTIONSTRING, COMMENTEOL_OPTIONDEFAULT);
 		commentPREInclude = opt.getBoolean(COMMENTPRE_OPTIONSTRING, COMMENTPRE_OPTIONDEFAULT);
 		commentPOSTInclude = opt.getBoolean(COMMENTPOST_OPTIONSTRING, COMMENTPOST_OPTIONDEFAULT);
@@ -529,6 +554,8 @@ public class DecompileOptions {
 			COMMENTINDENT_OPTIONDESCRIPTION);
 		opt.registerOption(COMMENTSTYLE_OPTIONSTRING, COMMENTSTYLE_OPTIONDEFAULT, help,
 			COMMENTSTYLE_OPTIONDESCRIPTION);
+		opt.registerOption(INDENTATIONSTYLE_OPTIONSTRING,  INDENTATIONSTYLE_OPTIONDEFAULT,  help,
+			INDENTATIONSTYLE_OPTIONDESCRIPTION);
 		opt.registerOption(COMMENTEOL_OPTIONSTRING, COMMENTEOL_OPTIONDEFAULT, help,
 			COMMENTEOL_OPTIONDESCRIPTION);
 		opt.registerOption(COMMENTPRE_OPTIONSTRING, COMMENTPRE_OPTIONDEFAULT, help,
@@ -642,6 +669,8 @@ public class DecompileOptions {
 		appendOption(buf, "commentindent", Integer.toString(commentindent), "", "");
 		String curstyle = CommentStyleEnum.CPPStyle.equals(commentStyle) ? "cplusplus" : "c";
 		appendOption(buf, "commentstyle", curstyle, "", "");
+		String indentationstyle = IndentationStyleEnum.KR.equals(indentationStyle) ? "kr" : "allman";
+		appendOption(buf, "indentationstyle", indentationstyle, "", "");
 		appendOption(buf, "commentinstruction", "header", commentPLATEInclude ? "on" : "off", "");
 		appendOption(buf, "commentinstruction", "user2", commentPREInclude ? "on" : "off", "");
 		appendOption(buf, "commentinstruction", "user1", commentEOLInclude ? "on" : "off", "");
@@ -845,6 +874,14 @@ public class DecompileOptions {
 
 	public void setCommentStyle(CommentStyleEnum commentStyle) {
 		this.commentStyle = commentStyle;
+	}
+	
+	public IndentationStyleEnum getIndentationStyle() {
+		return indentationStyle;
+	}
+	
+	public void setIndentationStyle(IndentationStyleEnum indentationStyle) {
+		this.indentationStyle = indentationStyle;
 	}
 
 	public int getCacheSize() {


### PR DESCRIPTION
This change also adds support for two indentation styles:

K&R style,

while (x == y) {
    something();
    somethingelse();
}

Allman style,

while (x == y)
{
    something();
    somethingelse();
}

The default style is K&R.