### PR TITLE
Check discovered application.properties file to increase the odds it is ours

### DIFF
--- a/Ghidra/Framework/Utility/src/main/java/utility/application/ApplicationUtilities.java
+++ b/Ghidra/Framework/Utility/src/main/java/utility/application/ApplicationUtilities.java
@@ -60,8 +60,21 @@ public class ApplicationUtilities {
 			try {
 				ResourceFile pathFile = new ResourceFile(new File(pathEntry).getCanonicalPath());
 				while (pathFile != null && pathFile.exists()) {
-					if (new ResourceFile(pathFile, ApplicationProperties.PROPERTY_FILE).exists()) {
-						return pathFile;
+					ResourceFile applicationPropertiesFile =
+						new ResourceFile(pathFile, ApplicationProperties.PROPERTY_FILE);
+					if (applicationPropertiesFile.exists()) {
+						try {
+							ApplicationProperties applicationProperties =
+								new ApplicationProperties(applicationPropertiesFile);
+							if (!applicationProperties.getApplicationName().isEmpty()) {
+								return pathFile;
+							}
+						}
+						catch (IOException e2) {
+							Msg.error(ApplicationUtilities.class,
+								"Failed to read: " + applicationPropertiesFile, e2);
+							break;
+						}
 					}
 					pathFile = pathFile.getParentFile();
 				}


### PR DESCRIPTION
Ghidra finds its application root directory by searching for the application.properties file in directories found on the classpath it was launched with.  If there is a situation where a non-Ghidra application.properties file appears on the classpath before Ghidra's application.properties file, Ghidra will fail to launch.  This PR adds a basic check to make sure that the application.properties file it discovers has an application.name property.

Fixes #2353