### PR TITLE
Update handling of 6502's indirect JMP opcode.

### DIFF
--- a/Ghidra/Processors/6502/build.gradle
+++ b/Ghidra/Processors/6502/build.gradle
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 apply from: "$rootProject.projectDir/gradle/distributableGhidraModule.gradle"
+apply from: "$rootProject.projectDir/gradle/javaProject.gradle"
 apply from: "$rootProject.projectDir/gradle/processorProject.gradle"
+apply from: "$rootProject.projectDir/gradle/jacocoProject.gradle"
+apply from: "$rootProject.projectDir/gradle/javaTestProject.gradle"
 apply plugin: 'eclipse'
 
 eclipse.project.name = 'Processors 6502'
 
-
+dependencies {
+    api project(':Base')
+}

--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -303,7 +303,7 @@ ADDRI:  imm16   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 	goto ADDR16;
 }
 
-:JMP ADDRI     is (op=0x6c); ADDRI
+:JMP (ADDRI)     is (op=0x6c); ADDRI
 {
 	goto [ADDRI];
 }

--- a/Ghidra/Processors/6502/src/main/java/ghidra/app/plugin/core/analysis/MOS6502IndirectJumpPageCrossingAnalyzer.java
+++ b/Ghidra/Processors/6502/src/main/java/ghidra/app/plugin/core/analysis/MOS6502IndirectJumpPageCrossingAnalyzer.java
@@ -1,0 +1,96 @@
+package ghidra.app.plugin.core.analysis;
+
+import ghidra.app.services.AbstractAnalyzer;
+import ghidra.app.services.AnalysisPriority;
+import ghidra.app.services.AnalyzerType;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.model.address.AddressFactory;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.lang.LanguageID;
+import ghidra.program.model.lang.OperandType;
+import ghidra.program.model.listing.FlowOverride;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.InstructionIterator;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.mem.MemoryAccessException;
+import ghidra.program.model.scalar.Scalar;
+import ghidra.util.Msg;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.task.TaskMonitor;
+
+/*
+
+The NMOS version of the 6502 has an hardware bug in which indirect jumps whose effective address lies across two
+256-bytes pages, the higher byte of the address is fetched in the same page as the lower byte rather than the following
+one.  For example, assume the instruction being analysed is at $1000 and once decoded turns into "JMP ($10FF)", and
+memory at $10FF and $1100 contains $00 and $20 respectively.  One may assume the address being fetched from memory
+would be $2000 and then the program counter would be set to that address.  In fact what happens is that bytes at $10FF
+and $1000 would be fetched to obtain the effective target, which in this case would turn into $6C00 ($6C being the
+opcode for indirect JMP).
+
+CMOS versions and some clones did fix this mistake, but quite a few clones still keep this behaviour to be bug-for-bug
+compatible with the original.
+
+ */
+
+public class MOS6502IndirectJumpPageCrossingAnalyzer extends AbstractAnalyzer {
+
+    private static final String NAME = "Emulate indirect jump bug";
+    private static final String DESCRIPTION =
+            "Compute the correct effective indirect jump target on page boundary crossings.";
+
+    public MOS6502IndirectJumpPageCrossingAnalyzer() {
+        super(NAME, DESCRIPTION, AnalyzerType.INSTRUCTION_ANALYZER);
+        setPriority(AnalysisPriority.DISASSEMBLY.after().after().after());
+    }
+
+    @Override
+    public boolean canAnalyze(Program program) {
+        LanguageID languageID = program.getLanguageID();
+        return languageID.equals(new LanguageID("6502:LE:16:default"));
+    }
+
+    @Override
+    public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
+            throws CancelledException {
+
+        AddressFactory addressFactory = program.getAddressFactory();
+        Memory memory = program.getMemory();
+        AddressSpace addressSpace = addressFactory.getDefaultAddressSpace();
+
+        InstructionIterator instIter = program.getListing().getInstructions(set, true);
+        while (!monitor.isCancelled() && instIter.hasNext()) {
+            Instruction instr = instIter.next();
+
+            if (!instr.getMnemonicString().equalsIgnoreCase("JMP") ||
+                    instr.getNumOperands() != 1 ||
+                    (instr.getOperandType(0) & OperandType.INDIRECT) != OperandType.INDIRECT) {
+                continue;
+            }
+
+            Object[] operandObjects = instr.getOpObjects(0);
+            if (operandObjects[0] instanceof Scalar) {
+                Scalar scalarOperand = (Scalar) operandObjects[0];
+                long indirectTarget = scalarOperand.getUnsignedValue();
+                if ((indirectTarget & 0xFF) == 0xFF) {
+                    try {
+                        byte low = memory.getByte(addressSpace.getAddress(indirectTarget));
+                        byte high = memory.getByte(addressSpace.getAddress(indirectTarget & 0xFF00));
+                        long newIndirectTarget = (((long) high) << 8) + (long) low;
+                        instr.setFlowOverride(FlowOverride.BRANCH);
+                        instr.setFallThrough(addressSpace.getAddress(newIndirectTarget));
+                    } catch (MemoryAccessException e) {
+                        // Unless the computed indirect target is pointing to an unmapped memory area, this
+                        // should not happen.  This should also not happen in case of rolling over the address
+                        // space (say, "JMP ($FFFF)").
+                        Msg.error(this, "Computed jump target is outside mapped memory.");
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This fixes #783 in showing indirect jump target addresses differently than normal jumps.

Also, a simple analysis plugin has been written to work around a hardware bug when decoding indirect jumps - present in quite a few versions (early and late).  Quoting from [Wikipedia](https://en.wikipedia.org/wiki/MOS_Technology_6502#Bugs_and_quirks):

> The 6502's memory indirect jump instruction, JMP (\<address\>), is partly broken. If \<address\> is hex xxFF (i.e., any word ending in FF), the processor will not jump to the address stored in xxFF and xxFF+1 as expected, but rather the one defined by xxFF and xx00 (for example, JMP ($10FF) would jump to the address stored in 10FF and 1000, instead of the one stored in 10FF and 1100). This defect continued through the entire NMOS line, but was corrected in the CMOS derivatives.

Since keeping track of this decoding bug only comes handy when "interesting" code comes up, it is disabled by default.

I don't know what's the policy for the IP block in the Java code, so feel free to apply necessary changes for that.
