### PR TITLE
Prevent silent AddressOutOfBoundsException in MipsAddressAnalyzer

### DIFF
--- a/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsAddressAnalyzer.java
+++ b/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsAddressAnalyzer.java
@@ -349,7 +349,13 @@ public class MipsAddressAnalyzer extends ConstantPropagationAnalyzer {
 						BigInteger val = context.getValue(reg, false);
 						if (val != null) {
 							long lval = val.longValue();
-							Address refAddr = instr.getMinAddress().getNewAddress(lval);
+							Address refAddr = null;
+							try {
+								refAddr = instr.getMinAddress().getNewAddress(lval);
+							} catch (AddressOutOfBoundsException e) {
+								// invalid reference
+								return;
+							}
 							if ((lval > 4096 || lval < 0) && lval != 0xffff &&
 								program.getMemory().contains(refAddr)) {
 


### PR DESCRIPTION
I was encountering an issue where I was not seeing many dual instruction references and traced it back to this. When the AddressOutOfBoundsException occurs the analysis would immediately stop when instead it should just continue on since it isn't a reference.