### PR TITLE
Add an option to display namespaces in the "Functions" window

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/functionwindow/FunctionTableModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/functionwindow/FunctionTableModel.java
@@ -31,6 +31,8 @@ import ghidra.util.task.TaskMonitor;
 
 public class FunctionTableModel extends AddressBasedTableModel<FunctionRowObject> {
 
+    static final String OPTION_DISPLAY_NAMESPACE = "Display Namespace";
+    
 	static final int LOCATION_COL_WIDTH = 50;
 
 	static final int NAME_COL = 0;
@@ -172,7 +174,11 @@ public class FunctionTableModel extends AddressBasedTableModel<FunctionRowObject
 			if (function == null) {
 				return null;
 			}
-			return function.getName();
+			
+			var opt = ((PluginTool)sp).getOptions("Functions Window");
+			boolean displayNamespace = opt.getBoolean(OPTION_DISPLAY_NAMESPACE, false);
+			
+			return function.getName(displayNamespace);
 		}
 
 	}


### PR DESCRIPTION
This PR adds an option to decide if namespaces should be displayed in the "Functions" window (`FunctionWindowPlugin`).
### Before:
![Screenshot_5](https://user-images.githubusercontent.com/28494085/105646229-16303080-5e9f-11eb-8111-34abb427b76f.png)

### After:
![Screenshot_6](https://user-images.githubusercontent.com/28494085/105646246-306a0e80-5e9f-11eb-8e3c-118f2017eddf.png)
