### PR TITLE
Fix typo in Extension Installation Directory doc

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/FrontEndPlugin/Extensions.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/FrontEndPlugin/Extensions.htm
@@ -33,7 +33,7 @@ The list of extensions is populated when the dialog is launched. To build the li
 <ul>
 <li>Extension Installation Directories: Contains any extensions that have been installed. The directories are located at:</li>
   <ul>
-  <li><i>[user dir]/.ghidra/.ghidra-[version]/Extensions</i> - Installed/uninstalled from this dialog</li>
+  <li><i>[user dir]/.ghidra/.ghidra_[version]/Extensions</i> - Installed/uninstalled from this dialog</li>
   <li><i>[installation dir]/Ghidra/Extensions/</i> - Installed/uninstalled from filesystem manually</li>
   </ul>
 <li>Extensions Archive Directory: This is where all archive files (zips) are stored. It is located at <i>[installation dir]/Extensions/Ghidra/</i></li>


### PR DESCRIPTION
The user extension directory should be `[user dir]/.ghidra/.ghidra_[version]/Extensions` (it's an underscore rather than a hyphen).

![Ghidra's config dir](https://user-images.githubusercontent.com/16713498/94684283-6ae0f600-035a-11eb-89d4-a3d72e8bc43b.png)
