### PR TITLE
Added missing basic and condition cases to nameToType.

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeBlock.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeBlock.java
@@ -91,7 +91,12 @@ public class PcodeBlock {
 
 	public static int nameToType(String name) {
 		switch (name.charAt(0)) {
+			case 'b':
+				return BASIC;
 			case 'c':
+				if (name.equals("condition")) {
+					return CONDITION;
+				}
 				return COPY;
 			case 'd':
 				return DOWHILE;


### PR DESCRIPTION
Bug fix. Added missing cases to switch statement in `nameToType`.

This bug has not been exposed because `nameToType` is not (yet) ever called on `"basic"` or `"condition"`.