### PR TITLE
PIC12 and PIC17 analyzer updates

### DIFF
--- a/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic12Analyzer.java
+++ b/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic12Analyzer.java
@@ -633,14 +633,9 @@ public class Pic12Analyzer extends AbstractAnalyzer {
 			if (instr.getNumOperands() == 2) {
 				List<?> repObjs = instr.getDefaultOperandRepresentationList(1);
 				if (repObjs.size() == 1 && DEST_FREG.equals(repObjs.get(0))) {
-					if ("INCF".equals(mnemonic)) {
-						// do nothing - assume this will not affect high-order FSR<6:5> bits
-					}
-					else {
-						// Unhandled FSR modification
-						fsrContext.setValueUnknown();
-						Msg.warn(this, "Unhandled FSR change at: " + instr.getMinAddress());
-					}
+					// Unhandled FSR modification
+					fsrContext.setValueUnknown();
+					Msg.warn(this, "Unhandled FSR change at: " + instr.getMinAddress());
 				}
 			}
 			else if (instr.getNumOperands() == 1) {

--- a/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic17c7xxAnalyzer.java
+++ b/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic17c7xxAnalyzer.java
@@ -903,8 +903,7 @@ public class Pic17c7xxAnalyzer extends AbstractAnalyzer {
 		}
 		else if ("MOVFP".equals(mnemonic) || "MOVPF".equals(mnemonic)) {
 			Object[] objs = instr.getOpObjects(0);
-			if (objs.length == 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) &&
-				wContext.hasValue()) {
+			if (objs.length > 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) && wContext.hasValue()) {
 				fs32Context.setValueAt(instr, wContext.longValue() >> 6, false);
 				fs10Context.setValueAt(instr, wContext.longValue() >> 4, false);
 			}
@@ -986,8 +985,7 @@ public class Pic17c7xxAnalyzer extends AbstractAnalyzer {
 		}
 		else if ("MOVFP".equals(mnemonic) || "MOVPF".equals(mnemonic)) {
 			Object[] objs = instr.getOpObjects(0);
-			if (objs.length == 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) &&
-				wContext.hasValue()) {
+			if (objs.length > 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) && wContext.hasValue()) {
 				bsrContext.setValueAt(instr, wContext.longValue(), false);
 			}
 			else {
@@ -1064,8 +1062,7 @@ public class Pic17c7xxAnalyzer extends AbstractAnalyzer {
 		}
 		else if ("MOVFP".equals(mnemonic) || "MOVPF".equals(mnemonic)) {
 			Object[] objs = instr.getOpObjects(0);
-			if (objs.length == 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) &&
-				wContext.hasValue()) {
+			if (objs.length > 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) && wContext.hasValue()) {
 				pclathContext.setValueAt(instr, wContext.longValue(), false);
 			}
 			else {
@@ -1107,8 +1104,7 @@ public class Pic17c7xxAnalyzer extends AbstractAnalyzer {
 		}
 		else if ("MOVFP".equals(mnemonic) || "MOVPF".equals(mnemonic)) {
 			Object[] objs = instr.getOpObjects(0);
-			if (objs.length == 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) &&
-				wContext.hasValue()) {
+			if (objs.length > 0 && (wReg.equals(objs[0]) || wReg.getAddress().equals(objs[0])) && wContext.hasValue()) {
 				handleComputedFlow(instr, wContext.longValue(), Reference.MNEMONIC);
 			}
 			else {


### PR DESCRIPTION
* PIC12 analyzer attempted to handle the `INCF` opcode twice in different places.
* PIC17 analyzer had an impossible condition for triggering `MOVFP` and `MOVPF` opcodes analysis.