### PR TITLE
[memory] Update state after changing the `overlay` property

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/AddBlockModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/AddBlockModel.java
@@ -151,6 +151,8 @@ class AddBlockModel {
 
 	void setOverlay(boolean b) {
 		this.isOverlay = b;
+		validateInfo();
+		listener.stateChanged(null);
 	}
 
 	void setInitializedType(InitializedType type) {


### PR DESCRIPTION
Fix #2020.