### PR TITLE
Added GnuDemanglerFormat, changed analyzer options

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/AutoAnalysisPlugin/AutoAnalysis.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/AutoAnalysisPlugin/AutoAnalysis.htm
@@ -379,32 +379,13 @@
 			<U><B>Use Deprecated Demangler</B></U> -
 				By default, GCC symbols will be demangled using the most up-to-date demangler
 				that Ghidra contains (<B>version 2.33.1</B> as of this writing).   Turning this 
-				option on will also invoke the now deprecated previous version of the demangler
-				(<B>version 2.24</B>) if the preferred demangler cannot demangle a given symbol.
+				option on will invoke the now deprecated version of the demangler (<B>version 2.24</B>).
 		</P>
 		<P>	
 				Support for older demangling styles was removed in <CODE>c++filt (v2.32)</CODE>.
 				Specifically, the following formats are no longer supported: 
-				<CODE>Lucid, ARM, HP, and EDG</CODE>.   To use these formats, you must enable
-				usage of the deprecated demangler, which is <B>version 2.24</B>.  Further, you 
-				may have to pass the required external demangler options using the Ghidra 
-				option below.
-		</P>
-		<P>
-		
-			<U><B>Use External Demangler Options</B></U> - 
-			
-				This allows users to pass settings to the demangler. As an example, you can enter 
-				in this Ghidra option text field the following text to use the <CODE>rust</CODE>
-				format: <CODE>-s rust</CODE>.  This is not needed for
-				normal operation.   To see a full list of supported options, query each demangler
-				directly using the <CODE>--help</CODE> switch.
-			</P>
-			<P>
-				The GNU demanglers can be found at: 
-				<CODE CLASS="path">
-				&lt;GHIDRA_INSTALL_DIR&gt;/GPL/DemanglerGnu/build/os/&lt;OS&gt;/
-				</CODE><BR>				
+				<CODE>Lucid, ARM, HP, GNU and EDG</CODE>.   To use these formats, you must enable
+				usage of the deprecated demangler, which is <B>version 2.24</B>.
 		</P>
 		
 				

--- a/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/plugin/core/analysis/GnuDemanglerAnalyzer.java
+++ b/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/plugin/core/analysis/GnuDemanglerAnalyzer.java
@@ -15,16 +15,18 @@
  */
 package ghidra.app.plugin.core.analysis;
 
-import java.io.IOException;
-
-import org.apache.commons.lang3.StringUtils;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Arrays;
 
 import ghidra.app.util.demangler.*;
 import ghidra.app.util.demangler.gnu.*;
 import ghidra.app.util.importer.MessageLog;
-import ghidra.framework.options.Options;
+import ghidra.framework.options.*;
 import ghidra.program.model.listing.Program;
 import ghidra.util.HelpLocation;
+
+import docking.options.editor.BooleanEditor;
 
 /**
  * A version of the demangler analyzer to handle GNU GCC symbols 
@@ -51,15 +53,14 @@ public class GnuDemanglerAnalyzer extends AbstractDemanglerAnalyzer {
 		"Signals to use the deprecated demangler when the modern demangler cannot demangle a " +
 			"given string";
 
-	static final String OPTION_NAME_DEMANGLER_PARAMETERS =
-		"Use External Demangler Options";
-	private static final String OPTION_DESCRIPTION_DEMANGLER_PARAMETERS =
-		"Signals to use pass the given parameters to the demangler program";
+	static final String OPTION_NAME_DEMANGLER_FORMAT = "Demangler Format";
+	private static final String OPTION_DESCRIPTION_DEMANGLER_FORMAT =
+		"The demangling format to use";
 
 	private boolean doSignatureEnabled = true;
 	private boolean demangleOnlyKnownPatterns = false;
+	private GnuDemanglerFormat demanglerFormat = GnuDemanglerFormat.AUTO;
 	private boolean useDeprecatedDemangler = false;
-	private String demanglerParameters = "";
 
 	private GnuDemangler demangler = new GnuDemangler();
 
@@ -75,20 +76,23 @@ public class GnuDemanglerAnalyzer extends AbstractDemanglerAnalyzer {
 
 	@Override
 	public void registerOptions(Options options, Program program) {
+		BooleanEditor editor = new BooleanEditor();
+		editor.setValue(Boolean.valueOf(useDeprecatedDemangler));
+		FormatEditor formatEditor = new FormatEditor(demanglerFormat, editor);
+		editor.addPropertyChangeListener(formatEditor);
 
 		HelpLocation help = new HelpLocation("AutoAnalysisPlugin", "Demangler_Analyzer");
 		options.registerOption(OPTION_NAME_APPLY_SIGNATURE, doSignatureEnabled, help,
 			OPTION_DESCRIPTION_APPLY_SIGNATURE);
 
 		options.registerOption(OPTION_NAME_DEMANGLE_USE_KNOWN_PATTERNS, demangleOnlyKnownPatterns,
-			help,
-			OPTION_DESCRIPTION_USE_KNOWN_PATTERNS);
-
-		options.registerOption(OPTION_NAME_USE_DEPRECATED_DEMANGLER, useDeprecatedDemangler, help,
-			OPTION_DESCRIPTION_DEPRECATED_DEMANGLER);
-
-		options.registerOption(OPTION_NAME_DEMANGLER_PARAMETERS, demanglerParameters, help,
-			OPTION_DESCRIPTION_DEMANGLER_PARAMETERS);
+			help, OPTION_DESCRIPTION_USE_KNOWN_PATTERNS);
+		
+		options.registerOption(OPTION_NAME_USE_DEPRECATED_DEMANGLER, OptionType.BOOLEAN_TYPE,
+			useDeprecatedDemangler, help, OPTION_DESCRIPTION_DEPRECATED_DEMANGLER, editor);
+		
+		options.registerOption(OPTION_NAME_DEMANGLER_FORMAT, OptionType.ENUM_TYPE,
+			demanglerFormat, help, OPTION_DESCRIPTION_DEMANGLER_FORMAT, formatEditor);
 	}
 
 	@Override
@@ -96,94 +100,113 @@ public class GnuDemanglerAnalyzer extends AbstractDemanglerAnalyzer {
 		doSignatureEnabled = options.getBoolean(OPTION_NAME_APPLY_SIGNATURE, doSignatureEnabled);
 		demangleOnlyKnownPatterns =
 			options.getBoolean(OPTION_NAME_DEMANGLE_USE_KNOWN_PATTERNS, demangleOnlyKnownPatterns);
-
+		demanglerFormat = options.getEnum(OPTION_NAME_DEMANGLER_FORMAT, GnuDemanglerFormat.AUTO);
 		useDeprecatedDemangler =
-			options.getBoolean(OPTION_NAME_USE_DEPRECATED_DEMANGLER, useDeprecatedDemangler);
-
-		demanglerParameters =
-			options.getString(OPTION_NAME_DEMANGLER_PARAMETERS, demanglerParameters);
+				options.getBoolean(OPTION_NAME_USE_DEPRECATED_DEMANGLER, useDeprecatedDemangler);
 	}
 
 	@Override
 	protected DemanglerOptions getOptions() {
-
-		GnuDemanglerOptions options = new GnuDemanglerOptions();
+		GnuDemanglerOptions options =
+			new GnuDemanglerOptions(demanglerFormat, useDeprecatedDemangler);
 		options.setDoDisassembly(true);
 		options.setApplySignature(doSignatureEnabled);
 		options.setDemangleOnlyKnownPatterns(demangleOnlyKnownPatterns);
-		options.setDemanglerApplicationArguments(demanglerParameters);
 		return options;
 	}
 
 	@Override
-	protected boolean validateOptions(DemanglerOptions demanglerOtions, MessageLog log) {
-
-		GnuDemanglerOptions options = (GnuDemanglerOptions) demanglerOtions;
-		String applicationArguments = options.getDemanglerApplicationArguments();
-		if (StringUtils.isBlank(applicationArguments)) {
-			return true;
-		}
-
-		// Check that the supplied arguments will work with at least one of the requested
-		// demanglers.  (Different versions of the GNU demangler support different arguments.)
-		String demanglerName = options.getDemanglerName();
-		try {
-			GnuDemanglerNativeProcess.getDemanglerNativeProcess(demanglerName,
-				applicationArguments);
-			return true;
-		}
-		catch (IOException e) {
-			log.appendMsg(getName(), "Invalid options for GNU dangler '" + demanglerName +
-				"': " + applicationArguments);
-			log.appendException(e);
-		}
-
-		if (useDeprecatedDemangler) {
-			// see if the options work in the deprecated demangler
-			GnuDemanglerOptions deprecatedOptions = options.withDeprecatedDemangler();
-			String deprecatedName = deprecatedOptions.getDemanglerName();
-			try {
-				GnuDemanglerNativeProcess.getDemanglerNativeProcess(deprecatedName,
-					applicationArguments);
-				return true;
-			}
-			catch (IOException e) {
-				log.appendMsg(getName(),
-					"Invalid options for GNU dangler '" + deprecatedName + "': " +
-						applicationArguments);
-				log.appendException(e);
-			}
-		}
-
-		return false;
-
+	protected DemangledObject doDemangle(String mangled, DemanglerOptions demanglerOtions,
+			MessageLog log) throws DemangledException {
+		return demangler.demangle(mangled, (GnuDemanglerOptions) demanglerOtions);
 	}
 
-	@Override
-	protected DemangledObject doDemangle(String mangled, DemanglerOptions demanglerOtions,
-			MessageLog log)
-			throws DemangledException {
+	private static class FormatEditor extends EnumEditor implements PropertyChangeListener {
 
-		GnuDemanglerOptions options = (GnuDemanglerOptions) demanglerOtions;
-		DemangledObject demangled = null;
-		try {
-			demangled = demangler.demangle(mangled, options);
+		private final FormatSelector selector;
+		private final BooleanEditor isDeprecated;
+
+		FormatEditor(GnuDemanglerFormat value, BooleanEditor isDeprecated) {
+			setValue(value);
+			this.isDeprecated = isDeprecated;
+			this.selector = new FormatSelector(this);
 		}
-		catch (DemangledException e) {
-			if (!useDeprecatedDemangler) {
-				throw e; // let our parent handle this
+
+		@Override
+		public boolean supportsCustomEditor() {
+			return true;
+		}
+
+		@Override
+		public FormatSelector getCustomEditor() {
+			return selector;
+		}
+
+		@Override
+		public GnuDemanglerFormat[] getEnums() {
+			return Arrays.stream(GnuDemanglerFormat.values())
+				.filter(this::filter)
+				.toArray(GnuDemanglerFormat[]::new);
+		}
+
+		@Override
+		public String[] getTags() {
+			return Arrays.stream(GnuDemanglerFormat.values())
+				.filter(this::filter)
+				.map(GnuDemanglerFormat::name)
+				.toArray(String[]::new);
+		}
+
+		@Override
+		public void propertyChange(PropertyChangeEvent evt) {
+			GnuDemanglerFormat format = selector.getFormat();
+			selector.reset(getTags());
+			if (format.isAvailable(isDeprecatedDemangler())) {
+				setValue(format);
+				selector.setFormat(format);
+			} else {
+				setValue(GnuDemanglerFormat.AUTO);
+			}
+		}
+		
+		@Override
+		public void setAsText(String s) {
+			if (s != null) {
+				super.setAsText(s);
 			}
 		}
 
-		if (demangled != null) {
-			return demangled;
+		private boolean isDeprecatedDemangler() {
+			return (Boolean) isDeprecated.getValue();
 		}
 
-		if (useDeprecatedDemangler) {
-			GnuDemanglerOptions newOptions = options.withDeprecatedDemangler();
-			demangled = demangler.demangle(mangled, newOptions);
+		private boolean filter(GnuDemanglerFormat f) {
+			return f.isAvailable(isDeprecatedDemangler());
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static class FormatSelector extends PropertySelector {
+
+		public FormatSelector(FormatEditor fe) {
+			super(fe);
 		}
 
-		return demangled;
+		@SuppressWarnings("unchecked")
+		void reset(String[] tags) {
+			removeAllItems();
+			for (int i = 0; i < tags.length; i++) {
+				addItem(tags[i]);
+			}
+		}
+
+		GnuDemanglerFormat getFormat() {
+			return GnuDemanglerFormat.valueOf((String) getSelectedItem());
+		}
+
+		void setFormat(GnuDemanglerFormat format) {
+			setSelectedItem(format.name());
+		}
+		
 	}
 }

--- a/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemangler.java
+++ b/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemangler.java
@@ -72,11 +72,11 @@ public class GnuDemangler implements Demangler {
 	public DemangledObject demangle(String mangled, DemanglerOptions demanglerOtions)
 			throws DemangledException {
 
-		if (skip(mangled, demanglerOtions)) {
+		GnuDemanglerOptions options = getGnuOptions(demanglerOtions);
+		if (skip(mangled, options)) {
 			return null;
 		}
 
-		GnuDemanglerOptions options = getGnuOptions(demanglerOtions);
 		String originalMangled = mangled;
 		String globalPrefix = null;
 		if (mangled.startsWith(GLOBAL_PREFIX)) {
@@ -163,7 +163,7 @@ public class GnuDemangler implements Demangler {
 			applicationOptions);
 	}
 
-	private boolean skip(String mangled, DemanglerOptions options) {
+	private boolean skip(String mangled, GnuDemanglerOptions options) {
 
 		// Ignore versioned symbols which are generally duplicated at the same address
 		if (mangled.indexOf("@") > 0) { // do not demangle versioned symbols
@@ -179,21 +179,28 @@ public class GnuDemangler implements Demangler {
 			return false; // let it go through
 		}
 
-		// add to this list if we find any other known GNU start patterns
-		if (mangled.startsWith("_Z")) {
+		// TODO provide some checks specific to the other formats
+		GnuDemanglerFormat format = options.getDemanglerFormat();
+		if (format == GnuDemanglerFormat.AUTO) {
 			return false;
 		}
-		else if (mangled.startsWith("__Z")) {
-			return false;
-		}
-		else if (mangled.startsWith("h__")) {
-			return false; // not sure about this one
-		}
-		else if (mangled.startsWith("?")) {
-			return false; // not sure about this one
-		}
-		else if (isGnu2Or3Pattern(mangled)) {
-			return false;
+		if (format == GnuDemanglerFormat.GNUV3) {
+			// add to this list if we find any other known GNU start patterns
+			if (mangled.startsWith("_Z")) {
+				return false;
+			}
+			if (mangled.startsWith("__Z")) {
+				return false;
+			}
+			if (mangled.startsWith("h__")) {
+				return false; // not sure about this one
+			}
+			if (mangled.startsWith("?")) {
+				return false; // not sure about this one
+			}
+			if (isGnu2Or3Pattern(mangled)) {
+				return false;
+			}
 		}
 
 		return true;

--- a/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerFormat.java
+++ b/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerFormat.java
@@ -1,0 +1,89 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.demangler.gnu;
+
+/**
+ * Enum representation of the available GnuDemangler formats
+ */
+public enum GnuDemanglerFormat {
+    // OLD: none,auto,gnu,lucid,arm,hp,edg,gnu-v3,java,gnat
+    // NEW: none,auto,gnu-v3,java,gnat,dlang,rust
+    /** Automatic mangling format detection */
+    AUTO("", 0),
+    /** GNUv2 mangling format */
+    GNU("gnu", -1),
+    /** lucid mangling format */
+    LUCID("lucid", -1),
+    /** arm mangling format */
+    ARM("arm", -1),
+    /** hp mangling format */
+    HP("hp", -1),
+    /** mangling format used by the Edison Design Group (EDG) compiler */
+    EDG("edg", -1),
+    /** GNUv3 mangling format */
+    GNUV3("gnu-v3", 0),
+    /** Java mangling format */
+    JAVA("java", 0),
+    /** GNAT Ada compiler mangling format */
+    GNAT("gnat", 0),
+    /** D mangling format */
+    DLANG("dlang", 1),
+    /** Rust mangling format */
+    RUST("rust", 1);
+
+    /** the format option string */
+    private final String format;
+    /** private sentinal. deprecated = -1, both = 0, new = 1 */
+    private final byte version;
+
+    private GnuDemanglerFormat(String format, int version) {
+        this.format = format;
+        this.version = (byte) version;
+    }
+
+    /**
+     * Checks if this format is available in the deprecated gnu demangler
+     * @return true if this format is available in the deprecated gnu demangler
+     */
+    public boolean isDeprecatedFormat() {
+        return version <= 0;
+    }
+
+    /**
+     * Checks if this format is available in a modern version of the gnu demangler
+     * @return true if this format is available in a modern version of the gnu demangler.
+     */
+    public boolean isModernFormat() {
+        return version >= 0;
+    }
+    
+    /**
+     * Checks if this format is available for the specified demangler
+     * @param isDeprecated true for the deprecated demangler, false for the modern demangler.
+     * @return true if the format is available
+     */
+    public boolean isAvailable(boolean isDeprecated) {
+        return isDeprecated ? isDeprecatedFormat() : isModernFormat();
+    }
+
+    /**
+     * Gets the format option to be passed to the demangler via the <code>-s</code> option
+     * @return the format option to be passed to the demangler
+     */
+    public String getFormat() {
+        return format;
+    }
+}

--- a/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerOptions.java
+++ b/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerOptions.java
@@ -43,11 +43,27 @@ public class GnuDemanglerOptions extends DemanglerOptions {
 	 */
 	public static final String GNU_DEMANGLER_DEFAULT = GNU_DEMANGLER_V2_33_1;
 
-	private String demanglerName = GNU_DEMANGLER_DEFAULT;
-	private String demanglerApplicationArguments;
+	private final GnuDemanglerFormat format;
+	private final boolean isDeprecated;
 
 	public GnuDemanglerOptions() {
 		// use default values
+		this(GnuDemanglerFormat.AUTO);
+	}
+
+	public GnuDemanglerOptions(GnuDemanglerFormat format) {
+		this.format = format;
+		// default to the "new" demangler if the format is available in both
+		this.isDeprecated = !format.isModernFormat();
+	}
+
+	public GnuDemanglerOptions(GnuDemanglerFormat format, boolean isDeprecated) {
+		this.format = format;
+		this.isDeprecated = isDeprecated;
+		if (!format.isAvailable(isDeprecated)) {
+			throw new IllegalArgumentException(
+				format.name() + " is not available in the "+getDemanglerName());
+		}
 	}
 
 	public GnuDemanglerOptions(DemanglerOptions copy) {
@@ -55,9 +71,19 @@ public class GnuDemanglerOptions extends DemanglerOptions {
 
 		if (copy instanceof GnuDemanglerOptions) {
 			GnuDemanglerOptions gCopy = (GnuDemanglerOptions) copy;
-			demanglerName = gCopy.demanglerName;
-			demanglerApplicationArguments = gCopy.demanglerApplicationArguments;
+			format = gCopy.format;
+			isDeprecated = gCopy.isDeprecated;
+		} else {
+			format = GnuDemanglerFormat.AUTO;
+			isDeprecated = false;
 		}
+	}
+
+	private GnuDemanglerOptions(GnuDemanglerOptions copy, GnuDemanglerFormat format,
+			boolean deprecated) {
+		super(copy);
+		this.format = format;
+		this.isDeprecated = deprecated;
 	}
 
 	/**
@@ -66,15 +92,28 @@ public class GnuDemanglerOptions extends DemanglerOptions {
 	 * @return the name
 	 */
 	public String getDemanglerName() {
-		return demanglerName;
+		return isDeprecated ? GNU_DEMANGLER_V2_24 : GNU_DEMANGLER_V2_33_1;
 	}
 
 	/**
-	 * Sets the external demangler executable name to be used for demangling
-	 * @param name the name
+	 * A convenience method to copy the state of this options object, changing the 
+	 * demangler executable name and demangler format to the specified values.
+	 * @param format the demangling format to use
+	 * @param isDeprecated true to use the deprecated gnu demangler, else false
+	 * @return the new options
+	 * @throws IllegalArgumentException if the current format is not available in the
+	 * selected demangler.
 	 */
-	public void setDemanglerName(String name) {
-		this.demanglerName = name;
+	public GnuDemanglerOptions withDemanglerFormat(GnuDemanglerFormat format, boolean isDeprecated)
+			throws IllegalArgumentException {
+		if (this.format == format && this.isDeprecated == isDeprecated) {
+			return this;
+		}
+		if (format.isAvailable(isDeprecated)) {
+			return new GnuDemanglerOptions(this, format, isDeprecated);
+		}
+		throw new IllegalArgumentException(
+			format.name() + " is not available in the "+getDemanglerName());
 	}
 
 	/**
@@ -82,26 +121,19 @@ public class GnuDemanglerOptions extends DemanglerOptions {
 	 * @return the arguments
 	 */
 	public String getDemanglerApplicationArguments() {
-		return demanglerApplicationArguments;
+		if (format == GnuDemanglerFormat.AUTO) {
+			// no format argument
+			return "";
+		}
+		return "-s " + format.getFormat();
 	}
 
 	/**
-	 * Sets the arguments to be passed to the external demangler executable
-	 * @param args the arguments
+	 * Gets the current demangler format
+	 * @return the demangler format
 	 */
-	public void setDemanglerApplicationArguments(String args) {
-		this.demanglerApplicationArguments = args;
-	}
-
-	/**
-	 * A convenience method to copy the state of this options object, changing the 
-	 * demangler executable name to the deprecated demangler
-	 * @return the new options
-	 */
-	public GnuDemanglerOptions withDeprecatedDemangler() {
-		GnuDemanglerOptions newOptions = new GnuDemanglerOptions(this);
-		newOptions.setDemanglerName(GNU_DEMANGLER_V2_24);
-		return newOptions;
+	public GnuDemanglerFormat getDemanglerFormat() {
+		return format;
 	}
 
 	@Override
@@ -111,8 +143,8 @@ public class GnuDemanglerOptions extends DemanglerOptions {
 			"\tdoDisassembly: " + doDisassembly() + ",\n" +
 			"\tapplySignature: " + applySignature() + ",\n" +
 			"\tdemangleOnlyKnownPatterns: " + demangleOnlyKnownPatterns() + ",\n" +
-			"\tdemanglerName: " + demanglerName + ",\n" +
-			"\tdemanglerApplicationArguments: " + demanglerApplicationArguments + ",\n" +
+			"\tdemanglerName: " + getDemanglerName() + ",\n" +
+			"\tdemanglerApplicationArguments: " + getDemanglerApplicationArguments() + ",\n" +
 		"}";
 		//@formatter:on
 	}

--- a/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerParser.java
+++ b/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemanglerParser.java
@@ -1177,7 +1177,7 @@ public class GnuDemanglerParser {
 		DemangledObject doBuild(Demangled namespace) {
 			DemangledString demangledString = new DemangledString(mangledSource, demangledSource,
 				"typeinfo-name", type, -1/*unknown length*/, false);
-			demangledString.setSpecialPrefix("typeinfo name for ");
+			demangledString.setSpecialPrefix(TYPEINFO_NAME_FOR);
 			String namespaceString = removeBadSpaces(type);
 			setNamespace(demangledString, namespaceString);
 			return demangledString;

--- a/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/plugin/core/analysis/GnuDemanglerAnalyzerTest.java
+++ b/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/plugin/core/analysis/GnuDemanglerAnalyzerTest.java
@@ -17,13 +17,11 @@ package ghidra.app.plugin.core.analysis;
 
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import ghidra.app.cmd.label.AddLabelCmd;
-import ghidra.app.util.demangler.gnu.GnuDemanglerOptions;
+import ghidra.app.util.demangler.gnu.GnuDemanglerFormat;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.framework.options.Options;
 import ghidra.program.database.ProgramBuilder;
@@ -34,7 +32,6 @@ import ghidra.program.model.symbol.*;
 import ghidra.test.AbstractGhidraHeadlessIntegrationTest;
 import ghidra.test.ToyProgramBuilder;
 import ghidra.util.Msg;
-import ghidra.util.StringUtilities;
 import ghidra.util.task.TaskMonitor;
 
 public class GnuDemanglerAnalyzerTest extends AbstractGhidraHeadlessIntegrationTest {
@@ -99,29 +96,12 @@ public class GnuDemanglerAnalyzerTest extends AbstractGhidraHeadlessIntegrationT
 		Address addr = addr("0x110");
 		createSymbol(addr, mangled);
 
+		setFormat(GnuDemanglerFormat.AUTO);
 		setOption(GnuDemanglerAnalyzer.OPTION_NAME_USE_DEPRECATED_DEMANGLER, true);
 
 		analyze();
 
 		assertDemangled(addr, "__dt");
-	}
-
-	@Test
-	public void testMangledString_WithArguments_Valid() {
-
-		//
-		// The below demangles to std::io::Read::read_to_end
-		//
-		String mangled = "_ZN3std2io4Read11read_to_end17hb85a0f6802e14499E";
-
-		Address addr = addr("0x110");
-		createSymbol(addr, mangled);
-
-		setOption(GnuDemanglerAnalyzer.OPTION_NAME_DEMANGLER_PARAMETERS, "-s rust");
-
-		analyze();
-
-		assertDemangled(addr, "read_to_end");
 	}
 
 	@Test
@@ -135,7 +115,7 @@ public class GnuDemanglerAnalyzerTest extends AbstractGhidraHeadlessIntegrationT
 		Address addr = addr("0x110");
 		createSymbol(addr, mangled);
 
-		setOption(GnuDemanglerAnalyzer.OPTION_NAME_DEMANGLER_PARAMETERS, "-s dlang");
+		setFormat(GnuDemanglerFormat.DLANG);
 
 		analyze();
 
@@ -143,104 +123,35 @@ public class GnuDemanglerAnalyzerTest extends AbstractGhidraHeadlessIntegrationT
 	}
 
 	@Test
-	public void testMangledString_WithArguments_Invalid() {
-
-		//
-		// The below demangles to std::io::Read::read_to_end
-		//
-		String mangled = "_ZN3std2io4Read11read_to_end17hb85a0f6802e14499E";
-
-		Address addr = addr("0x110");
-		createSymbol(addr, mangled);
-
-		setOption(GnuDemanglerAnalyzer.OPTION_NAME_DEMANGLER_PARAMETERS, "-s badformatname");
-
-		analyze();
-
-		assertNotDemangled(addr, "read_to_end");
-		assertMessageLogLine("java.io.IOException: Error starting demangler with command");
-		assertMessageLogLine("Invalid options", GnuDemanglerOptions.GNU_DEMANGLER_V2_33_1);
+	public void testUseDeprecatedOptionRemoval_WithDeprecatedFormat() {
+		setFormat(GnuDemanglerFormat.GNU);
+		Options options = program.getOptions("Analyzers");
+		assertFalse(options.contains(GnuDemanglerAnalyzer.OPTION_NAME_USE_DEPRECATED_DEMANGLER));
 	}
 
 	@Test
-	public void testDeprecatedMangledString_WithArguments_Invalid() {
-
-		//
-		// The below demangles to std::io::Read::read_to_end
-		//
-		String mangled = "_ZN3std2io4Read11read_to_end17hb85a0f6802e14499E";
-
-		Address addr = addr("0x110");
-		createSymbol(addr, mangled);
-
-		setOption(GnuDemanglerAnalyzer.OPTION_NAME_USE_DEPRECATED_DEMANGLER, true);
-		setOption(GnuDemanglerAnalyzer.OPTION_NAME_DEMANGLER_PARAMETERS, "-s badformatname");
-
-		analyze();
-
-		assertNotDemangled(addr, "read_to_end");
-		assertMessageLogLine("java.io.IOException: Error starting demangler with command");
-		assertMessageLogLine("Invalid options", GnuDemanglerOptions.GNU_DEMANGLER_V2_33_1);
-		assertMessageLogLine("Invalid options", GnuDemanglerOptions.GNU_DEMANGLER_V2_24);
+	public void testUseDeprecatedOptionRemoval_WithRecentFormat() {
+		setFormat(GnuDemanglerFormat.RUST);
+		Options options = program.getOptions("Analyzers");
+		assertFalse(options.contains(GnuDemanglerAnalyzer.OPTION_NAME_USE_DEPRECATED_DEMANGLER));
 	}
 
 	@Test
-	public void testDeprecatedMangledString_WithArguments_InvalidModernArguments_ValidDeprecatedArguments() {
-
-		//
-		// The below demangles to std::io::Read::read_to_end
-		//
-		String mangled = "_ZN3std2io4Read11read_to_end17hb85a0f6802e14499E";
-
-		Address addr = addr("0x110");
-		createSymbol(addr, mangled);
-
-		setOption(GnuDemanglerAnalyzer.OPTION_NAME_USE_DEPRECATED_DEMANGLER, true);
-		setOption(GnuDemanglerAnalyzer.OPTION_NAME_DEMANGLER_PARAMETERS, "-s arm");
-
-		analyze();
-
-		assertNotDemangled(addr, "read_to_end");
-		assertMessageLogLine("java.io.IOException: Error starting demangler with command");
-		assertMessageLogLine("Invalid options", GnuDemanglerOptions.GNU_DEMANGLER_V2_33_1);
-		assertMessageNotInLogLine("Invalid options", GnuDemanglerOptions.GNU_DEMANGLER_V2_24);
+	public void testUseDeprecatedOptionAddition() {
+		// remove it first
+		testUseDeprecatedOptionRemoval_WithDeprecatedFormat();
+		setFormat(GnuDemanglerFormat.AUTO);
+		Options options = program.getOptions("Analyzers");
+		assertTrue(options.contains(GnuDemanglerAnalyzer.OPTION_NAME_USE_DEPRECATED_DEMANGLER));
 	}
 
 	// things missed:
 	// -demangle error case in base class...this is OK
 	// -error case in applyTo method in base class
 
-	// -use deprecated demangler case in validateOptions
-
 //==================================================================================================
 // Private Methods
 //==================================================================================================	
-
-	private void assertMessageLogLine(String... expected) {
-
-		String allMessages = log.toString();
-		String[] logLines = allMessages.split("\n");
-		for (String line : logLines) {
-			if (StringUtilities.containsAllIgnoreCase(line, expected)) {
-				return;
-			}
-		}
-
-		fail("The folllowing source text did not have a line containing:\n" +
-			Arrays.toString(expected) + "\n\nActual Text:\n" + allMessages);
-	}
-
-	private void assertMessageNotInLogLine(String... expected) {
-
-		String allMessages = log.toString();
-		String[] logLines = allMessages.split("\n");
-		for (String line : logLines) {
-			if (StringUtilities.containsAllIgnoreCase(line, expected)) {
-				fail("The folllowing source text unexpectedly has a line containing:\n" +
-					Arrays.toString(expected) + "\n\nActual Text:\n" + allMessages);
-			}
-		}
-	}
 
 	private void analyze() {
 		tx(program, () -> analyzer.added(program, program.getMemory(), TaskMonitor.DUMMY, log));
@@ -288,14 +199,15 @@ public class GnuDemanglerAnalyzerTest extends AbstractGhidraHeadlessIntegrationT
 		fail("Could not find option '" + optionName + "'");
 	}
 
-	private void setOption(String optionName, String value) {
+	private void setFormat(GnuDemanglerFormat format) {
 
+		String optionName = GnuDemanglerAnalyzer.OPTION_NAME_DEMANGLER_FORMAT;
 		String fullOptionName = analyzer.getName() + Options.DELIMITER_STRING + optionName;
 		Options options = program.getOptions("Analyzers");
 
 		for (String name : options.getOptionNames()) {
 			if (name.equals(fullOptionName)) {
-				tx(program, () -> options.setString(optionName, value));
+				tx(program, () -> options.setEnum(optionName, format));
 
 				// we must call this manually, since we are not using a tool
 				analyzer.optionsChanged(options, program);

--- a/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/GnuDemanglerParserTest.java
+++ b/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/GnuDemanglerParserTest.java
@@ -1385,8 +1385,11 @@ public class GnuDemanglerParserTest extends AbstractGenericTest {
 		String mangled = "uv__dup";
 
 		GnuDemangler demangler = new GnuDemangler();
-		DemangledObject res = demangler.demangle(mangled);
-		assertNull(res);
+		try {
+			demangler.demangle(mangled);
+		} catch (DemangledException e) {
+			assertTrue(e.isInvalidMangledName());
+		}
 	}
 
 	@Test

--- a/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/gnu/GnuDemanglerOptionsTest.java
+++ b/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/gnu/GnuDemanglerOptionsTest.java
@@ -1,0 +1,160 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.demangler.gnu;
+
+import ghidra.test.AbstractGhidraHeadlessIntegrationTest;
+
+import org.junit.Test;
+
+import static ghidra.app.util.demangler.gnu.GnuDemanglerFormat.*;
+
+import java.io.IOException;
+
+public class GnuDemanglerOptionsTest extends AbstractGhidraHeadlessIntegrationTest {
+
+    @Test
+    public void testAuto_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(AUTO, true);
+        getNativeProcess(options);
+    }
+    
+    @Test
+    public void testAuto_withModern() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(AUTO, false);
+        getNativeProcess(options);
+    }
+
+    @Test
+    public void testGnu_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(GNU, true);
+        getNativeProcess(options);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testGnu_withModern() {
+        new GnuDemanglerOptions(GNU, false);
+    }
+
+    @Test
+    public void testLucid_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(LUCID, true);
+        getNativeProcess(options);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testLucid_withModern() {
+        new GnuDemanglerOptions(LUCID, false);
+    }
+
+    @Test
+    public void testArm_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(ARM, true);
+        getNativeProcess(options);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testArm_withModern() {
+        new GnuDemanglerOptions(ARM, false);
+    }
+
+    @Test
+    public void testHp_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(HP, true);
+        getNativeProcess(options);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHp_withModern() {
+        new GnuDemanglerOptions(HP, false);
+    }
+
+    @Test
+    public void testEdg_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(EDG, true);
+        getNativeProcess(options);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testEdg_withModern() {
+        new GnuDemanglerOptions(EDG, false);
+    }
+
+    @Test
+    public void testGnuV3_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(GNUV3, true);
+        getNativeProcess(options);
+    }
+    
+    @Test
+    public void testGnuV3_withModern() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(GNUV3, false);
+        getNativeProcess(options);
+    }
+
+    @Test
+    public void testJava_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(JAVA, true);
+        getNativeProcess(options);
+    }
+    
+    @Test
+    public void testJava_withModern() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(JAVA, false);
+        getNativeProcess(options);
+    }
+
+    @Test
+    public void testGnat_withDeprecated() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(GNAT, true);
+        getNativeProcess(options);
+    }
+    
+    @Test
+    public void testGnat_withModern() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(GNAT, false);
+        getNativeProcess(options);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDlang_withDeprecated() {
+        new GnuDemanglerOptions(DLANG, true);
+    }
+    
+    @Test
+    public void testDlang_withModern() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(DLANG, false);
+        getNativeProcess(options);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRust_withDeprecated() {
+        new GnuDemanglerOptions(RUST, true);
+    }
+    
+    @Test
+    public void testRust_withModern() throws IOException {
+        GnuDemanglerOptions options = new GnuDemanglerOptions(RUST, false);
+        getNativeProcess(options);
+    }
+
+    private static GnuDemanglerNativeProcess getNativeProcess(GnuDemanglerOptions options)
+            throws IOException {
+        String demanglerName = options.getDemanglerName();
+		String applicationOptions = options.getDemanglerApplicationArguments();
+		return GnuDemanglerNativeProcess.getDemanglerNativeProcess(demanglerName,
+			applicationOptions);
+    }
+}

--- a/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/gnu/GnuDemanglerTest.java
+++ b/Ghidra/Features/GnuDemangler/src/test/java/ghidra/app/util/demangler/gnu/GnuDemanglerTest.java
@@ -55,7 +55,11 @@ public class GnuDemanglerTest extends AbstractGenericTest {
 		demangler.canDemangle(program);// this perform initialization
 
 		// this throws an exception with the bug in place
-		demangler.demangle(mangled);
+		try {
+			demangler.demangle(mangled);
+		} catch (DemangledException e) {
+			assertTrue(e.isInvalidMangledName());
+		}
 	}
 
 	@Test
@@ -158,23 +162,6 @@ public class GnuDemanglerTest extends AbstractGenericTest {
 	}
 
 	@Test
-	public void testDemangler_Format_EDG_DemangleOnlyKnownPatterns_False()
-			throws DemangledException {
-
-		String mangled = "_$_10MyFunction";
-
-		GnuDemangler demangler = new GnuDemangler();
-		demangler.canDemangle(program);// this perform initialization
-
-		GnuDemanglerOptions options = new GnuDemanglerOptions();
-		options.setDemangleOnlyKnownPatterns(false);
-		options.setDemanglerName(GnuDemanglerOptions.GNU_DEMANGLER_V2_24);
-		DemangledObject result = demangler.demangle(mangled, options);
-		assertNotNull(result);
-		assertEquals("undefined MyFunction::~MyFunction(void)", result.getSignature(false));
-	}
-
-	@Test
 	public void testDemangler_Format_EDG_DemangleOnlyKnownPatterns_True()
 			throws DemangledException {
 
@@ -192,16 +179,15 @@ public class GnuDemanglerTest extends AbstractGenericTest {
 		GnuDemangler demangler = new GnuDemangler();
 		demangler.canDemangle(program);// this perform initialization
 
-		GnuDemanglerOptions options = new GnuDemanglerOptions();
-		options.setDemangleOnlyKnownPatterns(true); // do not try
-		options.setDemanglerName(GnuDemanglerOptions.GNU_DEMANGLER_V2_24);
+		GnuDemanglerOptions options = new GnuDemanglerOptions(GnuDemanglerFormat.EDG);
 		DemangledObject result = demangler.demangle(mangled, options);
 		assertNull(result);
 	}
 
 	@Test
 	public void testDemangler_Format_CodeWarrior_MacOS8or9() throws DemangledException {
-
+		// NOTE: mangled CodeWarrior format symbols with templates will fail
+		// This is because the GNU demangler does not support CodeWarrior
 		// .scroll__10TTextPanelFUcsi
 
 		String mangled = ".scroll__10TTextPanelFUcsi";
@@ -209,9 +195,7 @@ public class GnuDemanglerTest extends AbstractGenericTest {
 		GnuDemangler demangler = new GnuDemangler();
 		demangler.canDemangle(program);// this perform initialization
 
-		GnuDemanglerOptions options = new GnuDemanglerOptions();
-		options.setDemangleOnlyKnownPatterns(false);
-		options.setDemanglerName(GnuDemanglerOptions.GNU_DEMANGLER_V2_24);
+		GnuDemanglerOptions options = new GnuDemanglerOptions(GnuDemanglerFormat.AUTO, true);
 		DemangledObject result = demangler.demangle(mangled, options);
 		assertNotNull(result);
 		assertEquals("undefined TTextPanel::scroll(unsigned char,short,int)",


### PR DESCRIPTION
All available demangler formats have been added to GnuDemanglerFormat. The options in GnuDemanglerAnalyzer now only reflect the available formats to remove any user error when specifying a format. This also prevents a format from being used on a demangler which doesn't support it.

Fixes #1770 

Is there a way to make the "Use Deprecated Demangler" option disappear when not applicable? It currently is only disappearing/reappearing after the options are saved or the user clicks analyze which isn't helpful. The other option would be to just leave it and changing the option just won't do anything when not applicable.