### PR TITLE
Improve documentation for context variables

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
@@ -3571,6 +3571,20 @@ make the final decision about which form to generate. The setting of
 this state is (at least partially) out of the control of SLEIGH,
 although see the following sections.
 </para>
+<para>
+Note that a context variable is tied to a specific register (in the
+example above, it is <emphasis>statusreg</emphasis>). Although this
+register can be one that is used by the actual processor for the same
+purpose, it is often convenient to use a separate register, as
+context variables can be used for purposes where the real processor
+does not have an (exposed) register. Context variables are not updated
+in the semantic actions section of a constructor, only in the disassembly
+actions section (see below), which also makes using the same register
+awkward. Lastly, note that due to implementation constraints, the
+register associated with a context variable must have a size that is
+a multiple of 4 bytes, though each context variable itself can be any
+size up to 32 bits.
+</para>
 </sect2>
 <sect2 id="sleigh_local_change">
 <title>Local Context Change</title>

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
@@ -4,7 +4,7 @@
   <title>SLEIGH</title>
   <subtitle>A Language for Rapid Processor Specification</subtitle>
   <pubdate>Originally published December 16, 2005</pubdate>
-  <releaseinfo>Last updated October 28, 2020</releaseinfo>
+  <releaseinfo>Last updated July 16, 2021</releaseinfo>
 </info>
 <simplesect>
 <info>

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
@@ -3525,6 +3525,7 @@ define space ram type=ram_space size=4 default;
 define space register type=register_space size=4;
 define register offset=0 size=4 [ r0 r1 r2 r3 r4 r5 r6 r7 ];
 define register offset=0x100 size=4 [ s0 s1 s2 s3 s4 s5 s6 s7 ];
+define register offset=0x180 size=4 [ statusreg ];
 
 define token instr(16)
   op=(10,15) rreg1=(7,9) sreg1=(7,9) imm=(0,6)

--- a/GhidraDocs/languages/html/additionalpcode.html
+++ b/GhidraDocs/languages/html/additionalpcode.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <title>Additional P-CODE Operations</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="pseudo-ops.html" title="Pseudo P-CODE Operations">
@@ -36,7 +36,7 @@ introduced at a later stage by various analysis algorithms.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_multiequal"></a>MULTIEQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="multiequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="multiequal.htmltable"></a><table xml:id="multiequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -91,7 +91,7 @@ was last executed. All inputs and outputs must be the same size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_indirect"></a>INDIRECT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="indirect.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="indirect.htmltable"></a><table xml:id="indirect.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -152,7 +152,7 @@ to the operation was used or preserved.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_ptradd"></a>PTRADD</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="ptradd.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="ptradd.htmltable"></a><table xml:id="ptradd.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -210,7 +210,7 @@ and stores it in output.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_ptrsub"></a>PTRSUB</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="ptrsub.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="ptrsub.htmltable"></a><table xml:id="ptrsub.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -261,7 +261,7 @@ pointer to the subcomponent and stores it in output.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_cast"></a>CAST</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="cast.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="cast.htmltable"></a><table xml:id="cast.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -305,7 +305,7 @@ interpretation as a data-type changes at this point.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_insert"></a>INSERT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="insert.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="insert.htmltable"></a><table xml:id="insert.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -373,7 +373,7 @@ to SLEIGH <span class="bold"><strong>bitrange</strong></span> syntax such as inp
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_extract"></a>EXTRACT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="extract.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="extract.htmltable"></a><table xml:id="extract.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">

--- a/GhidraDocs/languages/html/pcodedescription.html
+++ b/GhidraDocs/languages/html/pcodedescription.html
@@ -4,7 +4,7 @@
 <title>P-Code Operation Reference</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="pcoderef.html" title="P-Code Reference Manual">
@@ -37,7 +37,7 @@ describing semantics in a processor specification file.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_copy"></a>COPY</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="copy.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="copy.htmltable"></a><table xml:id="copy.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -78,7 +78,7 @@ input0 and output must be the same.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_load"></a>LOAD</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="load.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="load.htmltable"></a><table xml:id="load.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -149,7 +149,7 @@ correct byte offset into the space.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_store"></a>STORE</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="store.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="store.htmltable"></a><table xml:id="store.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -212,7 +212,7 @@ correct byte offset into the space.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_branch"></a>BRANCH</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="branch.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="branch.htmltable"></a><table xml:id="branch.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -272,7 +272,7 @@ with index 8 by specifying a constant destination &#8220;address&#8221; of
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_cbranch"></a>CBRANCH</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="cbranch.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="cbranch.htmltable"></a><table xml:id="cbranch.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -322,7 +322,7 @@ relative branching</em></span>.  See the discussion for the
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_branchind"></a>BRANCHIND</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="branchind.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="branchind.htmltable"></a><table xml:id="branchind.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -364,7 +364,7 @@ relative branching is not possible with <span class="bold"><strong>BRANCHIND</st
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_call"></a>CALL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="call.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="call.htmltable"></a><table xml:id="call.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -428,7 +428,7 @@ into the call.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_callind"></a>CALLIND</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="callind.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="callind.htmltable"></a><table xml:id="callind.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -482,7 +482,7 @@ the parameters being passed to the logical call.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_return"></a>RETURN</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="return.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="return.htmltable"></a><table xml:id="return.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -534,7 +534,7 @@ subroutine.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_piece"></a>PIECE</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="piece.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="piece.htmltable"></a><table xml:id="piece.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -583,7 +583,7 @@ makes up the most significant part of the output.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_subpiece"></a>SUBPIECE</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="subpiece.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="subpiece.htmltable"></a><table xml:id="subpiece.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -634,7 +634,7 @@ truncated.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_popcount"></a>POPCOUNT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="popcount.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="popcount.htmltable"></a><table xml:id="popcount.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -678,7 +678,7 @@ count is zero extended into the output varnode.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_equal"></a>INT_EQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intequal.htmltable"></a><table xml:id="intequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -727,7 +727,7 @@ must have a size of 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_notequal"></a>INT_NOTEQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intnotequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intnotequal.htmltable"></a><table xml:id="intnotequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -776,7 +776,7 @@ and the output must have a size of 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_less"></a>INT_LESS</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intless.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intless.htmltable"></a><table xml:id="intless.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -824,7 +824,7 @@ same size, and the output must have a size of 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_sless"></a>INT_SLESS</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intsless.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intsless.htmltable"></a><table xml:id="intsless.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -872,7 +872,7 @@ the output must have a size of 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_lessequal"></a>INT_LESSEQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intlessequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intlessequal.htmltable"></a><table xml:id="intlessequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -920,7 +920,7 @@ same size, and the output must have a size of 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_slessequal"></a>INT_SLESSEQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intslessequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intslessequal.htmltable"></a><table xml:id="intslessequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -968,7 +968,7 @@ and the output must have a size of 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_zext"></a>INT_ZEXT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intzext.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intzext.htmltable"></a><table xml:id="intzext.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1012,7 +1012,7 @@ size of input.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_sext"></a>INT_SEXT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intsext.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intsext.htmltable"></a><table xml:id="intsext.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1057,7 +1057,7 @@ than the size of input0.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_add"></a>INT_ADD</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intadd.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intadd.htmltable"></a><table xml:id="intadd.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1108,7 +1108,7 @@ and <span class="bold"><strong>INT_SCARRY</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_sub"></a>INT_SUB</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intsub.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intsub.htmltable"></a><table xml:id="intsub.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1159,7 +1159,7 @@ and <span class="bold"><strong>INT_LESS</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_carry"></a>INT_CARRY</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intcarry.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intcarry.htmltable"></a><table xml:id="intcarry.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1208,7 +1208,7 @@ and output must be size 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_scarry"></a>INT_SCARRY</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intscarry.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intscarry.htmltable"></a><table xml:id="intscarry.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1257,7 +1257,7 @@ and output must be size 1.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_sborrow"></a>INT_SBORROW</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intsborrow.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intsborrow.htmltable"></a><table xml:id="intsborrow.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1308,7 +1308,7 @@ is <span class="bold"><strong>INT_LESS</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_2comp"></a>INT_2COMP</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="int2comp.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="int2comp.htmltable"></a><table xml:id="int2comp.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1351,7 +1351,7 @@ be the same size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_negate"></a>INT_NEGATE</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intnegate.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intnegate.htmltable"></a><table xml:id="intnegate.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1393,7 +1393,7 @@ the same size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_xor"></a>INT_XOR</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intxor.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intxor.htmltable"></a><table xml:id="intxor.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1439,7 +1439,7 @@ and input1. Both inputs and output must be the same size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_and"></a>INT_AND</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intand.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intand.htmltable"></a><table xml:id="intand.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1485,7 +1485,7 @@ output must be the same size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_or"></a>INT_OR</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intor.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intor.htmltable"></a><table xml:id="intor.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1531,7 +1531,7 @@ output must be the same size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_left"></a>INT_LEFT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intleft.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intleft.htmltable"></a><table xml:id="intleft.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1582,7 +1582,7 @@ size. Input1 can be any size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_right"></a>INT_RIGHT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intright.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intright.htmltable"></a><table xml:id="intright.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1633,7 +1633,7 @@ the same size. Input1 can be any size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_sright"></a>INT_SRIGHT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intsright.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intsright.htmltable"></a><table xml:id="intsright.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1686,7 +1686,7 @@ any size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_mult"></a>INT_MULT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intmult.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intmult.htmltable"></a><table xml:id="intmult.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1737,7 +1737,7 @@ sign-extended to the desired size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_div"></a>INT_DIV</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intdiv.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intdiv.htmltable"></a><table xml:id="intdiv.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1787,7 +1787,7 @@ the <span class="bold"><strong>INT_DIV</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_rem"></a>INT_REM</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intrem.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intrem.htmltable"></a><table xml:id="intrem.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1838,7 +1838,7 @@ and <span class="bold"><strong>INT_ADD</strong></span> operations.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_sdiv"></a>INT_SDIV</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intsdiv.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intsdiv.htmltable"></a><table xml:id="intsdiv.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1888,7 +1888,7 @@ be used before the <span class="bold"><strong>INT_SDIV</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int_srem"></a>INT_SREM</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="intsrem.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="intsrem.htmltable"></a><table xml:id="intsrem.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1939,7 +1939,7 @@ and <span class="bold"><strong>INT_ADD</strong></span> operations.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_bool_negate"></a>BOOL_NEGATE</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="boolnegate.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="boolnegate.htmltable"></a><table xml:id="boolnegate.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -1984,7 +1984,7 @@ or <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_bool_xor"></a>BOOL_XOR</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="boolxor.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="boolxor.htmltable"></a><table xml:id="boolxor.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2034,7 +2034,7 @@ or <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_bool_and"></a>BOOL_AND</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="booland.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="booland.htmltable"></a><table xml:id="booland.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2084,7 +2084,7 @@ or <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_bool_or"></a>BOOL_OR</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="boolor.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="boolor.htmltable"></a><table xml:id="boolor.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2134,7 +2134,7 @@ or <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_equal"></a>FLOAT_EQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatequal.htmltable"></a><table xml:id="floatequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2184,7 +2184,7 @@ to <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_notequal"></a>FLOAT_NOTEQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatnotequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatnotequal.htmltable"></a><table xml:id="floatnotequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2234,7 +2234,7 @@ to <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_less"></a>FLOAT_LESS</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatless.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatless.htmltable"></a><table xml:id="floatless.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2284,7 +2284,7 @@ to <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_lessequal"></a>FLOAT_LESSEQUAL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatlessequal.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatlessequal.htmltable"></a><table xml:id="floatlessequal.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2334,7 +2334,7 @@ to <span class="emphasis"><em>false</em></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_add"></a>FLOAT_ADD</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatadd.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatadd.htmltable"></a><table xml:id="floatadd.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2384,7 +2384,7 @@ occurs, output is set to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_sub"></a>FLOAT_SUB</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatsub.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatsub.htmltable"></a><table xml:id="floatsub.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2434,7 +2434,7 @@ occurs, output is set to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_mult"></a>FLOAT_MULT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatmult.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatmult.htmltable"></a><table xml:id="floatmult.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2484,7 +2484,7 @@ occurs, output is set to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_div"></a>FLOAT_DIV</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatdiv.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatdiv.htmltable"></a><table xml:id="floatdiv.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2534,7 +2534,7 @@ occurs, output is set to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_neg"></a>FLOAT_NEG</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatneg.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatneg.htmltable"></a><table xml:id="floatneg.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2578,7 +2578,7 @@ to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_abs"></a>FLOAT_ABS</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatabs.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatabs.htmltable"></a><table xml:id="floatabs.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2621,7 +2621,7 @@ to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_sqrt"></a>FLOAT_SQRT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatsqrt.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatsqrt.htmltable"></a><table xml:id="floatsqrt.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2664,7 +2664,7 @@ to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_ceil"></a>FLOAT_CEIL</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatceil.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatceil.htmltable"></a><table xml:id="floatceil.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2709,7 +2709,7 @@ to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_floor"></a>FLOAT_FLOOR</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatfloor.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatfloor.htmltable"></a><table xml:id="floatfloor.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2756,7 +2756,7 @@ to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_round"></a>FLOAT_ROUND</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatround.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatround.htmltable"></a><table xml:id="floatround.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2803,7 +2803,7 @@ to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float_nan"></a>FLOAT_NAN</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="floatnan.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="floatnan.htmltable"></a><table xml:id="floatnan.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2845,7 +2845,7 @@ size 1, and input0 can be any size.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_int2float"></a>INT2FLOAT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="int2float.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="int2float.htmltable"></a><table xml:id="int2float.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2889,7 +2889,7 @@ precision.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_float2float"></a>FLOAT2FLOAT</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="float2float.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="float2float.htmltable"></a><table xml:id="float2float.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -2935,7 +2935,7 @@ to <span class="bold"><strong>NaN</strong></span>.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_trunc"></a>TRUNC</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="trunc.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="trunc.htmltable"></a><table xml:id="trunc.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">

--- a/GhidraDocs/languages/html/pcoderef.html
+++ b/GhidraDocs/languages/html/pcoderef.html
@@ -4,7 +4,7 @@
 <title>P-Code Reference Manual</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="next" href="pcodedescription.html" title="P-Code Operation Reference">
 </head>
@@ -25,13 +25,13 @@
 <div class="titlepage">
 <div>
 <div><h1 class="title">
-<a name="idm140035470386944"></a>P-Code Reference Manual</h1></div>
+<a name="idm1"></a>P-Code Reference Manual</h1></div>
 <div><p class="releaseinfo">Last updated September 5, 2019</p></div>
 </div>
 <hr>
 </div>
 <div class="table">
-<a name="mytoc.htmltable"></a><table width="90%" frame="none">
+<a name="mytoc.htmltable"></a><table xml:id="mytoc.htmltable" width="90%" frame="none">
 <col width="25%">
 <col width="25%">
 <col width="25%">
@@ -215,7 +215,7 @@ The core concepts of p-code are:
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140035470234080"></a>Address Space</h3></div></div></div>
+<a name="idm200"></a>Address Space</h3></div></div></div>
 <p>
 The <span class="bold"><strong>address space</strong></span> for p-code is a generalization
 of RAM. It is defined simply as an indexed sequence of bytes that can
@@ -256,7 +256,7 @@ any of the other p-code operations.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140035470224608"></a>Varnode</h3></div></div></div>
+<a name="idm214"></a>Varnode</h3></div></div></div>
 <p>
 A <span class="bold"><strong>varnode</strong></span> is a generalization of
 either a register or a memory location. It is represented by the formal triple:
@@ -303,7 +303,7 @@ on them by the p-code operations that use them.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140035470216864"></a>P-code Operation</h3></div></div></div>
+<a name="idm229"></a>P-code Operation</h3></div></div></div>
 <p>
 A <span class="bold"><strong>p-code operation</strong></span> is the analog of a
 machine instruction. All p-code operations have the same basic format

--- a/GhidraDocs/languages/html/pseudo-ops.html
+++ b/GhidraDocs/languages/html/pseudo-ops.html
@@ -4,7 +4,7 @@
 <title>Pseudo P-CODE Operations</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="pcodedescription.html" title="P-Code Operation Reference">
@@ -40,7 +40,7 @@ placed on other p-code operations that all effects must be explicit.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_userdefined"></a>USERDEFINED</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="userdefined.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="userdefined.htmltable"></a><table xml:id="userdefined.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -112,7 +112,7 @@ still have normal data-flow and can be manipulated symbolically.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_cpoolref"></a>CPOOLREF</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="cpoolref.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="cpoolref.htmltable"></a><table xml:id="cpoolref.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">
@@ -174,7 +174,7 @@ of emulation and analysis, are necessarily architecture dependent.
 <div class="titlepage"><div><div><h3 class="title">
 <a name="cpui_new"></a>NEW</h3></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="new.htmltable"></a><table frame="above" width="80%" rules="groups">
+<a name="new.htmltable"></a><table xml:id="new.htmltable" frame="above" width="80%" rules="groups">
 <col width="23%">
 <col width="15%">
 <col width="61%">

--- a/GhidraDocs/languages/html/reference.html
+++ b/GhidraDocs/languages/html/reference.html
@@ -4,7 +4,7 @@
 <title>Syntax Reference</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="additionalpcode.html" title="Additional P-CODE Operations">
@@ -26,7 +26,7 @@
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
 <a name="reference"></a>Syntax Reference</h2></div></div></div>
 <div class="informalexample"><div class="table">
-<a name="ref.htmltable"></a><table width="90%" frame="box" rules="rows">
+<a name="ref.htmltable"></a><table xml:id="ref.htmltable" width="90%" frame="box" rules="rows">
 <col width="25%">
 <col width="25%">
 <col width="50%">
@@ -45,7 +45,7 @@
   <td>LOAD</td>
   <td>
     <div class="table">
-<a name="loadtmp.htmltable"></a><table frame="none"><tbody>
+<a name="loadtmp.htmltable"></a><table xml:id="loadtmp.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">* v1</code></td>
       </tr>
@@ -68,7 +68,7 @@
   <td>STORE</td>
   <td>
     <div class="table">
-<a name="storetmp.htmltable"></a><table frame="none"><tbody>
+<a name="storetmp.htmltable"></a><table xml:id="storetmp.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">*v0 = v1;</code></td>
       </tr>
@@ -153,7 +153,7 @@
   <td>INT_LESS</td>
   <td>
     <div class="table">
-<a name="less.htmltable"></a><table frame="none"><tbody>
+<a name="less.htmltable"></a><table xml:id="less.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">v0 &lt; v1</code></td>
       </tr>
@@ -169,7 +169,7 @@
   <td>INT_SLESS</td>
   <td>
     <div class="table">
-<a name="sless.htmltable"></a><table frame="none"><tbody>
+<a name="sless.htmltable"></a><table xml:id="sless.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">v0 s&lt; v1</code></td>
       </tr>
@@ -185,7 +185,7 @@
   <td>INT_LESSEQUAL</td>
   <td>
     <div class="table">
-<a name="lessequal.htmltable"></a><table frame="none"><tbody>
+<a name="lessequal.htmltable"></a><table xml:id="lessequal.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">v0 &lt;= v1</code></td>
       </tr>
@@ -201,7 +201,7 @@
   <td>INT_SLESSEQUAL</td>
   <td>
     <div class="table">
-<a name="slessequal.htmltable"></a><table frame="none"><tbody>
+<a name="slessequal.htmltable"></a><table xml:id="slessequal.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">v0 s&lt;= v1</code></td>
       </tr>
@@ -347,7 +347,7 @@
   <td>FLOAT_LESS</td>
   <td>
     <div class="table">
-<a name="floatlesstmp.htmltable"></a><table frame="none"><tbody>
+<a name="floatlesstmp.htmltable"></a><table xml:id="floatlesstmp.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">v0 f&lt; v1</code></td>
       </tr>
@@ -363,7 +363,7 @@
   <td>FLOAT_LESSEQUAL</td>
   <td>
     <div class="table">
-<a name="floatlessequaltmp.htmltable"></a><table frame="none"><tbody>
+<a name="floatlessequaltmp.htmltable"></a><table xml:id="floatlessequaltmp.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">v0 f&lt;= v1</code></td>
       </tr>
@@ -454,7 +454,7 @@
   <td>NEW</td>
   <td>
     <div class="table">
-<a name="newtmp.htmltable"></a><table frame="none"><tbody>
+<a name="newtmp.htmltable"></a><table xml:id="newtmp.htmltable" frame="none"><tbody>
 <tr>
         <td><code class="code">newobject(v0)</code></td>
       </tr>

--- a/GhidraDocs/languages/html/sleigh.html
+++ b/GhidraDocs/languages/html/sleigh.html
@@ -4,7 +4,7 @@
 <title>SLEIGH</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="next" href="sleigh_layout.html" title="2. Basic Specification Layout">
 </head>
@@ -25,9 +25,9 @@
 <div class="titlepage">
 <div>
 <div><h1 class="title">
-<a name="idm140526921073488"></a>SLEIGH</h1></div>
+<a name="idm1"></a>SLEIGH</h1></div>
 <div><h3 class="subtitle"><i>A Language for Rapid Processor Specification</i></h3></div>
-<div><p class="releaseinfo">Last updated October 28, 2020</p></div>
+<div><p class="releaseinfo">Last updated July 16, 2021</p></div>
 <div><p class="pubdate">Originally published December 16, 2005</p></div>
 </div>
 <hr>
@@ -35,51 +35,51 @@
 <div class="toc">
 <p><b>Table of Contents</b></p>
 <dl class="toc">
-<dt><span class="sect1"><a href="sleigh.html#idm140526921048752">1. Introduction to P-Code</a></span></dt>
+<dt><span class="sect1"><a href="sleigh.html#idm22">1. Introduction to P-Code</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh.html#idm140526921040400">1.1. Address Spaces</a></span></dt>
+<dt><span class="sect2"><a href="sleigh.html#idm41">1.1. Address Spaces</a></span></dt>
 <dt><span class="sect2"><a href="sleigh.html#sleigh_varnodes">1.2. Varnodes</a></span></dt>
-<dt><span class="sect2"><a href="sleigh.html#idm140526921024752">1.3. Operations</a></span></dt>
+<dt><span class="sect2"><a href="sleigh.html#idm75">1.3. Operations</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_layout.html">2. Basic Specification Layout</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920986416">2.1. Comments</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920983776">2.2. Identifiers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920982144">2.3. Strings</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920980384">2.4. Integers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920976000">2.5. White Space</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm144">2.1. Comments</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm149">2.2. Identifiers</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm152">2.3. Strings</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm155">2.4. Integers</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm163">2.5. White Space</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_preprocessing.html">3. Preprocessing</a></span></dt>
 <dd><dl>
 <dt><span class="sect2"><a href="sleigh_preprocessing.html#sleigh_including_files">3.1. Including Files</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm140526920968368">3.2. Preprocessor Macros</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm140526920961536">3.3. Conditional Compilation</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm176">3.2. Preprocessor Macros</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm187">3.3. Conditional Compilation</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_definitions.html">4. Basic Definitions</a></span></dt>
 <dd><dl>
 <dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_endianess_definition">4.1. Endianess Definition</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526921098128">4.2. Alignment Definition</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526921095104">4.3. Space Definitions</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm250">4.2. Alignment Definition</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm256">4.3. Space Definitions</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_naming_registers">4.4. Naming Registers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526920875744">4.5. Bit Range Registers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526920863712">4.6. User-Defined Operations</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm319">4.5. Bit Range Registers</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm340">4.6. User-Defined Operations</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_symbols.html">5. Introduction to Symbols</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_symbols.html#idm140526920845152">5.1. Notes on Namespaces</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_symbols.html#idm376">5.1. Notes on Namespaces</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_symbols.html#sleigh_predefined_symbols">5.2. Predefined Symbols</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_tokens.html">6. Tokens and Fields</a></span></dt>
 <dd><dl>
 <dt><span class="sect2"><a href="sleigh_tokens.html#sleigh_defining_tokens">6.1. Defining Tokens and Fields</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_tokens.html#idm140526920800080">6.2. Fields as Family Symbols</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_tokens.html#idm140526920794256">6.3. Attaching Alternate Meanings to Fields</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_tokens.html#idm468">6.2. Fields as Family Symbols</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_tokens.html#idm476">6.3. Attaching Alternate Meanings to Fields</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_tokens.html#sleigh_context_variables">6.4. Context Variables</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_constructors.html">7. Constructors</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920750848">7.1. The Five Sections of a Constructor</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920746272">7.2. The Table Header</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm552">7.1. The Five Sections of a Constructor</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm562">7.2. The Table Header</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_display_section">7.3. The Display Section</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_bit_pattern">7.4. The Bit Pattern Section</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_disassembly_actions">7.5. Disassembly Actions Section</a></span></dt>
@@ -87,12 +87,12 @@
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_semantic_section">7.7. The Semantic Section</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_tables">7.8. Tables</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_macros">7.9. P-code Macros</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920290640">7.10. Build Directives</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920281024">7.11. Delay Slot Directives</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm1345">7.10. Build Directives</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm1358">7.11. Delay Slot Directives</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_context.html">8. Using Context</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_context.html#idm140526920261472">8.1. Basic Use of Context Variables</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_context.html#idm1389">8.1. Basic Use of Context Variables</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_context.html#sleigh_local_change">8.2. Local Context Change</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_context.html#sleigh_global_change">8.3. Global Context Change</a></span></dt>
 </dl></dd>
@@ -101,7 +101,7 @@
 </div>
 <div class="simplesect">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="idm140526921055904"></a>History</h2></div></div></div>
+<a name="idm7"></a>History</h2></div></div></div>
 <p>
   This document describes the syntax for the SLEIGH processor
   specification language, which was developed for the GHIDRA
@@ -129,7 +129,7 @@
 </div>
 <div class="simplesect">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="idm140526921052720"></a>Overview</h2></div></div></div>
+<a name="idm12"></a>Overview</h2></div></div></div>
 <p>
 SLEIGH is a language for describing the instruction sets of general
 purpose microprocessors, in order to facilitate the reverse
@@ -162,7 +162,7 @@ Italics are used when defining terms and for named entities. Bold is used for SL
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="idm140526921048752"></a>1. Introduction to P-Code</h2></div></div></div>
+<a name="idm22"></a>1. Introduction to P-Code</h2></div></div></div>
 <p>
 Although p-code is a distinct language from SLEIGH, because a major
 purpose of SLEIGH is to specify the translation from machine code to
@@ -221,7 +221,7 @@ respectively.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921040400"></a>1.1. Address Spaces</h3></div></div></div>
+<a name="idm41"></a>1.1. Address Spaces</h3></div></div></div>
 <p>
 An <span class="emphasis"><em>address</em></span> space for p-code is a generalization of
 the indexed memory (RAM) that a typical processor has access to, and
@@ -322,7 +322,7 @@ must be provided and enforced by the specification designer.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921024752"></a>1.3. Operations</h3></div></div></div>
+<a name="idm75"></a>1.3. Operations</h3></div></div></div>
 <p>
 P-code is intended to emulate a target processor by substituting a
 sequence of p-code operations for each machine instruction. Thus every
@@ -353,7 +353,7 @@ general purpose processor instruction sets. They break up into groups.
 <div class="informalexample">
 <div class="table">
 <a name="ops.htmltable"></a><p class="title"><b>Table 1. P-code Operations</b></p>
-<div class="table-contents"><table width="70%" frame="box" rules="all">
+<div class="table-contents"><table xml:id="ops.htmltable" width="70%" frame="box" rules="all">
 <col width="40%">
 <col width="60%">
 <thead><tr>

--- a/GhidraDocs/languages/html/sleigh_constructors.html
+++ b/GhidraDocs/languages/html/sleigh_constructors.html
@@ -4,7 +4,7 @@
 <title>7. Constructors</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh_tokens.html" title="6. Tokens and Fields">
@@ -60,7 +60,7 @@ multiple constructors into a single table are addressed in <a class="xref" href=
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920750848"></a>7.1. The Five Sections of a Constructor</h3></div></div></div>
+<a name="idm552"></a>7.1. The Five Sections of a Constructor</h3></div></div></div>
 <p>
 A single complex statement in the specification file describes a
 constructor. This statement is always made up of five distinct
@@ -92,7 +92,7 @@ in turn.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920746272"></a>7.2. The Table Header</h3></div></div></div>
+<a name="idm562"></a>7.2. The Table Header</h3></div></div></div>
 <p>
 Every constructor must be part of a table, which is the element with
 an actual family symbol identifier associated with it. So each
@@ -230,7 +230,7 @@ no such requirement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920716688"></a>7.3.2. The '^' character</h4></div></div></div>
+<a name="idm615"></a>7.3.2. The '^' character</h4></div></div></div>
 <p>
 The &#8216;^&#8217; character in the display section is used to separate
 identifiers from other characters where there shouldn&#8217;t be white space
@@ -278,7 +278,7 @@ to <span class="emphasis"><em>match</em></span> the constructor being defined.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920705248"></a>7.4.1. Constraints</h4></div></div></div>
+<a name="idm635"></a>7.4.1. Constraints</h4></div></div></div>
 <p>
 The patterns required for processor specifications can almost always
 be described as a mask and value pair. Given a specific instruction
@@ -337,7 +337,7 @@ requires two or more mask/value style checks to correctly implement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920691312"></a>7.4.3. Defining Operands and Invoking Subtables</h4></div></div></div>
+<a name="idm660"></a>7.4.3. Defining Operands and Invoking Subtables</h4></div></div></div>
 <p>
 The principle way of defining a constructor operand, left undefined
 from the display section, is done in the bit pattern section. If an
@@ -396,7 +396,7 @@ statement of the grouping of old symbols into the new constructor.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920679904"></a>7.4.4. Variable Length Instructions</h4></div></div></div>
+<a name="idm678"></a>7.4.4. Variable Length Instructions</h4></div></div></div>
 <p>
 There are some additional complexities to designing a specification
 for a processor with variable length instructions. Some initial
@@ -419,7 +419,7 @@ designer control over how tokens fit together.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920676432"></a>7.4.4.1. The ';' Operator</h5></div></div></div>
+<a name="idm681"></a>7.4.4.1. The ';' Operator</h5></div></div></div>
 <p>
 The most important operator for patterns defining variable length
 instructions is the concatenation operator &#8216;;&#8217;. When building a
@@ -481,7 +481,7 @@ operator, so parentheses may be necessary to get the intended meaning.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920661120"></a>7.4.4.2. The '...' Operator</h5></div></div></div>
+<a name="idm708"></a>7.4.4.2. The '...' Operator</h5></div></div></div>
 <p>
 The ellipsis operator &#8216;...&#8217; is used to satisfy the token matching
 requirements of the &#8216;&amp;&#8217; and &#8216;|&#8217; operators (described in the previous
@@ -557,7 +557,7 @@ don&#8217;t quite match the assembly.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920640560"></a>7.4.6. Empty Patterns</h4></div></div></div>
+<a name="idm746"></a>7.4.6. Empty Patterns</h4></div></div></div>
 <p>
 Occasionally there is a need for an empty pattern when building
 tables. An empty pattern matches everything. There is a predefined
@@ -567,7 +567,7 @@ to indicate an empty pattern.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920638720"></a>7.4.7. Advanced Constraints</h4></div></div></div>
+<a name="idm750"></a>7.4.7. Advanced Constraints</h4></div></div></div>
 <p>
 A constraint does not have to be of the form &#8220;field = constant&#8221;,
 although this is almost always what is needed. In certain situations,
@@ -593,7 +593,7 @@ the following:
 <div class="informalexample">
 <div class="table">
 <a name="constraints.htmltable"></a><p class="title"><b>Table 3. Constraint Operators</b></p>
-<div class="table-contents"><table width="50%" frame="box" rules="all">
+<div class="table-contents"><table xml:id="constraints.htmltable" width="50%" frame="box" rules="all">
 <col width="50%">
 <col width="50%">
 <thead><tr>
@@ -720,7 +720,7 @@ is built up out of the following typical operators:
 <div class="informalexample">
 <div class="table">
 <a name="patexp.htmltable"></a><p class="title"><b>Table 4. Pattern Expression Operators</b></p>
-<div class="table-contents"><table width="50%" frame="box" rules="all">
+<div class="table-contents"><table xml:id="patexp.htmltable" width="50%" frame="box" rules="all">
 <col width="50%">
 <col width="50%">
 <thead><tr>
@@ -756,7 +756,7 @@ is built up out of the following typical operators:
   <td>Bitwise and</td>
   <td>
     <div class="informaltable">
-<a name="bitwiseand.htmltable"></a><table frame="none"><tbody>
+<a name="bitwiseand.htmltable"></a><table xml:id="bitwiseand.htmltable" frame="none"><tbody>
 <tr>
         <td>$and</td>
       </tr>
@@ -771,7 +771,7 @@ is built up out of the following typical operators:
   <td>Bitwise or</td>
   <td>
     <div class="informaltable">
-<a name="bitwiseor.htmltable"></a><table frame="none"><tbody>
+<a name="bitwiseor.htmltable"></a><table xml:id="bitwiseor.htmltable" frame="none"><tbody>
 <tr>
         <td>$or</td>
       </tr>
@@ -786,7 +786,7 @@ is built up out of the following typical operators:
   <td>Bitwise xor</td>
   <td>
     <div class="informaltable">
-<a name="bitwisexor.htmltable"></a><table frame="none"><tbody>
+<a name="bitwisexor.htmltable"></a><table xml:id="bitwisexor.htmltable" frame="none"><tbody>
 <tr>
         <td>$xor</td>
       </tr>
@@ -939,7 +939,7 @@ varnode is <span class="emphasis"><em>r1</em></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920530304"></a>7.7.1. Expressions</h4></div></div></div>
+<a name="idm919"></a>7.7.1. Expressions</h4></div></div></div>
 <p>
 Expressions are built out of symbols and the binary and unary
 operators listed in <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table 5. Semantic Expression Operators and Syntax">Table 5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
@@ -954,7 +954,7 @@ within expressions to affect this order.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920527872"></a>7.7.1.1. Arithmetic, Logical and Boolean Operators</h5></div></div></div>
+<a name="idm924"></a>7.7.1.1. Arithmetic, Logical and Boolean Operators</h5></div></div></div>
 <p>
 For the most part these operators should be familiar to software
 developers. The only real differences arise from the fact that
@@ -1017,7 +1017,7 @@ set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920515552"></a>7.7.1.3. Extension</h5></div></div></div>
+<a name="idm944"></a>7.7.1.3. Extension</h5></div></div></div>
 <p>
 Most processors have instructions that extend small values into big
 values, and many instructions do these minor data manipulations
@@ -1039,7 +1039,7 @@ the <span class="bold"><strong>sext</strong></span> operator.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920508832"></a>7.7.1.4. Truncation</h5></div></div></div>
+<a name="idm957"></a>7.7.1.4. Truncation</h5></div></div></div>
 <p>
 There are two forms of syntax indicating a truncation of the input
 varnode. In one the varnode is followed by a colon &#8216;:&#8217; and an integer
@@ -1169,7 +1169,7 @@ the offset portion of the address, and to copy the desired value, the
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920484032"></a>7.7.1.7. Managed Code Operations</h5></div></div></div>
+<a name="idm1005"></a>7.7.1.7. Managed Code Operations</h5></div></div></div>
 <p>
 SLEIGH provides basic support for instructions where encoding and context
 don't provide a complete description of the semantics. This is the case
@@ -1231,7 +1231,7 @@ define pcodeop arctan;
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920471120"></a>7.7.2. Statements</h4></div></div></div>
+<a name="idm1027"></a>7.7.2. Statements</h4></div></div></div>
 <p>
 We describe the types of semantic statements that are allowed in SLEIGH.
 </p>
@@ -1305,7 +1305,7 @@ and may be enforced in future compiler versions.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920458176"></a>7.7.2.2. Storage Statements</h5></div></div></div>
+<a name="idm1049"></a>7.7.2.2. Storage Statements</h5></div></div></div>
 <p>
 SLEIGH supports fairly standard <span class="emphasis"><em>storage statement</em></span>
 syntax to complement the load operator. The left-hand side of an
@@ -1336,7 +1336,7 @@ attribute is set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920452240"></a>7.7.2.3. Exports</h5></div></div></div>
+<a name="idm1059"></a>7.7.2.3. Exports</h5></div></div></div>
 <p>
 The semantic section doesn&#8217;t just specify how to generate p-code for a
 constructor. Except for those constructors in the root table, this
@@ -1388,7 +1388,7 @@ varnode being modified to be exported as an integer constant.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920441008"></a>7.7.2.4. Dynamic References</h5></div></div></div>
+<a name="idm1078"></a>7.7.2.4. Dynamic References</h5></div></div></div>
 <p>
 The only other operator allowed as part of
 an <span class="bold"><strong>export</strong></span> statement, is the &#8216;*&#8217;
@@ -1447,7 +1447,7 @@ levels.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920427360"></a>7.7.2.5. Branching Statements</h5></div></div></div>
+<a name="idm1102"></a>7.7.2.5. Branching Statements</h5></div></div></div>
 <p>
 This section discusses statements that generate p-code branching
 operations. These are listed in <a class="xref" href="sleigh_ref.html#branchref.htmltable" title="Table 7. Branching Statements">Table 7, &#8220;Branching Statements&#8221;</a>, in the Appendix.
@@ -1802,7 +1802,7 @@ each followed by a variation which corrects the error.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920360336"></a>7.7.4. Unimplemented Semantics</h4></div></div></div>
+<a name="idm1222"></a>7.7.4. Unimplemented Semantics</h4></div></div></div>
 <p>
 The semantic section must be present for every constructor in the
 specification. But the designer can leave the semantics explicitly
@@ -1962,7 +1962,7 @@ should generally be avoided.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920333184"></a>7.8.2. Specific Symbol Trees</h4></div></div></div>
+<a name="idm1272"></a>7.8.2. Specific Symbol Trees</h4></div></div></div>
 <p>
 When the SLEIGH parser analyzes an instruction, it starts with the
 root symbol <span class="emphasis"><em>instruction</em></span>, and decides which of the
@@ -2045,7 +2045,7 @@ and p-code for these encodings by walking the trees.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920314640"></a>7.8.2.1. Disassembly Trees</h5></div></div></div>
+<a name="idm1308"></a>7.8.2.1. Disassembly Trees</h5></div></div></div>
 <p>
 If the nodes of each tree are replaced with the display information of
 the corresponding specific symbol, we see how the disassembly
@@ -2068,7 +2068,7 @@ statements corresponding to the original instruction encodings.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920308256"></a>7.8.2.2. P-code Trees</h5></div></div></div>
+<a name="idm1319"></a>7.8.2.2. P-code Trees</h5></div></div></div>
 <p>
 A similar procedure produces the resulting p-code translation of the
 instruction. If each node in the specific symbol tree is replaced with
@@ -2147,7 +2147,7 @@ directive however should not be used in a macro.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920290640"></a>7.10. Build Directives</h3></div></div></div>
+<a name="idm1345"></a>7.10. Build Directives</h3></div></div></div>
 <p>
 Because the nodes of a specific symbol tree are traversed in a
 depth-first order, the p-code for a child node in general comes before
@@ -2202,7 +2202,7 @@ normal action of the instruction.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920281024"></a>7.11. Delay Slot Directives</h3></div></div></div>
+<a name="idm1358"></a>7.11. Delay Slot Directives</h3></div></div></div>
 <p>
 For processors with a pipe-lined architecture, multiple instructions
 are typically executing simultaneously. This can lead to processor

--- a/GhidraDocs/languages/html/sleigh_context.html
+++ b/GhidraDocs/languages/html/sleigh_context.html
@@ -4,7 +4,7 @@
 <title>8. Using Context</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh_constructors.html" title="7. Constructors">
@@ -85,7 +85,7 @@ whose encodings are otherwise the same.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920261472"></a>8.1. Basic Use of Context Variables</h3></div></div></div>
+<a name="idm1389"></a>8.1. Basic Use of Context Variables</h3></div></div></div>
 <p>
 Suppose a processor supports the use of two different sets of
 registers in its main addressing mode, based on the setting of a
@@ -100,6 +100,7 @@ define space ram type=ram_space size=4 default;
 define space register type=register_space size=4;
 define register offset=0 size=4 [ r0 r1 r2 r3 r4 r5 r6 r7 ];
 define register offset=0x100 size=4 [ s0 s1 s2 s3 s4 s5 s6 s7 ];
+define register offset=0x180 size=4 [ statusreg ];
 
 define token instr(16)
   op=(10,15) rreg1=(7,9) sreg1=(7,9) imm=(0,6)
@@ -144,6 +145,20 @@ state associated with the <span class="emphasis"><em>mode</em></span> variable t
 make the final decision about which form to generate. The setting of
 this state is (at least partially) out of the control of SLEIGH,
 although see the following sections.
+</p>
+<p>
+Note that a context variable is tied to a specific register (in the
+example above, it is <span class="emphasis"><em>statusreg</em></span>). Although this
+register can be one that is used by the actual processor for the same
+purpose, it is often convenient to use a separate register, as
+context variables can be used for purposes where the real processor
+does not have an (exposed) register. Context variables are not updated
+in the semantic actions section of a constructor, only in the disassembly
+actions section (see below), which also makes using the same register
+awkward. Lastly, note that due to implementation constraints, the
+register associated with a context variable must have a size that is
+a multiple of 4 bytes, though each context variable itself can be any
+size up to 32 bits.
 </p>
 </div>
 <div class="sect2">

--- a/GhidraDocs/languages/html/sleigh_definitions.html
+++ b/GhidraDocs/languages/html/sleigh_definitions.html
@@ -4,7 +4,7 @@
 <title>4. Basic Definitions</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh_preprocessing.html" title="3. Preprocessing">
@@ -56,7 +56,7 @@ otherwise the specification language hides endianess issues.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921098128"></a>4.2. Alignment Definition</h3></div></div></div>
+<a name="idm250"></a>4.2. Alignment Definition</h3></div></div></div>
 <p>
 An alignment definition looks like
 </p>
@@ -73,7 +73,7 @@ instruction as an error.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921095104"></a>4.3. Space Definitions</h3></div></div></div>
+<a name="idm256"></a>4.3. Space Definitions</h3></div></div></div>
 <p>
 The definition of an address space looks like
 </p>
@@ -228,7 +228,7 @@ define register offset=0 size=1
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920875744"></a>4.5. Bit Range Registers</h3></div></div></div>
+<a name="idm319"></a>4.5. Bit Range Registers</h3></div></div></div>
 <p>
 Many processors define registers that either consist of a single bit
 or otherwise don't use an integral number of bytes. A recurring
@@ -299,7 +299,7 @@ used as an alternate syntax for defining overlapping registers.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920863712"></a>4.6. User-Defined Operations</h3></div></div></div>
+<a name="idm340"></a>4.6. User-Defined Operations</h3></div></div></div>
 <p>
 The specification designer can define new p-code operations using
 a <span class="bold"><strong>define pcodeop</strong></span> statement.  This

--- a/GhidraDocs/languages/html/sleigh_layout.html
+++ b/GhidraDocs/languages/html/sleigh_layout.html
@@ -4,7 +4,7 @@
 <title>2. Basic Specification Layout</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh.html" title="SLEIGH">
@@ -36,7 +36,7 @@ by the compiler.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920986416"></a>2.1. Comments</h3></div></div></div>
+<a name="idm144"></a>2.1. Comments</h3></div></div></div>
 <p>
 Comments start with the &#8216;#&#8217; character and continue to the end of the
 line. Comments can appear anywhere except the <span class="emphasis"><em>display section</em></span> of a
@@ -46,7 +46,7 @@ interpreted as something that should be printed in disassembly.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920983776"></a>2.2. Identifiers</h3></div></div></div>
+<a name="idm149"></a>2.2. Identifiers</h3></div></div></div>
 <p>
 Identifiers are made up of letters a-z, capitals A-Z, digits 0-9 and
 the characters &#8216;.&#8217; and &#8216;_&#8217;. An identifier can use these characters in
@@ -55,7 +55,7 @@ any order and for any length, but it must not start with a digit.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920982144"></a>2.3. Strings</h3></div></div></div>
+<a name="idm152"></a>2.3. Strings</h3></div></div></div>
 <p>
 String literals can be used, when specifying names and when specifying
 how disassembly should be printed, so that special characters are
@@ -66,7 +66,7 @@ meaning.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920980384"></a>2.4. Integers</h3></div></div></div>
+<a name="idm155"></a>2.4. Integers</h3></div></div></div>
 <p>
 Integers are specified either in a decimal format or in a standard
 <span class="emphasis"><em>C-style</em></span> hexadecimal format by prepending the
@@ -92,7 +92,7 @@ integers internally with 64 bits of precision.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920976000"></a>2.5. White Space</h3></div></div></div>
+<a name="idm163"></a>2.5. White Space</h3></div></div></div>
 <p>
 White space characters include space, tab, line-feed, vertical
 line-feed, and carriage-return (&#8216; &#8216;, &#8216;\t&#8217;, &#8216;\r&#8217;, &#8216;\v&#8217;,

--- a/GhidraDocs/languages/html/sleigh_preprocessing.html
+++ b/GhidraDocs/languages/html/sleigh_preprocessing.html
@@ -4,7 +4,7 @@
 <title>3. Preprocessing</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh_layout.html" title="2. Basic Specification Layout">
@@ -54,7 +54,7 @@ own <span class="bold"><strong>@include</strong></span> directives.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920968368"></a>3.2. Preprocessor Macros</h3></div></div></div>
+<a name="idm176"></a>3.2. Preprocessor Macros</h3></div></div></div>
 <p>
 SLEIGH allows simple (unparameterized) macro definitions and
 expansions. A macro definition occurs on one line and starts with
@@ -85,7 +85,7 @@ definition of a macro from that point on in the file.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920961536"></a>3.3. Conditional Compilation</h3></div></div></div>
+<a name="idm187"></a>3.3. Conditional Compilation</h3></div></div></div>
 <p>
 SLEIGH supports several directives that allow conditional inclusion of
 parts of a specification, based on the existence of a macro, or its
@@ -103,7 +103,7 @@ and <span class="bold"><strong>@endif</strong></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920955392"></a>3.3.1. @ifdef and @ifndef</h4></div></div></div>
+<a name="idm197"></a>3.3.1. @ifdef and @ifndef</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@ifdef</strong></span> directive is followed by a
 macro identifier and evaluates to true if the macro is defined.
@@ -129,7 +129,7 @@ or <span class="bold"><strong>@elif</strong></span> directive (See below).
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920949120"></a>3.3.2. @if</h4></div></div></div>
+<a name="idm208"></a>3.3.2. @if</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@if</strong></span> directive is followed by a
 boolean expression with macros as the variables and strings as the
@@ -158,7 +158,7 @@ is defined.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920942032"></a>3.3.3. @else and @elif</h4></div></div></div>
+<a name="idm220"></a>3.3.3. @else and @elif</h4></div></div></div>
 <p>
 An <span class="bold"><strong>@else</strong></span> directive splits the lines
 bounded by an <span class="bold"><strong>@if</strong></span> directive and

--- a/GhidraDocs/languages/html/sleigh_ref.html
+++ b/GhidraDocs/languages/html/sleigh_ref.html
@@ -4,7 +4,7 @@
 <title>9. P-code Tables</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh_context.html" title="8. Using Context">
@@ -47,7 +47,7 @@ to lowest.
 <div class="informalexample">
 <div class="table">
 <a name="syntaxref.htmltable"></a><p class="title"><b>Table 5. Semantic Expression Operators and Syntax</b></p>
-<div class="table-contents"><table width="95%" frame="box" rules="all">
+<div class="table-contents"><table xml:id="syntaxref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
 <col width="50%">
@@ -61,7 +61,7 @@ to lowest.
   <td><code class="code">SUBPIECE</code></td>
   <td>
     <div class="informaltable">
-<a name="subpieceref.htmltable"></a><table frame="none"><tbody>
+<a name="subpieceref.htmltable"></a><table xml:id="subpieceref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">v0:2</code></td>
         </tr>
@@ -98,7 +98,7 @@ to lowest.
   <td><code class="code">LOAD</code></td>
   <td>
     <div class="informaltable">
-<a name="loadref.htmltable"></a><table frame="none"><tbody>
+<a name="loadref.htmltable"></a><table xml:id="loadref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">* v1</code></td>
         </tr>
@@ -214,7 +214,7 @@ to lowest.
   <td><code class="code">INT_SLESS</code></td>
   <td>
     <div class="informaltable">
-<a name="slessref.htmltable"></a><table frame="none"><tbody>
+<a name="slessref.htmltable"></a><table xml:id="slessref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">v0 s&lt; v1</code></td>
         </tr>
@@ -230,7 +230,7 @@ to lowest.
   <td><code class="code">INT_SLESSEQUAL</code></td>
   <td>
     <div class="informaltable">
-<a name="slessequalref.htmltable"></a><table frame="none"><tbody>
+<a name="slessequalref.htmltable"></a><table xml:id="slessequalref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">v0 s&lt;= v1</code></td>
         </tr>
@@ -246,7 +246,7 @@ to lowest.
   <td><code class="code">INT_LESS</code></td>
   <td>
     <div class="informaltable">
-<a name="lessref.htmltable"></a><table frame="none"><tbody>
+<a name="lessref.htmltable"></a><table xml:id="lessref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">v0 &lt; v1</code></td>
         </tr>
@@ -262,7 +262,7 @@ to lowest.
   <td><code class="code">INT_LESSEQUAL</code></td>
   <td>
     <div class="informaltable">
-<a name="lessequalref.htmltable"></a><table frame="none"><tbody>
+<a name="lessequalref.htmltable"></a><table xml:id="lessequalref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">v0 &lt;= v1</code></td>
         </tr>
@@ -278,7 +278,7 @@ to lowest.
   <td><code class="code">FLOAT_LESS</code></td>
   <td>
     <div class="informaltable">
-<a name="flessref.htmltable"></a><table frame="none"><tbody>
+<a name="flessref.htmltable"></a><table xml:id="flessref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">v0 f&lt; v1</code></td>
         </tr>
@@ -294,7 +294,7 @@ to lowest.
   <td><code class="code">FLOAT_LESSEQUAL</code></td>
   <td>
     <div class="informaltable">
-<a name="flessequalref.htmltable"></a><table frame="none"><tbody>
+<a name="flessequalref.htmltable"></a><table xml:id="flessequalref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">v0 f&lt;= v1</code></td>
         </tr>
@@ -454,7 +454,7 @@ The following table lists the basic forms of a semantic statement.
 <div class="informalexample">
 <div class="table">
 <a name="statementref.htmltable"></a><p class="title"><b>Table 6. Basic Statements and Associated Operators</b></p>
-<div class="table-contents"><table width="95%" frame="box" rules="all">
+<div class="table-contents"><table xml:id="statementref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
 <col width="50%">
@@ -473,7 +473,7 @@ The following table lists the basic forms of a semantic statement.
   <td><code class="code">STORE</code></td>
   <td>
     <div class="informaltable">
-<a name="storeref.htmltable"></a><table frame="none"><tbody>
+<a name="storeref.htmltable"></a><table xml:id="storeref.htmltable" frame="none"><tbody>
 <tr>
           <td><code class="code">*v0 = v1</code></td>
         </tr>
@@ -533,7 +533,7 @@ The following table lists the branching operations and the statements which invo
 <div class="informalexample">
 <div class="table">
 <a name="branchref.htmltable"></a><p class="title"><b>Table 7. Branching Statements</b></p>
-<div class="table-contents"><table width="95%" frame="box" rules="all">
+<div class="table-contents"><table xml:id="branchref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
 <col width="50%">

--- a/GhidraDocs/languages/html/sleigh_symbols.html
+++ b/GhidraDocs/languages/html/sleigh_symbols.html
@@ -4,7 +4,7 @@
 <title>5. Introduction to Symbols</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh_definitions.html" title="4. Basic Definitions">
@@ -105,7 +105,7 @@ the predefined identifier <span class="emphasis"><em>instruction</em></span>.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920845152"></a>5.1. Notes on Namespaces</h3></div></div></div>
+<a name="idm376"></a>5.1. Notes on Namespaces</h3></div></div></div>
 <p>
 Almost all identifiers live in the same global "scope". The global scope includes
 </p>
@@ -150,7 +150,7 @@ We list all of the symbols that are predefined by SLEIGH.
 <div class="informalexample">
 <div class="table">
 <a name="predefine.htmltable"></a><p class="title"><b>Table 2. Predefined Symbols</b></p>
-<div class="table-contents"><table width="80%" frame="box" rules="all">
+<div class="table-contents"><table xml:id="predefine.htmltable" width="80%" frame="box" rules="all">
 <col width="30%">
 <col width="70%">
 <thead><tr>

--- a/GhidraDocs/languages/html/sleigh_tokens.html
+++ b/GhidraDocs/languages/html/sleigh_tokens.html
@@ -4,7 +4,7 @@
 <title>6. Tokens and Fields</title>
 <link rel="stylesheet" type="text/css" href="Frontpage.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh_symbols.html" title="5. Introduction to Symbols">
@@ -88,7 +88,7 @@ different names.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920800080"></a>6.2. Fields as Family Symbols</h3></div></div></div>
+<a name="idm468"></a>6.2. Fields as Family Symbols</h3></div></div></div>
 <p>
 Fields are the most basic form of family symbol; they define a natural
 map from instruction bits to a specific symbol as follows. We take the
@@ -113,7 +113,7 @@ the <span class="bold"><strong>dec</strong></span> attribute is not supported]
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920794256"></a>6.3. Attaching Alternate Meanings to Fields</h3></div></div></div>
+<a name="idm476"></a>6.3. Attaching Alternate Meanings to Fields</h3></div></div></div>
 <p>
 The default interpretation of a field is probably the most natural but
 of course processors interpret fields within an instruction in a wide
@@ -124,7 +124,7 @@ interpretations must be built up out of tables.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920792112"></a>6.3.1. Attaching Registers</h4></div></div></div>
+<a name="idm480"></a>6.3.1. Attaching Registers</h4></div></div></div>
 <p>
 Probably <span class="emphasis"><em>the</em></span> most common processor interpretation
 of a field is as an encoding of a particular register. In SLEIGH this
@@ -163,7 +163,7 @@ of the instruction.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920783840"></a>6.3.2. Attaching Other Integers</h4></div></div></div>
+<a name="idm495"></a>6.3.2. Attaching Other Integers</h4></div></div></div>
 <p>
 Sometimes a processor interprets a field as an integer but not the
 integer given by the default interpretation. A different integer
@@ -185,7 +185,7 @@ unspecified positions in the list using a &#8216;_&#8217;]
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920778208"></a>6.3.3. Attaching Names</h4></div></div></div>
+<a name="idm505"></a>6.3.3. Attaching Names</h4></div></div></div>
 <p>
 It is possible to just modify the display characteristics of a field
 without changing the semantic meaning. The need for this is rare, but


### PR DESCRIPTION
I've adjusted the example to actually compile on its own (the register needs to be declared), and also added a paragraph about registers in regards to context variables.  That paragraph could perhaps be located earlier in the document (in the "Context Variables" section under "Tokens and Fields"), but I think the location I put is fine.  I'm not an expert, so there's a chance that what I wrote isn't completely accurate, but it's information I would have found helpful when I first messed with context variables.

The 32-bit limitation is handled [here](https://github.com/NationalSecurityAgency/ghidra/blob/b6ba209ed796343880327bc3337355c303b760cd/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc#L1844-L1856) (and also [here](https://github.com/NationalSecurityAgency/ghidra/blob/2b1235814d83355088411bace66a5e228ed2bd84/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java#L381-L406), but without a big comment):

https://github.com/NationalSecurityAgency/ghidra/blob/b6ba209ed796343880327bc3337355c303b760cd/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc#L1823-L1835

I also rebuilt the documentation using `gradle buildDecompilerHelpHtml buildDecompilerHelpPdf buildDecompilerDocumentationPdfs buildDecompilerDocumentationHtml`.  I have a slightly newer version of xsltproc, which seems to have resulted in a bit of noise, so that change is a separate commit.