### PR TITLE
fix decompiler display of char array

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
@@ -1316,7 +1316,7 @@ public class DecompileCallback {
 		}
 		Data data = program.getListing().getDataContaining(addr);
 		Settings settings = SettingsImpl.NO_SETTINGS;
-		StringDataInstance stringInstance = null;
+		StringDataInstance stringInstance = StringDataInstance.NULL_INSTANCE;
 		int length = 0;
 		if (data != null) {
 			if (data.getDataType() instanceof AbstractStringDataType

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
@@ -1318,9 +1318,7 @@ public class DecompileCallback {
 		Settings settings = SettingsImpl.NO_SETTINGS;
 		StringDataInstance stringInstance = null;
 		int length = 0;
-		if (data != null) {
-			stringInstance = StringDataInstance.getStringDataInstance(data);
-		}
+		stringInstance = StringDataInstance.getStringDataInstance(data);
 		if (stringInstance == StringDataInstance.NULL_INSTANCE) {
 			// There is no string and/or something else at the address.
 			// Setup StringDataInstance based on raw memory

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
@@ -1319,32 +1319,9 @@ public class DecompileCallback {
 		StringDataInstance stringInstance = null;
 		int length = 0;
 		if (data != null) {
-			if (data.getDataType() instanceof AbstractStringDataType
-					|| data.getDataType() instanceof Array) {
-				// There is already a string here, or there is a possible array of chars.
-				// Use its configuration to set up the StringDataInstance.
-				settings = data;
-				length = data.getLength();
-				if (length <= 0) {
-					return null;
-				}
-				long diff = addr.subtract(data.getAddress()) *
-					addr.getAddressSpace().getAddressableUnitSize();
-				if (diff < 0 || diff >= length) {
-					return null;
-				}
-				length -= diff;
-				MemoryBufferImpl buf = new MemoryBufferImpl(program.getMemory(), addr, 64);
-				if (data.getDataType() instanceof AbstractStringDataType) {
-					AbstractStringDataType dataType = (AbstractStringDataType) data.getDataType();
-					stringInstance = dataType.getStringDataInstance(buf, settings, length);
-				} else {
-					Array dataType = (Array) data.getDataType();
-					stringInstance = dataType.getStringDataInstance(buf, settings, length);
-				}
-			}
+			stringInstance = StringDataInstance.getStringDataInstance(data);
 		}
-		if (stringInstance == null) {
+		if (stringInstance == StringDataInstance.NULL_INSTANCE) {
 			// There is no string and/or something else at the address.
 			// Setup StringDataInstance based on raw memory
 			DataType dt = dtmanage.findBaseType(dtName, dtId);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
@@ -1316,15 +1316,14 @@ public class DecompileCallback {
 		}
 		Data data = program.getListing().getDataContaining(addr);
 		Settings settings = SettingsImpl.NO_SETTINGS;
-		AbstractStringDataType dataType = null;
 		StringDataInstance stringInstance = null;
 		int length = 0;
 		if (data != null) {
-			if (data.getDataType() instanceof AbstractStringDataType) {
-				// There is already a string here.  Use its configuration to
-				// set up the StringDataInstance
+			if (data.getDataType() instanceof AbstractStringDataType
+					|| data.getDataType() instanceof Array) {
+				// There is already a string here, or there is a possible array of chars.
+				// Use its configuration to set up the StringDataInstance.
 				settings = data;
-				dataType = (AbstractStringDataType) data.getDataType();
 				length = data.getLength();
 				if (length <= 0) {
 					return null;
@@ -1336,13 +1335,20 @@ public class DecompileCallback {
 				}
 				length -= diff;
 				MemoryBufferImpl buf = new MemoryBufferImpl(program.getMemory(), addr, 64);
-				stringInstance = dataType.getStringDataInstance(buf, settings, length);
+				if (data.getDataType() instanceof AbstractStringDataType) {
+					AbstractStringDataType dataType = (AbstractStringDataType) data.getDataType();
+					stringInstance = dataType.getStringDataInstance(buf, settings, length);
+				} else {
+					Array dataType = (Array) data.getDataType();
+					stringInstance = dataType.getStringDataInstance(buf, settings, length);
+				}
 			}
 		}
 		if (stringInstance == null) {
 			// There is no string and/or something else at the address.
 			// Setup StringDataInstance based on raw memory
 			DataType dt = dtmanage.findBaseType(dtName, dtId);
+			AbstractStringDataType dataType = null;
 			if (dt instanceof AbstractStringDataType) {
 				dataType = (AbstractStringDataType) dt;
 			}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Array.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Array.java
@@ -120,6 +120,23 @@ public interface Array extends DataType {
 	 * @param length length of array
 	 * @return a String if it is an array of chars; otherwise null.
 	 */
+	public default StringDataInstance getStringDataInstance(MemBuffer buf, Settings settings, int length) {
+		if (!buf.getMemory().getAllInitializedAddressSet().contains(buf.getAddress())) {
+			return null;
+		}
+		ArrayStringable as = ArrayStringable.getArrayStringable(getDataType());
+		return (as != null) ? as.getArrayStringInstance(buf, settings, length) : null;
+	}
+
+	/**
+	 * Get the value object which corresponds to an array in memory.  This will either be a
+	 * String for the ArrayStringable case or null.
+	 * 
+	 * @param buf data buffer
+	 * @param settings data settings
+	 * @param length length of array
+	 * @return a String if it is an array of chars; otherwise null.
+	 */
 	default Object getArrayValue(MemBuffer buf, Settings settings, int length) {
 		if (!buf.getMemory().getAllInitializedAddressSet().contains(buf.getAddress())) {
 			return null;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Array.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Array.java
@@ -111,6 +111,23 @@ public interface Array extends DataType {
 		return (value != null) ? value : "";
 	}
 
+	/**
+	 * Get the value object which corresponds to an array in memory.  This will either be a
+	 * StringDataInstance for the ArrayStringable case or null.
+	 * 
+	 * @param buf data buffer
+	 * @param settings data settings
+	 * @param length length of array
+	 * @return a StringDataInstance if it is an array of chars; otherwise null.
+	 */
+	default StringDataInstance getStringDataInstance(MemBuffer buf, Settings settings, int length) {
+		if (!buf.getMemory().getAllInitializedAddressSet().contains(buf.getAddress())) {
+			return null;
+		}
+		ArrayStringable as = ArrayStringable.getArrayStringable(getDataType());
+		return (as != null) ? as.getArrayStringInstance(buf, settings, length) : null;
+	}
+
 
 	/**
 	 * Get the value object which corresponds to an array in memory.  This will either be a

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Array.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Array.java
@@ -111,22 +111,6 @@ public interface Array extends DataType {
 		return (value != null) ? value : "";
 	}
 
-	/**
-	 * Get the value object which corresponds to an array in memory.  This will either be a
-	 * String for the ArrayStringable case or null.
-	 * 
-	 * @param buf data buffer
-	 * @param settings data settings
-	 * @param length length of array
-	 * @return a String if it is an array of chars; otherwise null.
-	 */
-	public default StringDataInstance getStringDataInstance(MemBuffer buf, Settings settings, int length) {
-		if (!buf.getMemory().getAllInitializedAddressSet().contains(buf.getAddress())) {
-			return null;
-		}
-		ArrayStringable as = ArrayStringable.getArrayStringable(getDataType());
-		return (as != null) ? as.getArrayStringInstance(buf, settings, length) : null;
-	}
 
 	/**
 	 * Get the value object which corresponds to an array in memory.  This will either be a

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/ArrayStringable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/ArrayStringable.java
@@ -45,9 +45,26 @@ public interface ArrayStringable extends DataType {
 	 * @param length length of array
 	 * @return array value expressed as a string or null if data is not character data
 	 */
-	public default String getArrayString(MemBuffer buf, Settings settings, int length) {
+	public default StringDataInstance getArrayStringInstance(MemBuffer buf, Settings settings, int length) {
 		if (hasStringValue(settings) && buf.isInitializedMemory()) {
-			return new StringDataInstance(this, settings, buf, length, true).getStringValue();
+			return new StringDataInstance(this, settings, buf, length, true);
+		}
+		return null;
+	}
+
+	/**
+	 * For cases where an array of this type exists, get the array value as a String.
+	 * When data corresponds to character data it should generally be expressed as a string.
+	 * A null value is returned if not supported or memory is uninitialized.
+	 * @param buf data buffer
+	 * @param settings data settings
+	 * @param length length of array
+	 * @return array value expressed as a string or null if data is not character data
+	 */
+	public default String getArrayString(MemBuffer buf, Settings settings, int length) {
+		StringDataInstance instance = getArrayStringInstance(buf, settings, length);
+		if (instance != null) {
+			return instance.getStringValue();
 		}
 		return null;
 	}


### PR DESCRIPTION
When a char array is splitted out of a long char array, the decompiler's display does not respect the defined data and display the whole string.
This happens a lot when decompiling Rust.

For example, before this patch:

![image](https://user-images.githubusercontent.com/19388242/116964075-285f0d80-acdd-11eb-836c-5da4294cc498.png)

After this patch:

![image](https://user-images.githubusercontent.com/19388242/116964084-301eb200-acdd-11eb-824a-8b81a34d9a74.png)

According to [this comment](https://github.com/NationalSecurityAgency/ghidra/issues/2181#issuecomment-670578679), this issue should be resolved in 9.2. But when I try it, it is still a problem. This should fix it.

Previous PR(#3000 ) contains some commits not belong to this patch. It should all be OK now.