### PR TITLE
Hide "Archived non-system classes are disabled" warning

### DIFF
--- a/Ghidra/Features/Base/.launch/Ghidra.launch
+++ b/Ghidra/Features/Base/.launch/Ghidra.launch
@@ -26,7 +26,8 @@
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="ghidra.GhidraLauncher"/>
     <listAttribute key="org.eclipse.jdt.launching.MODULEPATH"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="Framework Utility"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="ghidra.GhidraRun"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="Framework Utility"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:+IgnoreUnrecognizedVMOptions -Djava.system.class.loader=ghidra.GhidraClassLoader -Dfile.encoding=UTF8 -Duser.country=US -Duser.language=en -Dsun.java2d.pmoffscreen=false -Dsun.java2d.xrender=true -Dsun.java2d.d3d=false -Xdock:name=&quot;Ghidra&quot; -Dvisualvm.display.name=Ghidra -Dpython.console.encoding=UTF-8 -DContinuesInterceptor.disabled=true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:+IgnoreUnrecognizedVMOptions -Djava.system.class.loader=ghidra.GhidraClassLoader -Xshare:off -Dfile.encoding=UTF8 -Duser.country=US -Duser.language=en -Dsun.java2d.pmoffscreen=false -Dsun.java2d.xrender=true -Dsun.java2d.d3d=false -Xdock:name=&quot;Ghidra&quot; -Dvisualvm.display.name=Ghidra -Dpython.console.encoding=UTF-8 -DContinuesInterceptor.disabled=true"/>
 </launchConfiguration>

--- a/Ghidra/RuntimeScripts/Common/support/launch.properties
+++ b/Ghidra/RuntimeScripts/Common/support/launch.properties
@@ -4,8 +4,9 @@
 # NOTE: Ghidra requires a JDK to launch.
 JAVA_HOME_OVERRIDE=
 
-# Required Ghidra class loader
+# Required Ghidra class loader (forces class data sharing to be disabled...hide warning) 
 VMARGS=-Djava.system.class.loader=ghidra.GhidraClassLoader
+VMARGS=-Xshare:off
 
 # Set default encoding to UTF8
 VMARGS=-Dfile.encoding=UTF8


### PR DESCRIPTION
When launching Ghidra on Linux, the JVM warning "`OpenJDK 64-Bit Server VM warning: Archived non-system classes are disabled because the java.system.class.loader property is specified (value = "ghidra.GhidraClassLoader"). To use archived non-system classes, this property must not be set`" gets output to the terminal.  

Use the `-Xshare:off` JVM argument so the warning doesn't appear.

From https://docs.oracle.com/en/java/javase/14/docs/specs/man/java.html
> -Xshare:mode
> Sets the class data sharing (CDS) mode.
> 
> Possible mode arguments for this option include the following:
> 
> auto
> Use shared class data if possible (default).
> on
> Require using shared class data, otherwise fail.
> Note: The -Xshare:on option is used for testing purposes only and may cause intermittent failures due to the use of address space layout randomization by the operation system. This option should not be used in production environments.
> 
> off
> Do not attempt to use shared class data.

Fixes #2400