### PR TITLE
Support MIPS-specific section index values

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderConstants.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderConstants.java
@@ -191,4 +191,10 @@ public class ElfSectionHeaderConstants {
 	public static final short SHN_XINDEX = (short) 0xffff;
 	/**upper bound on range of reserved indexes*/
 	public static final short SHN_HIRESERVE = (short) 0xffff;
+	
+	/** MIPS-specific SHN values */
+	/** MIPS text symbol */
+	public static final short SHN_MIPS_TEXT = (short) 0xff01;
+	/**MIPS data symbol*/
+	public static final short SHN_MIPS_DATA = (short) 0xff02;
 }


### PR DESCRIPTION
Adds support for MIPS-specific `SHN_MIPS_TEXT` and `SHN_MIPS_DATA` elf section index processing. Spot checked this with a normal executable and a shared object that uses these indexes, and symbols that were previously ignored are now being correctly applied. The full test suite was run and there were no failures that appeared to be associated with this change.