### PR TITLE
Fix ARM Neon VMRS instruction for little endian

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -3049,7 +3049,7 @@ define pcodeop VectorCopyNarrow;
 
 @if defined(VFPv2) || defined(VFPv3) || defined(SIMD)
 
-:vmrs^COND VRd,fpscr	is  COND & ( ($(AMODE) & c1627=0xef1 & c0011=0xa10) | ($(TMODE_E) &  c1627=0xef1 & c0011=0xa10)) & fpscr & VRd
+:vmrs^COND VRd,fpscr	is  COND & ( ($(AMODE) & c1627=0xef1 & c0011=0xa10) | ($(TMODE_E) &  thv_c1627=0xef1 & thv_c0011=0xa10)) & fpscr & VRd
 {
 	VRd = fpscr;
 }


### PR DESCRIPTION
I discovered this while working on an ARM binary. This was previously recognized as `mrc` variants defined in `ARMTHUMBinstructions.sinc`.
I also checked for similar mistakes in `ARMneon.sinc`, but this was the only one I found.