### PR TITLE
Update URL of cdt-8.6.0.zip

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -198,7 +198,7 @@ Download `cdt-8.6.0.zip` from The Eclipse Foundation, and place it in:
 
 ```bash
 cd ~/Downloads   # Or wherever
-curl -OL 'http://www.eclipse.org/downloads/download.php?r=1&protocol=https&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
+curl -OL 'https://archive.eclipse.org/tools/cdt/releases/8.6/cdt-8.6.0.zip'
 curl -o 'cdt-8.6.0.zip.sha512' -L --retry 3 'https://www.eclipse.org/downloads/sums.php?type=sha512&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
 shasum -a 512 -c 'cdt-8.6.0.zip.sha512'
 mkdir -p ~/git/ghidra/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/build/

--- a/gradle/support/fetchDependencies.gradle
+++ b/gradle/support/fetchDependencies.gradle
@@ -54,7 +54,7 @@ ext.AXML_ZIP = 'https://storage.googleapis.com/google-code-archive-downloads/v2/
 ext.HFS_ZIP = 'https://sourceforge.net/projects/catacombae/files/HFSExplorer/0.21/hfsexplorer-0_21-bin.zip'
 ext.YAJSW_ZIP = 'https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-12.12/yajsw-stable-12.12.zip'
 ext.PYDEV_ZIP = 'https://sourceforge.net/projects/pydev/files/pydev/PyDev%206.3.1/PyDev%206.3.1.zip'
-ext.CDT_ZIP = 'http://www.eclipse.org/downloads/download.php?r=1&protocol=https&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip'
+ext.CDT_ZIP = 'https://archive.eclipse.org/tools/cdt/releases/8.6/cdt-8.6.0.zip'
 
 // The SHA-256s for each of the dependencies
 ext.DEX_SHA_256 = '7907eb4d6e9280b6e17ddce7ee0507eae2ef161ee29f70a10dbc6944fdca75bc'


### PR DESCRIPTION
The old URL (http://www.eclipse.org/downloads/download.php?r=1&protocol=https&file=/tools/cdt/releases/8.6/cdt-8.6.0.zip) redirects to http://archive.eclipse.org/tools/cdt/releases/8.6/cdt-8.6.0.zip, which supports HTTPS. To avoid unencrypted HTTP, let's use https://archive.eclipse.org/tools/cdt/releases/8.6/cdt-8.6.0.zip directly.