### PR TITLE
Add the Debug and Processor jars to the API dependencies in buildExtension.gradle

### DIFF
--- a/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
+++ b/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
@@ -51,6 +51,8 @@ dependencies {
 	api fileTree(dir: 'lib', include: "*.jar")
 	api fileTree(dir: ghidraDir + '/Framework', include: "**/*.jar")
 	api fileTree(dir: ghidraDir + '/Features', include: "**/*.jar")
+	api fileTree(dir: ghidraDir + '/Debug', include: "**/*.jar")
+	api fileTree(dir: ghidraDir + '/Processors', include: "**/*.jar")
 	helpPath fileTree(dir: ghidraDir + '/Features/Base', include: "**/Base.jar")
 }
 	


### PR DESCRIPTION
I am not sure why `/Processors` wasn't included before,  but it seems like `/Debug` should definitely be included here. This allows other IDEs to automatically add those jars as dependencies, index them, and add them to the classpath when starting Ghidra. If `api` is not the proper scope because they aren't supposed to be used in Extensions, they should at least be `runtimeOnly` so an IDE can add them to the classpath when starting Java Application Configuration (to start Ghidra via the IDE) 