### PR TITLE
Typo fix in logged BundleHost error

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/BundleHost.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/BundleHost.java
@@ -871,7 +871,7 @@ public class BundleHost {
 				}
 				if (isSystem != bundle.isSystemBundle()) {
 					bundle.systemBundle = isSystem;
-					Msg.error(this, String.format("Error, bundle %s went from %system to %system",
+					Msg.error(this, String.format("Error, bundle %s went from %ssystem to %ssystem",
 						bundleFile, isSystem ? "not " : "", isSystem ? "" : "not "));
 				}
 			}


### PR DESCRIPTION
I myself made a type when naming the branch. Oh well.

Also, I am having this message logged but am assuming it is due to the presence of outdated bundles.