### PR TITLE
Fixing overzealous new project path validation (Eclipse Plugin)

### DIFF
--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/GhidraDev_README.html
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/GhidraDev_README.html
@@ -53,8 +53,16 @@ change with future releases.</p>
 </ul>
 
 <h2><a name="ChangeHistory"></a>Change History</h2>
-<p><u><b>2.1.1</b>:</u> Python debugging now works when PyDev is installed via the Eclipse "dropins"
-directory.</p>
+<p><u><b>2.1.1</b>:</u> 
+<ul>
+  <li>
+    Python debugging now works when PyDev is installed via the Eclipse "dropins" directory.
+  </li>
+  <li>
+    Fixed a bug in the check that prevents Ghidra projects from being created within the Ghidra 
+    installation directory.
+  </li>
+</ul>
 <p><u><b>2.1.0</b>:</u> 
 <ul>
   <li>

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/CreateGhidraModuleProjectWizard.java
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/CreateGhidraModuleProjectWizard.java
@@ -37,6 +37,7 @@ import ghidradev.EclipseMessageUtils;
 import ghidradev.ghidraprojectcreator.utils.GhidraModuleUtils;
 import ghidradev.ghidraprojectcreator.utils.GhidraModuleUtils.ModuleTemplateType;
 import ghidradev.ghidraprojectcreator.wizards.pages.*;
+import utilities.util.FileUtilities;
 
 /**
  * Wizard to create a new Ghidra module project.
@@ -160,10 +161,10 @@ public class CreateGhidraModuleProjectWizard extends Wizard implements INewWizar
 	 * @return True if the data returned from the wizard pages are valid; otherwise, false
 	 */
 	private boolean validate() {
-		if (projectPage.getProjectDir().getAbsolutePath().startsWith(
-			ghidraInstallationPage.getGhidraInstallDir().getAbsolutePath())) {
+		if (FileUtilities.isPathContainedWithin(ghidraInstallationPage.getGhidraInstallDir(),
+				projectPage.getProjectDir())) {
 			EclipseMessageUtils.showErrorDialog("Invalid Project Root Directory",
-				"Project root directory cannot reside inside of the selected Ghidra installation directory.");
+					"Project root directory cannot reside inside of the selected Ghidra installation directory.");
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Improved check that prevents Eclipse projects from being created within the Ghidra installation directory.

Fixes #2298 