### PR TITLE
RISC-V j/jr semantics: use goto instead of call

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32i.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32i.sinc
@@ -128,7 +128,7 @@
 # j a 0000006f 00000fff BRANCH|ALIAS (0, 0)
 :j immUJ is RV32 & RVI & immUJ & op0001=0x3 & op0204=0x3 & op0506=0x3 & op0711=0x0
 {
-	call immUJ;
+	goto immUJ;
 }
 
 
@@ -144,14 +144,14 @@
 :jr immI(rs1) is RV32 & RVI & immI & rs1 & op0001=0x3 & op0204=0x1 & op0506=0x3 & funct3=0x0 & op0711=0x0 & op2031!=0
 {
 	local ea:$(XLEN) = (rs1 + immI) & ~1;
-	call [ea];
+	goto [ea];
 }
 
 # jr s 00000067 fff07fff BRANCH|ALIAS (0, 0)
 :jr rs1 is RV32 & RVI & rs1 & op0001=0x3 & op0204=0x1 & op0506=0x3 & funct3=0x0 & op0711=0x0 & op2031=0x0 & op1519>1
 {
 	local ea:$(XLEN) = rs1 & ~1;
-	call [ea];
+	goto [ea];
 }
 
 # ret  00008067 ffffffff BRANCH|ALIAS (0, 0)


### PR DESCRIPTION
In the RISC-V binaries that I've been looking at, the j and jr
instructions have been used exclusively for intraprocedural control flow
transfers, where the function-call hinting associated with the CALL
p-code op leads to nasty side effects in the control flow
reconstruction.