### PR TITLE
Hitachi/Renesas SH2 float support improvements

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.cspec
+++ b/Ghidra/Processors/SuperH/data/languages/superh.cspec
@@ -29,6 +29,19 @@
     <default_proto>
     <prototype name="__stdcall" extrapop="0" stackshift="0">
         <input>
+            <pentry minsize="4" maxsize="4" metatype="float">
+              <register name="fr4"/>
+            </pentry>
+            <pentry minsize="4" maxsize="4" metatype="float">
+              <register name="fr5"/>
+            </pentry>
+            <pentry minsize="4" maxsize="4" metatype="float">
+              <register name="fr6"/>
+            </pentry>
+            <pentry minsize="4" maxsize="4" metatype="float">
+              <register name="fr7"/>
+            </pentry>
+
             <pentry minsize="1" maxsize="4" extension="inttype">
               <register name="r4"/>
             </pentry>
@@ -46,6 +59,9 @@
             </pentry>
         </input>
         <output killedbycall="true">
+            <pentry minsize="4" maxsize="4" metatype="float">
+              <register name="fr0"/>
+            </pentry>
             <pentry minsize="1" maxsize="4" extension="inttype">
               <register name="r0"/>
             </pentry>

--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -2228,7 +2228,7 @@ define pcodeop Sleep_Standby;
 # FSUB FRm, FRn               1111nnnnmmmm0001 FRn - FRm → FRn
 :fsub ffrm_04_07, ffrn_08_11        is fop_12_15=0b1111 & ffrn_08_11 & ffrm_04_07 & fop_00_03=0b0001
 {
-    ffrn_08_11 = ffrn_08_11 - ffrm_04_07;
+    ffrn_08_11 = ffrn_08_11 f- ffrm_04_07;
 }
 
 # TODO: FSUB DRm, DRn               1111nnn0mmm00001 DRn - DRm → DRn


### PR DESCRIPTION
Two small changes for SuperH processor module:

* typo in `fsub` instruction (substract two float values)
* calling convention for float arguments. I took this info from real firmware, and it looks compatible with gcc (see gcc link in [wiki](https://en.wikipedia.org/wiki/Calling_convention#SuperH))

I am tested it with firmware from Mazda engine computer, works fine.