### PR TITLE
Fix 6502's BIT instruction description.

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -168,8 +168,10 @@ ADDRI:  imm16   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 
 :BIT OP2     is (op=0x24 | op=0x2C) ... & OP2
 {
+	N = (OP2 & 0x80) == 0x80;
+	V = (OP2 & 0x40) == 0x40;
 	local value = A & OP2;
-	resultFlags(value);
+	Z = (value == 0);
 }
 
 :BMI  REL			is op=0x30; REL


### PR DESCRIPTION
Flag handling for the BIT instruction did not follow the datasheet.

This fixes #2558.