### PR TITLE
Fix xml import

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
@@ -23,6 +23,7 @@ import ghidra.program.model.data.*;
 import ghidra.program.model.listing.Program;
 import ghidra.util.*;
 import ghidra.util.exception.DuplicateNameException;
+import org.apache.commons.lang3.StringUtils;
 
 public class CParserUtils {
 
@@ -165,6 +166,18 @@ public class CParserUtils {
 			return null;
 		}
 
+        GenericCallingConvention convention = null;
+
+        for (GenericCallingConvention conv : GenericCallingConvention.values()) {
+            if (conv == GenericCallingConvention.unknown) continue;
+
+            if (StringUtils.endsWith(signatureParts[0], " " + conv)) {
+                convention = conv;
+                signatureParts[0] = StringUtils.removeEnd(signatureParts[0], " " + conv);
+                break;
+            }
+        }
+
 		String replacedText =
 			signatureParts[0] + " " + getTempName(signatureParts[1].length()) + signatureParts[2];
 
@@ -180,7 +193,9 @@ public class CParserUtils {
 			// put back the old signature name
 			dt.setName(signatureParts[1]);
 
-			return (FunctionDefinitionDataType) dt;
+            FunctionDefinitionDataType fdt = (FunctionDefinitionDataType) dt;
+            if (convention != null) fdt.setGenericCallingConvention(convention);
+            return fdt;
 		}
 		catch (InvalidNameException | DuplicateNameException e) {
 			// can't happen since we are calling setName() with the value that was 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/FunctionsXmlMgr.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/FunctionsXmlMgr.java
@@ -155,6 +155,12 @@ class FunctionsXmlMgr {
 							Namespace namespace =
 								NamespaceUtils.getFunctionNamespaceAt(program, namespacePath,
 									entryPoint);
+							if(namespace == null && namespacePath != null){
+							    namespace = NamespaceUtils.createNamespaceHierarchy(
+							            namespacePath.getPath(),
+                                        program.getGlobalNamespace(),
+                                        program,SourceType.IMPORTED);
+                            }
 							if (namespace == null) {
 								namespace = program.getGlobalNamespace();
 							}
@@ -210,7 +216,11 @@ class FunctionsXmlMgr {
 						}
 					}
 					else {
-						tryToParseTypeInfoComment(monitor, func, typeInfoComment);
+                        tryToParseTypeInfoComment(monitor, func, typeInfoComment);
+
+                        if (func.getSignature().getGenericCallingConvention() == GenericCallingConvention.thiscall && func.getParentNamespace() != null) {
+                            NamespaceUtils.convertNamespaceToClass(func.getParentNamespace());
+                        }
 					}
 					addLocalVars(func, stackVariables, overwriteConflicts);
 

--- a/gradle/support/ip.gradle
+++ b/gradle/support/ip.gradle
@@ -133,6 +133,7 @@ def Map<String, List<String>> getIpForModule(Project p) {
 		exclude "**/data/build.xml" // language build file (generated for dev only)
 		exclude "**/.vs/**"
 		exclude "**/*.vcxproj.user"
+		exclude "**/*.iml" // Intellij project files
 	}
 	tree.each { file ->
 			String ip = getIp(p.projectDir, file)


### PR DESCRIPTION
CParser does not support calling convention. This small workaround picks calling convention from function definition, removes it from CParser argument and set's related calling convention to parsed function. As benefit:
- arguments now parse correctly (previously if calling convention presented, just function name is imported)
- calling convention parsed properly.

It unblocks class import, what was added as well. Important change, now if namespace does not present, it will be created, instead of setting namespace as Global. Probably it would be nice to add as an argument to import script.