### PR TITLE
Added support for small objc methods

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Implementation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Implementation.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 public class ObjectiveC2_Implementation implements StructConverter {
 	private boolean _is32bit;
 	private long _index;
+	private boolean _isSmall = false;
 
 	private long imp;
 
@@ -43,6 +44,14 @@ public class ObjectiveC2_Implementation implements StructConverter {
 		}
 	}
 
+	public ObjectiveC2_Implementation(ObjectiveC2_State state, BinaryReader reader, boolean isSmall) throws IOException {
+		this._is32bit = state.is32bit;
+		this._index = reader.getPointerIndex();
+		this._isSmall = isSmall;
+		
+		imp = _index + reader.readNextInt();
+	}
+
 	public long getImplementation() {
 		return imp;
 	}
@@ -52,7 +61,10 @@ public class ObjectiveC2_Implementation implements StructConverter {
 	}
 
 	public DataType toDataType() throws DuplicateNameException, IOException {
-		if (_is32bit) {
+		if (_isSmall) {
+			return new TypedefDataType("ImplementationOffset", DWORD);
+		}
+		else if (_is32bit) {
 			return new TypedefDataType("Implementation", DWORD);
 		}
 		return new TypedefDataType("Implementation", QWORD);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_MethodList.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_MethodList.java
@@ -26,7 +26,7 @@ import ghidra.util.exception.DuplicateNameException;
 public class ObjectiveC2_MethodList extends ObjectiveC_MethodList {
 	public final static String NAME = "method_list_t";
 
-	private int entsize;
+	private int entsizeAndFlags;
 	private int count;
 
 	public ObjectiveC2_MethodList(ObjectiveC2_State state, BinaryReader reader, ObjectiveC_MethodType methodType) throws IOException {
@@ -36,16 +36,18 @@ public class ObjectiveC2_MethodList extends ObjectiveC_MethodList {
 			return;
 		}
 
-		entsize = reader.readNextInt();
+		entsizeAndFlags = reader.readNextInt();
 		count   = reader.readNextInt();
 
+		boolean isSmallList = (entsizeAndFlags & 0x80000000) != 0;
+
 		for (int i = 0 ; i < count ; ++i) {
-			methods.add( new ObjectiveC2_Method(state, reader, methodType) );
+			methods.add( new ObjectiveC2_Method(state, reader, methodType, isSmallList) );
 		}
 	}
 
 	public long getEntsize() {
-		return entsize;
+		return entsizeAndFlags & ~0xffff0003;
 	}
 
 	public long getCount() {
@@ -54,7 +56,7 @@ public class ObjectiveC2_MethodList extends ObjectiveC_MethodList {
 
 	public static DataType toGenericDataType() throws DuplicateNameException {
 		Structure struct = new StructureDataType(NAME, 0);
-		struct.add(DWORD, "entsize", null);
+		struct.add(DWORD, "entsizeAndFlags", null);
 		struct.add(DWORD,   "count", null);
 		struct.setCategoryPath(ObjectiveC2_Constants.CATEGORY_PATH);
 		return struct;
@@ -63,7 +65,7 @@ public class ObjectiveC2_MethodList extends ObjectiveC_MethodList {
 	public DataType toDataType() throws DuplicateNameException, IOException {
 		Structure struct = new StructureDataType(NAME+'_'+count+'_', 0);
 
-		struct.add(DWORD, "entsize", null);
+		struct.add(DWORD, "entsizeAndFlags", null);
 		struct.add(DWORD,   "count", null);
 
 		for (int i = 0 ; i < methods.size() ; ++i) {


### PR DESCRIPTION
As described in #2719, this adds support for small methods in ObjC where struct fields are offsets instead of pointers.
![image](https://user-images.githubusercontent.com/40927866/107105384-01835f00-67f4-11eb-9078-f3ca0c997744.png)
