### PR TITLE
6502: Fix SBC carry handling (#3189)

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -420,7 +420,7 @@ ADDRI:  imm16   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 :SBC OP1     is (cc=1 & aaa=7) ... & OP1
 {
 	local op1 = OP1;
-	local result = A - op1 - (1 - C);
+	local result = A - op1 - !C;
 	
 	subtraction_flags1(A, op1, result);
 	A = result;	

--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -420,7 +420,7 @@ ADDRI:  imm16   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 :SBC OP1     is (cc=1 & aaa=7) ... & OP1
 {
 	local op1 = OP1;
-	local result = A - op1 - C;
+	local result = A - op1 - (1 - C);
 	
 	subtraction_flags1(A, op1, result);
 	A = result;	


### PR DESCRIPTION
This PR fixes the bug in #3189 - where the 6502's carry flag is being incorrectly interpreted as a borrow flag in the SBC instruction SLEIGH definition.