### PR TITLE
Infineon Tricore: simplify st.t instruction

### DIFF
--- a/Ghidra/Processors/tricore/data/languages/tricore.sinc
+++ b/Ghidra/Processors/tricore/data/languages/tricore.sinc
@@ -7972,8 +7972,10 @@ macro multiply_u_u(mres0, rega, regb, n) {
 # ST.T off18, bpos3, b (ABSB)
 :st.t off18,const0810Z,const1111Z is PCPMode=0 & ( const0810Z & const1111Z & op0007=0xd5 ; op2627=0x0 ) & off18
 {
-	local tmp:4 = *[ram]:1 off18;
-	tmp = (tmp & ~(1 << const0810Z)) | (const1111Z << const0810Z);
+	local tmp:1 = *[ram]:1 off18;
+	ternary(tmp, const1111Z,
+		tmp |  (1 << const0810Z),
+		tmp & ~(1 << const0810Z));
 	*[ram]:1 off18 = tmp;
 }
 


### PR DESCRIPTION
Current `st.t` implementation performs a lot of unnecessary operations.

Sample:
```
FUN_8012fe98
	ld.bu      d15,BYTE_d000254b                               = ??
	jz.t       d15,#0x1,LAB_8012fea4
	st.t       BYTE_d0000144,#0x7,#0x1                         = ??
	j          LAB_8012fea8
LAB_8012fea4                                    XREF[1]:     8012fe9c (j)
	st.t       BYTE_d0000144,#0x7,#0x0                         = ??
LAB_8012fea8                                    XREF[1]:     8012fea2 (j)
	ret
```
Current realization:
```
/* WARNING: Globals starting with '_' overlap smaller symbols at the same address */
void FUN_8012fe98(void)
{
  if ((BYTE_d000254b & 2) == 0) {
    _BYTE_d0000144 = _BYTE_d0000144 & 0xffffff7f;
  }
  else {
    _BYTE_d0000144 = _BYTE_d0000144 & 0xffffff7f | 0x80;
  }
  return;
}
```
(also, there is may be error: `st.t` reads and writes only one byte, but decompiler assumes it as multibyte variable).


Modified:
```
void FUN_8012fe98(void)
{
  if ((BYTE_d000254b & 2) == 0) {
    BYTE_d0000144 = BYTE_d0000144 & 0x7f;
  }
  else {
    BYTE_d0000144 = BYTE_d0000144 | 0x80;
  }
  return;
}
```