### PR TITLE
General UI/UX improvements for the parser plugin

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/CParserPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/CParserPlugin.java
@@ -277,7 +277,7 @@ public class CParserPlugin extends ProgramPlugin {
 	 */
 	protected void parse(String[] filenames, String options, String dataFilename) {
 		CParserTask parseTask = new CParserTask(this, filenames, options, dataFilename);
-		this.getTool().execute(parseTask, 500);
+		parseDialog.executeProgressTask(parseTask, 500);
 	}
 
 	/*
@@ -286,6 +286,7 @@ public class CParserPlugin extends ProgramPlugin {
 	protected void parse(String[] filenames, String options, DataTypeManager dtMgr,
 			TaskMonitor monitor) throws ghidra.app.util.cparser.C.ParseException,
 			ghidra.app.util.cparser.CPP.ParseException {
+		monitor.initialize(filenames.length + 1);
 		String[] args = parseOptions(options);
 
 		DataTypeManager openDTmanagers[] = null;
@@ -313,7 +314,8 @@ public class CParserPlugin extends ProgramPlugin {
 					"</ul>" + "<p><b>The new archive will become dependent on these archives<br>" +
 					"for any datatypes already defined in them </b>(only unique <br>" +
 					"data types will be added to the new archive).",
-				"Continue?", OptionDialog.QUESTION_MESSAGE) != OptionDialog.OPTION_ONE) {
+				"Continue", OptionDialog.QUESTION_MESSAGE) != OptionDialog.OPTION_ONE) {
+				monitor.cancel();
 				return;
 			}
 		}
@@ -349,15 +351,18 @@ public class CParserPlugin extends ProgramPlugin {
 					if (children == null) {
 						continue;
 					}
+					monitor.setMaximum(monitor.getMaximum() + children.length);
 					for (String element : children) {
 						File child = new File(file.getAbsolutePath() + "/" + element);
 						if (child.getName().endsWith(".h")) {
 							parseFile(child.getAbsolutePath(), monitor, cpp);
 						}
+						monitor.incrementProgress(1);
 					}
 				}
 				else {
 					parseFile(filename, monitor, cpp);
+					monitor.incrementProgress(1);
 				}
 			}
 		}
@@ -395,6 +400,7 @@ public class CParserPlugin extends ProgramPlugin {
 					parseDialog.setDialogText("Successfully parsed header file(s).");
 				}
 			});
+			monitor.incrementProgress(1);
 		}
 
 	}
@@ -429,7 +435,7 @@ public class CParserPlugin extends ProgramPlugin {
 		CParserTask parseTask =
 			new CParserTask(this, filenames, options, currentProgram.getDataTypeManager());
 
-		tool.execute(parseTask);
+		parseDialog.executeProgressTask(parseTask, 500);
 	}
 
 	ParseDialog getDialog() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/ParseDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/ParseDialog.java
@@ -43,6 +43,7 @@ import ghidra.program.model.data.FileDataTypeManager;
 import ghidra.util.HelpLocation;
 import ghidra.util.Msg;
 import ghidra.util.filechooser.ExtensionFileFilter;
+import ghidra.util.task.Task;
 import resources.Icons;
 import resources.ResourceManager;
 
@@ -94,7 +95,7 @@ class ParseDialog extends DialogComponentProvider {
 	private boolean saveAsInProgress;
 
 	ParseDialog(CParserPlugin plugin) {
-		super("Parse C Source", false);
+		super("Parse C Source", false, true, true, true);
 
 		this.plugin = plugin;
 		itemList = new ArrayList<>();
@@ -685,12 +686,18 @@ class ParseDialog extends DialogComponentProvider {
 
 	@Override
 	public void close() {
+		if(pathPanel.getTable().isEditing())
+			pathPanel.getTable().getCellEditor().cancelCellEditing();
 		cancelCurrentTask();
 		super.close();
 	}
 
 	public String getParseOptions() {
 		return parseOptionsField.getText();
+	}
+
+	public void executeProgressTask(Task task, int delay) {
+		super.executeProgressTask(task, delay);
 	}
 
 	private class ComboBoxItem {

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/pathmanager/PathnameTablePanel.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/pathmanager/PathnameTablePanel.java
@@ -226,6 +226,7 @@ public class PathnameTablePanel extends JPanel {
 		pathnameTable.setSelectionForeground(Color.BLACK);
 		pathnameTable.setTableHeader(null);
 		pathnameTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+		pathnameTable.putClientProperty("terminateEditOnFocusLost", true);
 		JScrollPane scrollPane = new JScrollPane(pathnameTable);
 		scrollPane.getViewport().setBackground(pathnameTable.getBackground());
 


### PR DESCRIPTION
This commit does a few things:
- Removes the extra `TaskDialog`
- Cleans up `CParseTask` (someone a little more crafty could probably reduce this even further)
- Cleans up errors
- Makes `CParseTask` progress-aware

In an ideal world the `pathPanel.getTable().getCellEditor().cancelCellEditing();` could probably move into `PathnameTablePanel` but that'd require a rather large rework from `JPanel` -> `GPanel` so we can propagate the fact that the dialog is closing down the hierarchy.

Another weird behaviour of the UI is that clicking empty space doesn't stop the editing, this also proves rather tough to implement, it could be done with a `MouseListener` but it's again a rather large patch and it's definitely not pretty.