### PR TITLE
Fixed EmulatorHelper.writeStackValue

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/EmulatorHelper.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/EmulatorHelper.java
@@ -288,10 +288,10 @@ public class EmulatorHelper implements MemoryFaultHandler, EmulatorConfiguration
 		long offset = readRegister(stackPtrReg).longValue() + relativeOffset;
 		byte[] bytes = new byte[size];
 		if (program.getMemory().isBigEndian()) {
-			BigEndianDataConverter.INSTANCE.getBytes(value, bytes);
+			BigEndianDataConverter.INSTANCE.getBytes(value, size, bytes, 0);
 		}
 		else {
-			LittleEndianDataConverter.INSTANCE.getBytes(value, bytes);
+			LittleEndianDataConverter.INSTANCE.getBytes(value, size, bytes, 0);
 		}
 		writeMemory(stackMemorySpace.getAddress(offset), bytes);
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/disassemble/Disassembler.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/disassemble/Disassembler.java
@@ -922,7 +922,13 @@ public class Disassembler implements DisassemblerConflictHandler {
 
 				// TODO: An overall better caching of bytes for this block could be done instead
 				//       the previous buffering done here was not doing any buffering
-				MemBuffer instrMemBuffer = new DumbMemBufferImpl(blockMemBuffer.getMemory(), addr);
+				MemBuffer instrMemBuffer;
+
+				try {
+					instrMemBuffer = new DumbMemBufferImpl(blockMemBuffer.getMemory(), addr);
+				} catch(UnsupportedOperationException e) {
+					instrMemBuffer = blockMemBuffer;
+				}
 
 				adjustPreParseContext(instrMemBuffer);
 


### PR DESCRIPTION
Fixed an error in `EmulatorHelper.writeStackValue` where the size of the value was not passed to the data converter. This caused an out of bounds error.

While fixing this, I also came across an error where `getMemory` was called on an object of type `EmulateMemoryStateBuffer` which is unsupported for that type.