### PR TITLE
ELF NOBITS sections don't need bits

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
@@ -2711,7 +2711,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 					continue;
 				}
 				long size = elfSectionToLoad.getSize();
-				if (size <= 0 || size >= fileBytes.getSize()) {
+				if (size <= 0 || (elfSectionToLoad.getType() != ElfSectionHeaderConstants.SHT_NOBITS &&  size >= fileBytes.getSize())) {
 					log("Skipping section [" + elfSectionToLoad.getNameAsString() +
 						"] with invalid size");
 					continue;


### PR DESCRIPTION
Elf sections that are NOBITS aren't backed by data in the file,
consequently, we shouldn't check to see if the size of the section is
reasonable by comparing it against the file size

This fixes #2135 