### PR TITLE
Fix INSx.REP instruction

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -2732,10 +2732,10 @@ enterFrames: low5 is low5 { tmp:1 = low5; export tmp; }
 :INC  Rmr32        is vexMode=0 & opsize=1 & row = 4 & page = 0 & Rmr32 { OF = scarry(Rmr32,1);   Rmr32 =  Rmr32 + 1; resultflags( Rmr32); }
 @endif
 
-:INSB^rep^reptail eseDI1,DX is vexMode=0 & rep & reptail & byte=0x6c & eseDI1 & DX      { eseDI1 = in(DX); }
-:INSW^rep^reptail eseDI2,DX is vexMode=0 & rep & reptail & opsize=0 & byte=0x6d & eseDI2 & DX   { eseDI2 = in(DX); }
-:INSD^rep^reptail eseDI4,DX is vexMode=0 & rep & reptail & opsize=1 & byte=0x6d & eseDI4 & DX   { eseDI4 = in(DX); }
-:INSD^rep^reptail eseDI4,DX is vexMode=0 & rep & reptail & opsize=2 & byte=0x6d & eseDI4 & DX   { eseDI4 = in(DX); }
+:INSB^rep^reptail eseDI1,DX is vexMode=0 & rep & reptail & byte=0x6c & eseDI1 & DX      { build rep; build eseDI1; eseDI1 = in(DX); build reptail; }
+:INSW^rep^reptail eseDI2,DX is vexMode=0 & rep & reptail & opsize=0 & byte=0x6d & eseDI2 & DX   { build rep; build eseDI2; eseDI2 = in(DX); build reptail; }
+:INSD^rep^reptail eseDI4,DX is vexMode=0 & rep & reptail & opsize=1 & byte=0x6d & eseDI4 & DX   { build rep; build eseDI4; eseDI4 = in(DX); build reptail; }
+:INSD^rep^reptail eseDI4,DX is vexMode=0 & rep & reptail & opsize=2 & byte=0x6d & eseDI4 & DX   { build rep; build eseDI4; eseDI4 = in(DX); build reptail; }
 
 :INT1           is vexMode=0 & byte=0xf1                            { tmp:1 = 0x1; intloc:$(SIZE) = swi(tmp); call [intloc]; return [0:1]; }
 :INT3           is vexMode=0 & byte=0xcc                            { tmp:1 = 0x3; intloc:$(SIZE) = swi(tmp); call [intloc]; return [0:1]; }
@@ -3208,9 +3208,9 @@ define pcodeop swap_bytes;
 :OUT DX,AX          is vexMode=0 & opsize=0 & byte=0xef & DX & AX       { out(DX,AX); }
 :OUT DX,EAX         is vexMode=0 &            byte=0xef & DX & EAX      { out(DX,EAX); }
 
-:OUTSB^rep^reptail DX,dseSI1    is vexMode=0 & rep & reptail & byte=0x6e & DX & dseSI1      { out(dseSI1,DX); }
-:OUTSW^rep^reptail DX,dseSI2    is vexMode=0 & rep & reptail & opsize=0 & byte=0x6f & DX & dseSI2   { out(dseSI2,DX); }
-:OUTSD^rep^reptail DX,dseSI4    is vexMode=0 & rep & reptail &            byte=0x6f & DX & dseSI4   { out(dseSI4,DX); }
+:OUTSB^rep^reptail DX,dseSI1    is vexMode=0 & rep & reptail & byte=0x6e & DX & dseSI1      { build rep; build dseSI1; out(dseSI1,DX); build reptail;}
+:OUTSW^rep^reptail DX,dseSI2    is vexMode=0 & rep & reptail & opsize=0 & byte=0x6f & DX & dseSI2   { build rep; build dseSI2; out(dseSI2,DX); build reptail;}
+:OUTSD^rep^reptail DX,dseSI4    is vexMode=0 & rep & reptail &            byte=0x6f & DX & dseSI4   { build rep; build dseSI4; out(dseSI4,DX); build reptail;}
 
 :PAUSE          is vexMode=0 & opsize=0 & $(PRE_F3) & byte=0x90     {  }
 :PAUSE          is vexMode=0 & opsize=1 & $(PRE_F3) & byte=0x90     {  }


### PR DESCRIPTION
Problem originally discovered by @moyix


Without this fix the decompiler would produce something like this:
![image](https://user-images.githubusercontent.com/8415354/110809613-59930280-8285-11eb-9675-ff40ee66afd0.png)

because the instruction was incorrectly lifted to this PCode:
![image](https://user-images.githubusercontent.com/8415354/110809677-69aae200-8285-11eb-9efa-02e6c4ba8686.png)


With the changes it gets properly lifted as:

```
INSD.REP   ES:DI,DX
                                                      $U8980:1 = INT_EQUAL CX, 0:2
                                                      CBRANCH *[ram]0xfe901:4, $U8980:1
                                                      CX = INT_SUB CX, 1:2
                                                      $U7180:4 = CALLOTHER "segment", ES, DI
                                                      $U7200:2 = INT_ADD DI, 4:2
                                                      $U7280:2 = INT_ZEXT DF
                                                      $U7300:2 = INT_MULT 8:2, $U7280:2
                                                      DI = INT_SUB $U7200:2, $U7300:2
                                                      $U7400:4 = CALLOTHER "in", DX
                                                      STORE ram($U7180:4), $U7400:4
                                                      BRANCH *[ram]0xfe8fe:4
```

`INSD` vs `INSW` is just due to loading with different word size, and is not because of the PR itself.

Credit to @SamL98 for walking me through how to actually fix this, thus they are added as a co-author to the commit.