### PR TITLE
Go to field in data type editor when double clicking in decompiler

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/DefaultDataTypeManagerService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/DefaultDataTypeManagerService.java
@@ -146,6 +146,11 @@ public class DefaultDataTypeManagerService implements DataTypeManagerService {
 	}
 
 	@Override
+	public void edit(DataType dt, int offset) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public DataTypeManager getBuiltInDataTypesManager() {
 		return builtInDataTypesManager;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompositeEditorPanel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompositeEditorPanel.java
@@ -1148,6 +1148,22 @@ public abstract class CompositeEditorPanel extends JPanel
 		clsm.setLeadSelectionIndex(column);
 	}
 
+	/**
+	 * Select and scroll to the component at the given offset.
+	 * @param offset The offset of the component to scroll to.
+	 */
+	public void selectComponentWithOffset(int offset) {
+		int num = model.getNumComponents();
+		for (int i = 0; i < num; i++) {
+			DataTypeComponent dtc = model.getComponent(i);
+			if (dtc.getOffset() >= offset) {
+				model.setSelection(new int[]{i});
+				scrollToCell(i, 0);
+				return;
+			}
+		}
+	}
+
 	private class ComponentStringCellEditor extends ComponentCellEditor {
 		public ComponentStringCellEditor(JTextField textField) {
 			super(textField);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/StructureEditorProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/StructureEditorProvider.java
@@ -87,4 +87,12 @@ public class StructureEditorProvider extends CompositeEditorProvider {
 	public String getHelpTopic() {
 		return "DataTypeEditors";
 	}
+
+	/**
+	 * Scroll to the field at the given offset.
+	 * @param offset The offset of the field to scroll to.
+	 */
+	public void goToOffset(int offset) {
+		editorPanel.selectComponentWithOffset(offset);
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/DataTypeManagerPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/DataTypeManagerPlugin.java
@@ -468,6 +468,11 @@ public class DataTypeManagerPlugin extends ProgramPlugin
 
 	@Override
 	public void edit(DataType dt) {
+		edit(dt, -1);
+	}
+
+	@Override
+	public void edit(DataType dt, int offset) {
 		DataTypeManager dataTypeManager = dt.getDataTypeManager();
 		if (dataTypeManager == null) {
 			throw new IllegalArgumentException(
@@ -479,7 +484,7 @@ public class DataTypeManagerPlugin extends ProgramPlugin
 			throw new IllegalArgumentException(
 				"DataType " + dt.getName() + " has no category path!");
 		}
-		editorManager.edit(dt);
+		editorManager.edit(dt, offset);
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/services/DataTypeManagerService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/services/DataTypeManagerService.java
@@ -102,6 +102,16 @@ public interface DataTypeManagerService extends DataTypeQueryService {
 	public void edit(DataType dt);
 
 	/**
+	 * Pop up an editor dialog for the given data type and offset.
+	 *
+	 * @param dt data type that either a Structure or a Union; built in types cannot be edited
+	 * @param offset offset of the field within dt to edit / focus
+	 * @throws IllegalArgumentException if the given has not been resolved by a DataTypeManager;
+	 *         in other words, if {@link DataType#getDataTypeManager()} returns null.
+	 */
+	public void edit(DataType dt, int offset);
+
+	/**
 	 * Closes the archive for the given {@link DataTypeManager}.  This will ignore request to 
 	 * close the open Program's manager and the built-in manager.  
 	 * 

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/services/TestDoubleDataTypeManagerService.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/services/TestDoubleDataTypeManagerService.java
@@ -95,6 +95,11 @@ public class TestDoubleDataTypeManagerService implements DataTypeManagerService 
 	}
 
 	@Override
+	public void edit(DataType dt, int offset) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void closeArchive(DataTypeManager dtm) {
 		throw new UnsupportedOperationException();
 	}

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/CDisplayPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/CDisplayPanel.java
@@ -24,6 +24,7 @@ import ghidra.app.decompiler.DecompileOptions;
 import ghidra.app.plugin.core.decompile.DecompilerClipboardProvider;
 import ghidra.app.util.viewer.listingpanel.ProgramLocationListener;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.data.DataType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
@@ -137,6 +138,11 @@ public class CDisplayPanel extends JPanel implements DecompilerCallbackHandler {
 
 	@Override
 	public void goToFunction(Function function, boolean newWindow) {
+		// stub
+	}
+
+	@Override
+	public void goToField(DataType dataType, int offset) {
 		// stub
 	}
 

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerCallbackHandler.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerCallbackHandler.java
@@ -16,6 +16,7 @@
 package ghidra.app.decompiler.component;
 
 import ghidra.program.model.address.Address;
+import ghidra.program.model.data.DataType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.util.ProgramLocation;
 import ghidra.program.util.ProgramSelection;
@@ -47,4 +48,6 @@ public interface DecompilerCallbackHandler {
 	void goToFunction(Function function, boolean newWindow);
 
 	void doWheNotBusy(Callback c);
+
+	void goToField(DataType dataType, int offset);
 }

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerController.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerController.java
@@ -25,6 +25,7 @@ import docking.widgets.fieldpanel.support.ViewerPosition;
 import ghidra.app.decompiler.*;
 import ghidra.app.plugin.core.decompile.DecompilerClipboardProvider;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.data.DataType;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.pcode.HighFunction;
 import ghidra.program.util.ProgramLocation;
@@ -289,6 +290,10 @@ public class DecompilerController {
 
 	void goToScalar(long value, boolean newWindow) {
 		callbackHandler.goToScalar(value, newWindow);
+	}
+
+	public void goToField(DataType dataType, int offset) {
+		callbackHandler.goToField(dataType, offset);
 	}
 
 	public DecompileData getDecompileData() {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
@@ -45,6 +45,7 @@ import ghidra.app.plugin.core.decompile.DecompilerClipboardProvider;
 import ghidra.app.plugin.core.decompile.actions.FieldBasedSearchLocation;
 import ghidra.app.plugin.core.decompile.actions.TokenHighlightColorProvider;
 import ghidra.program.model.address.*;
+import ghidra.program.model.data.DataType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.pcode.*;
@@ -599,6 +600,9 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		else if (token instanceof ClangSyntaxToken) {
 			tryGoToSyntaxToken((ClangSyntaxToken) token);
 		}
+		else if (token instanceof ClangFieldToken) {
+			tryGoToFieldToken((ClangFieldToken) token);
+		}
 	}
 
 	private void tryGoToComment(FieldLocation location, MouseEvent event, ClangTextField textField,
@@ -729,6 +733,12 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		catch (Exception e) {
 			return; // give up
 		}
+	}
+
+	private void tryGoToFieldToken(ClangFieldToken token) {
+		DataType dataType = token.getDataType();
+		int offset = token.getOffset();
+		controller.goToField(dataType, offset);
 	}
 
 	Program getProgram() {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
@@ -32,6 +32,7 @@ import ghidra.GhidraOptions;
 import ghidra.app.decompiler.*;
 import ghidra.app.decompiler.component.*;
 import ghidra.app.nav.*;
+import ghidra.app.plugin.core.datamgr.util.DataTypeUtils;
 import ghidra.app.plugin.core.decompile.actions.*;
 import ghidra.app.services.*;
 import ghidra.app.util.HelpTopics;
@@ -42,6 +43,8 @@ import ghidra.framework.options.*;
 import ghidra.framework.plugintool.NavigatableComponentProviderAdapter;
 import ghidra.framework.plugintool.util.ServiceListener;
 import ghidra.program.model.address.*;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.DataTypeManager;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.symbol.*;
@@ -643,6 +646,19 @@ public class DecompilerProvider extends NavigatableComponentProviderAdapter
 			Address address = function.getEntryPoint();
 			service.goTo(navigatable, new ProgramLocation(program, address), program);
 		}
+	}
+
+	@Override
+	public void goToField(DataType dataType, int offset) {
+		DataType baseDataType = DataTypeUtils.getBaseDataType(dataType);
+		DataTypeManager dataTypeManager = program.getDataTypeManager();
+		DataTypeManager baseDtDTM = baseDataType.getDataTypeManager();
+		if (baseDtDTM != dataTypeManager) {
+			baseDataType = baseDataType.clone(dataTypeManager);
+		}
+		final DataTypeManagerService service =
+			tool.getService(DataTypeManagerService.class);
+		service.edit(baseDataType, offset);
 	}
 
 	@Override


### PR DESCRIPTION
Hi and thank you for the wonderful software.

I would like to propose the following small usability improvement. This change set enables double-clicking on a reference to a struct field within the decompiler view. Doing so will scroll to and focus the row corresponding to the clicked field, which should make it easier to navigate and edit very large structure types.

If there's anything less than perfect about the changes, I'll be happy to adjust as directed. :)