### PR TITLE
Decompiler: add for loop construct

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/blockaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/blockaction.hh
@@ -211,6 +211,7 @@ class CollapseStructure {
   bool ruleBlockIfElse(FlowBlock *bl);		///< Attempt to apply a 3 component form of BlockIf
   bool ruleBlockIfNoExit(FlowBlock *bl);	///< Attempt to apply BlockIf where the body does not exit
   bool ruleBlockWhileDo(FlowBlock *bl);		///< Attempt to apply the BlockWhileDo structure
+  bool ruleBlockFor(FlowBlock *bl);		///< TODO
   bool ruleBlockDoWhile(FlowBlock *bl);		///< Attempt to apply the BlockDoWhile structure
   bool ruleBlockInfLoop(FlowBlock *bl);		///< Attempt to apply the BlockInfLoop structure
   bool ruleBlockSwitch(FlowBlock *bl);		///< Attempt to apply the BlockSwitch structure

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
@@ -439,6 +439,7 @@ public:
   void opMarkStartBasic(PcodeOp *op) { op->setFlag(PcodeOp::startbasic); }	///< Mark PcodeOp as starting a basic block
   void opMarkStartInstruction(PcodeOp *op) { op->setFlag(PcodeOp::startmark); }	///< Mark PcodeOp as starting its instruction
   void opMarkNonPrinting(PcodeOp *op) { op->setFlag(PcodeOp::nonprinting); }	///< Mark PcodeOp as not being printed
+  void opClearNonPrinting(PcodeOp *op) { op->clearFlag(PcodeOp::nonprinting); }	///< Unmark PcodeOp as being non printingptr
   void opMarkSpecialPrint(PcodeOp *op) { op->setAdditionalFlag(PcodeOp::special_print); }	///< Mark PcodeOp as needing special printing
   void opMarkNoCollapse(PcodeOp *op) { op->setFlag(PcodeOp::nocollapse); }	///< Mark PcodeOp as not collapsible
   void opMarkCpoolTransformed(PcodeOp *op) { op->setAdditionalFlag(PcodeOp::is_cpool_transformed); }	///< Mark cpool record was visited

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
@@ -220,6 +220,7 @@ public:
   virtual void emitBlockCondition(const BlockCondition *bl);
   virtual void emitBlockIf(const BlockIf *bl);
   virtual void emitBlockWhileDo(const BlockWhileDo *bl);
+  virtual void emitBlockFor(const BlockFor *bl);
   virtual void emitBlockDoWhile(const BlockDoWhile *bl);
   virtual void emitBlockInfLoop(const BlockInfLoop *bl);
   virtual void emitBlockSwitch(const BlockSwitch *bl);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
@@ -63,6 +63,7 @@ class BlockCopy;
 class BlockGoto;
 class BlockIf;
 class BlockCondition;
+class BlockFor;
 class BlockWhileDo;
 class BlockDoWhile;
 class BlockInfLoop;
@@ -465,6 +466,7 @@ public:
   virtual void emitBlockCondition(const BlockCondition *bl)=0;		///< Emit a conditional statement
   virtual void emitBlockIf(const BlockIf *bl)=0;			///< Emit an if/else style construct
   virtual void emitBlockWhileDo(const BlockWhileDo *bl)=0;		///< Emit a loop structure, check at top
+  virtual void emitBlockFor(const BlockFor *bl)=0;			///< TODO
   virtual void emitBlockDoWhile(const BlockDoWhile *bl)=0;		///< Emit a loop structure, check at bottom
   virtual void emitBlockInfLoop(const BlockInfLoop *bl)=0;		///< Emit an infinite loop structure
   virtual void emitBlockSwitch(const BlockSwitch *bl)=0;		///< Emit a switch structure


### PR DESCRIPTION
For loops are one of the most natural and popular loop constructs for programmers. The decompiler currently only supports `while` variant loops (Issue https://github.com/NationalSecurityAgency/ghidra/issues/644), which are typically harder to quickly grok when scanning through decompiled code. Once I realized that this wasn't already being worked on, it seemed like the perfect project to jump into. So, here is my attempt to add a for loop control flow structure to the decompiler.

The main challenges with getting this code to behave were:
* Taking ownership of FlowBlock objects that were inferred to be used to initialize a for loop, but were already in a structured block (e.g. in a List)
* Determining how much of a basic block should be printed in the initializer and post-body sections of the for loop

The big parts of the patch are the For block rule (blockaction.cc) and the For block printer (printc.cc).

## For Block Rule
Starting at the `CollapseStructure::collapseInternal`, I created a new structure `BlockFor` and added the matching rule to this inner loop. `BlockFor` can have either 2 or 3 child blocks: the comparison block, the clause block, and an optional initializer block.

Matching a `BlockFor` follows a similar pattern to `BlockWhile` and diverges right after an appropriate clause block is found. From here, we need to identify potential initializer and post-body blocks that would make up a for loop in addition to the loop body and condition. This rule appears before the BlockWhile rule meaning it will match patterns that would typically be emitted as `while` loops. For example, this:

```c
initializer;
while (condition) {
   body;
   post-body;
}
```

Would become:

```c
for (initializer; condition; post-body) {
   body;
}
```

Let's start by finding the initializer block. Normally you'd assume this to be simply one of the in-blocks to the condition, but the extra catch is that we need a block that is not a child of any other block or control flow (meaning it will unconditionally execute after the body). For example, if the selected in block was a BlockList, it may contain other blocks that do not act as an initializer. I added a new helper function `FlowBlock::getBackBasicLeaf` to extract out the single block that meets this criteria. It descends a BlockGraph object and gets the last graph object, including those that are members of a BlockList. Here is an example of a initializer block:

```
List block 113 invalid_addr-invalid_addr
  If block 113 invalid_addr-invalid_addr
    Condition block(&&) 113 invalid_addr-invalid_addr
      Basic Block 113 0x001aabd9-0x001aac0a
      Basic Block 114 0x001aabdf-0x001aabee
    Basic Block 115 0x001aabee-0x001aabee
  Basic Block 116 0x001aabf2-0x001aabf9
```
The block of interest is`Basic Block 116 0x001aabf2-0x001aabf9`.

But now there is an issue: there is no way to transfer ownership of a structured block that is owned by another structured block. This seems intentional given that structure recovery is progressive and one-way, but if a List grabbed my initializer block before the For rule, then this recovery would fail. To handle this, I added `BlockGraph::reparent` which will allow for a block to be transferred to a new BlockGraph parent. This destroys all edges, but adding them back when the block has a known position is simple. I ran into a ton of segfaults/double frees/use after frees when trying to figure out the right way to do this. Enabling `-DBLOCKCONSISTENT_DEBUG` in the Makefile was essential for getting this working.

We need to do the same `getBackBasicLeaf` check for the post-body block, BUT we don't need to reparent it as we take ownership of its parent, which is the body block. This brings us to the next part, which is properly printing the for loop.

## For Block Printer

Now that our for block has all of the necessary blocks, we need to pretty print this for the reverse engineer. This brings extra challenges as the selected initializer and post-body blocks may contain statements or expressions that are not relevant to be in these fields. For example, below shows the actual transform we need to make:


```c
initializer -> [not-relevant, initializer]
while (condition) {
   body -> [body, post-body]
}
```

We need to determine the split between `not-relevant`/`initializer` for the initializer field and the `body`/`post-body` split for the post-body field. The way to do this, is to selectively walk the PCode of each block in reverse to determine how much of the previous statements should be printed in the for construct or elsewhere. With this approach, I had to employ a hacky way to print the same block twice in two different places without rewriting a lot of logic. To do this, I selectively mark PCode ops as non-printing and restore them once the second half of the block has been printed. Then I use a comma separated scheme to emit the remaining ops for the for construct. This is a bit tricky and messy and could probably be made into a helper function of some kind.

Overall, I'm not happy with the way I solved some of these problems and I've likely missed some corner cases here. As such, this PR should be reviewed by a lot of people for testing on a diverse set of binaries. For my evaluation, I decompiled GLibc before and after the introduction of for loops.

## Results

I decompiled all of libc with and without the the patch enabled.

Tool: Ghidra 9.2 (decompiler hot swapped using symbolic link)
Input binary: [libc6_2.19-0ubuntu6_amd64.so](https://ubuntu.pkgs.org/14.04/ubuntu-main-amd64/libc6_2.19-0ubuntu6_amd64.deb.html) (not sure why I chose this, just had it lying around)
Eliminate deadcode disabled
Line break at 100 characters.

| Metric        |  Stock | ForLoop |
|---------------|:------:|:-------:|
| # If-Statements | 29114  | 28778   |
| # Gotos         | 7326   | 7214    |
| # DoWhile       | 2237   | 2232    |
| # While         | 1705   | 785     |
| # For           | 0      | 869     |
| # Lines of Code | 281109 | 288861  |

The reduction of while loops by over 50% is really promising!