### PR TITLE
Fix manual switching in the middle of an .idx file

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SleighLanguage.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SleighLanguage.java
@@ -1327,10 +1327,8 @@ public class SleighLanguage implements Language {
 							currentManual = Application.findDataFileInAnyModule(
 								"manuals/" + matcher.group(1).trim());
 						}
-						if (currentManual == null) {
-							currentManual =
-								new ResourceFile(manualDirectory, matcher.group(1).trim());
-						}
+						currentManual =
+							new ResourceFile(manualDirectory, matcher.group(1).trim());
 						FileResolutionResult result =
 							FileUtilities.existsAndIsCaseDependent(currentManual);
 						missingDescription = matcher.group(2).trim();


### PR DESCRIPTION
Several .idx files in the distribution, such as PowerISA.idx, switch manuals in the middle with a description. Currently, the incorrect manual is used for instructions after the switch. With this fix, switching manuals in the middle of the .idx file works as expected.

This also makes it match the behaviour of the description-less switch at line 1349.