### PR TITLE
Fix typo in DevGuide.md

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -129,7 +129,7 @@ directory populated with the following files:
  * cdt-8.6.0.zip
  * PyDev 6.3.1.zip
  * yajsw-stable-12.12.zip
- * fid/*.fidb
+ * fidb/*.fidb
 
 If you see these, congrats! Skip to [building](#building-ghidra) or [developing](#developing-ghidra). If not, continue with manual download 
 instructions below...


### PR DESCRIPTION
According to [fetchDependencies.gradle](https://github.com/NationalSecurityAgency/ghidra/blob/3507820e03191fd4fce34aae4e921778f1e12ccc/gradle/support/fetchDependencies.gradle#L51), the folder that contains *.fidb files is `fidb`, not `fid`.

```
ext.FID_DIR = file("${DEPS_DIR}/fidb")
```