### PR TITLE
Add more functions to PEFunctionsThatDoNotReturn

### DIFF
--- a/Ghidra/Features/Base/data/PEFunctionsThatDoNotReturn
+++ b/Ghidra/Features/Base/data/PEFunctionsThatDoNotReturn
@@ -1,7 +1,15 @@
+abort
 CxxThrowException
 CxxThrowException@8
 CxxFrameHandler3
 crtExitProcess
 ExitProcess
+ExitThread
 exit
+FreeLibraryAndExitThread
+invalid_parameter_noinfo_noreturn
+invoke_watson
 longjmp
+quick_exit
+RpcRaiseException
+terminate


### PR DESCRIPTION
Similar as ExitProcess, there are more functions don't return to its caller. I searched through the Windows SDK headers. The following should be all noreturn user-mode functions:

Commands are:
`findstr.exe /s /n /c:DECLSPEC_NORETURN "C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\*.h"`
and `findstr.exe /s /n /c:"__declspec(noreturn)" "C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\*.h"`
```
loaderapi.h: WINBASEAPI DECLSPEC_NORETURN VOID WINAPI FreeLibraryAndExitThread(_In_ HMODULE hLibModule, _In_ DWORD dwExitCode);
processthreadsapi.h: WINBASEAPI DECLSPEC_NORETURN VOID WINAPI ExitThread(_In_ DWORD dwExitCode);
rpcdce.h: RPCRTAPI DECLSPEC_NORETURN void RPC_ENTRY RpcRaiseException(_In_ RPC_STATUS exception);
stdlib.h:55: _ACRTIMP __declspec(noreturn) void __cdecl quick_exit(_In_ int _Code);
stdlib.h:56: _ACRTIMP __declspec(noreturn) void __cdecl abort(void);
corecrt.h:279: _ACRTIMP __declspec(noreturn) void __cdecl _invalid_parameter_noinfo_noreturn(void);
corecrt.h:281: __declspec(noreturn) _ACRTIMP void __cdecl _invoke_watson(wchar_t const* _Expression, wchar_t const* _FunctionName, wchar_t const* _FileName, unsigned int _LineNo, uintptr_t _Reserved);
corecrt_terminate.h:29: _ACRTIMP __declspec(noreturn) void __cdecl terminate() throw();
```
Before:
![before](https://user-images.githubusercontent.com/16713498/87850180-11ad0e80-c8a3-11ea-901d-ef0f887f7f1f.png)

After:
![after](https://user-images.githubusercontent.com/16713498/87850182-1a054980-c8a3-11ea-8d9b-19c1ebf164fc.png)

Related to #1820.
