### PR TITLE
Moved Jython cache directory from user temp to user settings directory.

### DIFF
--- a/Ghidra/Features/Python/src/main/java/ghidra/python/PythonUtils.java
+++ b/Ghidra/Features/Python/src/main/java/ghidra/python/PythonUtils.java
@@ -66,8 +66,9 @@ public class PythonUtils {
 	public static File setupPythonCacheDir(TaskMonitor monitor)
 			throws CancelledException, IOException {
 
-		File cacheDir = new File(Application.getUserTempDirectory(), PYTHON_CACHEDIR);
-		if (!FileUtilities.createDir(cacheDir)) {
+		File devDir = new File(Application.getUserSettingsDirectory(), "dev");
+		File cacheDir = new File(devDir, PYTHON_CACHEDIR);
+		if (!FileUtilities.mkdirs(cacheDir)) {
 			throw new IOException("Failed to create the python cache directory at: " + cacheDir);
 		}
 


### PR DESCRIPTION
Operating systems periodically clean up their temp directories.  Some users are noticing that if they keep their Ghidra open for a long time, their python interpreter stops working.  Moving the jython cache directory to .ghidra/.ghidra-&lt;version&gt; will prevent the cached files from being deleted.  A few things to note:

1. It makes sense to move them here, because that's where the compiled java script files live.
2. The jython cache directory used to live here, but I moved it to temp because it seemed more appropriate at the time.  I guess I was wrong about that.

Fixes #1842 