### PR TITLE
fix(mips32el): fix positions of float registers in Little-Endian MIPS32 CPU

### DIFF
--- a/Ghidra/Processors/MIPS/data/languages/mips.sinc
+++ b/Ghidra/Processors/MIPS/data/languages/mips.sinc
@@ -220,6 +220,7 @@ define register offset=0 size=4 [
 
 # Floating point registers
 @if FREGSIZE == "4"
+@if ENDIAN == "big"
 # For 64-bit Double floating point operands need to bond two 32-bit FPRs
 define register offset=0x1000 size=4 [
     f1  f0  f3  f2  f5  f4  f7  f6
@@ -227,6 +228,14 @@ define register offset=0x1000 size=4 [
     f17 f16 f19 f18 f21 f20 f23 f22
     f25 f24 f27 f26 f29 f28 f31 f30
 ];
+@else
+define register offset=0x1000 size=4 [
+    f0  f1  f2  f3  f4  f5  f6  f7
+    f8  f9  f10 f11 f12 f13 f14 f15
+    f16 f17 f18 f19 f20 f21 f22 f23
+    f24 f25 f26 f27 f28 f29 f30 f31
+];
+@endif # ENDIAN
 
 # Note ftD, fsD, and fdD and frD have been added to support 64-bit double floats
 define register offset=0x1000 size=8 [


### PR DESCRIPTION
Hello,

When loading double constants using two `lwc1` instructions ("Load Word in Coprocessor 1"), the words are swapped on Little-Endian MIPS machines.

More precisely, when compiling the following function with `mipsel-linux-gnu-gcc -O3 -mfp32 -march=mips1`

```c
    double add_0x100000000(double num) {
        return num + 4294967296.0;
    }
```

The produced assembly (seen with objdump) is:

    00000000 <add_0x100000000>:
       0:    3c1c0000     lui   gp,0x0
       4:    279c0000     addiu gp,gp,0
       8:    0399e021     addu  gp,gp,t9
       c:    8f820000     lw    v0,0(gp)
      10:    00000000     nop
      14:    c4400000     lwc1  $f0,0(v0)     ; load the first 32-bit word
      18:    00000000     nop
      1c:    c4410004     lwc1  $f1,4(v0)     ; load the second 32-bit word
      20:    03e00008     jr    ra
      24:    46206000     add.d $f0,$f12,$f0  ; perform the addition

(the rodata section contains `00000000 0000f041` to encode the constant).

When opening the produced file with Ghidra 10.0, the assembly code is fine but the decompiler outputs:

```c
    double add_0x100000000(double param_1)
    {
      return param_1 + 5.465589744795806e-315;
    }
```

5.465589744795806e-315 comes from the decoding of `0000f041 00000000` instead of `00000000 0000f041`: the words were swapped.

Fix this by swapping f0 and f1, f2 and f3... when using a Little-Endian MIPS machine with 32-bit floating-point registers.