### PR TITLE
Fix extensions with analyzer type set to ONE_SHOT_ANALYZER

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisManager.java
@@ -183,7 +183,9 @@ public class AutoAnalysisManager implements DomainObjectListener, DomainObjectCl
 			else if (type == AnalyzerType.INSTRUCTION_ANALYZER) {
 				instructionTasks.add(analyzer);
 			}
-			else {
+			else if (type == AnalyzerType.ONE_SHOT_ANALYZER) {
+				// ignored
+			} else {
 				Msg.showError(this, null, "Unknown Analysis Type",
 					"Unexpected Analysis type " + type);
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/services/AbstractAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/services/AbstractAnalyzer.java
@@ -36,6 +36,10 @@ public abstract class AbstractAnalyzer implements Analyzer {
 		this.name = name;
 		this.type = type;
 		this.description = description;
+
+		if (type == AnalyzerType.ONE_SHOT_ANALYZER) {
+			this.supportsOneTimeAnalysis = true;
+		}
 	}
 
 	protected void setPriority(AnalysisPriority priority) {


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/ghidra/issues/2250

The case for `ONE_SHOT_ANALYZER` was missing which results an error message "Unknown Analysis Type" to show up.