### PR TITLE
Longs are 64 bits in AARCH64 GCC/Clang

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64.cspec
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64.cspec
@@ -10,7 +10,7 @@
      <wchar_size value="4" />
      <short_size value="2" />
      <integer_size value="4" />
-     <long_size value="4" />
+     <long_size value="8" />
      <long_long_size value="8" />
      <float_size value="4" />
      <double_size value="8" />


### PR DESCRIPTION
You can see it [here](https://gcc.godbolt.org/z/e3YKMx) that only MSVC thinks longs are 32-bits, and there's already an `AARCH64_win.cspec` for that