### PR TITLE
RIP and EIP relative display

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -683,9 +683,9 @@ addr32: [Base + imm32]					is mod=2 & r_m=4; index=4 & Base; imm32      { local 
 addr32: [Base + Index*ss]				is mod=2 & r_m=4; Index & Base & ss; imm32=0 { local tmp=Base+Index*ss; export tmp; }
 addr32: [Base]							is mod=2 & r_m=4; index=4 & Base; imm32=0    { export Base; }
 @ifdef IA64
-addr32: [riprel]						is bit64=1 & mod=0 & r_m=4; index=4 & base=5; simm32 [ riprel=inst_next+simm32; ] { export *[const]:4 riprel; }
+addr32: [RIP + simm32]						is bit64=1 & mod=0 & r_m=4; index=4 & base=5; simm32 & RIP { local riprel:4 = inst_next + simm32; export *[const]:4 riprel; }
 
-Addr32_64: [eiprel]						is mod=0 & r_m=5; simm32	[ eiprel=inst_next+simm32; ] { export *[const]:8 eiprel; }
+Addr32_64: [EIP + simm32]						is mod=0 & r_m=5; simm32 & EIP	{ local eiprel:8 = inst_next + simm32; export *[const]:8 eiprel; }
 Addr32_64: [imm32]		is mod=0 & r_m=4; index=4 & base=5; imm32    { export *[const]:8 imm32; }
 Addr32_64: addr32		is addr32									 { tmp:8 = sext(addr32); export tmp; }
 	
@@ -699,7 +699,7 @@ addr64: [Rmr64 + simm8_64]				is mod=1 & Rmr64; simm8_64                        
 addr64: [Rmr64 + simm32_64]				is mod=2 & Rmr64; simm32_64                        { local tmp=Rmr64+simm32_64; export tmp; }
 addr64: [Rmr64]							is mod=1 & r_m!=4 & Rmr64; simm8=0                 { export Rmr64; }
 addr64: [Rmr64]							is mod=2 & r_m!=4 & Rmr64; simm32=0                { export Rmr64; }
-addr64: [riprel]						is mod=0 & r_m=5; simm32 [ riprel=inst_next+simm32; ] { export *[const]:8 riprel; }
+addr64: [RIP + simm32]						is mod=0 & r_m=5; simm32 & RIP	{ local riprel:8 = inst_next + simm32; export *[const]:8 riprel; }
 addr64: [Base64 + Index64*ss]			is mod=0 & r_m=4; Index64 & Base64 & ss            { local tmp=Base64+Index64*ss; export tmp; }
 addr64: [Base64]						is mod=0 & r_m=4; rexXprefix=0 & index64=4 & Base64    { export Base64; }
 addr64: [simm32_64 + Index64*ss]		is mod=0 & r_m=4; Index64 & base64=5 & ss; simm32_64   { local tmp=simm32_64+Index64*ss; export tmp; }


### PR DESCRIPTION
The display should print the register and immediate offset
instead of the relative value.