### PR TITLE
Fix some ARM NEON vmul opcodes

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -3093,13 +3093,13 @@ define pcodeop PolynomialMultiply;
 	Qd = FloatVectorMult(Qn,Qm,2:1,32:1);
 }
 
-:vmul.f64 Dd,Dn,Dm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=2 & c0811=11 & c0606=0 & c0404=0) |
+:vmul^COND^".f64" Dd,Dn,Dm	is COND & ( ($(AMODE) & c2327=0x1c & c2021=2 & c0811=11 & c0606=0 & c0404=0) |
                                     ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=11 & thv_c0606=0 & thv_c0404=0) ) & Dm & Dn & Dd 
 {
 	Dd = Dn f* Dm;
 }
 
-:vmul.f32 Sd,Sn,Sm		is COND & ( ($(AMODE) & cond=15 & c2327=0x1c & c2021=2 & c0811=10 & c0606=0 & c0404=0) |
+:vmul^COND^".f32" Sd,Sn,Sm	is COND & ( ($(AMODE) & c2327=0x1c & c2021=2 & c0811=10 & c0606=0 & c0404=0) |
                                     ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=2 & thv_c0811=10 & thv_c0606=0 & thv_c0404=0) ) & Sm & Sn & Sd 
 {
 	Sd = Sn f* Sm;


### PR DESCRIPTION
There are two `vmul` opcodes with conditions, but they weren't applied properly.
Related: #1217, #1758