### PR TITLE
Support preview versions of Visual Studio again

### DIFF
--- a/GPL/vsconfig.gradle
+++ b/GPL/vsconfig.gradle
@@ -29,7 +29,7 @@ def configureVisualStudio() {
 			println "Visual Studio not found!"
 			return
 		}
-		def vswhereOutput = "${vswherePath} -latest -format json".execute().text.trim()
+		def vswhereOutput = "${vswherePath} -latest -prerelease -format json".execute().text.trim()
 		def vswhereJson = new groovy.json.JsonSlurper().parseText(vswhereOutput);
 		if (vswhereJson.isEmpty()) {
 			println "Visual Studio not found!"


### PR DESCRIPTION
I spent a pretty long time figuring out why my visual studio install wasn't detected, until I found out that the `-prerelease` switch in `vswhere` is necessary to list preview versions as well.

Looking at previous revisions of the visual studio detection logic, preview versions were previously supported and found and therefor I believe this is a bug.