### PR TITLE
If a script cannot be found, don't try to run it. 

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeaderType.java
@@ -139,10 +139,6 @@ public class ElfSectionHeaderType {
 	public final String description;
 
 	public ElfSectionHeaderType(int value, String name, String description) {
-		if (value < 0) {
-			throw new IllegalArgumentException(
-				"ElfProgramHeaderType value out of range: 0x" + Long.toHexString(value));
-		}
 		this.value = value;
 		this.name = name;
 		this.description = description;


### PR DESCRIPTION
In GhidraScriptComponentProvider.runScript(), if doGetScriptInstance() fails, it writes a diagnostic to the console and returns null.  Proceeding to call doRunScript() with this null will result in a null pointer reference, so if doGetScriptInstance() returns null, just cut things off there.