### PR TITLE
Ghidra decompiler context constant problem

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
@@ -71,8 +71,7 @@ public class RenameLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
-		EquateTable equateTable = context.getProgram().getEquateTable();
-		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+		if (highSymbol instanceof EquateSymbol) {
 			return false;
 		}
 		return !highSymbol.isGlobal();

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
@@ -71,6 +71,10 @@ public class RenameLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
+		EquateTable equateTable = context.getProgram().getEquateTable();
+		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+			return false;
+		}
 		return !highSymbol.isGlobal();
 	}
 

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
@@ -144,8 +144,7 @@ public class RetypeLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
-		EquateTable equateTable = context.getProgram().getEquateTable();
-		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+		if (highSymbol instanceof EquateSymbol) {
 			return false;
 		}
 		return !highSymbol.isGlobal();

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
@@ -144,6 +144,10 @@ public class RetypeLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
+		EquateTable equateTable = context.getProgram().getEquateTable();
+		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+			return false;
+		}
 		return !highSymbol.isGlobal();
 	}
 


### PR DESCRIPTION
When you set a new equate to a number appear in Listing area but not be identified to a variable in deompile area, and then if you want to rename a variable in decompile area, you will get a error message.

And I have found the reason, ghidra will storage all equate symbols in symbol table and produce their hash storage in LocalSymbolMap, so when you rename a variable, ghidra will search for the LocalSymbolMap and make you operate failed.

This should fix this problem: when program judge "DecompilerContext" enabled or not, I add a new judgment.

This judgment I add will determine whether the content exists in EquateTable, and then react differently.