### PR TITLE
Fixed PascalUnicode length size

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/string/PascalUtil.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/string/PascalUtil.java
@@ -23,7 +23,7 @@ import ghidra.util.ascii.Sequence;
 public class PascalUtil {
 
 	private static final int ONE_BYTE_OFFSET = -1;
-	private static final int TWO_BYTE_OFFSET = -2;
+	private static final int TWO_BYTE_OFFSET = -4;
 	private static final int NO_OFFSET = 0;
 	private static final int ASCII_CHAR_WIDTH = 1;
 	private static final int UNICODE16_CHAR_WIDTH = 2;
@@ -92,7 +92,7 @@ public class PascalUtil {
 		if (pascalLengthOffset < 0) {
 			return null;
 		}
-		int length = getShort(buf, pascalLengthOffset);
+		int length = getInt(buf, pascalLengthOffset);
 		int sequenceLength =
 			(sequence.getLength() - offset - PASCAL_LENGTH_SIZE) / UNICODE16_CHAR_WIDTH;
 		if (sequence.isNullTerminated()) {
@@ -157,6 +157,15 @@ public class PascalUtil {
 	private static int getShort(MemBuffer buf, int offset) {
 		try {
 			return buf.getShort(offset);
+		}
+		catch (MemoryAccessException e) {
+			return ONE_BYTE_OFFSET;
+		}
+	}
+
+	private static int getInt(MemBuffer buf, int offset) {
+		try {
+			return buf.getInt(offset);
 		}
 		catch (MemoryAccessException e) {
 			return ONE_BYTE_OFFSET;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StringDataInstance.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StringDataInstance.java
@@ -221,7 +221,7 @@ public class StringDataInstance {
 	private static final String BOM_RESULT_STR = "\ufeff";
 
 	private static final int SIZEOF_PASCAL255_STR_LEN_FIELD = 1;
-	private static final int SIZEOF_PASCAL64k_STR_LEN_FIELD = 2;
+	private static final int SIZEOF_PASCAL64k_STR_LEN_FIELD = 4;
 
 	private final String charsetName;
 	private final int charSize;
@@ -477,7 +477,7 @@ public class StringDataInstance {
 						(buf.getUnsignedByte(0) * paddedCharSize);
 				case PASCAL_64k:
 					return SIZEOF_PASCAL64k_STR_LEN_FIELD +
-						(buf.getUnsignedShort(0) * paddedCharSize);
+						((int)buf.getUnsignedInt(0) * paddedCharSize);
 				default:
 					return -1;
 			}


### PR DESCRIPTION
Encountered some pascal unicode earlier today and noticed the length type was to small. See https://wiki.freepascal.org/Character_and_string_types#UnicodeString