### PR TITLE
Fix arm CRn == cr1 coproc regs and add missing ones

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -680,7 +680,7 @@ define pcodeop coproc_moveto_Auxiliary_Control;
 define pcodeop coproc_moveto_Coprocessor_Access_Control;
 define pcodeop coproc_moveto_Secure_Configuration;
 define pcodeop coproc_moveto_Secure_Debug_Enable;
-define pcodeop coproc_moveto_Non-Secure_Access_Control;
+define pcodeop coproc_moveto_NonSecure_Access_Control;
 define pcodeop coproc_moveto_Translation_table_base_0;
 define pcodeop coproc_moveto_Translation_table_base_1;
 define pcodeop coproc_moveto_Translation_table_control;
@@ -733,7 +733,7 @@ define pcodeop coproc_movefrom_Auxiliary_Control;
 define pcodeop coproc_movefrom_Coprocessor_Access_Control;
 define pcodeop coproc_movefrom_Secure_Configuration;
 define pcodeop coproc_movefrom_Secure_Debug_Enable;
-define pcodeop coproc_movefrom_Non-Secure_Access_Control;
+define pcodeop coproc_movefrom_NonSecure_Access_Control;
 define pcodeop coproc_movefrom_Translation_table_base_0;
 define pcodeop coproc_movefrom_Translation_table_base_1;
 define pcodeop coproc_movefrom_Translation_table_control;
@@ -2987,7 +2987,7 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
         mcrOperands
 {
   build COND;
-  coproc_moveto_Non-Secure_Access_Control(Rd);
+  coproc_moveto_NonSecure_Access_Control(Rd);
 }
 
 
@@ -3667,7 +3667,7 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
         mcrOperands
 {
   build COND;
-  Rd = coproc_movefrom_Non-Secure_Access_Control();
+  Rd = coproc_movefrom_NonSecure_Access_Control();
 }
 
 

--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -676,8 +676,9 @@ define pcodeop coproc_moveto_Cache_Type;
 define pcodeop coproc_moveto_TCM_Status;
 define pcodeop coproc_moveto_TLB_Type;
 define pcodeop coproc_moveto_Control;
-define pcodeop coproc_moveto_Auxilary_Control;
+define pcodeop coproc_moveto_Auxiliary_Control;
 define pcodeop coproc_moveto_Coprocessor_Access_Control;
+define pcodeop coproc_moveto_Secure_Configuration;
 define pcodeop coproc_moveto_Translation_table_base_0;
 define pcodeop coproc_moveto_Translation_table_base_1;
 define pcodeop coproc_moveto_Translation_table_control;
@@ -726,8 +727,9 @@ define pcodeop coproc_movefrom_Cache_Type;
 define pcodeop coproc_movefrom_TCM_Status;
 define pcodeop coproc_movefrom_TLB_Type;
 define pcodeop coproc_movefrom_Control;
-define pcodeop coproc_movefrom_Auxilary_Control;
+define pcodeop coproc_movefrom_Auxiliary_Control;
 define pcodeop coproc_movefrom_Coprocessor_Access_Control;
+define pcodeop coproc_movefrom_Secure_Configuration;
 define pcodeop coproc_movefrom_Translation_table_base_0;
 define pcodeop coproc_movefrom_Translation_table_base_1;
 define pcodeop coproc_movefrom_Translation_table_control;
@@ -2941,20 +2943,29 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND &
+    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Auxilary_Control(Rd);
+  coproc_moveto_Auxiliary_Control(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=2 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND &
+    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND &
         mcrOperands
 {
   build COND;
   coproc_moveto_Coprocessor_Access_Control(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=1 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_Secure_Configuration(Rd);
 }
 
 
@@ -3590,21 +3601,31 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
 
 
 :mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND &
+    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND &
         mcrOperands
 {
   build COND;
-  Rd = coproc_movefrom_Auxilary_Control();
+  Rd = coproc_movefrom_Auxiliary_Control();
 }
 
 
 
 :mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=2 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND &
+    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND &
         mcrOperands
 {
   build COND;
   Rd = coproc_movefrom_Coprocessor_Access_Control();
+}
+
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=1 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_Secure_Configuration();
 }
 
 

--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -679,6 +679,8 @@ define pcodeop coproc_moveto_Control;
 define pcodeop coproc_moveto_Auxiliary_Control;
 define pcodeop coproc_moveto_Coprocessor_Access_Control;
 define pcodeop coproc_moveto_Secure_Configuration;
+define pcodeop coproc_moveto_Secure_Debug_Enable;
+define pcodeop coproc_moveto_Non-Secure_Access_Control;
 define pcodeop coproc_moveto_Translation_table_base_0;
 define pcodeop coproc_moveto_Translation_table_base_1;
 define pcodeop coproc_moveto_Translation_table_control;
@@ -730,6 +732,8 @@ define pcodeop coproc_movefrom_Control;
 define pcodeop coproc_movefrom_Auxiliary_Control;
 define pcodeop coproc_movefrom_Coprocessor_Access_Control;
 define pcodeop coproc_movefrom_Secure_Configuration;
+define pcodeop coproc_movefrom_Secure_Debug_Enable;
+define pcodeop coproc_movefrom_Non-Secure_Access_Control;
 define pcodeop coproc_movefrom_Translation_table_base_0;
 define pcodeop coproc_movefrom_Translation_table_base_1;
 define pcodeop coproc_movefrom_Translation_table_control;
@@ -2970,6 +2974,24 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
 
 
 :mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=1 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_Secure_Debug_Enable(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=1 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_Non-Secure_Access_Control(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
     $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=2 & c2020=0 & opc1=0 & c2427=14 & COND &
         mcrOperands
 {
@@ -3626,6 +3648,26 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
 {
   build COND;
   Rd = coproc_movefrom_Secure_Configuration();
+}
+
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=1 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_Secure_Debug_Enable();
+}
+
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=1 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_Non-Secure_Access_Control();
 }
 
 


### PR DESCRIPTION
While reversing some ARM code, I noticed Ghidra was misnaming the **Secure Configuration Register** as the **Auxiliary Control Register**. Some further investigating showed that it was a simple mix-up between the CRm and the opc2 parameters. After fixing this, I also added the 3 coproc registers that actually exist at CRm == cr1, since I needed them anyway.

This patch is based of the official ARM docs, found [here](https://developer.arm.com/documentation/ddi0438/i/system-control/register-summary/c1-registers?lang=en ).


