### PR TITLE
CreateFunctionCmd -- Return called addr instead of null

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CreateFunctionCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CreateFunctionCmd.java
@@ -577,7 +577,7 @@ public class CreateFunctionCmd extends BackgroundCommand {
 				}
 				Reference ref = iter.next();
 				if (ref.getReferenceType().isCall()) {
-					entry = fallFrom;
+					entry = followInstr.getAddress();
 					break;
 				}
 				fallFrom = ref.getFromAddress();


### PR DESCRIPTION
Code is trying to find the proper entry point and has found an instruction that is the To address of a call reference.  We should return the address of this instruction.  The original code would return fallFrom which was found to be null on line 573 above it.