### PR TITLE
Support Apple Silicon

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
@@ -166,7 +166,7 @@ typedef char int1;
 typedef uint4 uintp;
 #endif
 
-#if defined (__APPLE_CC__) && defined (__x86_64__)
+#if defined (__APPLE_CC__) && (defined (__x86_64__) || defined (__arm64__))
 #define HOST_ENDIAN 0
 typedef unsigned int uintm;
 typedef int intm;

--- a/build.gradle
+++ b/build.gradle
@@ -265,6 +265,7 @@ String getCurrentPlatformName() {
 		
 	boolean isX86_32 = archName.equals("x86") || archName.equals("i386");
 	boolean isX86_64 = archName.equals("x86_64") || archName.equals("amd64");
+	boolean isAArch64 = archName.equals("aarch64");
 
 	if (osName.startsWith("Windows")) {
 		if (isX86_32) {
@@ -280,7 +281,7 @@ String getCurrentPlatformName() {
 		}
 	}
 	else if (osName.startsWith("Mac OS X")) {
-		if (isX86_64) {
+		if (isX86_64 || isAArch64) {
 			return 'osx64'
 		}
 	}


### PR DESCRIPTION
* aarch64 in the Gradle build files

I'd also like to explore supporting Universal builds for all executables so that both x86_64 and arm64 can be shipped in the next Ghidra release.