### PR TITLE
Fix: handle whitespace paths for Windows launchers

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/server/ghidraSvr.bat
+++ b/Ghidra/RuntimeScripts/Windows/server/ghidraSvr.bat
@@ -24,7 +24,7 @@ set "SERVER_DIR=%~dp0"
 set "SERVER_DIR=%SERVER_DIR:~0,-1%"
 
 rem Ensure Ghidra path doesn't contain illegal characters
-if not %SERVER_DIR:!=%==%SERVER_DIR% (
+if not "%SERVER_DIR:!=%"=="%SERVER_DIR%" (
 	echo Ghidra path cannot contain a "!" character.
 	exit /B 1
 )

--- a/Ghidra/RuntimeScripts/Windows/support/launch.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/launch.bat
@@ -39,7 +39,7 @@ set "SUPPORT_DIR=%~dp0"
 set "SUPPORT_DIR=%SUPPORT_DIR:~0,-1%"
 
 :: Ensure Ghidra path doesn't contain illegal characters
-if not %SUPPORT_DIR:!=%==%SUPPORT_DIR% (
+if not "%SUPPORT_DIR:!=%"=="%SUPPORT_DIR%" (
 	echo Ghidra path cannot contain a "!" character.
 	set ERRORLEVEL=1
 	goto exit1


### PR DESCRIPTION
Follow-up to: https://github.com/NationalSecurityAgency/ghidra/commit/38edc05f812c752713ca0fcecf1239d99d3efc3c
Fixes: https://github.com/NationalSecurityAgency/ghidra/issues/3201
It seems like these instances for the "!" check were not quoted but need to be if the path contains whitespaces.
Not sure if there are other such cases, but this at least resolves the issue with the launcher for me with a path containing my name.

Prior:
```
C:\Users\Dominic Della Valle\path\Ghidra>ghidraRun.bat
Della was unexpected at this time.
```
Post:
Launches as expected (so long as some version of `java` is in `PATH`).

Even though this is a small change that looks obvious, it's Batch, so someone should scrutinize it as if it's intended to be malicious. Since that seems to be the default nature of the command interpreter.