### PR TITLE
Fix #2176 removing both backslash from path

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/support/launch.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/launch.bat
@@ -63,20 +63,20 @@ goto showUsage
 ::
 :: Production Environment
 ::
-set "INSTALL_DIR=%SUPPORT_DIR%..\"
-set "CPATH=%INSTALL_DIR%Ghidra\Framework\Utility\lib\Utility.jar"
-set "LS_CPATH=%SUPPORT_DIR%LaunchSupport.jar"
-set "DEBUG_LOG4J=%SUPPORT_DIR%debug.log4j.xml"
+set "INSTALL_DIR=%SUPPORT_DIR%.."
+set "CPATH=%INSTALL_DIR%\Ghidra\Framework\Utility\lib\Utility.jar"
+set "LS_CPATH=%SUPPORT_DIR%\LaunchSupport.jar"
+set "DEBUG_LOG4J=%SUPPORT_DIR%\debug.log4j.xml"
 
-if exist "%INSTALL_DIR%Ghidra" goto continue2
+if exist "%INSTALL_DIR%\Ghidra" goto continue2
 
 ::
 :: Development Environment
 ::
-set "INSTALL_DIR=%INSTALL_DIR%..\..\..\"
-set "CPATH=%INSTALL_DIR%Ghidra\Framework\Utility\bin\main"
-set "LS_CPATH=%INSTALL_DIR%GhidraBuild\LaunchSupport\bin\main"
-set "DEBUG_LOG4J=%INSTALL_DIR%Ghidra\RuntimeScripts\Common\support\debug.log4j.xml"
+set "INSTALL_DIR=%INSTALL_DIR%\..\..\.."
+set "CPATH=%INSTALL_DIR%\Ghidra\Framework\Utility\bin\main"
+set "LS_CPATH=%INSTALL_DIR%\GhidraBuild\LaunchSupport\bin\main"
+set "DEBUG_LOG4J=%INSTALL_DIR%\Ghidra\RuntimeScripts\Common\support\debug.log4j.xml"
 if not exist "%LS_CPATH%" (
 	echo Ghidra cannot launch in development mode because Eclipse has not compiled its class files.
 	set ERRORLEVEL=1
@@ -99,13 +99,13 @@ if not %ERRORLEVEL% == 0 (
 
 :: Get the JDK that will be used to launch Ghidra
 set JAVA_HOME=
-for /f "delims=*" %%i in ('java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%\" -jdk_home -save') do set JAVA_HOME=%%i
+for /f "delims=*" %%i in ('java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%" -jdk_home -save') do set JAVA_HOME=%%i
 if "%JAVA_HOME%" == "" (
 	:: No JDK has been setup yet.  Let the user choose one.
-	java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%\" -jdk_home -ask
+	java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%" -jdk_home -ask
 	
 	:: Now that the user chose one, try again to get the JDK that will be used to launch Ghidra
-	for /f "delims=*" %%i in ('java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%\" -jdk_home -save') do set JAVA_HOME=%%i
+	for /f "delims=*" %%i in ('java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%" -jdk_home -save') do set JAVA_HOME=%%i
 	if "!JAVA_HOME!" == "" (
 		echo.
 		echo Failed to find a supported JDK.  Please refer to the Ghidra Installation Guide's Troubleshooting section.
@@ -116,7 +116,7 @@ if "%JAVA_HOME%" == "" (
 set "JAVA_CMD=%JAVA_HOME%\bin\java"
 
 :: Get the configurable VM arguments from the launch properties
-for /f "delims=*" %%i in ('java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%\" -vmargs') do set VMARG_LIST=%VMARG_LIST% %%i
+for /f "delims=*" %%i in ('java -cp "%LS_CPATH%" LaunchSupport "%INSTALL_DIR%" -vmargs') do set VMARG_LIST=%VMARG_LIST% %%i
 
 :: Set Max Heap Size if specified
 if not "%MAXMEM%"=="" (


### PR DESCRIPTION
Hello,
Considering that one or two backlash in %INSTALL_DIR% generate different problems on different systems, I remove them altogether to fix it.
I try on my system with both JDK-11 and JDK-12 (editing the environmet path) and they both works fine.
without the backslash we don't have the double quote escaping problem, and the Java code accepts the path even without the backslash.

@ryanmkurtz let me know if this fix work fine on your system too.

Greetings.

Fixes #2176 