### PR TITLE
#462 Allow RulePushPtr to apply to ops with output varnodes having multiple descendants

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -6272,6 +6272,7 @@ int4 RulePushPtr::applyOp(PcodeOp *op,Funcdata &data)
   Varnode *vn;
   Varnode *vni = (Varnode *)0;
   const Datatype *ct;
+  int4 ret = 0;
 
   if (!data.isTypeRecoveryOn()) return 0;
   for(i=0;i<op->numInput();++i) { // Search for pointer type
@@ -6283,33 +6284,42 @@ int4 RulePushPtr::applyOp(PcodeOp *op,Funcdata &data)
   if ((i==0)&&(op->getIn(1)->getType()->getMetatype() == TYPE_PTR)) return 0;	// Prevent infinite loops
   
   vn = op->getOut();
-  if ((decop=vn->loneDescend()) == (PcodeOp *)0) return 0;
-  if (decop->code() != CPUI_INT_ADD) return 0;
 
-  j = decop->getSlot(vn);
-  if (decop->getIn(1-j)->getType()->getMetatype() == TYPE_PTR) return 0; // Prevent infinite loops
+  // Cache the descendants list now because otherwise the propagation steps would alter the list while
+  // it was being iterated
+  vector<PcodeOp *> descend(vn->beginDescend(), vn->endDescend());
+  for (vector<PcodeOp *>::iterator it = descend.begin(); it != descend.end(); ++it) {
+    decop = *it;
 
-  Varnode *vnadd1 = decop->getIn(1-j);
-  Varnode *vnadd2 = op->getIn(1-i);
-  Varnode *newout;
+    if (decop->code() != CPUI_INT_ADD) continue;
 
-  // vni and vnadd2 are propagated, so they shouldn't be free
-  if (vnadd2->isFree() && (!vnadd2->isConstant())) return 0;
-  if (vni->isFree() && (!vni->isConstant())) return 0;
+    j = decop->getSlot(vn);
+    if (decop->getIn(1-j)->getType()->getMetatype() == TYPE_PTR) continue; // Prevent infinite loops
 
-  newop = data.newOp(2,decop->getAddr());
-  data.opSetOpcode(newop,CPUI_INT_ADD);
-  newout = data.newUniqueOut(vnadd1->getSize(),newop);
+    Varnode *vnadd1 = decop->getIn(1-j);
+    Varnode *vnadd2 = op->getIn(1-i);
+    Varnode *newout;
 
-  data.opSetInput(decop,vni,0);
-  data.opSetInput(decop,newout,1);
+    // vni and vnadd2 are propagated, so they shouldn't be free
+    if (vnadd2->isFree() && (!vnadd2->isConstant())) continue;
+    if (vni->isFree() && (!vni->isConstant())) continue;
 
-  data.opSetInput(newop,vnadd1,0);
-  data.opSetInput(newop,vnadd2,1);
+    newop = data.newOp(2,decop->getAddr());
+    data.opSetOpcode(newop,CPUI_INT_ADD);
+    newout = data.newUniqueOut(vnadd1->getSize(),newop);
 
-  data.opInsertBefore(newop,decop);
+    data.opSetInput(decop,vni,0);
+    data.opSetInput(decop,newout,1);
 
-  return 1;
+    data.opSetInput(newop,vnadd1,0);
+    data.opSetInput(newop,vnadd2,1);
+
+    data.opInsertBefore(newop,decop);
+
+    ret = 1;
+  }
+
+  return ret;
 }
 
 /// \class RulePtraddUndo


### PR DESCRIPTION
Fixes #462 and possibly others. Previously, `RulePushPtr` only applied if the output varnode of the op being processed had a single descendant due to the usage of `loneDescend()`. This led to poor recognition of struct field accesses when a pointer is partially constructed and then reused multiple times for the actual accesses. For a simple example, consider the following test case (with decompilation debug output at [pushptr.txt](https://github.com/NationalSecurityAgency/ghidra/files/5212107/pushptr.txt)):

```c
typedef struct {
	int x;
	int array[4];
} test_struct;

void bug(test_struct *test, int i) {
	test->array[i] += test->x;
}
```

which compiles (with `arm-none-eabi-gcc -g -c -Os`) to:

```
                             **************************************************************
                             *                          FUNCTION                          *
                             **************************************************************
                             void __stdcall bug(test_struct * test, int i)
             void              <VOID>         <RETURN>
             test_struct *     r0:4           test
             int               r1:4           i
                             bug                                             XREF[4]:     Entry Point(*), 
                                                                                          _elfSectionHeaders::00000034(*), 
                                                                                          _elfSectionHeaders::00000084(*), 
                                                                                          _elfSectionHeaders::000000ac(*)  
        00010000 01 11 80 e0     add        r1,r0,r1, lsl #0x2
        00010004 04 30 91 e5     ldr        r3,[r1,#0x4]
        00010008 00 20 90 e5     ldr        r2,[r0,#0x0]
        0001000c 02 30 83 e0     add        r3,r3,r2
        00010010 04 30 81 e5     str        r3,[r1,#0x4]
        00010014 1e ff 2f e1     bx         lr
```

At `00010000`, the output varnode for `r1` is constructed to point to `&test->array[i]`. Because it is used at both `00010004` (for the load) and `00010010` (for the store), it ends up with multiple descendants and `RulePushPtr` would previously have failed to apply. This prevented the decompiler from recovering the field accesses to `test_struct.array`. Without the patch, the decompiler produces:

```c
void bug(test_struct *test,int i)

{
  (&test->x + i)[1] = (&test->x + i)[1] + test->x;
  return;
}
```

whereas with the patch, we get the much nicer looking:

```c
void bug(test_struct *test,int i)

{
  test->array[i] = test->array[i] + test->x;
  return;
}
```

As for the change itself, I think it's safe to apply `RulePushPtr` to all descendants of the output varnode, but it wouldn't hurt if someone with more knowledge of the decompiler internals could confirm this.