### PR TITLE
Implement Lzcnt zero test rule in the decompiler

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -5019,6 +5019,7 @@ void ActionDatabase::universalAction(Architecture *conf)
 	actprop->addRule( new RulePiece2Sext("analysis") );
 	actprop->addRule( new RulePopcountBoolXor("analysis") );
 	actprop->addRule( new RuleXorSwap("analysis") );
+    	actprop->addRule( new RuleLzcntZeroTest("analysis"));
 	actprop->addRule( new RuleSubvarAnd("subvar") );
 	actprop->addRule( new RuleSubvarSubpiece("subvar") );
 	actprop->addRule( new RuleSplitFlow("subvar") );

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
@@ -1488,5 +1488,15 @@ public:
   virtual void getOpList(vector<uint4> &oplist) const;
   virtual int4 applyOp(PcodeOp *op,Funcdata &data);
 };
+class RuleLzcntZeroTest : public Rule {
+public:
+  RuleLzcntZeroTest(const string &g) : Rule( g, 0, "lzcntzerotest") {}	///< Constructor
+  virtual Rule *clone(const ActionGroupList &grouplist) const {
+    if (!grouplist.contains(getGroup())) return (Rule *)0;
+    return new RuleLzcntZeroTest(getGroup());
+  }
+  virtual void getOpList(vector<uint4> &oplist) const;
+  virtual int4 applyOp(PcodeOp *op,Funcdata &data);
 
+};
 #endif


### PR DESCRIPTION
This adds a new rule that detects whether the result of a call to the PPC or Arm leading zero count userop is shifted to the left by log2(input_operand_size*CHAR_BIT) and replaces the shift with an INT_NOTEQUAL of the lzcnt operand and zero. 
This is a very common pattern on PPC and ARM, so this should improve codegen for those platforms. It doesn't seem ideal to directly check the userop names, but that seemed to be the only approach in this case. 

This rule does NOT eliminate the orphaned lzcnt calls when their outputs have zero descendants, that seemed like something for a different pull request. Ideally something would be added to the userop definitions in the pspecs that would indicate a userop is a pure function, allowing it to be killed off when its result is unused.