### PR TITLE
Fix #1680 by adding a comment field in the enum editor

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/editor/EnumEntry.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/editor/EnumEntry.java
@@ -19,10 +19,12 @@ package ghidra.app.plugin.core.datamgr.editor;
 public class EnumEntry {
 	private String name;
 	private long value;
+	private String comment;
 
-	public EnumEntry(String name, long value) {
+	public EnumEntry(String name, long value, String comment) {
 		this.name = name;
 		this.value = value;
+		this.comment = comment;
 	}
 
 	public String getName() {
@@ -33,11 +35,19 @@ public class EnumEntry {
 		return value;
 	}
 
+	public String getComment() {
+		return comment;
+	}
+
 	public void setName(String newName) {
 		this.name = newName;
 	}
 
 	public void setValue(Long newValue) {
 		this.value = newValue;
+	}
+
+	public void setComment(String newComment) {
+		this.comment = newComment;
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/editor/EnumTableModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/editor/EnumTableModel.java
@@ -29,10 +29,12 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 
 	final static int NAME_COL = 0;
 	final static int VALUE_COL = 1;
+	final static int COMMENT_COL = 2;
 
 	final static String NAME = "Name";
 	final static String VALUE = "Value";
-	private static String[] columnNames = { NAME, VALUE };
+	final static String COMMENT = "Comment";
+	private static String[] columnNames = { NAME, VALUE, COMMENT };
 
 	private EnumDataType enuum;
 	private List<EnumEntry> enumEntryList;
@@ -98,6 +100,9 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 				}
 
 				return "0x" + Long.toHexString(v.getValue() & mask);
+
+			case COMMENT_COL:
+				return v.getComment();
 		}
 		return null;
 	}
@@ -119,13 +124,14 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 		EnumEntry entry = enumEntryList.get(rowIndex);
 		Long oldValue = entry.getValue();
 		String oldName = entry.getName();
+		String oldComment = entry.getComment();
 
 		switch (columnIndex) {
 			case NAME_COL:
 				String newName = (String) aValue;
 				if (!oldName.equals(newName) && isNameValid(newName)) {
 					enuum.remove(oldName);
-					enuum.add(newName, oldValue);
+					enuum.add(newName, oldValue, oldComment);
 					entry.setName(newName);
 					notifyListener = true;
 				}
@@ -143,18 +149,28 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 					if (!oldValue.equals(newValue)) {
 						enuum.remove(oldName);
 						try {
-							enuum.add(oldName, newValue);
+							enuum.add(oldName, newValue, oldComment);
 							entry.setValue(newValue);
 							notifyListener = true;
 						}
 						catch (IllegalArgumentException e) {
-							enuum.add(oldName, oldValue);
+							enuum.add(oldName, oldValue, oldComment);
 							editorPanel.setStatusMessage(e.getMessage());
 						}
 					}
 				}
 				catch (NumberFormatException e) {
 					editorPanel.setStatusMessage("Invalid number entered");
+				}
+				break;
+
+			case COMMENT_COL:
+				String newComment = (String) aValue;
+				if (!oldComment.equals(newComment) && newComment != null) {
+					enuum.remove(oldName);
+					enuum.add(oldName, oldValue, newComment);
+					entry.setComment(newComment);
+					notifyListener = true;
 				}
 				break;
 		}
@@ -228,9 +244,10 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 	int addEntry(int afterRow) {
 		Long value = findNextValue(afterRow);
 		String name = getUniqueName();
-		EnumEntry newEntry = new EnumEntry(name, value);
+		String comment = "";
+		EnumEntry newEntry = new EnumEntry(name, value, comment);
 		try {
-			enuum.add(name, value.longValue());
+			enuum.add(name, value.longValue(), comment);
 			int index = getIndexForRowObject(newEntry);
 			if (index < 0) {
 				index = -index - 1;
@@ -300,7 +317,7 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 		enumEntryList = new ArrayList<>();
 		String[] names = enuum.getNames();
 		for (String name : names) {
-			enumEntryList.add(new EnumEntry(name, enuum.getValue(name)));
+			enumEntryList.add(new EnumEntry(name, enuum.getValue(name), enuum.getComment(name)));
 		}
 		fireTableDataChanged();
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/dataArchiveUtilities/ArchiveConverterPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/dataArchiveUtilities/ArchiveConverterPlugin.java
@@ -408,13 +408,15 @@ public class ArchiveConverterPlugin extends ProgramPlugin {
 		else if (fieldId.compareToIgnoreCase("ENUM") == 0) {
 			ArrayList<String> fNames = new ArrayList<>();
 			ArrayList<String> fValues = new ArrayList<>();
+			ArrayList<String> fComments = new ArrayList<>();
 			while (tokenizer.hasMoreElements()) {
 				fNames.add(tokenizer.nextToken());
 				fValues.add(tokenizer.nextToken());
+				fComments.add(tokenizer.nextToken());
 			}
 			dt = new EnumDataType(cName.getCategoryPath(), cName.getName(), fNames.size(), null);
 			for (int i = 0; i < fNames.size(); i++) {
-				((EnumDataType) dt).add(fNames.get(i), new Long(fValues.get(i)).longValue());
+				((EnumDataType) dt).add(fNames.get(i), new Long(fValues.get(i)).longValue(), fComments.get(i));
 			}
 		}
 		else if (fieldId.compareToIgnoreCase("SYMBOL") == 0) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
@@ -2469,7 +2469,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 		long enumID = record.getKey();
 		String[] enumNames = enumm.getNames();
 		for (String enumName : enumNames) {
-			enumValueAdapter.createRecord(enumID, enumName, enumm.getValue(enumName));
+			enumValueAdapter.createRecord(enumID, enumName, enumm.getValue(enumName), enumm.getComment(enumName));
 		}
 		EnumDB enumDB = new EnumDB(this, dtCache, enumAdapter, enumValueAdapter, record);
 		return enumDB;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumValueDBAdapter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumValueDBAdapter.java
@@ -40,6 +40,7 @@ abstract class EnumValueDBAdapter {
 	static final int ENUMVAL_NAME_COL = EnumValueDBAdapterV0.V0_ENUMVAL_NAME_COL;
 	static final int ENUMVAL_VALUE_COL = EnumValueDBAdapterV0.V0_ENUMVAL_VALUE_COL;
 	static final int ENUMVAL_ID_COL = EnumValueDBAdapterV0.V0_ENUMVAL_ID_COL;
+	static final int ENUMVAL_COMMENT_COL = EnumValueDBAdapterV0.V0_ENUMVAL_COMMENT_COL;
 
 	/**
 	 * Gets an adapter for working with the enumeration data type values database table. The adapter is based 
@@ -95,7 +96,7 @@ abstract class EnumValueDBAdapter {
 		return new EnumValueDBAdapterV0(handle, true);
 	}
 
-	abstract void createRecord(long enumID, String name, long value) throws IOException;
+	abstract void createRecord(long enumID, String name, long value, String comment) throws IOException;
 
 	abstract Record getRecord(long valueID) throws IOException;
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumValueDBAdapterNoTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumValueDBAdapterNoTable.java
@@ -39,7 +39,7 @@ class EnumValueDBAdapterNoTable extends EnumValueDBAdapter {
 	}
 
 	@Override
-	public void createRecord(long enumID, String name, long value) throws IOException {
+	public void createRecord(long enumID, String name, long value, String comment) throws IOException {
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumValueDBAdapterV0.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumValueDBAdapterV0.java
@@ -33,10 +33,11 @@ class EnumValueDBAdapterV0 extends EnumValueDBAdapter {
 	static final int V0_ENUMVAL_NAME_COL = 0;
 	static final int V0_ENUMVAL_VALUE_COL = 1;
 	static final int V0_ENUMVAL_ID_COL = 2;
+	static final int V0_ENUMVAL_COMMENT_COL = 3;
 
 	static final Schema V0_ENUM_VALUE_SCHEMA = new Schema(0, "Enum Value ID", new Class[] {
-		StringField.class, LongField.class, LongField.class }, new String[] { "Name", "Value",
-		"Enum ID" });
+		StringField.class, LongField.class, LongField.class, StringField.class }, new String[] { "Name", "Value",
+		"Enum ID", "Comment" });
 
 	private Table valueTable;
 
@@ -74,11 +75,12 @@ class EnumValueDBAdapterV0 extends EnumValueDBAdapter {
 	}
 
 	@Override
-	public void createRecord(long enumID, String name, long value) throws IOException {
+	public void createRecord(long enumID, String name, long value, String comment) throws IOException {
 		Record record = V0_ENUM_VALUE_SCHEMA.createRecord(valueTable.getKey());
 		record.setLongValue(V0_ENUMVAL_ID_COL, enumID);
 		record.setString(V0_ENUMVAL_NAME_COL, name);
 		record.setLongValue(V0_ENUMVAL_VALUE_COL, value);
+		record.setString(V0_ENUMVAL_COMMENT_COL, comment);
 		valueTable.putRecord(record);
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Enum.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Enum.java
@@ -38,6 +38,14 @@ public interface Enum extends DataType {
 	public String getName(long value);
 
 	/**
+	 * Get the comment for the given name.
+	 * @param name name of the entry
+	 * @return the comment
+	 * @throws NoSuchElementException if the name does not exist in this Enum
+	 */
+	public String getComment(String name) throws NoSuchElementException;
+
+	/**
 	 * Get the values of the enum entries.
 	 * @return values sorted in ascending order
 	 */
@@ -47,6 +55,11 @@ public interface Enum extends DataType {
 	 * Get the names of the enum entries.
 	 */
 	public String[] getNames();
+
+	/**
+	 * Get the comments of the enum entries.
+	 */
+	public String[] getComments();
 
 	/**
 	 * Get the number of entries in this Enum. 
@@ -59,6 +72,14 @@ public interface Enum extends DataType {
 	 * @param value value of the new entry
 	 */
 	public void add(String name, long value);
+
+	/**
+	 * Add a enum entry.
+	 * @param name name of the new entry
+	 * @param value value of the new entry
+	 * @param comment comment of the new entry
+	 */
+	public void add(String name, long value, String comment);
 
 	/**
 	 * Remove the enum entry with the given name. 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/EnumDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/EnumDataType.java
@@ -33,6 +33,7 @@ public class EnumDataType extends GenericDataType implements Enum {
 
 	private Map<String, Long> nameMap; // name to value
 	private Map<Long, List<String>> valueMap; // value to names
+	private Map<String, String> commentMap; // name to comment
 	private int length;
 	private String description;
 	private List<BitGroup> bitGroups;
@@ -52,6 +53,7 @@ public class EnumDataType extends GenericDataType implements Enum {
 		}
 		nameMap = new HashMap<>();
 		valueMap = new HashMap<>();
+		commentMap = new HashMap<>();
 		this.length = length;
 	}
 
@@ -65,6 +67,7 @@ public class EnumDataType extends GenericDataType implements Enum {
 		}
 		nameMap = new HashMap<>();
 		valueMap = new HashMap<>();
+		commentMap = new HashMap<>();
 		this.length = length;
 	}
 
@@ -97,6 +100,15 @@ public class EnumDataType extends GenericDataType implements Enum {
 	}
 
 	@Override
+	public String getComment(String valueName) throws NoSuchElementException {
+		String valueNameComment = commentMap.get(valueName);
+		if (valueNameComment == null) {
+			valueNameComment = "";
+		}
+		return valueNameComment;
+	}
+
+	@Override
 	public long[] getValues() {
 		long[] values = valueMap.keySet().stream().mapToLong(Long::longValue).toArray();
 		Arrays.sort(values);
@@ -109,12 +121,23 @@ public class EnumDataType extends GenericDataType implements Enum {
 	}
 
 	@Override
+	public String[] getComments() {
+		return commentMap.values().toArray(new String[commentMap.size()]);
+	}
+
+	@Override
 	public int getCount() {
 		return nameMap.size();
 	}
 
 	@Override
 	public void add(String valueName, long value) {
+		String valueNameComment = "";
+		add(valueName, value, valueNameComment);
+	}
+
+	@Override
+	public void add(String valueName, long value, String valueNameComment) {
 		bitGroups = null;
 		checkValue(value);
 		if (nameMap.containsKey(valueName)) {
@@ -127,6 +150,10 @@ public class EnumDataType extends GenericDataType implements Enum {
 			valueMap.put(value, list);
 		}
 		list.add(valueName);
+		if (valueNameComment == null) {
+			valueNameComment = "";
+		}
+		commentMap.put(valueName, valueNameComment);
 	}
 
 	private void checkValue(long value) {
@@ -169,6 +196,7 @@ public class EnumDataType extends GenericDataType implements Enum {
 			if (list.isEmpty()) {
 				valueMap.remove(value);
 			}
+			commentMap.remove(valueName);
 		}
 	}
 
@@ -359,7 +387,9 @@ public class EnumDataType extends GenericDataType implements Enum {
 			for (int i = 0; i < names.length; i++) {
 				long value = getValue(names[i]);
 				long otherValue = enumm.getValue(names[i]);
-				if (!names[i].equals(otherNames[i]) || value != otherValue) {
+				String comment = getComment(names[i]);
+				String otherComment = enumm.getComment(names[i]);
+				if (!names[i].equals(otherNames[i]) || value != otherValue || !comment.equals(otherComment)) {
 					return false;
 				}
 			}
@@ -379,10 +409,11 @@ public class EnumDataType extends GenericDataType implements Enum {
 		Enum enumm = (Enum) dataType;
 		nameMap = new HashMap<>();
 		valueMap = new HashMap<>();
+		commentMap = new HashMap<>();
 		setLength(enumm.getLength());
 		String[] names = enumm.getNames();
 		for (int i = 0; i < names.length; i++) {
-			add(names[i], enumm.getValue(names[i]));
+			add(names[i], enumm.getValue(names[i]), enumm.getComment(names[i]));
 		}
 		stateChanged(null);
 	}


### PR DESCRIPTION
This should not be merged yet as it breaks a test and, somehow, fixes two others. More specifically,
1. It breaks
    - ```testEditNavigateNextPrevious``` from ```ghidra.app.plugin.core.datamgr.editor.EnumEditor1Test```.
I think that the reason this test breaks is due to the ```lastCol``` variable in line ```281```,  it should be ```2``` instead of ```1```. I did try doing that and it did fix it, but it broke other tests so I am not sure how I should proceed. Any guidance is appreciated.
2. It fixes
    - ```testTypeMismatchAskTheUserOpt1``` from ```ghidra.app.merge.propertylist.PropertyListMergeManager2Test```
    - ```testSaveToolAndNotLoseOptions``` from ```ghidra.framework.project.tool.ToolSaving1Test```
I don't know how. I probably messed up a src file or something.

Any notes on how I should proceed are, again, greatly appreciated.