### PR TITLE
Update 8085.slaspec with "XRA M" or "XRA HL"

### DIFF
--- a/Ghidra/Processors/8085/data/languages/8085.slaspec
+++ b/Ghidra/Processors/8085/data/languages/8085.slaspec
@@ -349,6 +349,14 @@ cc: "M"             is bits3_3=0x7                              { export S_flag;
 	setResultFlags(A);
 }
 
+:XRA (HL)  is op0_8=0xae & HL {
+	AC_flag = 0;
+	CY_flag = 0;
+	P_flag = 0;
+	A = A ^ *:1 HL;
+	setResultFlags(A);
+}
+
 :XRI imm8  is op0_8=0xee; imm8 {
 	AC_flag = 0;
 	CY_flag = 0;


### PR DESCRIPTION
This adds the instruction "XRA M" in addition to "XRA r", which already exists. "XRA M" is the Intel format, but the code being added will keep the Ghidra format of "XRA HL". Intel's MCS-80/85(tm) Family User's Manual from October 1979 indicates "XRA M" is a 1-byte instruction with value 0xAE.