### PR TITLE
Allow white-spaces in GHIDRA_PATH for createPdbXmlFiles.bat

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/support/createPdbXmlFiles.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/createPdbXmlFiles.bat
@@ -26,7 +26,7 @@ set OS_DIR=build\os
 :continue
 
 REM create absolute path
-for /f %%i in ("%GHIDRA_DIR%") do set GHIDRA_DIR=%%~fi
+for /f "delims=" %%i in ("%GHIDRA_DIR%") do set GHIDRA_DIR=%%~fi
 
 REM Determine if 64-bit or 32-bit
 if exist "%PROGRAMFILES(X86)%" (


### PR DESCRIPTION
Fix to be able to run the PDB to XML conversion script when GHIDRA is installed in C:\Program Files\Ghidra

The problem was that "for /f" (used to create an absolute path with the %%~f syntax) without the "delims=" options truncates the path at the first white-space.