### PR TITLE
PowerPC ISEL stomp register value

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
@@ -3849,6 +3849,8 @@ define pcodeop lswxOp;
 	EA:$(REGISTER_SIZE) = RA_OR_ZERO + B;
 	if (RESERVE == 0) goto inst_next;
 	*[ram]:8 EA = storeDoubleWordConditionalIndexed(S,RA_OR_ZERO,B);
+	# set when a stwcx. or stdcx. successfully completes
+	setCrBit(cr0, 2, 1);
 }
 
 #stdu r0,8(0)	0xf8 00 00 01	
@@ -4034,6 +4036,8 @@ define pcodeop stswxOp;
 	EA:$(REGISTER_SIZE) = RA_OR_ZERO + B;
 	if (RESERVE == 0) goto inst_next;
 	*[ram]:4 EA = storeWordConditionalIndexed(S,RA_OR_ZERO,B);
+	# set when a stwcx. or stdcx. successfully completes
+	setCrBit(cr0, 2, 1);
 }
 
 #stwu r0,r0			0x94 00 00 00

--- a/Ghidra/Processors/PowerPC/data/languages/quicciii.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/quicciii.sinc
@@ -65,9 +65,10 @@ define pcodeop invalidateTLB;
 
 :isel^CC_X_OPm D,RA_OR_ZERO,B,CC_X_OP  is OP=31 & D & RA_OR_ZERO & B & CC_X_OP & CC_X_OPm & XOP_1_5=15
 {
-		D = B;
-		if (!CC_X_OP) goto inst_next;
-		D = RA_OR_ZERO;
+	local tmp:$(REGISTER_SIZE) = RA_OR_ZERO;
+	D = B;
+	if (!CC_X_OP) goto inst_next;
+	D = tmp;
 #        D = (zext(CC_X_OP) * RA_OR_ZERO) + (zext(!CC_X_OP) * B);
 }
 


### PR DESCRIPTION
The ISEL instruction didn't preserve a register value while
calculating whether it should write the first or second value
resulting in unconditionally writing the one value if any of
the first three operands match.

For example:

lwz     r0,0x0(r3)
subf    r3,r4,r0
cmpw    cr7,r0,r4
li      r9,0
iselgt  r3,r3,r9,cr7
blr

would result in the decompiler always returning 0x0