### PR TITLE
PowerPC: multiple VLE-mode fixes

### DIFF
--- a/Ghidra/Processors/PowerPC/certification.manifest
+++ b/Ghidra/Processors/PowerPC/certification.manifest
@@ -7,6 +7,7 @@ data/languages/SPEF_SCR.sinc||GHIDRA||||END|
 data/languages/SPE_APU.sinc||GHIDRA||||END|
 data/languages/SPE_EFSD.sinc||GHIDRA||||END|
 data/languages/SPE_EFV.sinc||GHIDRA||||END|
+data/languages/SPE_FloatMulAdd.sinc||GHIDRA||||END|
 data/languages/Scalar_SPFP.sinc||GHIDRA||||END|
 data/languages/altivec.sinc||GHIDRA||||END|
 data/languages/evx.sinc||GHIDRA||||END|

--- a/Ghidra/Processors/PowerPC/data/languages/SPE_FloatMulAdd.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/SPE_FloatMulAdd.sinc
@@ -1,0 +1,101 @@
+
+# Additional SPE Instructions for Devices that Support VLE
+# Freescale engineering bulletin EB689
+# https://www.nxp.com/docs/en/engineering-bulletin/EB689.pdf
+
+# additional SPE instructions that are implemented on devices with an e200z3 or e200z6 core that supports VLE
+# - Vector Floating-Point Single-Precision Multiply-Add
+# - Vector Floating-Point Single-Precision Multiply-Substract
+# - Vector Floating-Point Single-Precision Negative Multiply-Add
+# - Vector Floating-Point Single-Precision Negative Multiply-Substract
+# - Floating-Point Single-Precision Multiply-Add
+# - Floating-Point Single-Precision Multiply-Substract
+# - Floating-Point Single-Precision Negative Multiply-Add
+# - Floating-Point Single-Precision Negative Multiply-Substract
+
+
+
+# evfsmadd rD,rA,rB
+# Vector Floating-Point Single-Precision Multiply-Add
+:evfsmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x282
+{
+	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
+	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
+	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+
+	tmpDL = ((tmpAL f* tmpBL) f+ tmpDL);
+	tmpDH = ((tmpAH f* tmpBH) f+ tmpDH);
+	D = (zext(tmpDH) << 32) | zext(tmpDL);
+}
+
+# evfsmsub rD,rA,rB
+# Vector Floating-Point Single-Precision Multiply-Substract
+:evfsmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x283
+{
+	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
+	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
+	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+
+	tmpDL = ((tmpAL f* tmpBL) f- tmpDL);
+	tmpDH = ((tmpAH f* tmpBH) f- tmpDH);
+	D = (zext(tmpDH) << 32) | zext(tmpDL);
+}
+
+# evfsnmadd
+# Vector Floating-Point Single-Precision Negative Multiply-Add
+:evfsnmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x28A
+{
+	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
+	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
+	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+
+	tmpDL = f- ((tmpAL f* tmpBL) f+ tmpDL);
+	tmpDH = f- ((tmpAH f* tmpBH) f+ tmpDH);
+	D = (zext(tmpDH) << 32) | zext(tmpDL);
+}
+
+# evfsnmsub
+# Vector Floating-Point Single-Precision Negative Multiply-Substract
+:evfsnmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x28B
+{
+	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
+	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
+	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+
+	tmpDL = f- ((tmpAL f* tmpBL) f- tmpDL);
+	tmpDH = f- ((tmpAH f* tmpBH) f- tmpDH);
+	D = (zext(tmpDH) << 32) | zext(tmpDL);
+}
+
+# efsmadd rD,rA,rB
+# Floating-Point Single-Precision Multiply-Add
+:efsmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x2C2
+{
+	local lo:4 = (A:4 f* B:4) f+ D:4;
+	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+}
+
+# efsmsub rD,rA,rB
+# Floating-Point Single-Precision Multiply-Substract
+:efsmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x2C3
+{
+	local lo:4 = (A:4 f* B:4) f- D:4;
+	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+}
+
+# efsnmadd rD,rA,rB
+# Floating-Point Single-Precision Negative Multiply-Add
+:efsnmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x2CA
+{
+	local lo:4 = f- ((A:4 f* B:4) f+ D:4);
+	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+}
+
+# efsnmsub rD,rA,rB
+# Floating-Point Single-Precision Negative Multiply-Substract
+:efsnmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x2CB
+{
+	local lo:4 = f- ((A:4 f* B:4) f- D:4);
+	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+}
+

--- a/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
@@ -138,7 +138,6 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 }
 
 # efscmpeq CRFD,rA,rB        010 1100 1110
-#define pcodeop FloatingPointCompareEqual;
 :efscmpeq CRFD,A,B is OP=4 & CRFD & A & B & XOP_0_10=0x2CE & BITS_21_22=0
 {
   CRFD[2,1] = A:4 f== B:4;
@@ -148,14 +147,12 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 # Page 415
 
 # efscmpgt CRFD,rA,rB        010 1100 1100
-#define pcodeop FloatingPointCompareGreaterThan;
 :efscmpgt CRFD,A,B is OP=4 & CRFD & A & B & XOP_0_10=0x2CC & BITS_21_22=0
 {
   CRFD[2,1] = A:4 f> B:4;
 }
 
 # efscmplt CRFD,rA,rB        010 1100 1101
-#define pcodeop FloatingPointCompareLessThan;
 :efscmplt CRFD,A,B is OP=4 & CRFD & A & B & XOP_0_10=0x2CD & BITS_21_22=0
 {
   CRFD[2,1] = A:4 f< B:4;

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_64_isa_vle_be.slaspec
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_64_isa_vle_be.slaspec
@@ -30,5 +30,6 @@
 @include "SPEF_SCR.sinc"
 @include "SPE_EFSD.sinc"
 @include "SPE_EFV.sinc"
+@include "SPE_FloatMulAdd.sinc"
 # OR
 #@include "altivec.sinc"

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
@@ -4516,7 +4516,7 @@ define pcodeop TLBSynchronize; # Outputs/affect TBD
 }
 
 #xor. r0,r0,r0	0x7c 00 02 79
-:xor. A,S,B		is $(NOTVLE) & OP=31 & S & A & B & XOP_1_10=316 & Rc=1
+:xor. A,S,B		is OP=31 & S & A & B & XOP_1_10=316 & Rc=1
 {
 	A = S ^ B;
 	cr0flags(A);

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -817,36 +817,34 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 :e_rlwimi A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=0 & MBL & ME & A & SHL & S {
 	tmpS:4 = S:4;
 	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
-	tmpM:4 = ~0:4;
-	if (ME:1 < MBL:1) goto <invert>;
-	tmpM = tmpM << MBL;
-	tmpM = tmpM >> ((31-ME) + MBL);
-	tmpM = tmpM << (31-ME);
-	goto <finish>;
-<invert>
-	tmpM = tmpM << ME;
-	tmpM = tmpM >> ((31-MBL) + ME);
-	tmpM = tmpM << (31-MBL);
-	tmpM = ~tmpM;
-<finish>
+
+	tmpM1 = (~0:4) << MBL;
+	tmpM1 = tmpM1 >> ((31-ME) + MBL);
+	tmpM1 = tmpM1 << (31-ME);
+
+	tmpM2 = (~0:4) << ME;
+	tmpM2 = tmpM2 >> ((31-MBL) + ME);
+	tmpM2 = tmpM2 << (31-MBL);
+	tmpM2 = ~tmpM2;
+
+	tmpM = zext(ME:1 >= MBL:1)*tmpM1 + zext(ME:1 < MBL:1)*tmpM2;
 	A = zext(tmpA & tmpM) | (A & zext(~tmpM));	
 }
 
 :e_rlwinm A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=1 & MBL & ME & A & SHL & S {
 	tmpS:4 = S:4;
 	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
-	tmpM:4 = ~0:4;
-	if (ME:1 < MBL:1) goto <invert>;
-	tmpM = tmpM << MBL;
-	tmpM = tmpM >> ((31-ME) + MBL);
-	tmpM = tmpM << (31-ME);
-	goto <finish>;
-<invert>
-	tmpM = tmpM << ME;
-	tmpM = tmpM >> ((31-MBL) + ME);
-	tmpM = tmpM << (31-MBL);
-	tmpM = ~tmpM;
-<finish>
+
+	tmpM1 = (~0:4) << MBL;
+	tmpM1 = tmpM1 >> ((31-ME) + MBL);
+	tmpM1 = tmpM1 << (31-ME);
+
+	tmpM2 = (~0:4) << ME;
+	tmpM2 = tmpM2 >> ((31-MBL) + ME);
+	tmpM2 = tmpM2 << (31-MBL);
+	tmpM2 = ~tmpM2;
+
+	tmpM = zext(ME:1 >= MBL:1)*tmpM1 + zext(ME:1 < MBL:1)*tmpM2;
 	A = zext(tmpA & tmpM);		
 }
 


### PR DESCRIPTION
I am tested Ghidra with binary for modern NXP MCP57xx MCU and I found a number of issues.

- XOR in VLE mode is valid. It is stated in https://www.nxp.com/files-static/32bit/doc/ref_manual/EREF_RM.pdf
> Instructions from primary opcode 4 and 31 in the standard instruction set decode the same for the
VLE instruction set, making all the instructions in those two primary opcodes available in VLE
mode

- ISEL works incorrectly when rD and rA points to the same register. In that case first step in semantic sections kills rA content.

- efscmpeq/efscmpgt/efscmplt modifies wrong bit. It is stated in https://www.nxp.com/files-static/32bit/doc/ref_manual/SPEPEM.pdf page 114
Also it can be tested with this code:
```
                     float  __stdcall  floatMIN (float  param_1 , float  param_2 )
                       assume vle = 0x1
     float             r3:4           <RETURN>
     float             r3:4           param_1
     float             r4:4           param_2
                     floatMIN
xxxxxx58 10  83  22  cc    efscmpgt   cr1 ,param_1 ,param_2
xxxxxx5c 7a  15  00  06    e_bgt      LAB_xxxxxx62
xxxxxx60 00  04           se_blr
                     LAB_xxxxxx62
xxxxxx62 01  43           se_mr      param_1 ,param_2
xxxxxx64 00  04           se_blr
```

- e_rlwinm with `if(...) goto ...` produces annoying warnings about unreachable code. Condition in `if` statement always constant (since it is a part of instruction itself), so better to write it in another form.

- modern NXP processors have extended signal processing instructions. I am added ones, that listed in https://www.nxp.com/docs/en/engineering-bulletin/EB689.pdf (note, it contain a lot of copy-paste errors). I don't know, maybe better to do another 'language' and add them there.