### PR TITLE
Fixes RenameFunctionAction and HighSymbol NPE

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/label/EditLabelAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/label/EditLabelAction.java
@@ -25,6 +25,7 @@ import ghidra.app.context.ListingActionContext;
 import ghidra.app.context.ListingContextAction;
 import ghidra.program.database.symbol.CodeSymbol;
 import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.symbol.SymbolType;
 import ghidra.program.util.LabelFieldLocation;
 import ghidra.program.util.OperandFieldLocation;
 
@@ -62,6 +63,10 @@ class EditLabelAction extends ListingContextAction {
 		Symbol symbol = plugin.getSymbol(context);
 		if (symbol != null) {
 			if (symbol.isExternal()) {
+				return false;
+			}
+			if (symbol.getSymbolType() == SymbolType.FUNCTION) {
+				// let the rename function action handle this
 				return false;
 			}
 			getPopupMenuData().setMenuItemName(EDIT_LABEL);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameGlobalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameGlobalAction.java
@@ -28,6 +28,7 @@ import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.pcode.HighCodeSymbol;
+import ghidra.program.model.pcode.HighFunctionShellSymbol;
 import ghidra.program.model.pcode.HighSymbol;
 import ghidra.program.model.symbol.Symbol;
 import ghidra.program.model.symbol.SymbolTable;
@@ -62,7 +63,7 @@ public class RenameGlobalAction extends AbstractDecompilerAction {
 			return false;
 		}
 		HighSymbol highSymbol = findHighSymbolFromToken(tokenAtCursor, context.getHighFunction());
-		if (highSymbol == null) {
+		if (highSymbol == null || highSymbol instanceof HighFunctionShellSymbol) {
 			return false;
 		}
 		return highSymbol.isGlobal();

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighSymbol.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighSymbol.java
@@ -144,7 +144,7 @@ public class HighSymbol {
 	 */
 	public Symbol getSymbol() {
 		if (id != 0) {
-			return function.getFunction().getProgram().getSymbolTable().getSymbol(id);
+			return getProgram().getSymbolTable().getSymbol(id);
 		}
 		return null;
 	}


### PR DESCRIPTION
`RenameFunctionAction` will now intercept a global function reference to allow renaming. `RenameGlobalAction` will no longer accept the `HighFunctionShellSymbol` which would cause an error since it is not an instance of `HighCodeSymbol`.