### PR TITLE
#573 Add shifted pointers

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/ShiftPointerAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/ShiftPointerAction.java
@@ -73,13 +73,16 @@ public class ShiftPointerAction extends CompositeEditorTableAction {
 	
 	@Override
 	public void adjustEnablement() {
-		boolean enabled = true;
-		enabled &= model.isEditComponentAllowed();
-		int row = model.getRow();
-		if (row < model.getNumComponents()) {
-			DataTypeComponent comp = model.getComponent(row);
-			enabled &= comp.getDataType() instanceof Pointer;
+		if (model.isEditComponentAllowed()) {
+			bool enabled = true;
+			int row = model.getRow();
+			if (row < model.getNumComponents()) {
+				DataTypeComponent comp = model.getComponent(row);
+				enabled &= comp.getDataType() instanceof Pointer;
+			}
+			setEnabled(enabled);
+		} else {
+			setEnabled(false);
 		}
-		setEnabled(enabled);
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/ShiftPointerAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/ShiftPointerAction.java
@@ -74,7 +74,7 @@ public class ShiftPointerAction extends CompositeEditorTableAction {
 	@Override
 	public void adjustEnablement() {
 		if (model.isEditComponentAllowed()) {
-			bool enabled = true;
+			boolean enabled = true;
 			int row = model.getRow();
 			if (row < model.getNumComponents()) {
 				DataTypeComponent comp = model.getComponent(row);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/ShiftPointerAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/ShiftPointerAction.java
@@ -1,0 +1,85 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.plugin.core.compositeeditor;
+
+import static docking.KeyBindingPrecedence.*;
+
+import java.awt.event.KeyEvent;
+
+import javax.swing.ImageIcon;
+import javax.swing.KeyStroke;
+
+import docking.ActionContext;
+import docking.action.KeyBindingData;
+import docking.widgets.dialogs.NumberInputDialog;
+import ghidra.program.model.data.DataTypeComponent;
+import ghidra.program.model.data.Pointer;
+import ghidra.program.model.data.PointerDataType;
+import ghidra.util.exception.UsrException;
+import resources.ResourceManager;
+
+/**
+ * Action to shift a pointer by a specific offset
+ */
+public class ShiftPointerAction extends CompositeEditorTableAction {
+
+	public final static String ACTION_NAME = "Shift Pointer";
+	private final static String GROUP_NAME = COMPONENT_ACTION_GROUP;
+	private final static String DESCRIPTION = "Shift selected pointer by an offset";
+	private final static ImageIcon ICON = ResourceManager.loadImage("images/red-cross.png");
+	private final static String[] POPUP_PATH = new String[] { "Shift Pointer" };
+	private final static KeyStroke KEY_STROKE = KeyStroke.getKeyStroke(KeyEvent.VK_T, 0);
+
+	public ShiftPointerAction(CompositeEditorProvider provider) {
+		super(provider, EDIT_ACTION_PREFIX + ACTION_NAME, GROUP_NAME, POPUP_PATH, null, ICON);
+		setDescription(DESCRIPTION);
+		setKeyBindingData(new KeyBindingData(KEY_STROKE, DefaultLevel));
+		adjustEnablement();
+	}
+
+	@Override
+	public void actionPerformed(ActionContext context) {
+		try {
+			int row = model.getRow();
+			if (row < model.getNumComponents()) {
+				DataTypeComponent comp = model.getComponent(row);
+				Pointer origPointer = (Pointer) comp.getDataType();
+				NumberInputDialog dialog = new NumberInputDialog("Shift Pointer", "Offset:", origPointer.getShiftOffset(), Integer.MIN_VALUE, Integer.MAX_VALUE, true);
+				tool.showDialog(dialog);
+				if (!dialog.wasCancelled()) {
+					Pointer shiftedPointer = new PointerDataType(origPointer.getDataType(), dialog.getValue(), origPointer.isDynamicallySized() ? -1 : origPointer.getLength(), origPointer.getDataTypeManager());
+					model.setComponentDataType(row, shiftedPointer);
+				}
+			}
+		}
+		catch (UsrException e1) {
+			model.setStatus(e1.getMessage());
+		}
+		requestTableFocus();
+	}
+	
+	@Override
+	public void adjustEnablement() {
+		boolean enabled = true;
+		enabled &= model.isEditComponentAllowed();
+		int row = model.getRow();
+		if (row < model.getNumComponents()) {
+			DataTypeComponent comp = model.getComponent(row);
+			enabled &= comp.getDataType() instanceof Pointer;
+		}
+		setEnabled(enabled);
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/StructureEditorProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/StructureEditorProvider.java
@@ -64,6 +64,7 @@ public class StructureEditorProvider extends CompositeEditorProvider {
 			new DeleteAction(this), 
 			new PointerAction(this), 
 			new ArrayAction(this),
+			new ShiftPointerAction(this),
 			new FindReferencesToField(this),
 			new UnpackageAction(this),
 			new EditComponentAction(this), 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/UnionEditorProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/UnionEditorProvider.java
@@ -60,6 +60,7 @@ public class UnionEditorProvider extends CompositeEditorProvider {
 			new DeleteAction(this), 
 			new PointerAction(this), 
 			new ArrayAction(this),
+			new ShiftPointerAction(this),
 			new ShowComponentPathAction(this), 
 			new EditComponentAction(this),
 			new EditFieldAction(this), 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/util/DataTypeUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/util/DataTypeUtils.java
@@ -456,7 +456,7 @@ public class DataTypeUtils {
 		if (dataType instanceof Pointer) {
 			Pointer pdt = (Pointer) dataType;
 			return new PointerDataType(copyToNamedBaseDataType(pdt.getDataType(), dtm),
-				pdt.isDynamicallySized() ? -1 : pdt.getLength(), dtm);
+				pdt.getShiftOffset(), pdt.isDynamicallySized() ? -1 : pdt.getLength(), dtm);
 		}
 		else if (dataType instanceof Array) {
 			Array adt = (Array) dataType;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/DWARFDataTypeImporter.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/DWARFDataTypeImporter.java
@@ -1311,7 +1311,7 @@ public class DWARFDataTypeImporter {
 		DataType result = copy;
 		for (int i = ptrChainTypes.size() - 1; i >= 0; i--) {
 			Pointer origPtr = ptrChainTypes.get(i);
-			result = new PointerDataType(result,
+			result = new PointerDataType(result, origPtr.getShiftOffset(),
 				origPtr.isDynamicallySized() ? -1 : origPtr.getLength(), dataTypeManager);
 		}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/DtParser.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/DtParser.java
@@ -64,14 +64,14 @@ class DtParser {
 	private DataType adjustPointerDataTypes(int size, DataType dt) {
 		if (dt instanceof Pointer) {
 			Pointer p = (Pointer) dt;
-			dt = new PointerDataType(p.getDataType(), size, dtManager);
+			dt = new PointerDataType(p.getDataType(), p.getShiftOffset(), size, dtManager);
 		}
 		else if (dt instanceof Array && ((Array) dt).getDataType() instanceof Pointer) {
 // TODO: does not handle multi-dimensional pointer arrays
 			Array array = (Array) dt;
 			DataType pointerDt = ((Pointer) array.getDataType()).getDataType();
 			int pointerSize = size / array.getNumElements();
-			DataType pointer = new PointerDataType(pointerDt, pointerSize, dtManager);
+			DataType pointer = new PointerDataType(pointerDt, ((Pointer) array.getDataType()).getShiftOffset(), pointerSize, dtManager);
 			dt = new ArrayDataType(pointer, array.getNumElements(), pointerSize, dtManager);
 		}
 		return dt;

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/data/DataTypeParser.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/data/DataTypeParser.java
@@ -590,7 +590,6 @@ public class DataTypeParser {
 			//	*8
 			//	-16*4
 
-
 			// Parse shift offset
 			if (piece.indexOf("*") != 0) {
 				switch(piece.charAt(0)) {
@@ -605,7 +604,7 @@ public class DataTypeParser {
 				}
 				
 				try {
-					shiftOffset *= Integer.decode(piece.substring(1, piece.indexOf("*")));
+					shiftOffset *= Integer.decode(piece.substring(1, piece.indexOf("*")).stripTrailing());
 				}
 				catch (NumberFormatException e) {
 					throw new InvalidDataTypeException("invalid pointer specification: " + piece);

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/data/DataTypeParser.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/data/DataTypeParser.java
@@ -581,6 +581,17 @@ public class DataTypeParser {
 				throw new InvalidDataTypeException("invalid pointer specification: " + piece);
 			}
 			
+			// Parse the pointer specification
+			// It's structured in a following way
+			// (+/-offset)*(pointer size)
+			// Examples:
+			//	*
+			//	+0x4*
+			//	*8
+			//	-16*4
+
+
+			// Parse shift offset
 			if (piece.indexOf("*") != 0) {
 				switch(piece.charAt(0)) {
 				case '+': 
@@ -601,6 +612,7 @@ public class DataTypeParser {
 				}
 			}
 			
+			// Parse pointer length
 			if (piece.indexOf("*") != piece.length()-1) {
 				try {
 					pointerSize = Integer.parseInt(piece.substring(piece.indexOf("*")+1));

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/cast.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/cast.cc
@@ -274,7 +274,7 @@ Datatype *CastStrategyC::castStandard(Datatype *reqtype,Datatype *curtype,
       if (isptr && (meta==TYPE_UNKNOWN)) // Don't cast pointers to unknown
 	return (Datatype *)0;
     }
-    if ((!care_ptr_uint)&&(curbase->getMetatype()==TYPE_PTR))
+    if ((!care_ptr_uint)&&(!care_uint_int)&&(curbase->getMetatype()==TYPE_PTR))
       return (Datatype *)0;
     break;
   case TYPE_CODE:

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/cast.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/cast.cc
@@ -274,6 +274,8 @@ Datatype *CastStrategyC::castStandard(Datatype *reqtype,Datatype *curtype,
       if (isptr && (meta==TYPE_UNKNOWN)) // Don't cast pointers to unknown
 	return (Datatype *)0;
     }
+    if ((!care_ptr_uint)&&(curbase->getMetatype()==TYPE_PTR))
+      return (Datatype *)0;
     break;
   case TYPE_CODE:
     if (curbase->getMetatype() == TYPE_CODE) {
@@ -283,6 +285,12 @@ Datatype *CastStrategyC::castStandard(Datatype *reqtype,Datatype *curtype,
       if (((TypeCode *)curbase)->getPrototype() == (const FuncProto *)0)
 	return (Datatype *)0;
     }
+    break;
+  case TYPE_PTR:
+    if ((!care_ptr_uint)&&(curbase->getMetatype()==TYPE_UINT))
+      return (Datatype *)0;
+    if ((!care_ptr_uint)&&(!care_uint_int)&&(curbase->getMetatype()==TYPE_INT))
+      return (Datatype *)0;
     break;
   default:
     break;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -268,8 +268,7 @@ void PrintC::pushTypeStart(const Datatype *ct,bool noident)
       const TypePointer *pt = (const TypePointer*) ct;
       pushMod();
       setMod(force_hex); 
-      if (pt->getShiftOffset() != 0) 
-        pushOp(&ptr_shift_space,(const PcodeOp *)0);
+      if (pt->getShiftOffset() != 0) pushOp(&ptr_shift_space,(const PcodeOp *)0);
       pushOp(&ptr_expr,(const PcodeOp *)0);
       if (pt->getShiftOffset() > 0) {
         pushOp(&unary_plus,(const PcodeOp *)0);
@@ -281,6 +280,7 @@ void PrintC::pushTypeStart(const Datatype *ct,bool noident)
         push_integer(-pt->getShiftOffset(),sizeof(intb),true,
           (const Varnode *)0,(const PcodeOp *)0);
       }
+      popMod();
     }
     else if (ct->getMetatype() == TYPE_ARRAY)
       pushOp(&array_expr,(const PcodeOp *)0);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -71,8 +71,7 @@ OpToken PrintC::xorequal = { "^=", 2, 14, false, OpToken::binary, 1, 5, (OpToken
 OpToken PrintC::type_expr_space = { "", 2, 10, false, OpToken::space, 1, 0, (OpToken *)0 };
 OpToken PrintC::type_expr_nospace = { "", 2, 10, false, OpToken::space, 0, 0, (OpToken *)0 };
 OpToken PrintC::ptr_expr = { "*", 1, 62, false, OpToken::unary_prefix, 0, 0, (OpToken *)0 };
-OpToken PrintC::ptr_shift_pos_expr = { "+", 2, 50, false, OpToken::binary, 0, 0, (OpToken*)0 };
-OpToken PrintC::ptr_shift_neg_expr = { "-", 2, 50, false, OpToken::binary, 0, 0, (OpToken*)0 };
+OpToken PrintC::ptr_shift_space = { "", 2, 61, false, OpToken::space, 1, 0, (OpToken *)0 };
 OpToken PrintC::array_expr = { "[]", 2, 66, false, OpToken::postsurround, 1, 0, (OpToken *)0 };
 OpToken PrintC::enum_cat = { "|", 2, 26, true, OpToken::binary, 0, 0, (OpToken *)0 };
 
@@ -232,15 +231,6 @@ void PrintC::emitSymbolScope(const Symbol *symbol)
   }
 }
 
-/// Push the appropriate pointer shift operation
-/// \param pt is the pointer data type
-void PrintC::pushPtrShiftOp(const TypePointer *pt)
-
-{
-  if(pt->getShiftOffset() > 0) pushOp(&ptr_shift_pos_expr, (const PcodeOp*)0);
-  else if(pt->getShiftOffset() < 0) pushOp(&ptr_shift_neg_expr, (const PcodeOp*)0);
-}
-
 /// Store off array sizes for printing after the identifier
 /// \param ct is the data-type to push
 /// \param noident is \b true if an identifier will not be pushed as part of the declaration
@@ -266,31 +256,31 @@ void PrintC::pushTypeStart(const Datatype *ct,bool noident)
     // We could support a struct or enum declaration here
     string name = genericTypeName(ct);
     pushOp(tok,(const PcodeOp *)0);
-    if (tsstart>=0 && typestack[tsstart]->getMetatype()==TYPE_PTR) pushPtrShiftOp((const TypePointer*)typestack[tsstart]);
     pushAtom(Atom(name,typetoken,EmitXml::type_color,ct));
   }
   else {
     pushOp(tok,(const PcodeOp *)0);
-    if (tsstart>=0 && typestack[tsstart]->getMetatype()==TYPE_PTR) pushPtrShiftOp((const TypePointer*)typestack[tsstart]);
     pushAtom(Atom(ct->getName(),typetoken,EmitXml::type_color,ct));
   }
   for(int4 i=tsstart;i>=0;--i) {
     ct = typestack[i];
-    if (i>0 && typestack[i-1]->getMetatype()==TYPE_PTR) pushPtrShiftOp((const TypePointer*)typestack[i-1]);
     if (ct->getMetatype() == TYPE_PTR) {
       const TypePointer *pt = (const TypePointer*) ct;
       pushMod();
       setMod(force_hex); 
+      if (pt->getShiftOffset() != 0) 
+        pushOp(&ptr_shift_space,(const PcodeOp *)0);
+      pushOp(&ptr_expr,(const PcodeOp *)0);
       if (pt->getShiftOffset() > 0) {
+        pushOp(&unary_plus,(const PcodeOp *)0);
         push_integer(pt->getShiftOffset(),sizeof(intb),true,
           (const Varnode *)0,(const PcodeOp *)0);
       }
       else if(pt->getShiftOffset() < 0) {
+        pushOp(&unary_minus,(const PcodeOp *)0);
         push_integer(-pt->getShiftOffset(),sizeof(intb),true,
           (const Varnode *)0,(const PcodeOp *)0);
       }
-      pushOp(&ptr_expr,(const PcodeOp *)0);
-      popMod();
     }
     else if (ct->getMetatype() == TYPE_ARRAY)
       pushOp(&array_expr,(const PcodeOp *)0);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
@@ -111,6 +111,8 @@ protected:
   static OpToken type_expr_space;	///< Type declaration involving a space (identifier or adornment)
   static OpToken type_expr_nospace;	///< Type declaration with no space
   static OpToken ptr_expr;		///< Pointer adornment for a type declaration
+  static OpToken ptr_shift_pos_expr; ///< The positive pointer shift operator
+  static OpToken ptr_shift_neg_expr; ///< The negative pointer shift operator
   static OpToken array_expr;		///< Array adornment for a type declaration
   static OpToken enum_cat;		///< The \e concatenation operator for enumerated values
   bool option_NULL;		///< Set to \b true if we should emit NULL keyword
@@ -127,6 +129,7 @@ protected:
   void pushPrototypeInputs(const FuncProto *proto);				///< Push input parameters
   void pushSymbolScope(const Symbol *symbol);			///< Push tokens resolving a symbol's scope
   void emitSymbolScope(const Symbol *symbol);			///< Emit tokens resolving a symbol's scope
+  void pushPtrShiftOp(const TypePointer *ct); ///< Push the appropriate pointer shift operator
   virtual void pushTypeStart(const Datatype *ct,bool noident);	///< Push part of a data-type declaration onto the RPN stack, up to the identifier
   virtual void pushTypeEnd(const Datatype *ct);			///< Push the tail ends of a data-type declaration onto the RPN stack
   void pushBoolConstant(uintb val,const TypeBase *ct,const Varnode *vn,

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
@@ -111,8 +111,7 @@ protected:
   static OpToken type_expr_space;	///< Type declaration involving a space (identifier or adornment)
   static OpToken type_expr_nospace;	///< Type declaration with no space
   static OpToken ptr_expr;		///< Pointer adornment for a type declaration
-  static OpToken ptr_shift_pos_expr; ///< The positive pointer shift operator
-  static OpToken ptr_shift_neg_expr; ///< The negative pointer shift operator
+  static OpToken ptr_shift_space;		///< Space between pointer shift offset and rest of the type stack
   static OpToken array_expr;		///< Array adornment for a type declaration
   static OpToken enum_cat;		///< The \e concatenation operator for enumerated values
   bool option_NULL;		///< Set to \b true if we should emit NULL keyword
@@ -129,7 +128,6 @@ protected:
   void pushPrototypeInputs(const FuncProto *proto);				///< Push input parameters
   void pushSymbolScope(const Symbol *symbol);			///< Push tokens resolving a symbol's scope
   void emitSymbolScope(const Symbol *symbol);			///< Emit tokens resolving a symbol's scope
-  void pushPtrShiftOp(const TypePointer *ct); ///< Push the appropriate pointer shift operator
   virtual void pushTypeStart(const Datatype *ct,bool noident);	///< Push part of a data-type declaration onto the RPN stack, up to the identifier
   virtual void pushTypeEnd(const Datatype *ct);			///< Push the tail ends of a data-type declaration onto the RPN stack
   void pushBoolConstant(uintb val,const TypeBase *ct,const Varnode *vn,

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
@@ -47,6 +47,7 @@ class AddTreeState {
   const Datatype *baseType;	///< The base data-type being pointed at
   int4 ptrsize;			///< Size of the pointer
   int4 size;			///< Size of data-type being pointed to (in address units)
+  intb shiftOffset; ///< Shift offset of the pointer (in address units)
   uintb ptrmask;		///< Mask for modulo calculations in ptr space
   uintb offset;			///< Number of bytes we dig into the base data-type
   uintb correct;		///< Number of bytes being double counted
@@ -1027,6 +1028,7 @@ public:
   virtual int4 applyOp(PcodeOp *op,Funcdata &data);
 };
 class RulePtrArith : public Rule {
+  static bool isShiftOp(const PcodeOp *op);
   static bool verifyAddTreeBottom(PcodeOp *op,int4 slot);
 public:
   RulePtrArith(const string &g) : Rule(g, 0, "ptrarith") {}	///< Constructor

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
@@ -328,7 +328,7 @@ bool Datatype::isPtrsubMatching(uintb offset) const
 
   Datatype *basetype = ((TypePointer *)this)->getPtrTo();
   uint4 wordsize = ((TypePointer *)this)->getWordSize();
-  off += AddrSpace::byteToAddressInt(((TypePointer *)this)->getShiftOffset(),wordsize);
+  offset += AddrSpace::byteToAddressInt(((TypePointer *)this)->getShiftOffset(),wordsize);
   if (basetype->metatype==TYPE_SPACEBASE) {
     uintb newoff = AddrSpace::addressToByte(offset,wordsize);
     basetype->getSubType(newoff,&newoff);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
@@ -229,16 +229,18 @@ class TypePointer : public Datatype {
 protected:
   friend class TypeFactory;
   Datatype *ptrto;		///< Type being pointed to
+  int4 shiftOffset;		///< The offset by which this pointer is shifted
   uint4 wordsize;               ///< What size unit does the pointer address
   virtual void restoreXml(const Element *el,TypeFactory &typegrp);
   /// Internal constructor for use with restoreXml
-  TypePointer(void) : Datatype(0,TYPE_PTR) { ptrto = (Datatype *)0; wordsize=1; }
+  TypePointer(void) : Datatype(0,TYPE_PTR) { ptrto = (Datatype *)0; shiftOffset=0; wordsize=1; }
 public:
   /// Construct from another TypePointer
-  TypePointer(const TypePointer &op) : Datatype(op) { ptrto = op.ptrto; wordsize=op.wordsize; }
+  TypePointer(const TypePointer &op) : Datatype(op) { ptrto = op.ptrto; shiftOffset=op.shiftOffset; wordsize=op.wordsize; }
   /// Construct from a size, pointed-to type, and wordsize
-  TypePointer(int4 s,Datatype *pt,uint4 ws) : Datatype(s,TYPE_PTR) { ptrto = pt; flags = ptrto->getInheritable(); wordsize=ws; }
+  TypePointer(int4 s,Datatype *pt,int4 shift, uint4 ws) : Datatype(s,TYPE_PTR) { ptrto = pt; shiftOffset = shift; flags = ptrto->getInheritable(); wordsize=ws; }
   Datatype *getPtrTo(void) const { return ptrto; }	///< Get the pointed-to Datatype
+  int4 getShiftOffset(void) const { return shiftOffset; } ///< Get the shift offset
   uint4 getWordSize(void) const { return wordsize; }	///< Get the wordsize of the pointer
   virtual void printRaw(ostream &s) const;
   virtual int4 numDepend(void) const { return 1; }
@@ -438,9 +440,9 @@ public:
   Datatype *getBase(int4 s,type_metatype m);			///< Get atomic type
   Datatype *getBase(int4 s,type_metatype m,const string &n);	///< Get named atomic type
   TypeCode *getTypeCode(void);					///< Get an "anonymous" function data-type
-  TypePointer *getTypePointerStripArray(int4 s,Datatype *pt,uint4 ws);	///< Construct a pointer data-type, stripping an ARRAY level
-  TypePointer *getTypePointer(int4 s,Datatype *pt,uint4 ws);	///< Construct an absolute pointer data-type
-  TypePointer *getTypePointerNoDepth(int4 s,Datatype *pt,uint4 ws);	///< Construct a depth limited pointer data-type
+  TypePointer *getTypePointerStripArray(int4 s,Datatype *pt,uint4 ws,int4 shift=0);	///< Construct a pointer data-type, stripping an ARRAY level
+  TypePointer *getTypePointer(int4 s,Datatype *pt,uint4 ws,int4 shift=0);	///< Construct an absolute pointer data-type
+  TypePointer *getTypePointerNoDepth(int4 s,Datatype *pt,uint4 ws,int4 shift=0);	///< Construct a depth limited pointer data-type
   TypeArray *getTypeArray(int4 as,Datatype *ao);		///< Construct an array data-type
   TypeStruct *getTypeStruct(const string &n);			///< Create an (empty) structure
   TypeEnum *getTypeEnum(const string &n);			///< Create an (empty) enumeration

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
@@ -75,6 +75,7 @@ public class DecompilerProvider extends NavigatableComponentProviderAdapter
 	private DockingAction retypeGlobalAction;
 	private DockingAction retypeReturnAction;
 	private DockingAction retypeFieldAction;
+	private DockingAction shiftPointerAction;
 	private DockingAction isolateVarAction;
 	private DockingAction specifyCProtoAction;
 	private DockingAction overrideSigAction;
@@ -801,6 +802,9 @@ public class DecompilerProvider extends NavigatableComponentProviderAdapter
 
 		retypeFieldAction = new RetypeFieldAction();
 		setGroupInfo(retypeFieldAction, variableGroup, subGroupPosition++);
+		
+		shiftPointerAction = new ShiftPointerAction();
+		setGroupInfo(shiftPointerAction, variableGroup, subGroupPosition++);
 
 		isolateVarAction = new IsolateVariableAction();
 		setGroupInfo(isolateVarAction, variableGroup, subGroupPosition++);
@@ -939,6 +943,7 @@ public class DecompilerProvider extends NavigatableComponentProviderAdapter
 		addLocalAction(retypeGlobalAction);
 		addLocalAction(retypeReturnAction);
 		addLocalAction(retypeFieldAction);
+		addLocalAction(shiftPointerAction);
 		addLocalAction(isolateVarAction);
 		addLocalAction(decompilerCreateStructureAction);
 		tool.addAction(listingCreateStructureAction);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ShiftPointerAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ShiftPointerAction.java
@@ -173,7 +173,9 @@ public class ShiftPointerAction extends AbstractDecompilerAction {
 
 		ClangToken token = context.getTokenAtCursor();
 		if (token.Parent() instanceof ClangReturnType) {
-			if (((ClangReturnType) token.Parent()).getDataType() instanceof Pointer) return true;
+			if (((ClangReturnType) token.Parent()).getDataType() instanceof Pointer) {
+				return true;
+			}
 		}
 		
 		DataType dt = DecompilerUtils.getDataType(context);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ShiftPointerAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ShiftPointerAction.java
@@ -1,0 +1,208 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.plugin.core.decompile.actions;
+
+import java.awt.event.KeyEvent;
+
+import docking.action.KeyBindingData;
+import docking.action.MenuData;
+import docking.widgets.OptionDialog;
+import docking.widgets.dialogs.NumberInputDialog;
+import ghidra.app.decompiler.*;
+import ghidra.app.decompiler.component.DecompilerUtils;
+import ghidra.app.plugin.core.decompile.DecompilerActionContext;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.DataTypeManager;
+import ghidra.program.model.data.Pointer;
+import ghidra.program.model.data.PointerDataType;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.pcode.*;
+import ghidra.program.model.symbol.SourceType;
+import ghidra.util.Msg;
+import ghidra.util.UndefinedFunction;
+import ghidra.util.exception.*;
+
+/**
+ * Action to shift a pointer by a specific offset
+ */
+public class ShiftPointerAction extends AbstractDecompilerAction {
+
+	public ShiftPointerAction() {
+		super("Shift Pointer");
+		setDescription("Shift selected pointer by an offset");
+		setPopupMenuData(new MenuData(new String[] { "Shift Pointer" }, "Decompile"));
+		setKeyBindingData(new KeyBindingData(KeyEvent.VK_T, 0));
+	}
+
+	/**
+	 * Retype a global or local symbol
+	 * @param program the program
+	 * @param highSymbol the symbol to retype
+	 * @param exactSpot the exact spot to retype
+	 * @param dt the new data type
+	 * @param tool the PluginTool
+	 */
+	private void retypeSymbol(Program program, HighSymbol highSymbol, Varnode exactSpot,
+			DataType dt, PluginTool tool) {
+		HighFunction hfunction = highSymbol.getHighFunction();
+
+		boolean commitRequired = checkFullCommit(highSymbol, hfunction);
+		if (commitRequired) {
+			exactSpot = null;		// Don't try to split out if commit is required
+		}
+
+		if (exactSpot != null) { // The user pointed at a particular usage, not just the vardecl
+			try {
+				HighVariable var = hfunction.splitOutMergeGroup(exactSpot.getHigh(), exactSpot);
+				highSymbol = var.getSymbol();
+			}
+			catch (PcodeException e) {
+				Msg.showError(this, tool.getToolFrame(), "Shift Failed", e.getMessage());
+				return;
+			}
+		}
+		DataTypeManager dataTypeManager = program.getDataTypeManager();
+		boolean successfulMod = false;
+		int transaction = program.startTransaction("Shift Pointer");
+		try {
+			if (dt.getDataTypeManager() != dataTypeManager) {
+				dt = dataTypeManager.resolve(dt, null);
+			}
+			if (commitRequired) {
+				// Don't use datatypes of other parameters if the datatypes were floating.
+				// Datatypes were floating if signature source was DEFAULT
+				boolean useDataTypes =
+					hfunction.getFunction().getSignatureSource() != SourceType.DEFAULT;
+				try {
+					HighFunctionDBUtil.commitParamsToDatabase(hfunction, useDataTypes,
+						SourceType.USER_DEFINED);
+					if (useDataTypes) {
+						HighFunctionDBUtil.commitReturnToDatabase(hfunction,
+							SourceType.USER_DEFINED);
+					}
+				}
+				catch (DuplicateNameException e) {
+					throw new AssertException("Unexpected exception", e);
+				}
+				catch (InvalidInputException e) {
+					Msg.showError(this, null, "Parameter Commit Failed", e.getMessage());
+				}
+			}
+			HighFunctionDBUtil.updateDBVariable(highSymbol, null, dt, SourceType.USER_DEFINED);
+			successfulMod = true;
+		}
+		catch (DuplicateNameException e) {
+			throw new AssertException("Unexpected exception", e);
+		}
+		catch (InvalidInputException e) {
+			Msg.showError(this, tool.getToolFrame(), "Shift Failed",
+				"Failed to shift pointer '" + highSymbol.getName() + "': " + e.getMessage());
+		}
+		finally {
+			program.endTransaction(transaction, successfulMod);
+		}
+	}
+
+	/**
+	 * Retype a function return value
+	 * @param program the program
+	 * @param highFunction the function to retype
+	 * @param dt the new datatype
+	 * @param tool the PluginTool
+	 */
+	private void retypeReturn(Program program, HighFunction highFunction, DataType dt, PluginTool tool) { 
+		boolean commitRequired = checkFullCommit(null, highFunction);
+		if (commitRequired) {
+			int resp = OptionDialog.showOptionDialog(tool.getToolFrame(),
+				"Parameter Commit Required",
+				"Shifting the pointer requires all other parameters to be committed!\nContinue with shift?",
+				"Continue");
+			if (resp != OptionDialog.OPTION_ONE) {
+				return;
+			}
+		}
+		boolean successfulMod = false;
+		int transactionID = program.startTransaction("Shift Pointer");
+		try {
+			if (dt.getDataTypeManager() != program.getDataTypeManager()) {
+				dt = program.getDataTypeManager().resolve(dt, null);
+			}
+			if (commitRequired) {
+				try {
+					HighFunctionDBUtil.commitParamsToDatabase(highFunction, true,
+						SourceType.USER_DEFINED);
+				}
+				catch (DuplicateNameException e) {
+					throw new AssertException("Unexpected exception", e);
+				}
+				catch (InvalidInputException e) {
+					Msg.showError(this, null, "Parameter Commit Failed", e.getMessage());
+				}
+			}
+			highFunction.getFunction().setReturnType(dt, SourceType.USER_DEFINED);
+			successfulMod = true;
+		}
+		catch (InvalidInputException e) {
+			Msg.showError(this, tool.getToolFrame(), "Shift Failed",
+				"Failed to shift pointer '" + getName() + "': " + e.getMessage());
+		}
+		program.endTransaction(transactionID, successfulMod);
+	}
+	
+	@Override
+	protected boolean isEnabledForDecompilerContext(DecompilerActionContext context) {
+		Function function = context.getFunction();
+		if (function == null || function instanceof UndefinedFunction) {
+			return false;
+		}
+
+		ClangToken token = context.getTokenAtCursor();
+		if (token.Parent() instanceof ClangReturnType) {
+			if (((ClangReturnType) token.Parent()).getDataType() instanceof Pointer) return true;
+		}
+		
+		DataType dt = DecompilerUtils.getDataType(context);
+		return dt instanceof Pointer;
+	}
+
+	@Override
+	protected void decompilerActionPerformed(DecompilerActionContext context) {
+		Program program = context.getProgram();
+		PluginTool tool = context.getTool();
+		ClangToken tokenAtCursor = context.getTokenAtCursor();
+		boolean isReturn = tokenAtCursor.Parent() instanceof ClangReturnType;
+		HighSymbol highSymbol = null;
+		
+		Pointer origPointer;
+		if (isReturn) {
+			origPointer = (Pointer) ((ClangReturnType) tokenAtCursor.Parent()).getDataType();
+		} else {
+			origPointer = (Pointer) DecompilerUtils.getDataType(context);
+			highSymbol = findHighSymbolFromToken(tokenAtCursor, context.getHighFunction());
+			if (highSymbol == null) return;
+		}
+		
+		NumberInputDialog dialog = new NumberInputDialog("Shift Pointer", "Offset:", origPointer.getShiftOffset(), Integer.MIN_VALUE, Integer.MAX_VALUE, true);
+		tool.showDialog(dialog);
+		if (!dialog.wasCancelled()) {
+			Pointer shiftedPointer = new PointerDataType(origPointer.getDataType(), dialog.getValue(), origPointer.isDynamicallySized() ? -1 : origPointer.getLength(), origPointer.getDataTypeManager());
+			if (isReturn) retypeReturn(program, context.getHighFunction(), shiftedPointer, tool);
+			else retypeSymbol(program, highSymbol, tokenAtCursor.getVarnode(), shiftedPointer, tool);
+		}
+	} 
+}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
@@ -2299,7 +2299,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 			else if (dt instanceof Pointer) {
 				Pointer ptr = (Pointer) dt;
 				int len = ptr.isDynamicallySized() ? -1 : ptr.getLength();
-				newDataType = createPointer(ptr.getDataType(), cat, (byte) len, handler);
+				newDataType = createPointer(ptr.getDataType(), cat, (byte) len, ptr.getShiftOffset(), handler);
 			}
 			else if (dt instanceof Structure) {
 				Structure structure = (Structure) dt;
@@ -2481,7 +2481,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 		return enumDB;
 	}
 
-	private Pointer createPointer(DataType dt, Category cat, byte length,
+	private Pointer createPointer(DataType dt, Category cat, byte length, int shiftOffset,
 			DataTypeConflictHandler handler) throws IOException {
 
 		if (dt != null) {
@@ -2489,7 +2489,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 		}
 		long dataTypeID = getResolvedID(dt);
 
-		Record record = pointerAdapter.createRecord(dataTypeID, cat.getID(), length);
+		Record record = pointerAdapter.createRecord(dataTypeID, cat.getID(), length, shiftOffset);
 		PointerDB ptrDB = new PointerDB(this, dtCache, pointerAdapter, record);
 		if (dt != null) {
 			dt.addParent(ptrDB);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDB.java
@@ -82,7 +82,7 @@ class PointerDB extends DataTypeDB implements Pointer {
 		} else if (shiftOffset > 0) {
 			shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
 		}
-		return dt.getName() + shiftSuffix + " *" + lenStr;
+		return dt.getName() + " *" + lenStr + shiftSuffix;
 	}
 
 	@Override
@@ -168,16 +168,16 @@ class PointerDB extends DataTypeDB implements Pointer {
 				}
 			}
 			else {
-				long shiftOffset = getShiftOffset();
-				String shiftSuffix = "";
-				if (shiftOffset < 0) {
-					shiftSuffix = "-0x" + Long.toHexString(-shiftOffset);
-				} else if (shiftOffset > 0) {
-					shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
-				}
-				localDisplayName = dt.getDisplayName() + shiftSuffix + " *";
+				localDisplayName = dt.getDisplayName() + " *";
 			}
-			displayName = localDisplayName;
+			long shiftOffset = getShiftOffset();
+			String shiftSuffix = "";
+			if (shiftOffset < 0) {
+				shiftSuffix = "-0x" + Long.toHexString(-shiftOffset);
+			} else if (shiftOffset > 0) {
+				shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
+			}
+			displayName = localDisplayName + shiftSuffix;
 		}
 		return localDisplayName;
 	}
@@ -198,7 +198,7 @@ class PointerDB extends DataTypeDB implements Pointer {
 			} else if (shiftOffset > 0) {
 				shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
 			}
-			return dataType.getMnemonic(settings) + shiftSuffix + " *";
+			return dataType.getMnemonic(settings) + " *" + shiftSuffix;
 		}
 		finally {
 			lock.release();

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDB.java
@@ -22,6 +22,7 @@ import ghidra.docking.settings.Settings;
 import ghidra.docking.settings.SettingsDefinition;
 import ghidra.program.database.DBObjectCache;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressOverflowException;
 import ghidra.program.model.data.*;
 import ghidra.program.model.mem.MemBuffer;
 import ghidra.util.InvalidNameException;
@@ -281,10 +282,10 @@ class PointerDB extends DataTypeDB implements Pointer {
 			// TODO: Which address space should pointer refer to ??
 
 			return PointerDataType.getAddressValue(buf, getLength(),
-					buf.getAddress().getAddressSpace());
+					buf.getAddress().getAddressSpace()).subtractNoWrap(getShiftOffset());
 
 		}
-		catch (IllegalArgumentException exc) {
+		catch (IllegalArgumentException | AddressOverflowException exc) {
 			return null;
 		}
 		finally {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV0.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV0.java
@@ -111,6 +111,8 @@ class PointerDBAdapterV0 extends PointerDBAdapter {
 		Record rec = PointerDBAdapter.SCHEMA.createRecord(oldRec.getKey());
 		rec.setLongValue(PTR_DT_ID_COL, oldRec.getLongValue(OLD_PTR_DTD_COL));
 		rec.setLongValue(PTR_CATEGORY_COL, 0);
+		rec.setByteValue(PTR_LENGTH_COL, (byte) -1);
+		rec.setLongValue(PTR_SHIFT_OFFSET_COL, 0);
 		return rec;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV1.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV1.java
@@ -58,6 +58,7 @@ class PointerDBAdapterV1 extends PointerDBAdapter {
 		rec.setLongValue(PTR_DT_ID_COL, oldRec.getLongValue(OLD_PTR_DT_ID_COL));
 		rec.setLongValue(PTR_CATEGORY_COL, oldRec.getLongValue(OLD_PTR_CATEGORY_COL));
 		rec.setByteValue(PTR_LENGTH_COL, (byte) -1);
+		rec.setLongValue(PTR_SHIFT_OFFSET_COL, 0);
 		return rec;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV3.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV3.java
@@ -1,6 +1,5 @@
 /* ###
  * IP: GHIDRA
- * REVIEWED: YES
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV3.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/PointerDBAdapterV3.java
@@ -46,17 +46,11 @@ class PointerDBAdapterV3 extends PointerDBAdapter {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see ghidra.program.database.data.PointerDBAdapter#createRecord(long, long, int)
-	 */
 	@Override
 	Record createRecord(long dataTypeID, long categoryID, int length) throws IOException {
 		return createRecord(dataTypeID, categoryID, length, 0);
 	}
 	
-	/* (non-Javadoc)
-	 * @see ghidra.program.database.data.PointerDBAdapter#createRecord(long, long, int, int)
-	 */
 	@Override
 	Record createRecord(long dataTypeID, long categoryID, int length, int shiftOffset) throws IOException {
 		long tableKey = table.getKey();
@@ -71,49 +65,31 @@ class PointerDBAdapterV3 extends PointerDBAdapter {
 		return record;
 	}
 
-	/* (non-Javadoc)
-	 * @see ghidra.program.database.data.PointerDBAdapter#getRecord(long)
-	 */
 	@Override
 	Record getRecord(long pointerID) throws IOException {
 		return table.getRecord(pointerID);
 	}
-
-	/* (non-Javadoc)
-	 * @see ghidra.program.database.data.PointerDBAdapter#getRecords()
-	 */
+	
 	@Override
 	RecordIterator getRecords() throws IOException {
 		return table.iterator();
 	}
 
-	/* (non-Javadoc)
-	 * @see ghidra.program.database.data.PointerDBAdapter#removeRecord(long)
-	 */
 	@Override
 	boolean removeRecord(long pointerID) throws IOException {
 		return table.deleteRecord(pointerID);
 	}
-
-	/* (non-Javadoc)
-	 * @see ghidra.program.database.data.PointerDBAdapter#updateRecord(ghidra.framework.store.db.Record)
-	 */
+	
 	@Override
 	void updateRecord(Record record) throws IOException {
 		table.putRecord(record);
 	}
 
-	/* (non-Javadoc)
-	 * @see ghidra.program.database.data.PointerDBAdapter#getRecordIdsInCategory(long)
-	 */
 	@Override
 	long[] getRecordIdsInCategory(long categoryID) throws IOException {
 		return table.findRecords(new LongField(categoryID), PTR_CATEGORY_COL);
 	}
 
-	/**
-	 * @see ghidra.program.database.data.PointerDBAdapter#deleteTable()
-	 */
 	@Override
 	void deleteTable(DBHandle handle) throws IOException {
 		handle.deleteTable(POINTER_TABLE_NAME);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer.java
@@ -31,6 +31,11 @@ public interface Pointer extends DataType {
 	DataType getDataType();
 
 	/**
+	 * Gets the offset by which this pointer is shifted
+	 */
+	int getShiftOffset();
+	
+	/**
 	 * Creates a pointer to the indicated data type.
 	 * @param dataType the data type to point to.
 	 * @return the newly created pointer.

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/PointerDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/PointerDataType.java
@@ -42,6 +42,7 @@ public class PointerDataType extends BuiltIn implements Pointer {
 	public static final String POINTER_LOOP_LABEL_PREFIX = "PTR_LOOP";
 
 	protected DataType referencedDataType;
+	protected int shiftOffset;
 	protected int length;
 
 	private boolean deleted = false;
@@ -127,14 +128,31 @@ public class PointerDataType extends BuiltIn implements Pointer {
 	 *                           organization will be used
 	 */
 	public PointerDataType(DataType referencedDataType, int length, DataTypeManager dtm) {
+		this(referencedDataType, 0, length, dtm);
+	}
+	
+	/**
+	 * Construct a pointer of a specified length to a referencedDataType. Note: It
+	 * is preferred to use default sized pointers when possible (i.e., length=-1,
+	 * see {@link #PointerDataType(DataType, DataTypeManager)}) instead of
+	 * explicitly specifying the pointer length value.
+	 * 
+	 * @param referencedDataType data type this pointer points to
+	 * @param length             pointer length (-1 will result in dynamically-sized
+	 *                           pointer)
+	 * @param dtm                associated data type manager whose data
+	 *                           organization will be used
+	 */
+	public PointerDataType(DataType referencedDataType,int shiftOffset, int length, DataTypeManager dtm) {
 		super(referencedDataType != null ? referencedDataType.getCategoryPath() : null,
-			constructUniqueName(referencedDataType, length), dtm);
+			constructUniqueName(referencedDataType, shiftOffset, length), dtm);
 		if (referencedDataType instanceof BitFieldDataType) {
 			throw new IllegalArgumentException(
 				"Pointer reference data-type may not be a bitfield: " +
 					referencedDataType.getName());
 		}
 		this.length = length <= 0 ? -1 : length;
+		this.shiftOffset = shiftOffset;
 		this.referencedDataType = referencedDataType;
 		if (referencedDataType != null) {
 			referencedDataType.addParent(this);
@@ -147,7 +165,7 @@ public class PointerDataType extends BuiltIn implements Pointer {
 			return this;
 		}
 		// don't clone referenced data-type to avoid potential circular reference
-		return new PointerDataType(referencedDataType, length, dtm);
+		return new PointerDataType(referencedDataType, shiftOffset, length, dtm);
 	}
 
 	@Override
@@ -155,6 +173,11 @@ public class PointerDataType extends BuiltIn implements Pointer {
 		return referencedDataType;
 	}
 
+	@Override
+	public int getShiftOffset() {
+		return shiftOffset;
+	}
+	
 	@Override
 	public boolean isDynamicallySized() {
 		return length <= 0;
@@ -272,7 +295,14 @@ public class PointerDataType extends BuiltIn implements Pointer {
 				}
 			}
 			else {
-				displayName = dt.getDisplayName() + " *";
+				String shiftSuffix = "";
+				if (shiftOffset < 0) {
+					shiftSuffix = "-0x" + Long.toHexString(-shiftOffset);
+				} else if (shiftOffset > 0) {
+					shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
+					
+				}
+				displayName = dt.getDisplayName() + shiftSuffix + " *";
 			}
 		}
 		return displayName;
@@ -281,7 +311,7 @@ public class PointerDataType extends BuiltIn implements Pointer {
 	/**
 	 * Return a unique name for this pointer
 	 */
-	private static String constructUniqueName(DataType referencedDataType, int ptrLength) {
+	private static String constructUniqueName(DataType referencedDataType, int shiftOffset, int ptrLength) {
 		if (referencedDataType == null) {
 			String s = POINTER_NAME;
 			if (ptrLength > 0) {
@@ -289,7 +319,14 @@ public class PointerDataType extends BuiltIn implements Pointer {
 			}
 			return s;
 		}
-		String s = referencedDataType.getName() + " *";
+		String shiftSuffix = "";
+		if (shiftOffset < 0) {
+			shiftSuffix = "-0x" + Integer.toHexString(-shiftOffset);
+		} else if (shiftOffset > 0) {
+			shiftSuffix = "+0x" + Integer.toHexString(shiftOffset);
+			
+		}
+		String s = referencedDataType.getName() + shiftSuffix + " *";
 		if (ptrLength > 0) {
 			s += Integer.toString(8 * ptrLength);
 		}
@@ -314,6 +351,17 @@ public class PointerDataType extends BuiltIn implements Pointer {
 				sbuf.append(getDataType().getDisplayName());
 			}
 		}
+		if (shiftOffset != 0) {
+			sbuf.append(" shifted by ");
+			if (shiftOffset < 0) {
+				sbuf.append("-0x");
+				sbuf.append(Long.toHexString(-shiftOffset));
+			} else if (shiftOffset > 0) {
+				sbuf.append("0x");
+				sbuf.append(Long.toHexString(shiftOffset));
+				
+			}
+		}
 		return sbuf.toString();
 	}
 
@@ -322,7 +370,14 @@ public class PointerDataType extends BuiltIn implements Pointer {
 		if (referencedDataType == null || referencedDataType == DataType.DEFAULT) {
 			return "addr";
 		}
-		return referencedDataType.getMnemonic(settings) + " *";
+		String shiftSuffix = "";
+		if (shiftOffset < 0) {
+			shiftSuffix = "-0x" + Long.toHexString(-shiftOffset);
+		} else if (shiftOffset > 0) {
+			shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
+			
+	}
+		return referencedDataType.getMnemonic(settings) + shiftSuffix + " *";
 	}
 
 	@Override
@@ -472,6 +527,11 @@ public class PointerDataType extends BuiltIn implements Pointer {
 			return false;
 		}
 
+		// if we have different shift offsets, we're not equivalent
+		if (shiftOffset != p.getShiftOffset()) {
+			return false;
+		}
+		
 		// if they contain datatypes that have same ids, then we are essentially
 		// equivalent.
 		if (DataTypeUtilities.isSameDataType(referencedDataType, otherDataType)) {
@@ -526,7 +586,7 @@ public class PointerDataType extends BuiltIn implements Pointer {
 			referencedDataType.addParent(this);
 			displayName = null;
 			String oldName = name;
-			name = constructUniqueName(referencedDataType, length);
+			name = constructUniqueName(referencedDataType, shiftOffset, length);
 			notifyNameChanged(oldName);
 		}
 	}
@@ -535,7 +595,7 @@ public class PointerDataType extends BuiltIn implements Pointer {
 	public void dataTypeNameChanged(DataType dt, String oldName) {
 		if (referencedDataType == dt) {
 			displayName = null;
-			name = constructUniqueName(referencedDataType, length);
+			name = constructUniqueName(referencedDataType, shiftOffset, length);
 			notifyNameChanged(oldName);
 		}
 	}
@@ -601,7 +661,7 @@ public class PointerDataType extends BuiltIn implements Pointer {
 	public String getName() {
 		if (referencedDataType != null) {
 			// referencedDataType may have had name set, so re-create this pointer name.
-			name = constructUniqueName(referencedDataType, length);
+			name = constructUniqueName(referencedDataType, shiftOffset, length);
 		}
 		return super.getName();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/PointerDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/PointerDataType.java
@@ -385,7 +385,11 @@ public class PointerDataType extends BuiltIn implements Pointer {
 
 		// TODO: Which address space should pointer refer to ??
 
-		return getAddressValue(buf, getLength(), buf.getAddress().getAddressSpace());
+		try {
+			return getAddressValue(buf, getLength(), buf.getAddress().getAddressSpace()).subtractNoWrap(shiftOffset);
+		} catch(AddressOverflowException e) {
+			return null;
+		}
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/PointerDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/PointerDataType.java
@@ -295,15 +295,16 @@ public class PointerDataType extends BuiltIn implements Pointer {
 				}
 			}
 			else {
-				String shiftSuffix = "";
-				if (shiftOffset < 0) {
-					shiftSuffix = "-0x" + Long.toHexString(-shiftOffset);
-				} else if (shiftOffset > 0) {
-					shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
-					
-				}
-				displayName = dt.getDisplayName() + shiftSuffix + " *";
+				displayName = dt.getDisplayName() + " *";
 			}
+			long shiftOffset = getShiftOffset();
+			String shiftSuffix = "";
+			if (shiftOffset < 0) {
+				shiftSuffix = "-0x" + Long.toHexString(-shiftOffset);
+			} else if (shiftOffset > 0) {
+				shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
+			}
+			displayName += shiftSuffix;
 		}
 		return displayName;
 	}
@@ -319,17 +320,17 @@ public class PointerDataType extends BuiltIn implements Pointer {
 			}
 			return s;
 		}
+		String s = referencedDataType.getName() + " *";
+		if (ptrLength > 0) {
+			s += Integer.toString(8 * ptrLength);
+		}
 		String shiftSuffix = "";
 		if (shiftOffset < 0) {
 			shiftSuffix = "-0x" + Integer.toHexString(-shiftOffset);
 		} else if (shiftOffset > 0) {
 			shiftSuffix = "+0x" + Integer.toHexString(shiftOffset);
-			
 		}
-		String s = referencedDataType.getName() + shiftSuffix + " *";
-		if (ptrLength > 0) {
-			s += Integer.toString(8 * ptrLength);
-		}
+		s += shiftSuffix;
 		return s;
 	}
 
@@ -377,7 +378,7 @@ public class PointerDataType extends BuiltIn implements Pointer {
 			shiftSuffix = "+0x" + Long.toHexString(shiftOffset);
 			
 	}
-		return referencedDataType.getMnemonic(settings) + shiftSuffix + " *";
+		return referencedDataType.getMnemonic(settings) + " *" + shiftSuffix;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeDataTypeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeDataTypeManager.java
@@ -184,11 +184,12 @@ public class PcodeDataTypeManager {
 			DataType restype = null;
 			if (meta.equals("ptr")) {
 				int size = SpecXmlUtils.decodeInt(el.getAttribute("size"));
+				int shiftOffset = SpecXmlUtils.decodeInt(el.getAttribute("shiftOffset"));
 				if (parser.peek().isStart()) {
 					DataType dt = readXMLDataType(parser);
 					boolean useDefaultSize = (size == dataOrganization.getPointerSize() ||
 						size > PointerDataType.MAX_POINTER_SIZE_BYTES);
-					restype = new PointerDataType(dt, useDefaultSize ? -1 : size, progDataTypes);
+					restype = new PointerDataType(dt, shiftOffset, useDefaultSize ? -1 : size, progDataTypes);
 				}
 			}
 			else if (meta.equals("array")) {
@@ -356,6 +357,7 @@ public class PcodeDataTypeManager {
 				appendNameIdAttributes(resBuf, origType);
 			}
 			SpecXmlUtils.encodeStringAttribute(resBuf, "metatype", "ptr");
+			SpecXmlUtils.encodeSignedIntegerAttribute(resBuf, "shiftOffset", ((Pointer) type).getShiftOffset());
 			int ptrLen = type.getLength();
 			if (ptrLen <= 0) {
 				ptrLen = size;


### PR DESCRIPTION
This patch adds shifted pointers to Ghidra, which allow to treat pointers as not pointing directly to they're base types, but to an offset away of them. See issue #573 

This patch is currently not ready to be merged, mainly because of three factors:
- Only 97% of integration tests succeed (might not be related to this patch, because some failures are GUI related)
- Help entries are missing
- Unit tests are missing

In the front end, this patch adds the context menu option "Shift Pointer" (hotkey T), which prompts for an offset and shifts the currently selected pointer by it. It also extends the TypeParser with the ability to parse the new shifted pointer syntax.

In the back end, this patch introduces:
- a new PointerDB-version, which also stores the shift offset
- a new method getShiftOffset to the Pointer interface
- XML-(de)serialization of the shift offset

In the decompiler, this patch works as follows:
- add a new field shiftOffset + XML-(de)serialization to TypePointer
- create a new CPUI_INT_ADD op to shift every shifted pointer back to it's original type
- type propagation logic to give the output of the above node the corresponding unshifted pointer type
- modify printc.cc to print shifted pointer types correctly

For everyone wanting to try this out, I created a simple test program which can be compiled + opened in Ghidra which specifically makes use of this feature. It's attached to this PR as a .txt file (because SO only supports .txt or .zip):
[ghidra_test.txt](https://github.com/NationalSecurityAgency/ghidra/files/5043636/ghidra_test.txt)

PS: This patch ended up affecting way more than I thought, so it might take a while to merge into the codebase

