### PR TITLE
DexHeaderFormatAnalyzer: do not fail when several methods refer to the same metadata

### DIFF
--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/android/dex/analyzer/DexHeaderFormatAnalyzer.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/android/dex/analyzer/DexHeaderFormatAnalyzer.java
@@ -633,32 +633,39 @@ public class DexHeaderFormatAnalyzer extends FileFormatAnalyzer {
 			if (annotationsDirectoryItem.getClassAnnotationsOffset() > 0) {
 				Address classAddress =
 					toAddr(program, annotationsDirectoryItem.getClassAnnotationsOffset());
-				AnnotationSetItem setItem = annotationsDirectoryItem.getClassAnnotations();
-				DataType setItemDataType = setItem.toDataType();
-				createData(program, classAddress, setItemDataType);
-				createFragment(program, "class_annotations", classAddress,
-					classAddress.add(setItemDataType.getLength()));
-				processAnnotationSetItem(program, setItem, monitor, log);
+				// Only create data if it has not been created already
+				if (getDataAt(program, classAddress) == null) {
+					AnnotationSetItem setItem = annotationsDirectoryItem.getClassAnnotations();
+					DataType setItemDataType = setItem.toDataType();
+					createData(program, classAddress, setItemDataType);
+					createFragment(program, "class_annotations", classAddress,
+						classAddress.add(setItemDataType.getLength()));
+					processAnnotationSetItem(program, setItem, monitor, log);
+				}
 			}
 			for (FieldAnnotation field : annotationsDirectoryItem.getFieldAnnotations()) {
 				monitor.checkCanceled();
 				Address fieldAddress = toAddr(program, field.getAnnotationsOffset());
-				AnnotationSetItem setItem = field.getAnnotationSetItem();
-				DataType setItemDataType = setItem.toDataType();
-				createData(program, fieldAddress, setItemDataType);
-				createFragment(program, "annotation_fields", fieldAddress,
-					fieldAddress.add(setItemDataType.getLength()));
-				processAnnotationSetItem(program, setItem, monitor, log);
+				if (getDataAt(program, fieldAddress) == null) {
+					AnnotationSetItem setItem = field.getAnnotationSetItem();
+					DataType setItemDataType = setItem.toDataType();
+					createData(program, fieldAddress, setItemDataType);
+					createFragment(program, "annotation_fields", fieldAddress,
+						fieldAddress.add(setItemDataType.getLength()));
+					processAnnotationSetItem(program, setItem, monitor, log);
+				}
 			}
 			for (MethodAnnotation method : annotationsDirectoryItem.getMethodAnnotations()) {
 				monitor.checkCanceled();
 				Address methodAddress = toAddr(program, method.getAnnotationsOffset());
-				AnnotationSetItem setItem = method.getAnnotationSetItem();
-				DataType setItemDataType = setItem.toDataType();
-				createData(program, methodAddress, setItemDataType);
-				createFragment(program, "annotation_methods", methodAddress,
-					methodAddress.add(setItemDataType.getLength()));
-				processAnnotationSetItem(program, setItem, monitor, log);
+				if (getDataAt(program, methodAddress) == null) {
+					AnnotationSetItem setItem = method.getAnnotationSetItem();
+					DataType setItemDataType = setItem.toDataType();
+					createData(program, methodAddress, setItemDataType);
+					createFragment(program, "annotation_methods", methodAddress,
+						methodAddress.add(setItemDataType.getLength()));
+					processAnnotationSetItem(program, setItem, monitor, log);
+				}
 			}
 			for (ParameterAnnotation parameter : annotationsDirectoryItem
 					.getParameterAnnotations()) {
@@ -666,20 +673,24 @@ public class DexHeaderFormatAnalyzer extends FileFormatAnalyzer {
 				Address parameterAddress = toAddr(program, parameter.getAnnotationsOffset());
 				AnnotationSetReferenceList annotationSetReferenceList =
 					parameter.getAnnotationSetReferenceList();
-				DataType listDataType = annotationSetReferenceList.toDataType();
-				createData(program, parameterAddress, listDataType);
-				createFragment(program, "annotation_parameters", parameterAddress,
-					parameterAddress.add(listDataType.getLength()));
+				if (getDataAt(program, parameterAddress) == null) {
+					DataType listDataType = annotationSetReferenceList.toDataType();
+					createData(program, parameterAddress, listDataType);
+					createFragment(program, "annotation_parameters", parameterAddress,
+						parameterAddress.add(listDataType.getLength()));
+				}
 
 				for (AnnotationSetReferenceItem refItem : annotationSetReferenceList.getItems()) {
 					AnnotationItem annotationItem = refItem.getItem();
 					if (annotationItem != null) {
 						int annotationsItemOffset = refItem.getAnnotationsOffset();
 						Address annotationItemAddress = toAddr(program, annotationsItemOffset);
-						DataType annotationItemDataType = annotationItem.toDataType();
-						createData(program, annotationItemAddress, annotationItemDataType);
-						createFragment(program, "annotation_item", annotationItemAddress,
-							annotationItemAddress.add(annotationItemDataType.getLength()));
+						if (getDataAt(program, annotationItemAddress) == null) {
+							DataType annotationItemDataType = annotationItem.toDataType();
+							createData(program, annotationItemAddress, annotationItemDataType);
+							createFragment(program, "annotation_item", annotationItemAddress,
+								annotationItemAddress.add(annotationItemDataType.getLength()));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Some Android applications use the same class annotations metadata structure for several annotations. When using the `Android DEX Header Format` auto analysis, this makes `processClassAnnotations()` create a structure twice at the same location. As `setItem.toDataType()` always creates a new structure which is not "compatible" with any existing one, `createData()` fails:

    Could not create Data at address 007f35f8
    java.lang.RuntimeException: Could not create Data at address 007f35f8
            at ghidra.file.analyzers.FileFormatAnalyzer.createData(FileFormatAnalyzer.java:211)
            at ghidra.file.formats.android.dex.analyzer.DexHeaderFormatAnalyzer.processClassAnnotations(DexHeaderFormatAnalyzer.java:640)
            at ghidra.file.formats.android.dex.analyzer.DexHeaderFormatAnalyzer.processClassDefs(DexHeaderFormatAnalyzer.java:373)
            at ghidra.file.formats.android.dex.analyzer.DexHeaderFormatAnalyzer.analyze(DexHeaderFormatAnalyzer.java:76)
            at ghidra.file.analyzers.FileFormatAnalyzer.added(FileFormatAnalyzer.java:52)
            at ghidra.app.plugin.core.analysis.AnalysisScheduler.runAnalyzer(AnalysisScheduler.java:186)
            at ghidra.app.plugin.core.analysis.AnalysisTask.applyTo(AnalysisTask.java:39)
            at ghidra.app.plugin.core.analysis.AutoAnalysisManager$AnalysisTaskWrapper.run(AutoAnalysisManager.java:688)
            at ghidra.app.plugin.core.analysis.AutoAnalysisManager.startAnalysis(AutoAnalysisManager.java:788)
            at ghidra.app.plugin.core.analysis.AutoAnalysisManager.startAnalysis(AutoAnalysisManager.java:667)
            at ghidra.app.plugin.core.analysis.AutoAnalysisManager.startAnalysis(AutoAnalysisManager.java:632)
            at ghidra.app.plugin.core.analysis.AnalysisBackgroundCommand.applyTo(AnalysisBackgroundCommand.java:58)
            at ghidra.framework.plugintool.mgr.BackgroundCommandTask.run(BackgroundCommandTask.java:102)
            at ghidra.framework.plugintool.mgr.ToolTaskManager.run(ToolTaskManager.java:315)
            at java.base/java.lang.Thread.run(Thread.java:829)

Fix this by only creating data if there is no data already defined.