### PR TITLE
Fixed enablement of Apply Enum action

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/equate/EquatePlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/equate/EquatePlugin.java
@@ -739,7 +739,7 @@ public class EquatePlugin extends Plugin {
 
 			@Override
 			protected boolean isEnabledForContext(ListingActionContext context) {
-				return context.hasSelection();
+				return isEquatePermitted(context);
 			}
 		};
 		applyEnumAction.setHelpLocation(new HelpLocation("EquatePlugin", "Apply_Enum"));


### PR DESCRIPTION
Previously this action was only enabled when the entire instruction or more was selected which did not make sense. As a result it was also hidden due to the large amount of enabled actions.

On second though this action may no longer be necessary.