### PR TITLE
68000: fix disassembly of fmove.p with dynamic k-factor

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -1747,7 +1747,7 @@ fcc: "sne"	is fcode=0x1e			{ tmp:1 = $(Z_FP); clearflags_fp(); export tmp; }
 
 @define FormatByteWordLongSimple "( ffmt=0 | ffmt=1 | ffmt=4 | ffmt=6 )"
 
-# The following constraint should be used when using fprec (ffmt=7 is not valid) 
+# The following constraint should be used when using fprec
 @define FPREC_BWLS "fprec & ( ffmt=0 | ffmt=1 | ffmt=4 | ffmt=6 )" # Byte,Word,Long,Simple only
 @define FPREC_DXP "fprec & ( ffmt=2 | ffmt=3 | ffmt=5)" # Double,Extended,Packed only
 @define FPREC_XP "fprec & ( ffmt=2 | ffmt=3)" # Extended,Packed only
@@ -1764,6 +1764,7 @@ fprec: "p"                  is ffmt=3              {}
 fprec: "w"                  is ffmt=4              {}
 fprec: "d"                  is ffmt=5              {}
 fprec: "b"                  is ffmt=6              {}
+fprec: "p"                  is ffmt=7              {}
 
 
 :fabs.^fprec e2l, fdst	is op=15 & $(FP_COP) & op68=0 & $(DAT_ALTER_ADDR_MODES); frm=1 & f1515=0 & f1313=0 & fdst & $(FPREC_BWLS) & fopmode=0x18; e2l  


### PR DESCRIPTION
This fixes disassembly of fmove.p instructions using a dynamic K-factor.

https://github.com/NationalSecurityAgency/ghidra/blob/4904a0e7b549d40fa8f9c8fa9a13af960b2288c9/Ghidra/Processors/68000/data/languages/68000.sinc#L2025-L2026 
The problem was that the definition above uses `${FPREC_Pd}`, but does not define any `fprec` for `ffmt=7` so the constraint fails and the instruction would not be recognised ("Unable to resolve constructor" in the listing). This patch adds the suffix definition for ffmt 7 and now dissassmbles correctly:

![ghidra-68k-fmovepd](https://user-images.githubusercontent.com/578095/107839400-88f84180-6da3-11eb-8dbb-4f82bafc5e4a.png)
