### PR TITLE
Fix access violation on unicode string management

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/stringmanage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/stringmanage.cc
@@ -332,7 +332,7 @@ const vector<uint1> &StringManagerUnicode::getStringData(const Address &addr,Dat
     stringData.byteData.reserve(newSize + 1);
     const uint1 *ptr = (const uint1 *)resString.c_str();
     stringData.byteData.assign(ptr,ptr+newSize);
-    stringData.byteData[newSize] = 0;		// Make sure there is a null terminator
+	stringData.byteData.push_back(0);	// Make sure there is a null terminator	
   }
   stringData.isTruncated = (numChars >= maximumChars);
   isTrunc = stringData.isTruncated;


### PR DESCRIPTION
Hello Ghidra Team,
Please concider the following fix.

Accessing a reserved memory led to a memory access violation. We fix it by using push_back method.

Have a nice day,
Sylvain from Airbus CERT