### PR TITLE
[bugfix]fix duplicated imported symbol

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/dyld/AbstractDyldInfoState.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/dyld/AbstractDyldInfoState.java
@@ -77,8 +77,14 @@ abstract public class AbstractDyldInfoState {
 
 	private Symbol getSymbol() {
 		SymbolIterator symbolIterator = program.getSymbolTable().getSymbols(symbolName);
-		if (symbolIterator.hasNext()) {
-			return symbolIterator.next();
+		while (symbolIterator.hasNext()) {
+			Symbol symbol = symbolIterator.next();
+			// In some situation, a imported symbol could appear both in `Binding Info` and `IndSym Table`.
+			// We select the one which is in the global name space.
+			if (symbol.getParentNamespace().isGlobal()
+				|| symbolIterator.hasNext() == false) {
+				return symbol;
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
<img width="811" alt="屏幕快照 2020-08-23 上午11 34 07" src="https://user-images.githubusercontent.com/70063806/90970221-9b03d080-e534-11ea-9b72-bcd1ea6e132e.png">

In iOS 13.4 emulator `Foundation` framework,  there is an imported  `_OBJC_CLASS_$_NSObject` symbol  in `__got` section.

when perform binding, the duplicated symbol will result in wrong address.
