### PR TITLE
Remove symbol servers that don't have PDB symbols

### DIFF
--- a/Ghidra/Configurations/Public_Release/data/PDB_SYMBOL_SERVER_URLS.pdburl
+++ b/Ghidra/Configurations/Public_Release/data/PDB_SYMBOL_SERVER_URLS.pdburl
@@ -1,6 +1,3 @@
 Internet|https://msdl.microsoft.com/download/symbols/|WARNING: Check your organization's security policy before downloading files from the internet.
 Internet|https://chromium-browser-symsrv.commondatastorage.googleapis.com|WARNING: Check your organization's security policy before downloading files from the internet.
 Internet|https://symbols.mozilla.org/|WARNING: Check your organization's security policy before downloading files from the internet.
-Internet|https://software.intel.com/sites/downloads/symbols/|WARNING: Check your organization's security policy before downloading files from the internet.
-Internet|https://driver-symbols.nvidia.com/|WARNING: Check your organization's security policy before downloading files from the internet.
-Internet|https://download.amd.com/dir/bin|WARNING: Check your organization's security policy before downloading files from the internet.


### PR DESCRIPTION
These symbol servers ([Intel](https://software.intel.com/sites/downloads/symbols/), [Nvidia](https://driver-symbols.nvidia.com/), and [AMD](https://download.amd.com/dir/bin)) only provide dll files, not PDB files. So these URLs are not useful when users want to load a PDB symbol.