### PR TITLE
Accept leading 0x on Elf image base addresses

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
@@ -182,6 +182,12 @@ public class ElfLoaderOptionsFactory {
 			return "Invalid type for option: " + name + " - " + option.getValueClass();
 		}
 		String value = (String) option.getValue();
+
+		/* Strip any leading 0x prefix */
+		if (value.startsWith("0x")) {
+			value = value.substring(2);
+		}
+
 		try {
 			space.getAddress(Long.parseUnsignedLong(value, 16), true);// verify valid address
 		}


### PR DESCRIPTION
This finally bugged me enough to make a PR :-)

When setting the `Image Base` in the options when importing an ELF file, the validator complains if the input is a valid hex number with a `0x` prefix. This is mostly an issue when copy pasting an address.