### PR TITLE
Add call fixup for edi on IA-32 and a corresponding pattern

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86gcc.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86gcc.cspec
@@ -339,12 +339,23 @@
     </pcode>
   </callfixup>
   
-    <callfixup name="get_pc_thunk_si">
+  <callfixup name="get_pc_thunk_si">
     <target name="__i686.get_pc_thunk.si"/>
     <target name="__x86.get_pc_thunk.si"/>
     <pcode>
       <body><![CDATA[
       ESI = * ESP;
+      ESP = ESP + 4;
+      ]]></body>
+    </pcode>
+  </callfixup>
+
+  <callfixup name="get_pc_thunk_di">
+    <target name="__i686.get_pc_thunk.di"/>
+    <target name="__x86.get_pc_thunk.di"/>
+    <pcode>
+      <body><![CDATA[
+      EDI = * ESP;
       ESP = ESP + 4;
       ]]></body>
     </pcode>

--- a/Ghidra/Processors/x86/data/patterns/x86gcc_patterns.xml
+++ b/Ghidra/Processors/x86/data/patterns/x86gcc_patterns.xml
@@ -56,6 +56,11 @@
      <funcstart label="__i686.get_pc_thunk.si" validcode="function"/>
   </pattern>
 
+  <pattern>
+     <data>0x8b 0x3c 0x24 0xc3 </data> <!-- MOV  EDI,[ESP] / RET -->
+     <funcstart label="__i686.get_pc_thunk.di" validcode="function"/>
+  </pattern>
+
   <patternpairs totalbits="32" postbits="16">
     <prepatterns>
       <data>0x90</data> <!-- NOP filler -->


### PR DESCRIPTION
This seems to have been missing from the list of fixups and I had some trouble with analysis of a program that used `__i686.get_pc_thunk.di`. I have not been able to make proper testing for this patch, so sorry for that, but it works on Ghidra 9.2.3, so I'd expect it to work properly on the latest head, especially considering this is just copy-pasting the same section with esi but modified for edi.

Note: I have squashed the two commits that previously made up this change, but I've had trouble understanding what exactly the "issue number" in "squash your commits to using a message that starts with the issue number" is referring to, so I haven't been able to put any. I have also removed some bad indentation on `get_pc_thunk_si` right before the new pattern for `get_pc_thunk_di` because it really bugged me, though I can put that in a separate patch if really necessary.