### PR TITLE
Added DomainObjectChangeRecord event type information

### DIFF
--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/model/DomainObjectChangeRecord.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/model/DomainObjectChangeRecord.java
@@ -19,7 +19,10 @@ import java.io.Serializable;
 
 /**
  * Information about a change that was made to a domain object. The
- * record is delivered as part of the change notification.
+ * record is delivered as part of the change notification. The event
+ * types correspond to the constants in
+ * {@link ghidra.program.util.ChangeManager ChangeManager}.
+ * @see ghidra.program.util.ChangeManager ChangeManager
  */
 public class DomainObjectChangeRecord implements Serializable {
 	private final static long serialVersionUID = 1;


### PR DESCRIPTION
This clarifies any confusion as to what the event type means when implementing DomainObjectListener. I actually had to follow the call stack and find where the event type value was coming from to find this information.

I also have realized that this is not what I wanted to implement.