### PR TITLE
Fix display issue for status message (VersionControlCheckOutAction)

### DIFF
--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/LogPanel.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/LogPanel.java
@@ -94,7 +94,7 @@ public class LogPanel extends JPanel implements LogListener {
 			if (isError) {
 				label.setForeground(Color.RED);
 			}
-			label.setText(message);
+			label.setText(message.replace("\n", " "));
 			label.setToolTipText(message);
 		});
 	}

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
@@ -223,13 +223,13 @@ public class VersionControlCheckOutAction extends VersionControlAction {
 			if (failedFiles.size() == 1) {
 				DomainFile df = failedFiles.get(0);
 				String s = "Exclusive checkout failed for: " + df.getName() +
-					"\nOne or more users have file checked out!";
+					" (One or more users have file checked out!)";
 				Msg.showError(this, tool.getToolFrame(), "Checkout Failed", s);
 				return;
 			}
 
 			String userMessage = "Multiple exclusive checkouts failed." +
-				"\nOne or more users have file checked out!";
+				" (One or more users have file checked out!)";
 			StringBuilder buffy = new StringBuilder(userMessage + '\n');
 			String message = "Exclusive checkout failed for: %s";
 			for (DomainFile df : failedFiles) {
@@ -238,7 +238,7 @@ public class VersionControlCheckOutAction extends VersionControlAction {
 			}
 
 			Msg.showError(this, tool.getToolFrame(), "Checkout Failed",
-				userMessage + "\n(see log for list of failed files)");
+				userMessage + " (see log for list of failed files)");
 		}
 
 	}

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
@@ -223,13 +223,13 @@ public class VersionControlCheckOutAction extends VersionControlAction {
 			if (failedFiles.size() == 1) {
 				DomainFile df = failedFiles.get(0);
 				String s = "Exclusive checkout failed for: " + df.getName() +
-					" (One or more users have file checked out!)";
+					"\nOne or more users have file checked out!";
 				Msg.showError(this, tool.getToolFrame(), "Checkout Failed", s);
 				return;
 			}
 
 			String userMessage = "Multiple exclusive checkouts failed." +
-				" (One or more users have file checked out!)";
+				"\nOne or more users have file checked out!";
 			StringBuilder buffy = new StringBuilder(userMessage + '\n');
 			String message = "Exclusive checkout failed for: %s";
 			for (DomainFile df : failedFiles) {
@@ -238,7 +238,7 @@ public class VersionControlCheckOutAction extends VersionControlAction {
 			}
 
 			Msg.showError(this, tool.getToolFrame(), "Checkout Failed",
-				userMessage + " (see log for list of failed files)");
+				userMessage + "\n(see log for list of failed files)");
 		}
 
 	}


### PR DESCRIPTION
Exclusive checkout message doesn't render correctly in the status-bar. Moving it onto the same line with a space and wrapping the message in parenthesis (as is already done for the multiple-failed message) will make it display correctly in both the statusbar and the logger.

![Screenshot from 2020-11-29 22-49-26](https://user-images.githubusercontent.com/3847441/100567531-b3ebf280-3296-11eb-9901-dc48030fa575.png)

![Screenshot from 2020-11-29 22-58-45](https://user-images.githubusercontent.com/3847441/100567530-b3ebf280-3296-11eb-9d7c-36413391e09f.png)
