### PR TITLE
fix(mips32r6): jic is not call but jump

### DIFF
--- a/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
+++ b/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
@@ -1644,7 +1644,14 @@ define pcodeop SYNC;
 	build RTsrc;
 	tmp:$(REGSIZE) = sext(simmed:2) + RTsrc;	
 	JXWritePC(tmp); 
-    call [pc];
+    goto [pc];
+}
+
+:jic RTsrc, simmed                                      is $(AMODE) & REL6=1 & prime=0x36 & jsub=0x00 & RTsrc & simmed & rt=0x1f {
+        build RTsrc;
+        tmp:$(REGSIZE) = sext(simmed:2) + RTsrc;
+        JXWritePC(tmp);
+	return [pc];
 }
 
 @ifndef COPR_C

--- a/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
+++ b/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
@@ -1647,10 +1647,9 @@ define pcodeop SYNC;
     goto [pc];
 }
 
-:jic RTsrc, simmed                                      is $(AMODE) & REL6=1 & prime=0x36 & jsub=0x00 & RTsrc & simmed & rt=0x1f {
+:jic RTsrc, simmed                                      is $(AMODE) & REL6=1 & prime=0x36 & jsub=0x00 & RTsrc & simmed & immed=0x00 & rt=0x1f {
         build RTsrc;
-        tmp:$(REGSIZE) = sext(simmed:2) + RTsrc;
-        JXWritePC(tmp);
+        JXWritePC(ra);
 	return [pc];
 }
 

--- a/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
+++ b/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
@@ -1644,12 +1644,12 @@ define pcodeop SYNC;
 	build RTsrc;
 	tmp:$(REGSIZE) = sext(simmed:2) + RTsrc;	
 	JXWritePC(tmp); 
-        goto [pc];
+	goto [pc];
 }
 
 :jic RTsrc, simmed                                      is $(AMODE) & REL6=1 & prime=0x36 & jsub=0x00 & RTsrc & simmed & immed=0x00 & rt=0x1f {
-        build RTsrc;
-        JXWritePC(ra);
+	build RTsrc;
+	JXWritePC(ra);
 	return [pc];
 }
 

--- a/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
+++ b/Ghidra/Processors/MIPS/data/languages/mips32Instructions.sinc
@@ -1644,7 +1644,7 @@ define pcodeop SYNC;
 	build RTsrc;
 	tmp:$(REGSIZE) = sext(simmed:2) + RTsrc;	
 	JXWritePC(tmp); 
-    goto [pc];
+        goto [pc];
 }
 
 :jic RTsrc, simmed                                      is $(AMODE) & REL6=1 & prime=0x36 & jsub=0x00 & RTsrc & simmed & immed=0x00 & rt=0x1f {


### PR DESCRIPTION
See https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MD00086-2B-MIPS32BIS-AFP-6.06.pdf,
page 205 (page 215 in file).
jic is not like jialc, which set ra by `GPR[31] <- PC + 4`, it's just a jump.
So, if meet jic reg,xxx , identify it as a jump.
If meet jic ra,xxx , identify it as a return.


---------

test_code:
```c
#include <stdio.h>

int hello(char * s){
	puts(s);
	return 123;
}

int main(){
	hello("hello world");
	return 0;
}
```

- before:

![image](https://user-images.githubusercontent.com/25763545/117762654-286e8880-b25c-11eb-9eb0-9ad348da423a.png)


- after:

![image](https://user-images.githubusercontent.com/25763545/117762543-f65d2680-b25b-11eb-87fc-bea2f4d3f493.png)



