### PR TITLE
__cdecl16far incorectly return 32bit value

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86-16.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-16.cspec
@@ -121,6 +121,9 @@
       <pentry minsize="1" maxsize="2">
         <register name="AX"/>
       </pentry>
+      <pentry minsize="3" maxsize="4">
+        <addr space="join" piece1="DX" piece2="AX"/>
+      </pentry>
     </output>
     <unaffected>
       <register name="SP"/>


### PR DESCRIPTION
Fixes: [#2632](https://github.com/NationalSecurityAgency/ghidra/issues/2632)