### PR TITLE
Copy Jars into lib folder during plugin build automatically

### DIFF
--- a/GhidraBuild/Skeleton/buildTemplate.gradle
+++ b/GhidraBuild/Skeleton/buildTemplate.gradle
@@ -31,3 +31,29 @@ else {
 	throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
+
+// Include the code below if you want dependency jars to be automatically managed
+
+task copyDependencies(type: Copy) {
+	from configurations.default
+	into "lib"
+	exclude {fileTreeElement ->
+		def fileAbsPath = fileTreeElement.getFile().getCanonicalFile().toPath()
+		// Avoid including Ghidra Jars in lib folder...
+		def isGhidraJar = fileAbsPath.startsWith(ghidraInstallDir)
+		// ...and jars already in the destination location
+		def destLibDir = project.file("lib").getCanonicalFile().toPath()
+		def isFromDest = fileAbsPath.startsWith(destLibDir)
+		return isGhidraJar || isFromDest
+	}
+}
+
+task cleanDependencyJars(type: Delete) {
+	delete fileTree("lib").matching {
+		include "**/*.jar"
+	}
+}
+
+tasks.buildExtension.dependsOn(copyDependencies)
+tasks.copyDependencies.dependsOn(cleanDependencyJars)
+tasks.clean.dependsOn(cleanDependencyJars)

--- a/GhidraBuild/Skeleton/lib/README.txt
+++ b/GhidraBuild/Skeleton/lib/README.txt
@@ -1,3 +1,3 @@
 The "lib" directory is intended to hold Jar files which this module
-is dependent upon.  This directory may be eliminated from a specific
-module if no other Jar files are needed.
+is dependent upon. If you use the copyDependencies task, this directory
+is automatically managed by Gradle and should not be modified.


### PR DESCRIPTION
Resolves #2219.

This is the patch mentioned in that issue, submitted in the form of a pull request for code review.