### PR TITLE
Fix std::vector oob access in StringManager::saveXml()

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/stringmanage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/stringmanage.cc
@@ -98,7 +98,7 @@ void StringManager::saveXml(ostream &s) const
     s << " <bytes";
     a_v_b(s, "trunc", stringData.isTruncated);
     s << ">\n" << setfill('0');
-    for(int4 i=0;stringData.byteData.size();++i) {
+    for(uintp i=0;i<stringData.byteData.size();++i) {
       s << hex << setw(2) << (int4)stringData.byteData[i];
       if (i%20 == 19)
 	s << "\n  ";


### PR DESCRIPTION
The for-loop was checking for `stringData.byteData.size()` which means if there was at least one element, it would loop infinitely and beyond the vector size.
Also, using `int4` is conceptually wrong here because it would allow for overflows. It must be `size_t` or equivalent.