### PR TITLE
NPE in GhidraApplicationLayout from GhidraDev

### DIFF
--- a/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraApplicationLayout.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraApplicationLayout.java
@@ -96,14 +96,21 @@ public class GhidraApplicationLayout extends ApplicationLayout {
 		// Application properties
 		applicationProperties = new ApplicationProperties(applicationRootDirs);
 
-		// Modules
-		modules = findGhidraModules();
-
 		// User directories
 		userTempDir = ApplicationUtilities.getDefaultUserTempDir(getApplicationProperties());
 		userCacheDir = ApplicationUtilities.getDefaultUserCacheDir(getApplicationProperties());
 		userSettingsDir = ApplicationUtilities.getDefaultUserSettingsDir(getApplicationProperties(),
 			getApplicationInstallationDir());
+		
+		// Extensions
+		extensionInstallationDirs = findExtensionInstallationDirectories();
+		extensionArchiveDir = findExtensionArchiveDirectory();
+
+		// Patch directory
+		patchDir = findPatchDirectory();
+		
+		// Modules
+		modules = findGhidraModules();
 	}
 
 	/**


### PR DESCRIPTION
Fixing a NullPointerException in GhidraApplicationLayout when the layout is used from the GhidraDev Eclipse plugin.

This bug was introduced into 9.2-DEV with the changes to move the Extensions to the user's home directory.