### PR TITLE
Decompiler: Add C deincrement and increment operator

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -30,6 +30,8 @@ OpToken PrintC::unary_minus = { "-", 1, 62, false, OpToken::unary_prefix, 0, 0, 
 OpToken PrintC::unary_plus = { "+", 1, 62, false, OpToken::unary_prefix, 0, 0, (OpToken *)0 };
 OpToken PrintC::pre_increment = { "++", 1, 66, false, OpToken::unary_prefix, 0, 0, (OpToken *)0 };
 OpToken PrintC::pre_decrement = { "--", 1, 66, false, OpToken::unary_prefix, 0, 0, (OpToken *)0 };
+OpToken PrintC::post_increment = { "++", 1, 66, false, OpToken::unary_postfix, 0, 0, (OpToken *)0 };
+OpToken PrintC::post_decrement = { "--", 1, 66, false, OpToken::unary_postfix, 0, 0, (OpToken *)0 };
 OpToken PrintC::addressof = { "&", 1, 62, false, OpToken::unary_prefix, 0, 0, (OpToken *)0 };
 OpToken PrintC::dereference = { "*", 1, 62, false, OpToken::unary_prefix, 0, 0, (OpToken *)0 };
 OpToken PrintC::typecast = { "()", 2, 62, false, OpToken::presurround, 0, 0, (OpToken *)0 };
@@ -2135,9 +2137,9 @@ bool PrintC::emitIncDecOp(const PcodeOp *op)
     num = -num;
 
   if (num == 1) {
-    token = &pre_increment;
+    token = &post_increment;
   } else if (num == -1) {
-    token = &pre_decrement;
+    token = &post_decrement;
   } else {
     return false;
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
@@ -72,6 +72,8 @@ protected:
   static OpToken boolean_not;		///< The \e boolean \e not operator
   static OpToken unary_minus;		///< The \e unary \e minus operator
   static OpToken unary_plus;		///< The \e unary \e plus operator
+  static OpToken pre_increment;		///< The \e increment \e operator
+  static OpToken pre_decrement;		///< The \e decrement \e operator
   static OpToken addressof;		///< The \e address \e of operator
   static OpToken dereference;		///< The \e pointer \e dereference operator
   static OpToken typecast;		///< The \e type \e cast operator
@@ -149,6 +151,7 @@ protected:
   void emitGlobalVarDeclsRecursive(Scope *scope);	///< Emit variable declarations for all global symbols under given scope
   void emitLocalVarDecls(const Funcdata *fd);		///< Emit variable declarations for a function
   void emitStatement(const PcodeOp *inst);		///< Emit a statement in the body of a function
+  bool emitIncDecOp(const PcodeOp *op);			///< Attempt to emit a increment or deincrement expression
   bool emitInplaceOp(const PcodeOp *op);		///< Attempt to emit an expression rooted at an \e in-place operator
   void emitGotoStatement(const FlowBlock *bl,const FlowBlock *exp_bl,uint4 type);
   void emitSwitchCase(int4 casenum,const BlockSwitch *switchbl);	///< Emit labels for a \e case block

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
@@ -72,8 +72,10 @@ protected:
   static OpToken boolean_not;		///< The \e boolean \e not operator
   static OpToken unary_minus;		///< The \e unary \e minus operator
   static OpToken unary_plus;		///< The \e unary \e plus operator
-  static OpToken pre_increment;		///< The \e increment \e operator
-  static OpToken pre_decrement;		///< The \e decrement \e operator
+  static OpToken pre_increment;		///< The \e pre increment \e operator
+  static OpToken pre_decrement;		///< The \e pre decrement \e operator
+  static OpToken post_increment;	///< The \e post increment \e operator
+  static OpToken post_decrement;	///< The \e post decrement \e operator
   static OpToken addressof;		///< The \e address \e of operator
   static OpToken dereference;		///< The \e pointer \e dereference operator
   static OpToken typecast;		///< The \e type \e cast operator

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
@@ -295,6 +295,12 @@ bool PrintLanguage::parentheses(const OpToken *op2)
     //    if (associative && (this == &op2)) return false;
     if ((op2->type==OpToken::unary_prefix)||(op2->type==OpToken::presurround)) return false;
     return true;
+  case OpToken::unary_postfix:
+    if (topToken->precedence > op2->precedence) return true;
+    if (topToken->precedence < op2->precedence) return false;
+    //    if (associative && (this == &op2)) return false;
+    if (op2->type==OpToken::postsurround) return false;
+    return true;
   case OpToken::postsurround:
     if (stage==1) return false;	// Inside the surround
     if (topToken->precedence > op2->precedence) return true;
@@ -342,6 +348,11 @@ void PrintLanguage::emitOp(const ReversePolish &entry)
     break;
   case OpToken::unary_prefix:
     if (entry.visited!=0) return;
+    emit->tagOp(entry.tok->print,EmitXml::no_color,entry.op);
+    emit->spaces(entry.tok->spacing,entry.tok->bump);
+    break;
+  case OpToken::unary_postfix:
+    if (entry.visited!=1) return;
     emit->tagOp(entry.tok->print,EmitXml::no_color,entry.op);
     emit->spaces(entry.tok->spacing,entry.tok->bump);
     break;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
@@ -87,7 +87,8 @@ public:
     postsurround,		///< Function or array operator form
     presurround,		///< Modifier form (like a cast operation)
     space,			///< No explicitly printed token
-    hiddenfunction		///< Operation that isn't explicitly printed
+    hiddenfunction,		///< Operation that isn't explicitly printed
+    unary_postfix		///< Unary operator form (printed after its input)
   };
   const char *print;		///< Printing characters for the token
   int4 stage;			///< Additional elements consumed from the RPN stack when emitting this token


### PR DESCRIPTION
To improve the readability of decompiled output, extend in place statement emission to include the C increment and decrement operators (++/--).

## Testing
Test data: [tests.zip](https://github.com/NationalSecurityAgency/ghidra/files/5600573/tests.zip)

Commands run (input.txt)
```
restore incdec.xml
load function entry
decompile
print C
q
```

`export SLEIGHHOME=~/ghidra; make decomp_dbg -j && ./decomp_dbg < input.txt`

incdec.xml (BEFORE)
```c
undefined8 entry(void)

{
  uint local_28;
  uint local_24;
  uint local_20;
  uint local_1c;
  uint local_18;
  int local_14;

  __stubs::_memset(&local_28,0,0x18);
  local_28 += 1;
  local_24 -= 1;
  local_20 += 1;
  local_1c -= 1;
  local_18 -= 1;
  local_14 += 1;
  __stubs::_printf("%d %d %d %d %d %d\n",(ulong)local_28,(ulong)local_24,(ulong)local_20,(ulong)local_1c,(ulong)local_18,local_14);
  __stubs::_printf("\n");
  return 0;
}
```
incdec.xml (AFTER)
```c
undefined8 entry(void)

{
  uint local_28;
  uint local_24;
  uint local_20;
  uint local_1c;
  uint local_18;
  int local_14;

  __stubs::_memset(&local_28,0,0x18);
  local_28++;
  local_24--;
  local_20++;
  local_1c--;
  local_18--;
  local_14++;
  __stubs::_printf("%d %d %d %d %d %d\n",(ulong)local_28,(ulong)local_24,(ulong)local_20,(ulong)local_1c,(ulong)local_18,local_14);
  __stubs::_printf("\n");
  return 0;
}
```
incdec_array.xml (BEFORE)
```c
undefined8 entry(void)

{
  uint local_28 [6];

  __stubs::_memset(local_28,0,0x18);
  local_28[0] += 1;
  local_28[1] -= 1;
  local_28[2] += 1;
  local_28[3] -= 1;
  local_28[4] -= 1;
  local_28[5] += 1;
  __stubs::_printf("%d %d %d %d %d %d\n",(ulong)local_28[0],(ulong)local_28[1],(ulong)local_28[2],(ulong)local_28[3],(ulong)local_28[4],local_28[5]);
  __stubs::_printf("\n");
  return 0;
}
```
incdec_array.xml (AFTER)
```c
undefined8 entry(void)

{
  uint local_28 [6];

  __stubs::_memset(local_28,0,0x18);
  local_28[0]++;
  local_28[1]--;
  local_28[2]++;
  local_28[3]--;
  local_28[4]--;
  local_28[5]++;
  __stubs::_printf("%d %d %d %d %d %d\n",(ulong)local_28[0],(ulong)local_28[1],(ulong)local_28[2],(ulong)local_28[3],(ulong)local_28[4],local_28[5]);
  __stubs::_printf("\n");
  return 0;
}
```

I've also tested on larger binaries with great results! Note that the inc/dec operators are not used in expressions, only pure statements, although in idiomatic C it is common for patterns like `while (*a++) { }` or `a[i++]`. To capture these might require more pattern matching.

