### PR TITLE
Fix monitor messages for constant propagation

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/PropagateConstantReferences.java
+++ b/Ghidra/Features/Base/ghidra_scripts/PropagateConstantReferences.java
@@ -36,7 +36,7 @@ public class PropagateConstantReferences extends GhidraScript {
 	public void run() throws Exception {
 		long numInstructions = currentProgram.getListing().getNumInstructions();
 		monitor.initialize((int) (numInstructions));
-		monitor.setMessage("Constant Propogation Markup");
+		monitor.setMessage("Constant Propagation Markup");
 
 		// set up the address set to restrict processing
 		AddressSet restrictedSet =

--- a/Ghidra/Features/Base/ghidra_scripts/PropagateX86ConstantReferences.java
+++ b/Ghidra/Features/Base/ghidra_scripts/PropagateX86ConstantReferences.java
@@ -57,7 +57,7 @@ public class PropagateX86ConstantReferences extends GhidraScript {
 	public void run() throws Exception {
 		long numInstructions = currentProgram.getListing().getNumInstructions();
 		monitor.initialize((int) (numInstructions));
-		monitor.setMessage("Constant Propogation Markup");
+		monitor.setMessage("Constant Propagation Markup");
 
 		// set up the address set to restrict processing
 		AddressSet restrictedSet = new AddressSet(currentSelection);


### PR DESCRIPTION
The task monitor message is misspelled during constant propagation in these scripts.