### PR TITLE
Export function prototypes from datatype manger

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DataTypeWriter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DataTypeWriter.java
@@ -231,6 +231,9 @@ public class DataTypeWriter {
 			return;
 		}
 		if (dt instanceof FunctionDefinition) {
+			writer.write(((FunctionDefinition) dt).getPrototypeString(true));
+			writer.write(";");
+			writer.write(EOL);
 			return;
 		}
 		if (dt instanceof FactoryDataType) {


### PR DESCRIPTION
Exported c headers will include function prototypes now. 

Fixes https://github.com/NationalSecurityAgency/ghidra/issues/1081

