### PR TITLE
Add double/float support for Convert

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -389,7 +389,7 @@ void Symbol::saveXmlHeader(ostream &s) const
       s << "bin\"";
     else if (format == force_float)
       s << "float\"";
-    else if (format == force_float)
+    else if (format == force_double)
       s << "double\"";
     else
       s << "hex\"";

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -387,6 +387,10 @@ void Symbol::saveXmlHeader(ostream &s) const
       s << "oct\"";
     else if (format == force_bin)
       s << "bin\"";
+    else if (format == force_float)
+      s << "float\"";
+    else if (format == force_float)
+      s << "double\"";
     else
       s << "hex\"";
   }
@@ -425,6 +429,10 @@ void Symbol::restoreXmlHeader(const Element *el)
 	    dispflags |= force_oct;
 	  else if (formString == "bin")
 	    dispflags |= force_bin;
+      else if (formString == "float")
+        dispflags |= force_float;
+      else if (formString == "double")
+        dispflags |= force_double;
 	}
 	break;
       case 'h':

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
@@ -181,6 +181,8 @@ public:
     force_oct = 3,		///< Force octal printing of constant symbol
     force_bin = 4,		///< Force binary printing of constant symbol
     force_char = 5,		///< Force integer to be printed as a character constant
+    force_float = 6,    ///< Force float to be printed as a character constant
+    force_double = 7,   ///< Force double to be printed as a character constant
     size_typelock = 8,	        ///< Only the size of the symbol is typelocked
     isolate = 16,		///< Symbol should not speculatively merge automatically
     merge_problems = 32,	///< Set if some SymbolEntrys did not get merged

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -15,6 +15,7 @@
  */
 #include "printc.hh"
 #include "funcdata.hh"
+#include <iomanip>
 
 // Operator tokens for expressions
 //                        token #in prec assoc   optype       space bump
@@ -1133,6 +1134,20 @@ void PrintC::push_integer(uintb val,int4 sz,bool sign,
     t << hex << "0x" << val;
   else if (displayFormat == Symbol::force_dec)
     t << dec << val;
+  else if (displayFormat == Symbol::force_float) {
+      const FloatFormat *format = glb->translate->getFloatFormat(sizeof(val));
+      FloatFormat::floatclass type;
+      double floatval = format->getHostFloat(val,&type);
+
+      t << showpoint << std::setprecision(7) << floatval;
+  }
+  else if (displayFormat == Symbol::force_double) {
+      const FloatFormat *format = glb->translate->getFloatFormat(sizeof(val));
+      FloatFormat::floatclass type;
+      double doubleval = format->getHostFloat(val,&type);
+
+      t << showpoint << std::setprecision(16) << doubleval;
+  }
   else if (displayFormat == Symbol::force_oct)
     t << oct << '0' << val;
   else if (displayFormat == Symbol::force_char) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/FloatFormat.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/FloatFormat.java
@@ -87,12 +87,12 @@ public strictfp class FloatFormat {
 			displayContext = new MathContext(7, RoundingMode.HALF_EVEN);
 		}
 		else if (size == 4) {
-			signbit_pos = 31;
-			exp_pos = 23;
-			exp_size = 8;
+			signbit_pos = 63;
+			exp_pos = 52;
+			exp_size = 11;
 			frac_pos = 0;
-			frac_size = 23;
-			bias = 127;
+			frac_size = 52;
+			bias = 1023;
 			jbitimplied = true;
 			displayContext = new MathContext(7, RoundingMode.HALF_EVEN);
 		}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/EquateSymbol.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/EquateSymbol.java
@@ -20,6 +20,8 @@ import ghidra.program.model.data.DataType;
 import ghidra.util.xml.SpecXmlUtils;
 import ghidra.xml.XmlElement;
 import ghidra.xml.XmlPullParser;
+import ghidra.pcode.floatformat.*;
+import java.math.BigInteger;
 
 public class EquateSymbol extends HighSymbol {
 
@@ -29,6 +31,8 @@ public class EquateSymbol extends HighSymbol {
 	public static final int FORMAT_OCT = 3;
 	public static final int FORMAT_BIN = 4;
 	public static final int FORMAT_CHAR = 5;
+	public static final int FORMAT_FLOAT = 6;
+	public static final int FORMAT_DOUBLE = 7;
 
 	private long value;			// Value of the equate
 	private int convert;		// Non-zero if this is a conversion equate
@@ -113,6 +117,12 @@ public class EquateSymbol extends HighSymbol {
 			else if (convert == FORMAT_CHAR) {
 				formString = "char";
 			}
+			else if (convert == FORMAT_FLOAT) {
+				formString = "float";
+			}
+			else if (convert == FORMAT_DOUBLE) {
+				formString = "double";
+			}
 			SpecXmlUtils.encodeStringAttribute(buf, "format", formString);
 		}
 		buf.append(">\n");
@@ -131,6 +141,16 @@ public class EquateSymbol extends HighSymbol {
 			}
 			else {
 				return FORMAT_DEFAULT;			// Bad equate name, just print number normally
+			}
+		}
+		else if (nm.contains("-")) {        //Characteristics of the current double type
+			int DoubleSize = 8;				//The double type does not have the problem of loss of precision, so it is used as a comparison method here
+			FloatFormat format = FloatFormatFactory.getFloatFormat(DoubleSize);
+			String doubleFormat = format.round(format.getHostFloat(new BigInteger(String.valueOf(val)))).toString();
+			if (doubleFormat.equals(nm)) {
+				return FORMAT_DOUBLE;
+			}else{
+				return FORMAT_FLOAT;
 			}
 		}
 		if (firstChar == '\'') {


### PR DESCRIPTION
Before that, convert did not implement the `float` and `double` types, and the float type has the problem of loss of precision.Then added `float` and `double` types to decompile, and added two types of judgment methods to `EuqateSymbol`.

After repair:

![image](https://user-images.githubusercontent.com/82093214/120188896-428efb80-c249-11eb-972d-38fe22b7fd35.png)

