### PR TITLE
Fix JavaDoc warning

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbol.java
@@ -111,7 +111,6 @@ public class ElfSymbol implements ByteArrayConverter {
 	 * @param reader to read symbol from
 	 * @param symbolIndex index of the symbol to read
 	 * @param symbolTable symbol table to associate the symbol to
-	 * @param stringTable string table to read symbols from
 	 * @param header else header
 	 * @return newly created ElfSymbol
 	 * 


### PR DESCRIPTION
The warning was introduced in 01b6027c771ab85a2278624fc1ba8e93bd62159f (which in fact removed that parameter).  The parameter instead applies to `initSymbolName`, where it already is documented.

The warning in question was:

```
> Task :createJavadocs
C:\<...>\Ghidra\Features\Base\src\main\java\ghidra\app\util\bin\format\elf\ElfSymbol.java:114: warning - @param argument "stringTable" is not a parameter name.
1 warning

```