### PR TITLE
Comparable ClangLine

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangLine.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangLine.java
@@ -23,7 +23,7 @@ import java.util.*;
  * A line of C code. This is an independent grouping
  * of C tokens from the statement, vardecl retype groups
  */
-public class ClangLine {
+public class ClangLine implements Comparable<ClangLine> {
 	private int indent_level;
 	private ArrayList<ClangToken> tokens;
 	private int lineNumber;
@@ -104,5 +104,10 @@ public class ClangLine {
 	@Override
 	public String toString() {
 		return toDebugString(Collections.emptyList());
+	}
+
+	@Override
+	public int compareTo(ClangLine o) {
+		return Integer.compare(lineNumber, o.lineNumber);
 	}
 }


### PR DESCRIPTION
This is to allow simplified sorting of a Collection of ClangLines. Comparison is done using its line number which is intuitive for its natural ordering.