### PR TITLE
Documentation: Tweaks to Installation Guide

### DIFF
--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -139,9 +139,10 @@ destination using any unzip program (built-in OS utilities, 7-Zip, WinZip, WinRA
     pre-existing configurations of Java that other software may rely on.
   </li>  
   <li>
-    Depending on your operating system, it may be possible to find and install a <a href="#Requirements">supported</a> 
-    version of a Java Runtime and Development Kit through your package manager, without the need to
-    set the Path environment variables as described below.
+    Depending on your operating system, it may be possible to find and install a 
+    <a href="#Requirements">supported</a> version of a Java Runtime and Development Kit through 
+    your package manager, without the need to set the Path environment variables as described 
+    below.
   </li>
   <li>
     If Ghidra failed to run because <i>no versions</i> of Java were on the PATH, a 

--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -139,6 +139,11 @@ destination using any unzip program (built-in OS utilities, 7-Zip, WinZip, WinRA
     pre-existing configurations of Java that other software may rely on.
   </li>  
   <li>
+    Depending on your operating system, it may be possible to find and install a <a href="#Requirements">supported</a> 
+    version of a Java Runtime and Development Kit through your package manager, without the need to
+    set the Path environment variables as described below.
+  </li>
+  <li>
     If Ghidra failed to run because <i>no versions</i> of Java were on the PATH, a 
     <a href="#Requirements">supported</a> JDK should be manually installed and added to the 
     PATH.  The following steps outline how to add a JDK distribution to the operating system's 
@@ -174,10 +179,11 @@ destination using any unzip program (built-in OS utilities, 7-Zip, WinZip, WinRA
           <li>
             <p>Add the JDK bin directory to the PATH variable:</p>
             <ol>
-              <li>Under System variables, highlight <i>Path</i> and click <b>Edit...</b></li>
+              <li>Under <b>System variables</b>, highlight <i>Path</i> and click <b>Edit...</b></li>
               <li>
                 At the end of the the <i>Variable value</i> field, add a semicolon followed by 
-                <i>&lt;path of extracted JDK dir&gt;\bin</i>  
+                <i>&lt;path of extracted JDK dir&gt;\bin</i>, or use the <b>New</b> button in the
+                <i>Edit environment variable</i> window to add a new entry to the <i>Path</i>.
               </li>
               <li>Click <b>OK</b></li>
               <li>Click <b>OK</b></li>


### PR DESCRIPTION
This adds:

 * Mention of installing Java through package manager on Linux, which often nullifies the need to make modifications to the path. 
 * Bold font to make more obvious the placement of the path for Java in the system path, something I have noticed is often mistaken. 
 * Updates the Windows Java Path setup to include the new style of path modification dialog.

Please inform me if you believe these changes could be better implemented.

~Lyell