### PR TITLE
Attempt to track inconsistent export sizes

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/ConsistencyChecker.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/ConsistencyChecker.java
@@ -690,7 +690,7 @@ class ConsistencyChecker {
 	}
 
 	boolean checkSubtable(SubtableSymbol sym) {
-		int tablesize = 0;
+		int tablesize = -1;
 		int numconstruct = sym.getNumConstructors();
 		Constructor ct;
 		boolean testresult = true;
@@ -722,9 +722,20 @@ class ConsistencyChecker {
 				}
 				seennonemptyexport = true;
 				int exsize = recoverSize(exportres.getSize(), ct);
-				if (tablesize == 0) {
+
+				if (!((exportres.getSize().getReal() == tablesize) &&
+						(exportres.getSize().getReal() == exsize)) &&
+						(tablesize != -1) &&
+						exportres.getSize().getType() == const_type.real) {
+					compiler.reportError(ct.location, String.format(
+						"Table '%s' has inconsistent export size; Constructor at %s is first conflict",
+						sym.getName(), ct.location));
+					testresult = false;
+				}
+				if (tablesize == -1) {
 					tablesize = exsize;
 				}
+
 				if ((exsize != 0) && (exsize != tablesize)) {
 					compiler.reportError(ct.location, String.format(
 						"Table '%s' has inconsistent export size; Constructor at %s is first conflict",
@@ -743,9 +754,9 @@ class ConsistencyChecker {
 			}
 		}
 		if (seennonemptyexport) {
-			if (tablesize == 0) {
+			if (tablesize == 0 || tablesize == -1) {
 				compiler.reportWarning(sym.location,
-					"Table '" + sym.getName() + "' exports size 0");
+					"Table '" + sym.getName() + "' exports size " + tablesize);
 
 			}
 			sizemap.put(sym, tablesize);	// Remember recovered size


### PR DESCRIPTION
Constructors that export sized elements are inconsistent when also exporting unsized elements.  This is commonly happens when exporting tokens or variables created in actions (without first assigning to a sized local/sized const/etc...)

I haven't run this through all the current processors, but testing with 6809 (see #2116 for reference), which found another potential issue with the two `EA: addr",PCR"`


@caheckman  looks like you may be the most familiar with this file based on blame, any thoughts?