### PR TITLE
Fix Dyld library extraction not working

### DIFF
--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dyldcache/FixupMacho32bitArmOffsets.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dyldcache/FixupMacho32bitArmOffsets.java
@@ -147,10 +147,15 @@ public class FixupMacho32bitArmOffsets {
 		Collections.sort( indexList );
 		
 		ByteArrayOutputStream tempOut = new ByteArrayOutputStream();
+		long fileLength = provider.length();
 		try {
 			long tempIndex = offsetAdjustment;
 			while ( !monitor.isCancelled() ) {
-				final int length = 0x10000;
+				long length = 0x10000;
+				if( tempIndex + length > fileLength ) {
+					length = fileLength - tempIndex;
+				}
+
 				byte [] buffer = provider.readBytes( tempIndex, length );
 
 				for ( Long index : indexList ) {
@@ -163,7 +168,7 @@ public class FixupMacho32bitArmOffsets {
 				tempOut.write( buffer );
 				tempIndex += buffer.length;
 				monitor.setMessage( "0x" + Long.toHexString( tempIndex ) );
-				if ( tempIndex > provider.length() ) {
+				if ( tempIndex >= provider.length() ) {
 					break;
 				}
 			}


### PR DESCRIPTION
-Fix extracting a library from the DYLD cache throwing an exception due
 to 4e1b743901b387518da9367c301860f0a1eef413 changing the behaviour
 of RandomAccessByteProvider not allowing reading past the end
 of the input. The FixupMacho32bitArmOffsets script used reading past
 the end of the input as it's loop terminator. This doesn't work since
 the provider changes.
-Change FixupMacho32bitArmOffsets to never attempt to read more
 then the input length bytes and check for the index being
 equal to the file length as the loop terminator.
-This was built and tested on the 9.2.3 branch and
 on master.

Fixes #2216