### PR TITLE
Fix bug in error string generation in SleighCompile.java

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
@@ -396,7 +396,7 @@ public class SleighCompile extends SleighBase {
 				reportError(qual.location,
 					String.format(
 						"Size of bitfield %s=(%d,%d) larger than %d bits in context register '%s'",
-						qual.name, min, (8 * 4), sym.getName()));
+						qual.name, min, max, (8 * 4), sym.getName()));
 
 			}
 			if (max > maxBits) {


### PR DESCRIPTION
The format string is missing an argument, leading to a String format error being printed out instead of the intended message. 