### PR TITLE
Include cspec docs in build

### DIFF
--- a/Ghidra/Features/Decompiler/build.gradle
+++ b/Ghidra/Features/Decompiler/build.gradle
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,8 @@ apply from: "$rootProject.projectDir/gradle/javadoc.gradle"
 apply plugin: 'eclipse'
 
 eclipse.project.name = 'Features Decompiler'
+
+ext.xsltproc = "xsltproc --nonet"
 
 dependencies {
 	api project(':Base')
@@ -122,8 +124,8 @@ task buildDecompilerHelpHtml(type: Exec) {
 		rm -f $installHelpPoint/topics/DecompilePlugin/*.html
 
 		echo '** Building html files **'
-		xsltproc --output $buildDir/decomp_noscaling.xml --stringparam profile.condition "noscaling" commonprofile.xsl decompileplugin.xml 2>&1
-		xsltproc --stringparam base.dir ${installHelpPoint}/topics/DecompilePlugin/ --stringparam root.filename Decompiler decompileplugin_html.xsl $buildDir/decomp_noscaling.xml 2>&1
+		$xsltproc --output $buildDir/decomp_noscaling.xml --stringparam profile.condition "noscaling" commonprofile.xsl decompileplugin.xml 2>&1
+		$xsltproc --stringparam base.dir ${installHelpPoint}/topics/DecompilePlugin/ --stringparam root.filename Decompiler decompileplugin_html.xsl $buildDir/decomp_noscaling.xml 2>&1
 		rm ${installHelpPoint}/topics/DecompilePlugin/Decompiler.html
 		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' ${installHelpPoint}/topics/DecompilePlugin/*.html 2>&1
 
@@ -185,8 +187,8 @@ task buildDecompilerHelpPdf(type: Exec) {
 		cp $installHelpPoint/shared/*.png $buildDir/images 2>&1
 
 		echo '** Building decompileplugin.fo **'
-		xsltproc --output $buildDir/decompileplugin_withscaling.xml --stringparam profile.condition "withscaling" commonprofile.xsl decompileplugin.xml 2>&1
-		xsltproc --output $buildDir/decompileplugin.fo decompileplugin_pdf.xsl $buildDir/decompileplugin_withscaling.xml 2>&1
+		$xsltproc --output $buildDir/decompileplugin_withscaling.xml --stringparam profile.condition "withscaling" commonprofile.xsl decompileplugin.xml 2>&1
+		$xsltproc --output $buildDir/decompileplugin.fo decompileplugin_pdf.xsl $buildDir/decompileplugin_withscaling.xml 2>&1
 
 		echo '** Building decompileplugin.pdf **'
 		fop $buildDir/decompileplugin.fo $buildDir/decompileplugin.pdf 2>&1
@@ -251,13 +253,13 @@ task buildDecompilerDocumentationPdfs(type: Exec) {
 		cp $installPoint/Diagram*.png $buildDir 2>&1
 
 		echo '** Building sleigh.fo **'
-		xsltproc --output $buildDir/sleigh.fo sleigh_pdf.xsl sleigh.xml 2>&1
+		$xsltproc --output $buildDir/sleigh.fo sleigh_pdf.xsl sleigh.xml 2>&1
 
 		echo '** Building sleigh.pdf **'
 		fop $buildDir/sleigh.fo $buildDir/sleigh.pdf 2>&1
 
 		echo '** Building pcoderef.fo **'
-		xsltproc --output $buildDir/pcoderef.fo pcoderef_pdf.xsl pcoderef.xml 2>&1
+		$xsltproc --output $buildDir/pcoderef.fo pcoderef_pdf.xsl pcoderef.xml 2>&1
 
 		echo '** Building pcoderef.pdf **'
 		fop $buildDir/pcoderef.fo $buildDir/pcoderef.pdf  2>&1
@@ -314,11 +316,11 @@ task buildDecompilerDocumentationHtml(type: Exec) {
 		which xsltproc 2>&1
 
 		echo -e '** Building index.html **'
-		xsltproc --output $buildDir/index.html main_html.xsl main.xml 2>&1
+		$xsltproc --output $buildDir/index.html main_html.xsl main.xml 2>&1
 		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' $buildDir/index.html
 
 		echo '** Building html/sleigh.html **'
-		xsltproc --stringparam base.dir $buildDir/html/ --stringparam root.filename sleigh sleigh_html.xsl sleigh.xml 2>&1
+		$xsltproc --stringparam base.dir $buildDir/html/ --stringparam root.filename sleigh sleigh_html.xsl sleigh.xml 2>&1
 		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' $buildDir/html/sleigh*.html
 		cp $installPoint/Frontpage.css $buildDir/html 2>&1
 		cp $installPoint/languages.css $buildDir/html
@@ -327,7 +329,7 @@ task buildDecompilerDocumentationHtml(type: Exec) {
 		cp $installPoint/Diagram3.png $buildDir/html
 
 		echo '** Building html/pcoderef.html **'
-		xsltproc --stringparam base.dir $buildDir/html/ --stringparam root.filename pcoderef pcoderef_html.xsl pcoderef.xml  2>&1
+		$xsltproc --stringparam base.dir $buildDir/html/ --stringparam root.filename pcoderef pcoderef_html.xsl pcoderef.xml  2>&1
 		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' $buildDir/html/pcoderef.html
 		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' $buildDir/html/pcodedescription.html
 		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' $buildDir/html/pseudo-ops.html

--- a/Ghidra/Features/Decompiler/build.gradle
+++ b/Ghidra/Features/Decompiler/build.gradle
@@ -107,6 +107,9 @@ task buildDecompilerHelpHtml(type: Exec) {
 
 	workingDir 'src/main/doc'
 
+	// Rebuild when anything in this directory changes. Crude, but effective.
+	inputs.dir(workingDir)
+
 	// 'which' returns the number of failed arguments
 	// Using the 'which' command first will allow the task to fail if the required
 	// executables are not installed.
@@ -166,6 +169,9 @@ task buildDecompilerHelpPdf(type: Exec) {
 	}
 
 	workingDir 'src/main/doc'
+
+	// Rebuild when anything in this directory changes. Crude, but effective.
+	inputs.dir(workingDir)
 
 	// 'which' returns the number of failed arguments
 	// Using 'which' first will allow the entire command to fail if the required 
@@ -229,6 +235,9 @@ task buildDecompilerDocumentationPdfs(type: Exec) {
 	}
 
 	workingDir 'src/main/doc'
+
+	// Rebuild when anything in this directory changes. Crude, but effective.
+	inputs.dir(workingDir)
 
 	// Gradle will provide a cleanBuildDecompilerDocumentationPdfs task that will remove these
 	// declared outputs.
@@ -303,6 +312,9 @@ task buildDecompilerDocumentationPdfs(type: Exec) {
 task buildDecompilerDocumentationHtml(type: Exec) {
 
 	workingDir 'src/main/doc'
+
+	// Rebuild when anything in this directory changes. Crude, but effective.
+	inputs.dir(workingDir)
 
 	// Gradle will provide a cleanBuildDecompilerDocumentationHtml task that will remove these
 	// declared outputs.
@@ -690,8 +702,8 @@ Task createLexTask(String filename, String binaryName) {
 
 rootProject.createInstallationZip {
 	dependsOn buildDecompilerDocumentationPdfs
-	
-	
+
+
 	def decompilerPdfZipPath = rootProject.ext.ZIP_DIR_PREFIX + "/docs/languages/"
 
 	// Add decompiler pdf files to zip. If the pdf files do not exist during execution time 

--- a/Ghidra/Features/Decompiler/build.gradle
+++ b/Ghidra/Features/Decompiler/build.gradle
@@ -234,6 +234,8 @@ task buildDecompilerDocumentationPdfs(type: Exec) {
 	// declared outputs.
 	outputs.file "$workingDir/$buildDir/pcoderef.fo"
 	outputs.file "$workingDir/$buildDir/pcoderef.pdf"
+	outputs.file "$workingDir/$buildDir/cspec.fo"
+	outputs.file "$workingDir/$buildDir/cspec.pdf"
 	outputs.file "$workingDir/$buildDir/sleigh.fo"
 	outputs.file "$workingDir/$buildDir/sleigh.pdf"
 
@@ -263,6 +265,12 @@ task buildDecompilerDocumentationPdfs(type: Exec) {
 
 		echo '** Building pcoderef.pdf **'
 		fop $buildDir/pcoderef.fo $buildDir/pcoderef.pdf  2>&1
+
+		echo '** Building cspec.fo **'
+		$xsltproc --output $buildDir/cspec.fo cspec_pdf.xsl cspec.xml 2>&1
+
+		echo '** Building cspec.pdf **'
+		fop $buildDir/cspec.fo $buildDir/cspec.pdf  2>&1
 
 		echo '** Done. **'
 		"""
@@ -336,6 +344,10 @@ task buildDecompilerDocumentationHtml(type: Exec) {
 		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' $buildDir/html/reference.html
 		cp $installPoint/Frontpage.css $buildDir/html
 		cp $installPoint/languages.css $buildDir/html
+
+		echo '** Building html/cspec.html **'
+		$xsltproc --stringparam base.dir $buildDir/html/ --stringparam root.filename cspec cspec_html.xsl cspec.xml 2>&1
+		sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' $buildDir/html/cspec*.html
 
 		echo '** Installing html documentation. **'
 		cp $buildDir/index.html $installPoint/index.html

--- a/Ghidra/Features/Decompiler/certification.manifest
+++ b/Ghidra/Features/Decompiler/certification.manifest
@@ -32,7 +32,9 @@ src/decompile/datatests/twodim.xml||GHIDRA||||END|
 src/decompile/datatests/wayoffarray.xml||GHIDRA||||END|
 src/main/doc/commonprofile.xsl||GHIDRA||||END|
 src/main/doc/cspec.xml||GHIDRA||||END|
+src/main/doc/cspec_common.xsl||GHIDRA||||END|
 src/main/doc/cspec_html.xsl||GHIDRA||||END|
+src/main/doc/cspec_pdf.xsl||GHIDRA||||END|
 src/main/doc/decompileplugin.xml||GHIDRA||||END|
 src/main/doc/decompileplugin_common.xsl||GHIDRA||||END|
 src/main/doc/decompileplugin_html.xsl||GHIDRA||||END|

--- a/Ghidra/Features/Decompiler/src/main/doc/cspec_common.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/cspec_common.xsl
@@ -1,0 +1,36 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+<xsl:param name="generate.toc">
+  article/appendix  nop
+  article   title,toc
+  book      toc,title,figure,table,example,equation
+  chapter   nop
+  part      toc,title
+  preface   toc,title
+  qandadiv  toc
+  qandaset  toc
+  reference toc,title
+  sect1     nop
+  sect2     nop
+  sect3     nop
+  sect4     nop
+  sect5     nop
+  section   nop
+  set       toc,title
+</xsl:param>
+
+<!-- Where does the title go, relative to the object -->
+<xsl:param name="formal.title.placement">
+  figure after
+  example before
+  equation before
+  table before
+  procedure before
+  task before
+</xsl:param>
+
+<!-- Automatically number sections -->
+<xsl:param name="section.autolabel" select="1"/>
+
+</xsl:stylesheet>

--- a/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
@@ -1,27 +1,9 @@
 <?xml version='1.0'?>
-<xsl:stylesheet
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
 <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
 
-<xsl:param name="generate.toc">
-  article/appendix  nop
-  article   toc,title
-  book      toc,title,figure,table,example,equation
-  chapter   nop
-  part      toc,title
-  preface   toc,title
-  qandadiv  toc
-  qandaset  toc
-  reference toc,title
-  sect1     nop
-  sect2     nop
-  sect3     nop
-  sect4     nop
-  sect5     nop
-  section   nop
-  set       toc,title
-</xsl:param>
+<xsl:include href="cspec_common.xsl" />
 
 <xsl:param name="use.id.as.filename" select="1"/>  <!-- Split up into files based on id attribute -->
 

--- a/Ghidra/Features/Decompiler/src/main/doc/cspec_pdf.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/cspec_pdf.xsl
@@ -1,0 +1,14 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+
+<xsl:include href="cspec_common.xsl" />
+
+<xsl:param name="fop1.extensions" select="1"/>  <!-- Use fop extensions when converting to pdf -->
+
+<xsl:param name="alignment" select="'left'"/>   <!-- Justify normal text (only) on the left -->
+
+<xsl:param name="draft.mode" select="'no'"/>    <!-- Turn off the draft background watermark -->
+
+</xsl:stylesheet>

--- a/Ghidra/Features/FunctionID/build.gradle
+++ b/Ghidra/Features/FunctionID/build.gradle
@@ -22,6 +22,7 @@ apply plugin: 'eclipse'
 
 eclipse.project.name = 'Features FunctionID'
 
+ext.xsltproc = "xsltproc --nonet"
 
 dependencies {
 	api project(":Base")
@@ -91,8 +92,8 @@ task buildFidDocumentationPdf(type: Exec) {
 		cp $installPoint/topics/FunctionID/images/*.png $buildDir/images
 
 		echo '** Building FunctionID.fo **'
-		xsltproc --output $buildDir/fid_withscaling.xml --stringparam profile.condition "withscaling" http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl fid.xml 2>&1
-		xsltproc --output $buildDir/FunctionID.fo fid_pdf.xsl $buildDir/fid_withscaling.xml 2>&1
+		$xsltproc --output $buildDir/fid_withscaling.xml --stringparam profile.condition "withscaling" http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl fid.xml 2>&1
+		$xsltproc --output $buildDir/FunctionID.fo fid_pdf.xsl $buildDir/fid_withscaling.xml 2>&1
 
 		echo '** Building FunctionID.pdf **'
 		fop $buildDir/FunctionID.fo $buildDir/FunctionID.pdf 2>&1
@@ -158,8 +159,8 @@ task buildFidDocumentationHtml(type: Exec) {
 	rm -f $installPoint/topics/FunctionID/*.html
 
 	echo '** Building html files **'
-	xsltproc --output $buildDir/fid_noscaling.xml --stringparam profile.condition "noscaling" http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl fid.xml 2>&1
-	xsltproc --stringparam base.dir ${installPoint}/topics/FunctionID/ fid_html.xsl $buildDir/fid_noscaling.xml 2>&1
+	$xsltproc --output $buildDir/fid_noscaling.xml --stringparam profile.condition "noscaling" http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl fid.xml 2>&1
+	$xsltproc --stringparam base.dir ${installPoint}/topics/FunctionID/ fid_html.xsl $buildDir/fid_noscaling.xml 2>&1
 	sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' ${installPoint}/topics/FunctionID/*.html
 
 	echo '** Done. **'

--- a/Ghidra/Features/FunctionID/build.gradle
+++ b/Ghidra/Features/FunctionID/build.gradle
@@ -91,7 +91,7 @@ task buildFidDocumentationPdf(type: Exec) {
 		cp $installPoint/topics/FunctionID/images/*.png $buildDir/images
 
 		echo '** Building FunctionID.fo **'
-		xsltproc --output $buildDir/fid_withscaling.xml --stringparam profile.condition "withscaling" /usr/share/sgml/docbook/xsl-stylesheets/profiling/profile.xsl fid.xml 2>&1
+		xsltproc --output $buildDir/fid_withscaling.xml --stringparam profile.condition "withscaling" http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl fid.xml 2>&1
 		xsltproc --output $buildDir/FunctionID.fo fid_pdf.xsl $buildDir/fid_withscaling.xml 2>&1
 
 		echo '** Building FunctionID.pdf **'
@@ -158,7 +158,7 @@ task buildFidDocumentationHtml(type: Exec) {
 	rm -f $installPoint/topics/FunctionID/*.html
 
 	echo '** Building html files **'
-	xsltproc --output $buildDir/fid_noscaling.xml --stringparam profile.condition "noscaling" /usr/share/sgml/docbook/xsl-stylesheets/profiling/profile.xsl fid.xml 2>&1
+	xsltproc --output $buildDir/fid_noscaling.xml --stringparam profile.condition "noscaling" http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl fid.xml 2>&1
 	xsltproc --stringparam base.dir ${installPoint}/topics/FunctionID/ fid_html.xsl $buildDir/fid_noscaling.xml 2>&1
 	sed -i -e '/Frontpage.css/ { p; s/Frontpage.css/languages.css/; }' ${installPoint}/topics/FunctionID/*.html
 

--- a/Ghidra/Features/FunctionID/src/main/doc/fid_html.xsl
+++ b/Ghidra/Features/FunctionID/src/main/doc/fid_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="/usr/share/sgml/docbook/xsl-stylesheets/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
 
 <xsl:include href="fid_common.xsl" />
 

--- a/Ghidra/Features/FunctionID/src/main/doc/fid_pdf.xsl
+++ b/Ghidra/Features/FunctionID/src/main/doc/fid_pdf.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="/usr/share/sgml/docbook/xsl-stylesheets/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
 
 <xsl:template match="table" mode="label.markup"/>
 

--- a/GhidraDocs/certification.manifest
+++ b/GhidraDocs/certification.manifest
@@ -108,6 +108,12 @@ languages/html/Diagram1.png||GHIDRA||||END|
 languages/html/Diagram2.png||GHIDRA||||END|
 languages/html/Diagram3.png||GHIDRA||||END|
 languages/html/additionalpcode.html||GHIDRA||||END|
+languages/html/cspec_dataorg.html||GHIDRA||||END|
+languages/html/cspec.html||GHIDRA||||END|
+languages/html/cspec_parampass.html||GHIDRA||||END|
+languages/html/cspec_pcodeinterp.html||GHIDRA||||END|
+languages/html/cspec_scopememory.html||GHIDRA||||END|
+languages/html/cspec_specialreg.html||GHIDRA||||END|
 languages/html/pcodedescription.html||GHIDRA||||END|
 languages/html/pcoderef.html||GHIDRA||||END|
 languages/html/pseudo-ops.html||GHIDRA||||END|


### PR DESCRIPTION
This is a rework of pull request #2108 that does less.

* Mostly copying the layout of the sleigh docs

* Adjust xsl include locations to use the canonical URL;
   this should be in the system XML catalog if docbook-xsl is installed.
   Works great on Debian without hardcoding the path.

   We use xsltproc's `--nonet` flag to make sure this actually works offline.
   Handy if you're paranoid, and also if you want it to work when sf.net project web service is down,
   as it was earlier today.)

* Don't pull any of these Linux-only tasks into the main build.

Fixes: #1856.