### PR TITLE
Fix non-ASCII characters handing in IDA 6.x exporter

### DIFF
--- a/GhidraBuild/IDAPro/Python/6xx/plugins/xmlexp.py
+++ b/GhidraBuild/IDAPro/Python/6xx/plugins/xmlexp.py
@@ -246,7 +246,7 @@ class XmlExporter:
         elif ch == '\'' : return "&apos;"
         elif ch == '"' :  return "&quot;"
         elif ch == '\x7F': return ''
-        elif ord(ch) > 0x7F: return '&#x' + format((ord(ch),"x")) + ";"
+        elif ord(ch) > 0x7F: return '&#x' + format(ord(ch),"x") + ";"
         return ch
     
 


### PR DESCRIPTION
PR fixes the way how IDA 6.x export plugin writes non-ASCII characters into XML file.
Example of non-ASCII character exported from IDA database before this change: `&#x(152, 'x');`
After this change the character is properly encoded: `&#x98;`
Trying to import XML that was influenced by this bug into Ghirda resulted in the following exception:
```org.xml.sax.SAXParseException; lineNumber: 169651; columnNumber: 67; A hexadecimal representation must immediately follow the "&#x" in a character reference.
java.io.IOException: org.xml.sax.SAXParseException; lineNumber: 169651; columnNumber: 67; A hexadecimal representation must immediately follow the "&#x" in a character reference.
	at ghidra.app.util.opinion.XmlLoader.doImportWork(XmlLoader.java:250)
	at ghidra.app.util.opinion.XmlLoader.doImport(XmlLoader.java:262)
	at ghidra.app.util.opinion.XmlLoader.loadProgram(XmlLoader.java:203)
	at ghidra.app.util.opinion.AbstractProgramLoader.load(AbstractProgramLoader.java:112)
	at ghidra.plugin.importer.ImporterUtilities.importSingleFile(ImporterUtilities.java:400)
	at ghidra.plugin.importer.ImporterDialog.lambda$okCallback$7(ImporterDialog.java:349)
	at ghidra.util.task.TaskLauncher$1.run(TaskLauncher.java:88)
	at ghidra.util.task.Task.monitoredRun(Task.java:124)
	at ghidra.util.task.TaskRunner.lambda$startTaskThread$0(TaskRunner.java:104)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.RuntimeException: org.xml.sax.SAXParseException; lineNumber: 169651; columnNumber: 67; A hexadecimal representation must immediately follow the "&#x" in a character reference.
	at ghidra.xml.ThreadedXmlPullParserImpl.checkForException(ThreadedXmlPullParserImpl.java:122)
	at ghidra.xml.ThreadedXmlPullParserImpl.waitForNextElement(ThreadedXmlPullParserImpl.java:159)
	at ghidra.xml.ThreadedXmlPullParserImpl.hasNext(ThreadedXmlPullParserImpl.java:154)
	at ghidra.xml.ThreadedXmlPullParserImpl.peek(ThreadedXmlPullParserImpl.java:181)
	at ghidra.xml.AbstractXmlPullParser.discardSubTree(AbstractXmlPullParser.java:138)
	at ghidra.app.util.xml.FunctionsXmlMgr.read(FunctionsXmlMgr.java:221)
	at ghidra.app.util.xml.ProgramXmlMgr.read(ProgramXmlMgr.java:329)
	at ghidra.app.util.opinion.XmlLoader.doImportWork(XmlLoader.java:237)
	... 11 more
Caused by: org.xml.sax.SAXParseException; lineNumber: 169651; columnNumber: 67; A hexadecimal representation must immediately follow the "&#x" in a character reference.
	at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1243)
	at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:635)
	at ghidra.xml.ThreadedXmlPullParserImpl$ContentHandlerRunnable.run(ThreadedXmlPullParserImpl.java:267)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	... 3 more```