### PR TITLE
RISCV Bad long size (and alignment)

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv64-fp.cspec
+++ b/Ghidra/Processors/RISCV/data/languages/riscv64-fp.cspec
@@ -9,7 +9,7 @@
 	<pointer_size value="8" />
 	<short_size value="2" />
 	<integer_size value="4" />
-	<long_size value="4" />
+	<long_size value="8" />
 	<long_long_size value="8" />
 	<float_size value="4" />
 	<double_size value="8" />
@@ -17,7 +17,7 @@
 		<entry size="1" alignment="1" />
 		<entry size="2" alignment="2" />
 		<entry size="4" alignment="4" />
-		<entry size="8" alignment="4" />
+		<entry size="8" alignment="8" />
 	</size_alignment_map>
   </data_organization>
   <spacebase name="gp" register="gp" space="ram"/>

--- a/Ghidra/Processors/RISCV/data/languages/riscv64.cspec
+++ b/Ghidra/Processors/RISCV/data/languages/riscv64.cspec
@@ -9,13 +9,13 @@
 	<pointer_size value="8" />
 	<short_size value="2" />
 	<integer_size value="4" />
-	<long_size value="4" />
+	<long_size value="8" />
 	<long_long_size value="8" />
 	<size_alignment_map>
 		<entry size="1" alignment="1" />
 		<entry size="2" alignment="2" />
 		<entry size="4" alignment="4" />
-		<entry size="8" alignment="4" />
+		<entry size="8" alignment="8" />
 	</size_alignment_map>
   </data_organization>
   <spacebase name="gp" register="gp" space="ram"/>


### PR DESCRIPTION
RISCV 64 bit cspec had bad values (likely copy/paste error) for long and it's alignment