### PR TITLE
#2762 Prevent unaligned inputs from sharing storage

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
@@ -64,6 +64,21 @@ bool ParamEntry::contains(const ParamEntry &op2) const
 
 {
   if ((type!=TYPE_UNKNOWN)&&(op2.type != type)) return false;
+  if (joinrec) {
+    if (op2.joinrec) {
+      for (const VarnodeData& var : op2.joinrec->getPieces()) {
+        bool contains = false;
+        const size_t len = joinrec->numPieces();
+        for (size_t i = 0; i < len && !contains; i++)
+          contains = joinrec->getPiece(i).contains(var);
+        if (!contains) return false;
+      }
+      return true;
+    }
+    VarnodeData v2{op2.spaceid, op2.addressbase, static_cast<int4>(op2.size)};
+    for (const VarnodeData& v1 : joinrec->getPieces())
+      if (v1.contains(v2)) return true;
+  }
   if (spaceid != op2.spaceid) return false;
   if (op2.addressbase < addressbase) return false;
   if ((op2.addressbase+op2.size-1) > (addressbase+size-1)) return false;
@@ -510,9 +525,7 @@ int4 ParamListStandard::characterizeAsParam(const Address &loc,int4 size) const
 Address ParamListStandard::assignAddress(const Datatype *tp,vector<int4> &status) const
 
 {
-  list<ParamEntry>::const_iterator iter;
-  for(iter=entry.begin();iter!=entry.end();++iter) {
-    const ParamEntry &curEntry( *iter );
+  for(const ParamEntry &curEntry : entry) {
     int4 grp = curEntry.getGroup();
     if (status[grp]<0) continue;
     if ((curEntry.getType() != TYPE_UNKNOWN)&&
@@ -521,14 +534,41 @@ Address ParamListStandard::assignAddress(const Datatype *tp,vector<int4> &status
 
     Address res = curEntry.getAddrBySlot(status[grp],tp->getSize());
     if (res.isInvalid()) continue; // If -tp- doesn't fit an invalid address is returned
-    if (curEntry.isExclusion()) {
-      int4 maxgrp = grp + curEntry.getGroupSize();
-      for(int4 j=grp;j<maxgrp;++j) // For an exclusion entry
-	status[j] = -1;		// some number of groups are taken up
-    }
+    if (curEntry.isExclusion()) consumeGroups(status, curEntry);
     return res;
   }
   return Address();		// Return invalid address to indicated we could not assign anything
+}
+
+static bool containsAny(const ParamEntry& p1,const ParamEntry& p2)
+
+{
+  for (const VarnodeData& v1 : p1.getJoinRecord()->getPieces())
+    for (const VarnodeData& v2 : p2.getJoinRecord()->getPieces())
+      if (v1.contains(v2)) return true;
+  return false;
+}
+
+void ParamListStandard::consumeGroups(vector<int4> &status,const ParamEntry &element) const
+
+{
+  int4 grp = element.getGroup();
+  const int4 maxgrp = grp + element.getGroupSize();
+  for(int4 j=grp;j<maxgrp;++j) // For an exclusion entry
+    status[j] = -1;		// some number of groups are taken up
+  
+  // any entries which this element contains must also be set as taken
+  for (const ParamEntry &e : entry) {
+    if (&e == &element) continue;
+    int4 group = e.getGroup();
+    if (status[group] < 0) continue;
+    if (element.contains(e) || e.contains(element)) {
+      status[group] -= 1;
+      continue;
+    }
+    if (element.getJoinRecord() && e.getJoinRecord())
+      if (containsAny(element, e)) status[group] -= 1;
+  }
 }
 
 void ParamListStandard::assignMap(const vector<Datatype *> &proto,bool isinput,TypeFactory &typefactory,

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.hh
@@ -69,7 +69,7 @@ private:
   int4 minsize;			///< Minimum bytes allowed for the logical value
   int4 alignment;		///< How much alignment (0 means only 1 logical value is allowed)
   int4 numslots;		///< (Maximum) number of slots that can store separate parameters
-  JoinRecord *joinrec;		///< Non-null if this is logical variable from joined pieces
+  JoinRecord *joinrec;		///< Non-null if this is a logical variable from joined pieces
   void resolveJoin(void); 	///< If the ParamEntry is initialized with a \e join address, cache the join record
 
   /// \brief Is the logical value left-justified within its container
@@ -98,6 +98,7 @@ public:
   void extraChecks(list<ParamEntry> &entry);
   bool isParamCheckHigh(void) const { return ((flags & extracheck_high)!=0); }	///< Return \b true if there is a high overlap
   bool isParamCheckLow(void) const { return ((flags & extracheck_low)!=0); }	///< Return \b true if there is a low overlap
+  const JoinRecord *getJoinRecord() const { return joinrec; } ///< Get the JoinRecord if present
 };
 
 /// \brief Class for storing ParamEntry objects in an interval range (rangemap)
@@ -514,6 +515,7 @@ protected:
   void forceInactiveChain(ParamActive *active,int4 maxchain,int4 start,int4 stop) const;
   void calcDelay(void);		///< Calculate the maximum heritage delay for any potential parameter in this list
   void populateResolver(void);	///< Build the ParamEntry resolver maps
+  void consumeGroups(vector<int4> &status,const ParamEntry &element) const;
 public:
   ParamListStandard(void) {}						///< Construct for use with restoreXml()
   ParamListStandard(const ParamListStandard &op2);			///< Copy constructor

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/translate.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/translate.hh
@@ -203,6 +203,7 @@ public:
   const VarnodeData &getUnified(void) const { return unified; }		///< Get the Varnode whole
   Address getEquivalentAddress(uintb offset,int4 &pos) const;	///< Given offset in \e join space, get equivalent address of piece
   bool operator<(const JoinRecord &op2) const; ///< Compare records lexigraphically by pieces
+  const vector<VarnodeData> &getPieces() const { return pieces; } ///< Get an iterator over the const pieces
 };
 
 /// \brief Comparator for JoinRecord objects

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/ParamEntry.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/ParamEntry.java
@@ -116,6 +116,27 @@ public class ParamEntry {
 		if ((type != TYPE_UNKNOWN)&&(op2.type != type)) {
 			return false;
 		}
+		if (joinrec != null) {
+			if (op2.joinrec != null) {
+				for (Varnode v2 : op2.joinrec) {
+					boolean contains = false;
+					for (int i = 0; i < joinrec.length && !contains; i++) {
+						contains = joinrec[i].contains(v2.getAddress());
+					}
+					if (!contains) {
+						return false;
+					}
+				}
+				return true;
+			}
+			Address addr = op2.getSpace().getAddress(op2.getAddressBase());
+			for (Varnode var : joinrec) {
+				if (var.contains(addr)) {
+					return true;
+				}
+			}
+			return false;
+		}
 		if (spaceid != op2.spaceid) {
 			return false;
 		}


### PR DESCRIPTION
I'm not certain this is 100% but it is a start. I also noticed that the compiler_spec.rxg is missing the `group` and `groupsize` attributes for `pentry_type` yet `ParamEntry::restoreXml` checks for its presence and it is correctly implemented.

Fixes #2762