### PR TITLE
Extensions installed per user (outside of installation dir)

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/FrontEndPlugin/Extensions.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/FrontEndPlugin/Extensions.htm
@@ -29,11 +29,17 @@ option on the project file menu.</p>
 <h2>Dialog Components</h2>
 <h3>Extensions List</h3>
 <blockquote>
-The list of extensions is populated when the dialog is launched. To build the list, Ghidra looks in two locations:
+The list of extensions is populated when the dialog is launched. To build the list, Ghidra looks in several locations:
 <ul>
-<li>Extensions Installation Directory: Contains any extensions that have been installed. This is located at <i>[installation dir]/Ghidra/Extensions/</i></li>
+<li>Extension Installation Directories: Contains any extensions that have been installed. The directories are located at:</li>
+  <ul>
+  <li><i>[user dir]/.ghidra/.ghidra-[version]/Extensions</i> - Installed/uninstalled from this dialog</li>
+  <li><i>[installation dir]/Ghidra/Extensions/</i> - Installed/uninstalled from filesystem manually</li>
+  </ul>
 <li>Extensions Archive Directory: This is where all archive files (zips) are stored. It is located at <i>[installation dir]/Extensions/Ghidra/</i></li>
 </ul>
+<p><b>Note: </b> Extensions that have been installed directly into the Ghidra installation directory cannot be uninstalled
+from this dialog.  They must be manually removed from the filesystem.</p>
 </blockquote>
 
 <h3>Description Panel</h3>

--- a/Ghidra/Features/Base/src/test/java/ghidra/util/extensions/ExtensionUtilsTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/util/extensions/ExtensionUtilsTest.java
@@ -15,8 +15,7 @@
  */
 package ghidra.util.extensions;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.*;
 import java.util.Set;
@@ -57,7 +56,9 @@ public class ExtensionUtilsTest extends AbstractGenericTest {
 		// we start with a clean slate). If they're not empty, CORRECT THE SITUATION.
 		if (!checkCleanInstall()) {
 			FileUtilities.deleteDir(gLayout.getExtensionArchiveDir().getFile(false));
-			FileUtilities.deleteDir(gLayout.getExtensionInstallationDir().getFile(false));
+			for (ResourceFile installDir : gLayout.getExtensionInstallationDirs()) {
+				FileUtilities.deleteDir(installDir.getFile(false));
+			}
 		}
 
 		createExtensionDirs();
@@ -248,7 +249,7 @@ public class ExtensionUtilsTest extends AbstractGenericTest {
 			}
 		}
 		
-		ResourceFile installDir = gLayout.getExtensionInstallationDir();
+		ResourceFile installDir = gLayout.getExtensionInstallationDirs().get(0);
 		if (!installDir.exists()) {
 			if (!installDir.mkdir()) {
 				throw new IOException("Failed to create extension installation directory for test");
@@ -260,7 +261,7 @@ public class ExtensionUtilsTest extends AbstractGenericTest {
 	 * Verifies that the installation folder is empty.
 	 */
 	private boolean checkCleanInstall() {
-		ResourceFile[] files = gLayout.getExtensionInstallationDir().listFiles();
+		ResourceFile[] files = gLayout.getExtensionInstallationDirs().get(0).listFiles();
 		return (files == null || files.length == 0);
 	}
 
@@ -271,7 +272,7 @@ public class ExtensionUtilsTest extends AbstractGenericTest {
 	 * @param name the name of the installed extension
 	 */
 	private void checkDirtyInstall(String name) {
-		ResourceFile[] files = gLayout.getExtensionInstallationDir().listFiles();
+		ResourceFile[] files = gLayout.getExtensionInstallationDirs().get(0).listFiles();
 		assertTrue(files.length >= 1);
 		assertTrue(files[0].getName().equals(name));
 	}

--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/remote/GhidraServerApplicationLayout.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/remote/GhidraServerApplicationLayout.java
@@ -17,6 +17,7 @@ package ghidra.server.remote;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Collections;
 
 import ghidra.framework.ApplicationProperties;
 import ghidra.util.SystemUtilities;
@@ -51,7 +52,7 @@ public class GhidraServerApplicationLayout extends ApplicationLayout {
 
 		// Extension directories
 		extensionArchiveDir = null;
-		extensionInstallationDir = null;
+		extensionInstallationDirs = Collections.emptyList();
 
 		// User directories (don't let anything use the user home directory...there may not be one)
 		userTempDir = ApplicationUtilities.getDefaultUserTempDir(applicationProperties);

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/ExtensionTableProvider.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/dialog/ExtensionTableProvider.java
@@ -123,7 +123,12 @@ public class ExtensionTableProvider extends DialogComponentProvider {
 				// Don't let the user attempt to install anything if they don't have write
 				// permissions on the installation dir.
 				ResourceFile installDir =
-					Application.getApplicationLayout().getExtensionInstallationDir();
+					Application.getApplicationLayout().getExtensionInstallationDirs().get(0);
+				if (!installDir.exists() && !installDir.mkdir()) {
+					Msg.showError(this, null, "Directory Error",
+						"Cannot install/uninstall extensions: Failed to create extension installation directory.\n" +
+							"See the \"Ghidra Extension Notes\" section of the Ghidra Installation Guide for more information.");
+				}
 				if (!installDir.canWrite()) {
 					Msg.showError(this, null, "Permissions Error",
 						"Cannot install/uninstall extensions: Invalid write permissions on installation directory.\n" +

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraApplicationLayout.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraApplicationLayout.java
@@ -62,7 +62,7 @@ public class GhidraApplicationLayout extends ApplicationLayout {
 			getApplicationInstallationDir());
 
 		// Extensions
-		extensionInstallationDir = findExtensionInstallationDirectory();
+		extensionInstallationDirs = findExtensionInstallationDirectories();
 		extensionArchiveDir = findExtensionArchiveDirectory();
 
 		// Patch directory
@@ -217,17 +217,20 @@ public class GhidraApplicationLayout extends ApplicationLayout {
 	}
 
 	/**
-	 * Returns the directory where all Ghidra extension archives should be
-	 * installed. This should be at the following location:<br>
+	 * Returns a prioritized list of directories where Ghidra extensions are installed. These 
+	 * should be at the following locations:<br>
 	 * <ul>
+	 * <li><code>[user settings dir]/Extensions</code></li>
 	 * <li><code>[application install dir]/Ghidra/Extensions</code></li>
 	 * <li><code>ghidra/Ghidra/Extensions</code> (development mode)</li>
 	 * </ul>
 	 * 
 	 * @return the install folder, or null if can't be determined
 	 */
-	protected ResourceFile findExtensionInstallationDirectory() {
+	protected List<ResourceFile> findExtensionInstallationDirectories() {
 
+		List<ResourceFile> dirs = new ArrayList<>();
+		
 		// Would like to find a better way to do this, but for the moment this seems the
 		// only solution. We want to get the 'Extensions' directory in ghidra, but there's 
 		// no way to retrieve that directory directly. We can only get the full set of 
@@ -237,13 +240,14 @@ public class GhidraApplicationLayout extends ApplicationLayout {
 			ResourceFile rootDir = getApplicationRootDirs().iterator().next();
 			File temp = new File(rootDir.getFile(false), "Extensions");
 			if (temp.exists()) {
-				return new ResourceFile(temp);
+				dirs.add(new ResourceFile(temp));
 			}
-
-			return null;
+		}
+		else {
+			dirs.add(new ResourceFile(new File(userSettingsDir, "Extensions")));
+			dirs.add(new ResourceFile(applicationInstallationDir, "Ghidra/Extensions"));
 		}
 
-		ResourceFile installDir = findGhidraApplicationInstallationDir();
-		return new ResourceFile(installDir, "Ghidra/Extensions");
+		return dirs;
 	}
 }

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraJarApplicationLayout.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraJarApplicationLayout.java
@@ -75,9 +75,9 @@ public class GhidraJarApplicationLayout extends GhidraApplicationLayout {
 	}
 
 	@Override
-	protected ResourceFile findExtensionInstallationDirectory() {
+	protected List<ResourceFile> findExtensionInstallationDirectories() {
 		ResourceFile extensionInstallDir = new ResourceFile(
 			ApplicationLayout.class.getResource("/_Root/Ghidra/Extensions").toExternalForm());
-		return extensionInstallDir;
+		return List.of(extensionInstallDir);
 	}
 }

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraTestApplicationLayout.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraTestApplicationLayout.java
@@ -16,6 +16,7 @@
 package ghidra;
 
 import java.io.*;
+import java.util.List;
 
 import generic.jar.ResourceFile;
 
@@ -51,9 +52,9 @@ public class GhidraTestApplicationLayout extends GhidraApplicationLayout {
 	}
 
 	@Override
-	protected ResourceFile findExtensionInstallationDirectory() {
+	protected List<ResourceFile> findExtensionInstallationDirectories() {
 		File installDir = new File(getUserTempDir(), "ExtensionInstallDir");
-		return new ResourceFile(installDir);
+		return List.of(new ResourceFile(installDir));
 	}
 
 	@Override

--- a/Ghidra/Framework/Utility/src/main/java/utility/application/ApplicationLayout.java
+++ b/Ghidra/Framework/Utility/src/main/java/utility/application/ApplicationLayout.java
@@ -17,8 +17,7 @@ package utility.application;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 
 import generic.jar.ResourceFile;
 import ghidra.framework.ApplicationProperties;
@@ -44,7 +43,7 @@ public abstract class ApplicationLayout {
 	protected File userSettingsDir;
 	protected ResourceFile patchDir;
 	protected ResourceFile extensionArchiveDir;
-	protected ResourceFile extensionInstallationDir;
+	protected List<ResourceFile> extensionInstallationDirs;
 
 	/**
 	 * Gets the application properties from the application layout
@@ -121,13 +120,13 @@ public abstract class ApplicationLayout {
 	}
 
 	/**
-	 * Returns the application Extensions installation folder.
+	 * Returns an {@link List ordered list} of the application Extensions installation directories.
 	 * 
-	 * @return the application Extensions installation directory.  Could be null if the 
-	 *   {@link ApplicationLayout} does not support application Extensions.
+	 * @return an {@link List ordered list} of the application Extensions installation directories.
+	 *   Could be empty if the {@link ApplicationLayout} does not support application Extensions.
 	 */
-	public final ResourceFile getExtensionInstallationDir() {
-		return extensionInstallationDir;
+	public final List<ResourceFile> getExtensionInstallationDirs() {
+		return extensionInstallationDirs;
 	}
 
 	/**

--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -18,7 +18,7 @@
 
 <h1>Ghidra Installation Guide</h1>
 <p>
-The installation information provided is effective as of Ghidra 9.1 and is subject to change with
+The installation information provided is effective as of Ghidra 9.2 and is subject to change with
 future releases.
 </p>
 
@@ -363,17 +363,14 @@ can be found in the <i>&lt;GhidraInstallDir&gt;</i>/Extensions directory.</p>
     </ol>
   </li>
   <li>
-    Installing or uninstalling Ghidra extensions may fail if the user does not have write
-    permissions to <i>&lt;GhidraInstallDir&gt;</i>.  This may occur if the user is running Ghidra
-    from a shared installation location.  In this situation, the owner of the Ghidra installation
-    directory will be responsible for managing what Ghidra extensions are available for that
-    particular installation of Ghidra.
+    Extensions installed from the Ghidra front-end GUI get installed at 
+    <i>&lt;UserDir&gt;</i>/.ghidra/.ghidra-[version]/Extensions.
   </li>
   <li>
-    <p>It is possible to install and uninstall Ghidra extensions manually when the Ghidra front-end
-    GUI is not available.  This may be required if a system administrator is managing the Ghidra
-    extensions of a shared Ghidra installation on behalf of a user, or if a user wishes to install
-    an extension into a Ghidra installation that is only ever used headlessly.<p>
+    <p>It is possible to install Ghidra extensions directly into the Ghidra installation directory.
+    This may be required if a system administrator is managing extensions for multiple users that
+    all use a shared installation of Ghidra.  It may also be more convenient to manage extensions
+    this way if a Ghidra installation is only ever used headlessly.<p>
     <p>To install an extension in these cases, simply extract the desired Ghidra extension archive
     file(s) to the <i>&lt;GhidraInstallDir&gt;</i>/Ghidra/Extensions directory.  For example, on
     Linux or macOS:</p>


### PR DESCRIPTION
There are a few things in Ghidra that are still guilty of writing to the installation directory, including extensions.  With this PR, extensions are now installed per user to the user settings directory, rather per installation.  Extensions can still manually be extracted to `Ghidra/Extensions` for shared installations or purely headless operation. 

Fixes #513 