### PR TITLE
Added Support for R_ARM_MOVW_ABS_NC and R_ARM_MOVT_ABS ELF Relocations

### DIFF
--- a/Ghidra/Processors/ARM/src/main/java/ghidra/app/util/bin/format/elf/relocation/ARM_ElfRelocationHandler.java
+++ b/Ghidra/Processors/ARM/src/main/java/ghidra/app/util/bin/format/elf/relocation/ARM_ElfRelocationHandler.java
@@ -344,12 +344,28 @@ public class ARM_ElfRelocationHandler extends ElfRelocationHandler {
 			case ARM_ElfRelocationConstants.R_ARM_PREL31: {
 				break;
 			}
-			case ARM_ElfRelocationConstants.R_ARM_MOVW_ABS_NC: {
+*/
+			case ARM_ElfRelocationConstants.R_ARM_MOVW_ABS_NC: 
+			case ARM_ElfRelocationConstants.R_ARM_MOVT_ABS: {	// Target Class: ARM Instruction		
+				oldValue = memory.getInt(relocationAddress, instructionBigEndian);
+				newValue = oldValue;
+				
+				oldValue = ((oldValue & 0xf0000) >> 4) | (oldValue & 0xfff);
+				oldValue = (oldValue ^ 0x8000) - 0x8000;
+
+				oldValue += symbolValue;
+				if (type == ARM_ElfRelocationConstants.R_ARM_MOVT_ABS)
+					oldValue >>= 16;
+
+				newValue &= 0xfff0f000;
+				newValue |= ((oldValue & 0xf000) << 4) |
+					(oldValue & 0x0fff);
+
+				memory.setInt(relocationAddress, newValue, instructionBigEndian);
+
 				break;
 			}
-			case ARM_ElfRelocationConstants.R_ARM_MOVT_ABS: {
-				break;
-			}
+/*
 			case ARM_ElfRelocationConstants.R_ARM_MOVW_PREL_NC: {
 				break;
 			}


### PR DESCRIPTION
Added support for two new ARM ELF relocations: `R_ARM_MOVW_ABS_NC` and `R_ARM_MOVT_ABS`. I ran in to these looking at proprietary arm linux drivers. These are typically used in conjunction in order to load two halves of an address in to a register like so:

```
movw %r3, 0xdead
movt %r3, 0xbeef
```

I looked at the linux kernel's source to figure out how the relocations should work: https://elixir.bootlin.com/linux/latest/source/arch/arm/kernel/module.c#L189

