### PR TITLE
Fix #2283 - 'persistent' spelling error

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
@@ -56,7 +56,7 @@ import ghidra.util.timer.GTimer;
  *
  * Refactor fileInfo -> needs dialog to show properties
  * Refactor GFile.getInfo() to return Map<> instead of String.
- * Persistant filesystem - when reopen tool, filesystems should auto-reopen.
+ * Persistent filesystem - when reopen tool, filesystems should auto-reopen.
  * Unify GhidraFileChooser with GFileSystem.
  * Add "Mounted Filesystems" button to show currently opened GFilesystems?
  * Dockable filesystem browser in FrontEnd.

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/state/VarnodeOperation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/state/VarnodeOperation.java
@@ -170,7 +170,7 @@ public class VarnodeOperation extends Varnode {
 	}
 
 	@Override
-	public boolean isPersistant() {
+	public boolean isPersistent() {
 		return false;
 	}
 

--- a/Ghidra/Features/Decompiler/ghidra_scripts/GraphAST.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/GraphAST.java
@@ -128,7 +128,7 @@ public class GraphAST extends GhidraScript {
 		else if (vn.isUnique()) {
 			colorattrib = "Black";
 		}
-		else if (vn.isPersistant()) {
+		else if (vn.isPersistent()) {
 			colorattrib = "DarkOrange";
 		}
 		else if (vn.isAddrTied()) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeFactory.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeFactory.java
@@ -61,7 +61,7 @@ public interface PcodeFactory {
 	public HighSymbol getSymbol(long symbolId);
 	public Varnode setInput(Varnode vn,boolean val);
 	public void setAddrTied(Varnode vn,boolean val);
-	public void setPersistant(Varnode vn,boolean val);
+	public void setPersistent(Varnode vn, boolean val);
 	public void setUnaffected(Varnode vn,boolean val);
 	public void setMergeGroup(Varnode vn,short val);
 	public void setDataType(Varnode vn,DataType type);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeSyntaxTree.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeSyntaxTree.java
@@ -392,9 +392,9 @@ public class PcodeSyntaxTree implements PcodeFactory {
 	}
 
 	@Override
-	public void setPersistant(Varnode vn, boolean val) {
+	public void setPersistent(Varnode vn, boolean val) {
 		VarnodeAST vnast = (VarnodeAST) vn;
-		vnast.setPersistant(val);
+		vnast.setPersistent(val);
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/Varnode.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/Varnode.java
@@ -255,9 +255,9 @@ public class Varnode {
 	}
 
 	/**
-	 * @return is persistant
+	 * @return is persistent
 	 */
-	public boolean isPersistant() {
+	public boolean isPersistent() {
 		return false;				// Not a valid query with a free varnode
 	}
 
@@ -476,7 +476,7 @@ public class Varnode {
 			}
 			attrstring = el.getAttribute("persists");
 			if ((attrstring != null) && (SpecXmlUtils.decodeBoolean(attrstring))) {
-				factory.setPersistant(vn, true);
+				factory.setPersistent(vn, true);
 			}
 			attrstring = el.getAttribute("addrtied");
 			if ((attrstring != null) && (SpecXmlUtils.decodeBoolean(attrstring))) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeAST.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeAST.java
@@ -37,7 +37,7 @@ public class VarnodeAST extends Varnode {
 
 	private boolean bInput;
 	private boolean bAddrTied;
-	private boolean bPersistant;
+	private boolean bPersistent;
 	private boolean bUnaffected;
 	private boolean bFree;
 	private int uniqId;					// Unique Id for distinguishing otherwise identical varnodes
@@ -50,7 +50,7 @@ public class VarnodeAST extends Varnode {
 		super(a, sz);
 		bInput = false;
 		bAddrTied = false;
-		bPersistant = false;
+		bPersistent = false;
 		bUnaffected = false;
 		bFree = true;
 		uniqId = id;
@@ -70,8 +70,8 @@ public class VarnodeAST extends Varnode {
 	}
 
 	@Override
-	public boolean isPersistant() {
-		return bPersistant;
+	public boolean isPersistent() {
+		return bPersistent;
 	}
 
 	@Override
@@ -132,8 +132,8 @@ public class VarnodeAST extends Varnode {
 		def = null;
 	}
 
-	public void setPersistant(boolean val) {
-		bPersistant = val;
+	public void setPersistent(boolean val) {
+		bPersistent = val;
 	}
 
 	public void setUnaffected(boolean val) {


### PR DESCRIPTION
This fixes #2283 by changing all instances of `persistant` to `persistent`. I've verified that all instances have been covered and no logic changes have been made, and `buildGhidra` still compiles and runs successfully.