### PR TITLE
Fix for exception when loading PE's with at least 1 empty section name

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
@@ -330,9 +330,6 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 	 * @return a readable ascii version of the name
 	 */
 	public String getReadableName() {
-		if (name.isBlank()) {
-			return "<empty>";
-		}
 		StringBuffer buffer = new StringBuffer();
 		for (int i = 0; i < name.length(); ++i) {
 			char ch = name.charAt(i);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
@@ -330,6 +330,9 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 	 * @return a readable ascii version of the name
 	 */
 	public String getReadableName() {
+		if (name.isBlank()) {
+			return "<empty>";
+		}
 		StringBuffer buffer = new StringBuffer();
 		for (int i = 0; i < name.length(); ++i) {
 			char ch = name.charAt(i);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
@@ -655,9 +655,12 @@ public class PeLoader extends AbstractPeDebugLoader {
 								sections[i].getName() + " section");
 						}
 						long offset = sections[i].getPointerToRawData();
-						MemoryBlockUtils.createInitializedBlock(prog, false,
-							sections[i].getReadableName(), address, fileBytes, offset, dataSize, "",
-							"", r, w, x, log);
+						String sectionName = sections[i].getReadableName();
+						if (sectionName.isBlank()) {
+							sectionName = "SECTION." + i;
+						}
+						MemoryBlockUtils.createInitializedBlock(prog, false, sectionName, address,
+							fileBytes, offset, dataSize, "", "", r, w, x, log);
 						sectionToAddress.put(sections[i], address);
 					}
 					if (rawDataSize == virtualSize) {


### PR DESCRIPTION
I came across some PE files where one of the section names was "".  When Ghidra tries to create a memory block for this section, it tries to give the block the name "", which results in an uncaught exception, preventing the PE from importing.  This just gives it a default name to allow the import to succeed.