### PR TITLE
Increase GhidraScript Usability of GenericSaveable

### DIFF
--- a/Ghidra/Framework/DB/src/main/java/db/Record.java
+++ b/Ghidra/Framework/DB/src/main/java/db/Record.java
@@ -44,7 +44,7 @@ public class Record implements Comparable<Record> {
 	 * @param key primary key value
 	 * @param schema
 	 */
-	Record(Field key, Field[] fieldValues) {
+	public Record(Field key, Field[] fieldValues) {
 		this.key = key;
 		this.fieldValues = fieldValues;
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/properties/GenericSaveable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/properties/GenericSaveable.java
@@ -39,9 +39,17 @@ public class GenericSaveable implements Saveable {
 	 * @param record the saveable's record.
 	 * @param schema the saveable's database table's schema.
 	 */
-	GenericSaveable(Record record, Schema schema) {
+	public GenericSaveable(Record record, Schema schema) {
 		this.record = record;
 		this.schema = schema;
+	}
+
+	
+	/*
+	 * Retrieve the Record saved within.
+	*/
+	public Record getRecord() {
+		return record;
 	}
 
 	@Override


### PR DESCRIPTION
Using PropertyMaps from a GhidraScript is problematic since the Saveable class isn't present when ghidra starts and wants to load the PropertyMap.  Ghidra loads it into the GenericSaveable class instead.
Providing a little more access into GenericSaveable and Record allows these classes to be used from a GhidraScript to store PropertyMap data in and subsequently retrieve it.