### PR TITLE
Load commands will now be marked up for dyld shared cache.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/sectionprovider/DSymSectionProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/sectionprovider/DSymSectionProvider.java
@@ -77,7 +77,7 @@ public class DSymSectionProvider implements DWARFSectionProvider {
 		
 		Section s = machSectionsByName.get(sectionName);
 		return (s != null) ? new ByteProviderWrapper(provider,
-			machHeader.getStartIndexInProvider() + s.getOffset(), s.getSize()) : null;
+			machHeader.getStartIndex() + s.getOffset(), s.getSize()) : null;
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/MachHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/MachHeader.java
@@ -46,6 +46,7 @@ public class MachHeader implements StructConverter {
 	private long _commandIndex;
 	private FactoryBundledWithBinaryReader _reader;
 	private long _machHeaderStartIndexInProvider;
+	private long _machHeaderStartIndex;
 	private boolean _parsed = false;
 
 	/**
@@ -123,9 +124,10 @@ public class MachHeader implements StructConverter {
 		}
 
 		if (isRemainingMachoRelativeToStartIndex) {
-			_machHeaderStartIndexInProvider = machHeaderStartIndexInProvider;
+			_machHeaderStartIndex = machHeaderStartIndexInProvider;
 		}
 
+		_machHeaderStartIndexInProvider = machHeaderStartIndexInProvider;
 		_reader = new FactoryBundledWithBinaryReader(factory, provider, isLittleEndian());
 		_reader.setPointerIndex(machHeaderStartIndexInProvider + 4);//skip magic number...
 
@@ -212,7 +214,19 @@ public class MachHeader implements StructConverter {
 		struct.setCategoryPath(new CategoryPath(MachConstants.DATA_TYPE_CATEGORY));
 		return struct;
 	}
+	
+	/**
+	 * Returns the start index that should be used for calculating offsets.
+	 * This will be 0 for things such as the dyld shared cache where offsets are
+	 * based off the beginning of the file.
+	 */
+	public long getStartIndex() {
+		return _machHeaderStartIndex;
+	}
 
+	/**
+	 * Returns offset of MachHeader in the ByteProvider
+	 */
 	public long getStartIndexInProvider() {
 		return _machHeaderStartIndexInProvider;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/Section.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/Section.java
@@ -171,7 +171,7 @@ public class Section implements StructConverter {
 			header.getFileType() == MachHeaderFileTypes.MH_EXECUTE) {
 			return new SectionInputStream(getSize(), (byte) 0xf4);
 		}
-		return reader.getByteProvider().getInputStream(header.getStartIndexInProvider() + offset);
+		return reader.getByteProvider().getInputStream(header.getStartIndex() + offset);
 	}
 
 	public String getSectionName() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DynamicSymbolTableCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DynamicSymbolTableCommand.java
@@ -105,38 +105,38 @@ public class DynamicSymbolTableCommand extends LoadCommand {
 		long index = reader.getPointerIndex();
 
 		if (tocoff > 0) {
-			reader.setPointerIndex(header.getStartIndexInProvider() + tocoff);
+			reader.setPointerIndex(header.getStartIndex() + tocoff);
 			for (int i = 0; i < ntoc; ++i) {
 				tocList.add(TableOfContents.createTableOfContents(reader));
 			}
 		}
 		if (modtaboff > 0) {
-			reader.setPointerIndex(header.getStartIndexInProvider() + modtaboff);
+			reader.setPointerIndex(header.getStartIndex() + modtaboff);
 			for (int i = 0; i < nmodtab; ++i) {
 				moduleList.add(DynamicLibraryModule.createDynamicLibraryModule(reader, header));
 			}
 		}
 		if (extrefsymoff > 0) {
-			reader.setPointerIndex(header.getStartIndexInProvider() + extrefsymoff);
+			reader.setPointerIndex(header.getStartIndex() + extrefsymoff);
 			for (int i = 0; i < nextrefsyms; ++i) {
 				referencedList.add(DynamicLibraryReference.createDynamicLibraryReference(reader));
 			}
 		}
 		if (indirectsymoff > 0) {
-			reader.setPointerIndex(header.getStartIndexInProvider() + indirectsymoff);
+			reader.setPointerIndex(header.getStartIndex() + indirectsymoff);
 			indirectSymbols = new int[nindirectsyms];
 			for (int i = 0; i < nindirectsyms; ++i) {
 				indirectSymbols[i] = reader.readNextInt();
 			}
 		}
 		if (extreloff > 0) {
-			reader.setPointerIndex(header.getStartIndexInProvider() + extreloff);
+			reader.setPointerIndex(header.getStartIndex() + extreloff);
 			for (int i = 0; i < nextrel; ++i) {
 				externalRelocations.add(RelocationFactory.readRelocation(reader, header.is32bit()));
 			}
 		}
 		if (locreloff > 0) {
-			reader.setPointerIndex(header.getStartIndexInProvider() + locreloff);
+			reader.setPointerIndex(header.getStartIndex() + locreloff);
 			for (int i = 0; i < nlocrel; ++i) {
 				localRelocations.add(RelocationFactory.readRelocation(reader, header.is32bit()));
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/SymbolTableCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/SymbolTableCommand.java
@@ -73,10 +73,10 @@ public class SymbolTableCommand extends LoadCommand {
 
 		long index = reader.getPointerIndex();
 
-		reader.setPointerIndex(header.getStartIndexInProvider() + symoff);
+		reader.setPointerIndex(header.getStartIndex() + symoff);
 
 		List<NList> nlistList = new ArrayList<>(nsyms);
-		long startIndex = header.getStartIndexInProvider();
+		long startIndex = header.getStartIndex();
 		boolean is32bit = header.is32bit();
 		reader.setPointerIndex(startIndex + symoff);
 


### PR DESCRIPTION
MachoProgramBuilder needs to know the offset into the ByteProvider where
the Mach-O starts. When parsing a dyld shared cache
_machHeaderStartIndexInProvider gets set to 0 and results in the load
commands not being marked up. The new function getStartIndex() now
serves the purpose of determining whether absolute or relative indexing
should be performed. The getStartIndexInProvider() gives you the index
where the Mach-O is in the ByteProvider.