### PR TITLE
Allow exclamation marks as filter delimiters.

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filter/FilterOptions.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filter/FilterOptions.java
@@ -41,7 +41,7 @@ public class FilterOptions {
 		DELIMITER_NAME_MAP.put(' ', "Space");
 		DELIMITER_NAME_MAP.put('~', "Tilde");
 		DELIMITER_NAME_MAP.put('`', "Back quote");
-		DELIMITER_NAME_MAP.put('@', "Exclamation point");
+		DELIMITER_NAME_MAP.put('!', "Exclamation point");
 		DELIMITER_NAME_MAP.put('@', "At sign");
 		DELIMITER_NAME_MAP.put('#', "Pound sign");
 		DELIMITER_NAME_MAP.put('$', "Dollar sign");


### PR DESCRIPTION
This PR fixes a typo in the creation of the delimiters name map for filter options - the exclamation mark character was explicitly named but an at sign was put in its place instead.