### PR TITLE
Add support for 32-bit ARC (legacy ARC)

### DIFF
--- a/Ghidra/Processors/ARC/build.gradle
+++ b/Ghidra/Processors/ARC/build.gradle
@@ -1,0 +1,19 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+apply from: "$rootProject.projectDir/gradle/distributableGhidraModule.gradle"
+apply from: "$rootProject.projectDir/gradle/processorProject.gradle"
+apply plugin: 'eclipse'
+eclipse.project.name = 'Processors ARC'

--- a/Ghidra/Processors/ARC/certification.manifest
+++ b/Ghidra/Processors/ARC/certification.manifest
@@ -1,0 +1,11 @@
+##VERSION: 2.0
+Module.manifest||GHIDRA||||END|
+data/build.xml||GHIDRA||||END|
+data/languages/ARC.ldefs||GHIDRA||||END|
+data/languages/ARC.opinion||GHIDRA||||END|
+data/languages/ARC32.cspec||GHIDRA||||END|
+data/languages/ARC32.dwarf||GHIDRA||||END|
+data/languages/ARC32.pspec||GHIDRA||||END|
+data/languages/ARC32.sinc||GHIDRA||||END|
+data/languages/ARC32_be.slaspec||GHIDRA||||END|
+data/languages/ARC32_le.slaspec||GHIDRA||||END|

--- a/Ghidra/Processors/ARC/data/languages/ARC.ldefs
+++ b/Ghidra/Processors/ARC/data/languages/ARC.ldefs
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language_definitions>
+  <language processor="ARC32"
+            endian="big"
+            size="32"
+            variant="default"
+            version="1.0"
+            slafile="ARC32_be.sla"
+            processorspec="ARC32.pspec"
+            id="ARC32:BE:32:default">
+    <description>ARC 32-bit (Legacy ARC), big endian</description>
+    <compiler name="default" spec="ARC32.cspec" id="default"/>
+    <external_name tool="DWARF.register.mapping.file" name="ARC32.dwarf"/>
+  </language>
+  <language processor="ARC32"
+            endian="little"
+            size="32"
+            variant="default"
+            version="1.0"
+            slafile="ARC32_le.sla"
+            processorspec="ARC32.pspec"
+            id="ARC32:LE:32:default">
+    <description>ARC 32-bit (Legacy ARC), little endian</description>
+    <compiler name="default" spec="ARC32.cspec" id="default"/>
+    <external_name tool="DWARF.register.mapping.file" name="ARC32.dwarf"/>
+  </language>
+</language_definitions>

--- a/Ghidra/Processors/ARC/data/languages/ARC.opinion
+++ b/Ghidra/Processors/ARC/data/languages/ARC.opinion
@@ -1,0 +1,5 @@
+<opinions>
+  <constraint loader="Executable and Linking Format (ELF)" compilerSpecID="default">
+    <constraint primary="45" processor="ARC32" size="32" variant="default" />
+  </constraint>
+</opinions>

--- a/Ghidra/Processors/ARC/data/languages/ARC32.cspec
+++ b/Ghidra/Processors/ARC/data/languages/ARC32.cspec
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<compiler_spec>
+  <global>
+    <range space="ram"/>
+  </global>
+
+  <stackpointer register="sp" space="ram"/>
+
+  <default_proto>
+    <prototype extrapop="0" stackshift="0" strategy="register" name="__stdcall">
+      <input>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r0"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r1"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r2"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r3"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r4"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r5"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r6"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r7"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r8"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r9"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r10"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r11"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r12"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r13"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r14"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r15"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r16"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r17"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r18"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r19"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r20"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r21"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r22"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r23"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r24"/>
+        </pentry>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r25"/>
+        </pentry>
+      </input>
+      <output>
+        <pentry minsize="1" maxsize="4" extension="inttype">
+          <register name="r0"/>
+        </pentry>
+      </output>
+    </prototype>
+  </default_proto>
+</compiler_spec>

--- a/Ghidra/Processors/ARC/data/languages/ARC32.dwarf
+++ b/Ghidra/Processors/ARC/data/languages/ARC32.dwarf
@@ -1,0 +1,9 @@
+<dwarf>
+  <register_mappings>
+    <register_mapping dwarf="0" ghidra="r0" auto_count="26" /> <!-- r0..r25 -->
+    <register_mapping dwarf="26" ghidra="gp" />
+    <register_mapping dwarf="27" ghidra="fp" />
+    <register_mapping dwarf="28" ghidra="sp" stackpointer="true" />
+    <register_mapping dwarf="29" ghidra="r29" auto_count="35" /> <!-- r29..r63 -->
+  </register_mappings>
+</dwarf>

--- a/Ghidra/Processors/ARC/data/languages/ARC32.pspec
+++ b/Ghidra/Processors/ARC/data/languages/ARC32.pspec
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<processor_spec>
+  <programcounter register="pc"/>
+</processor_spec>

--- a/Ghidra/Processors/ARC/data/languages/ARC32.sinc
+++ b/Ghidra/Processors/ARC/data/languages/ARC32.sinc
@@ -1,0 +1,598 @@
+define alignment=4;
+
+define space ram type=ram_space size=4 default;
+define space auxregs type=ram_space size=4;
+define space register type=register_space size=4;
+
+# Core register set
+define register offset=0 size=4 [
+	 r0  r1  r2  r3
+	 r4  r5  r6  r7
+	 r8  r9 r10 r11
+	r12 r13 r14 r15
+	r16 r17 r18 r19
+	r20 r21 r22 r23
+	r24 r25
+	gp
+	fp
+	sp
+	ilink1
+	ilink2
+	blink
+	r32 r33 r34 r35
+	r36 r37 r38 r39
+	r40 r41 r42 r43
+	r44 r45 r46 r47
+	r48 r49 r50 r51
+	r52 r53 r54 r55
+	r56 r57 r58 r59
+	lp_count
+	    r61 r62 r63
+];
+
+# Auxiliary register set (incomplete)
+define register offset=0x1000 size=4 [
+	status
+	semaphore
+	lp_start
+	lp_end
+	identity
+	debug
+	                                      ar6   ar7
+	  ar8   ar9  ar10  ar11  ar12  ar13  ar14  ar15
+	 ar16  ar17  ar18  ar19  ar20  ar21  ar22  ar23
+	 ar24  ar25  ar26  ar27  ar28  ar29  ar30  ar31
+	 ar32  ar33  ar34  ar35  ar36  ar37  ar38  ar39
+	 ar40  ar41  ar42  ar43  ar44  ar45  ar46  ar47
+	 ar48  ar49  ar50  ar51  ar52  ar53  ar54  ar55
+	 ar56  ar57  ar58  ar59  ar60  ar61  ar62  ar63
+	 ar64  ar65  ar66  ar67  ar68  ar69  ar70  ar71
+	 ar72  ar73  ar74  ar75  ar76  ar77  ar78  ar79
+	 ar80  ar81  ar82  ar83  ar84  ar85  ar86  ar87
+	 ar88  ar89  ar90  ar91  ar92  ar93  ar94  ar95
+	 ar96  ar97  ar98  ar99 ar100 ar101 ar102 ar103
+	ar104 ar105 ar106 ar107 ar108 ar109 ar110 ar111
+	ar112 ar113 ar114 ar115 ar116 ar117 ar118 ar119
+	ar120 ar121 ar122 ar123 ar124 ar125 ar126 ar127
+	ar128 ar129 ar130 ar131 ar132 ar133 ar134 ar135
+	ar136 ar137 ar138 ar139 ar140 ar141 ar142 ar143
+	ar144 ar145 ar146 ar147 ar148 ar149 ar150 ar151
+	ar152 ar153 ar154 ar155 ar156 ar157 ar158 ar159
+	ar160 ar161 ar162 ar163 ar164 ar165 ar166 ar167
+	ar168 ar169 ar170 ar171 ar172 ar173 ar174 ar175
+	ar176 ar177 ar178 ar179 ar180 ar181 ar182 ar183
+	ar184 ar185 ar186 ar187 ar188 ar189 ar190 ar191
+	ar192 ar193 ar194 ar195 ar196 ar197 ar198 ar199
+	ar200 ar201 ar202 ar203 ar204 ar205 ar206 ar207
+	ar208 ar209 ar210 ar211 ar212 ar213 ar214 ar215
+	ar216 ar217 ar218 ar219 ar220 ar221 ar222 ar223
+	ar224 ar225 ar226 ar227 ar228 ar229 ar230 ar231
+	ar232 ar233 ar234 ar235 ar236 ar237 ar238 ar239
+	ar240 ar241 ar242 ar243 ar244 ar245 ar246 ar247
+	ar248 ar249 ar250 ar251 ar252 ar253 ar254 ar255
+];
+
+define register offset=0x2000 size=1 [
+	# Condition codes.
+	Z   # Zero
+	NE  # Negative
+	CY  # Carry
+	V   # Overflow
+	E1  # Enable level 1 interrupts
+	E2  # Enable level 2 interrupts
+	H   # Halt
+];
+
+define register offset=0x3000 size=4 [
+	pc
+];
+
+define register offset=0x4000 size=4 [
+	dummy_write  # Dummy register to send writes to when the destination register points to an immediate.
+];
+
+define token instr(32)
+	I = (27, 31)
+	A = (21, 26)
+	B = (15, 20)
+	C = (9, 14)
+	D = (0, 8) signed
+
+	L = (7, 26) signed
+	F = (8, 8)
+	N = (5, 6)
+	Q = (0, 4)
+
+	# ST fields
+	st_Di = (26, 26)
+	st_25 = (25, 25)
+	st_A  = (24, 24)
+	st_Z  = (22, 23)
+	st_21 = (21, 21)
+
+	# LD, generic
+	ldg_Di = (5, 5)
+	ldg_A  = (3, 3)
+	ldg_Z  = (1, 2)
+	ldg_X  = (0, 0)
+
+	# LD, simm
+	lds_Di = (14, 14)
+	lds_13 = (13, 13)
+	lds_A  = (12, 12)
+	lds_Z  = (10, 11)
+	lds_X  = (9, 9)
+
+	# LR/SR
+	ar_D = (0, 7)
+;
+
+define token imm(32)
+	Limm = (0, 31)
+;
+
+attach variables [ A B C ] [
+	 r0  r1  r2  r3
+	 r4  r5  r6  r7
+	 r8  r9 r10 r11
+	r12 r13 r14 r15
+	r16 r17 r18 r19
+	r20 r21 r22 r23
+	r24 r25
+	gp
+	fp
+	sp
+	ilink1
+	ilink2
+	blink
+	r32 r33 r34 r35
+	r36 r37 r38 r39
+	r40 r41 r42 r43
+	r44 r45 r46 r47
+	r48 r49 r50 r51
+	r52 r53 r54 r55
+	r56 r57 r58 r59
+	lp_count
+	    r61 r62 r63
+];
+
+attach variables [ ar_D ] [
+	status
+	semaphore
+	lp_start
+	lp_end
+	identity
+	debug
+	                                      ar6   ar7
+	  ar8   ar9  ar10  ar11  ar12  ar13  ar14  ar15
+	 ar16  ar17  ar18  ar19  ar20  ar21  ar22  ar23
+	 ar24  ar25  ar26  ar27  ar28  ar29  ar30  ar31
+	 ar32  ar33  ar34  ar35  ar36  ar37  ar38  ar39
+	 ar40  ar41  ar42  ar43  ar44  ar45  ar46  ar47
+	 ar48  ar49  ar50  ar51  ar52  ar53  ar54  ar55
+	 ar56  ar57  ar58  ar59  ar60  ar61  ar62  ar63
+	 ar64  ar65  ar66  ar67  ar68  ar69  ar70  ar71
+	 ar72  ar73  ar74  ar75  ar76  ar77  ar78  ar79
+	 ar80  ar81  ar82  ar83  ar84  ar85  ar86  ar87
+	 ar88  ar89  ar90  ar91  ar92  ar93  ar94  ar95
+	 ar96  ar97  ar98  ar99 ar100 ar101 ar102 ar103
+	ar104 ar105 ar106 ar107 ar108 ar109 ar110 ar111
+	ar112 ar113 ar114 ar115 ar116 ar117 ar118 ar119
+	ar120 ar121 ar122 ar123 ar124 ar125 ar126 ar127
+	ar128 ar129 ar130 ar131 ar132 ar133 ar134 ar135
+	ar136 ar137 ar138 ar139 ar140 ar141 ar142 ar143
+	ar144 ar145 ar146 ar147 ar148 ar149 ar150 ar151
+	ar152 ar153 ar154 ar155 ar156 ar157 ar158 ar159
+	ar160 ar161 ar162 ar163 ar164 ar165 ar166 ar167
+	ar168 ar169 ar170 ar171 ar172 ar173 ar174 ar175
+	ar176 ar177 ar178 ar179 ar180 ar181 ar182 ar183
+	ar184 ar185 ar186 ar187 ar188 ar189 ar190 ar191
+	ar192 ar193 ar194 ar195 ar196 ar197 ar198 ar199
+	ar200 ar201 ar202 ar203 ar204 ar205 ar206 ar207
+	ar208 ar209 ar210 ar211 ar212 ar213 ar214 ar215
+	ar216 ar217 ar218 ar219 ar220 ar221 ar222 ar223
+	ar224 ar225 ar226 ar227 ar228 ar229 ar230 ar231
+	ar232 ar233 ar234 ar235 ar236 ar237 ar238 ar239
+	ar240 ar241 ar242 ar243 ar244 ar245 ar246 ar247
+	ar248 ar249 ar250 ar251 ar252 ar253 ar254 ar255
+];
+
+
+define pcodeop DebugBreak;
+define pcodeop ProcessorSleep;
+define pcodeop SoftwareInterrupt;
+
+
+macro resultflags(dst) { # Set Z flag for results
+	Z = dst == 0;
+	NE = ((dst >> 31) & 1) != 0;
+}
+
+macro addflags(dst, op1, op2) {  # Flags set by add instructions
+	CY = scarry(op1, op2);  # Check for signed carry
+	local dst_sign:1 = ((dst >> 31) & 1) != 0;
+	local op1_sign:1 = ((op1 >> 31) & 1) != 0;
+	local op2_sign:1 = ((op2 >> 31) & 1) != 0;
+	V = op1_sign == op2_sign && dst_sign != op1_sign;
+	resultflags(dst);
+}
+
+macro subflags(dst, op1, op2) {  # Flags set by sub instructions
+	CY = op1 s< op2;  # Check for signed carry
+	local dst_sign:1 = ((dst >> 31) & 1) != 0;
+	local op1_sign:1 = ((op1 >> 31) & 1) != 0;
+	local op2_sign:1 = ((op2 >> 31) & 1) != 0;
+	V = op1_sign != op2_sign && dst_sign != op1_sign;
+	resultflags(dst);
+}
+
+macro adcflags(dst, op1, op2) {  # Flags set by add-with-carry instruction
+	local old_CY = CY;
+	CY = scarry(op1, op2);  # Check for carry
+	if CY goto <skip>;
+	local tmp = op1 + op2;
+	CY = scarry(tmp, zext(old_CY));
+	<skip>
+	resultflags(dst);
+}
+
+macro sbcflags(dst, op1, op2) {  # Flags set by sub-with-carry instruction
+	local old_CY = CY;
+	CY = op1 s< op2;  # Check for carry
+	if CY goto <skip>;
+	local tmp = op1 - op2;
+	CY = tmp s< zext(old_CY);
+	<skip>
+	resultflags(dst);
+}
+
+macro jumpflags(val) {
+	Z  = (val & (1 << 31)) != 0;
+	NE = (val & (1 << 30)) != 0;
+	CY = (val & (1 << 29)) != 0;
+	V  = (val & (1 << 28)) != 0;
+	E2 = (val & (1 << 27)) != 0;
+	E1 = (val & (1 << 26)) != 0;
+}
+
+macro set_flags(val) {
+	Z  = (val & (1 << 6)) != 0;
+	NE = (val & (1 << 5)) != 0;
+	CY = (val & (1 << 4)) != 0;
+	V  = (val & (1 << 3)) != 0;
+	E2 = (val & (1 << 2)) != 0;
+	E1 = (val & (1 << 1)) != 0;
+
+	# Technically, if the "Halt" bit is set, then the other bits should be
+	# unaffected, but implementing this is difficult and would not be very
+	# useful.
+	H  = (val & (1 << 0)) != 0;
+}
+
+macro update_status() {
+	status =          (zext(Z  & 1) << 31);
+	status = status | (zext(NE & 1) << 30);
+	status = status | (zext(CY & 1) << 29);
+	status = status | (zext(V  & 1) << 28);
+	status = status | (zext(E1 & 1) << 27);
+	status = status | (zext(E2 & 1) << 26);
+	status = status | (zext(H  & 1) << 25);
+	status = status | ((inst_next >> 2) & 0xffffff);
+}
+
+macro link() {
+	update_status();
+	blink = status;
+}
+
+macro mulext(dst, op1, op2) {
+	local op1_ext:4 = sext(op1);
+	local op2_ext:4 = sext(op2);
+	dst = op1_ext * op2_ext;
+}
+
+macro rormultiple(dst, op1, op2) {
+	dst = op1 << (32 - op2);
+	dst = dst | (op1 >> op2);
+}
+
+macro roronce(dst, op1) {
+	rormultiple(dst, op1, 1);
+}
+
+macro rorflags(dst, op1) {
+	CY = (op1 & 1) != 0;
+	resultflags(dst);
+}
+
+macro swapwords(dst, op1) {
+	dst = op1 << 16;
+	dst = dst | (op1 >> 16);
+}
+
+macro ldext(dst, val, extend) {
+	dst = zext(val);
+	if (!extend) goto <skip>;
+	dst = sext(val);
+	<skip>
+}
+
+macro writeback(dst, addr, flag) {
+	if (!flag) goto <skip>;
+	dst = addr;
+	<skip>
+}
+
+
+dest: A is A { export A; }
+dest: 0 is A=61 | A=62 | A=63 { export dummy_write; }
+
+Qcc: "al"	is Q=0x00	{ export 1:1; }
+Qcc: "eq"	is Q=0x01	{ local tmp:1 = (Z!=0); export tmp; }
+Qcc: "ne"	is Q=0x02	{ local tmp:1 = (Z==0); export tmp; }
+Qcc: "pl"	is Q=0x03	{ local tmp:1 = (NE==0); export tmp; }
+Qcc: "mi"	is Q=0x04	{ local tmp:1 = (NE!=0); export tmp; }
+Qcc: "cs"	is Q=0x05	{ local tmp:1 = (CY!=0); export tmp; }
+Qcc: "cc"	is Q=0x06	{ local tmp:1 = (CY==0); export tmp; }
+Qcc: "vs"	is Q=0x07	{ local tmp:1 = (V!=0); export tmp; }
+Qcc: "vc"	is Q=0x08	{ local tmp:1 = (V==0); export tmp; }
+Qcc: "gt"	is Q=0x09	{ local tmp:1 = !Z && ((NE && V) || (!NE && !V)); export tmp; }
+Qcc: "ge"	is Q=0x0a	{ local tmp:1 = (NE && V) || (!NE && !V); export tmp; }
+Qcc: "lt"	is Q=0x0b	{ local tmp:1 = (NE && !V) || (!NE && V); export tmp; }
+Qcc: "le"	is Q=0x0c	{ local tmp:1 = Z || (NE && !V) || (!NE && V); export tmp; }
+Qcc: "hi"	is Q=0x0d	{ local tmp:1 = !CY && !Z; export tmp; }
+Qcc: "ls"	is Q=0x0e	{ local tmp:1 = CY || Z; export tmp; }
+Qcc: "pnz"	is Q=0x0f	{ local tmp:1 = !NE && !Z; export tmp; }
+
+cc:         is Q=0x00 {}
+cc: "."Qcc  is Q & Qcc { if (!Qcc) goto inst_next; }
+cj:         is Q=0x00 {}
+cj:    Qcc  is Q & Qcc { if (!Qcc) goto inst_next; }
+cl:         is Q=0x00  { export 1:1; }
+cl:    Qcc  is Q & Qcc { export Qcc; }
+
+Ndd: "nd"  is N=0b00  {}  # Only execute the next instruction when not jumping.
+Ndd: "d"   is N=0b01  { delayslot(1); }  # Always execute the next instruction.
+Ndd: "jd"  is N=0b10  { delayslot(1); }  # FIXME: This should be, "Only execute the next instruction when jumping."
+
+dd:         is N=0b00 {}
+dd: "."Ndd  is N & Ndd {}
+
+f:       is F=0 { export 0:1; }
+f: ".f"  is F=1 { export 1:1; }
+fi:       is B=63 | C=63 { export 0:1; }
+fi: ".f"  is B=61 | C=61 { export 1:1; }
+
+# ST flags
+st_di:        is st_Di=0 {}
+st_di: ".di"  is st_Di=1 {}
+st_a:         is st_A=0 { export 0:1; }
+st_a:  ".a"   is st_A=1 { export 1:1; }
+
+# LD, generic flags
+ldg_di:        is ldg_Di=0 {}
+ldg_di: ".di"  is ldg_Di=1 {}
+ldg_a:         is ldg_A=0 { export 0:1; }
+ldg_a:  ".a"   is ldg_A=1 { export 1:1; }
+ldg_x:         is ldg_X=0 { export 0:1; }
+ldg_x:  ".x"   is ldg_X=1 { export 1:1; }
+
+# LD, simm flags
+lds_di:        is lds_Di=0 {}
+lds_di: ".di"  is lds_Di=1 {}
+lds_a:         is lds_A=0 { export 0:1; }
+lds_a:  ".a"   is lds_A=1 { export 1:1; }
+lds_x:         is lds_X=0 { export 0:1; }
+lds_x:  ".x"   is lds_X=1 { export 1:1; }
+
+
+:nop  is I=0b01111 & A=63 & B=63 & C=63 & D=0x1ff {}
+
+:brk    is I=0b00011 & A=63 & B=63 & C=63 & D=0x000 { DebugBreak(); }
+:sleep  is I=0b00011 & A=63 & B=63 & C=63 & D=0x001 { ProcessorSleep(); }
+:swi    is I=0b00011 & A=63 & B=63 & C=63 & D=0x002 { SoftwareInterrupt(); }
+
+:j^cj^dd^f #jump_dest  is I=0b00111 & A=0 & B=62 & C=0 & f & dd & cj ; Limm [ jump_dest = (Limm & 0xffffff) << 2; ] { if (!f) goto <skip>; jumpflags(Limm:4); <skip> goto [jump_dest:4]; }
+:j^cj^dd^f [B]         is I=0b00111 & A=0 & B & B=31 & C=0 & f & dd & cj { if (!f) goto <skip>; jumpflags(B); <skip> return [(B & 0xffffff) << 2]; }
+:j^cj^dd^f [B]         is I=0b00111 & A=0 & B & C=0 & f & dd & cj { if (!f) goto <skip>; jumpflags(B); <skip> goto [(B & 0xffffff) << 2]; }
+
+:jl^cj^dd^f #jump_dest  is I=0b00111 & A=0 & B=62 & C=1 & f & dd & cj ; Limm [ jump_dest = (Limm & 0xffffff) << 2; ] { link(); if (!f) goto <skip>; jumpflags(Limm:4); <skip> goto [jump_dest:4]; }
+:jl^cj^dd^f [B]         is I=0b00111 & A=0 & B & B=31 & C=1 & f & dd & cj { link(); if (!f) goto <skip>; jumpflags(B); <skip> return [(B & 0xffffff) << 2]; }
+:jl^cj^dd^f [B]         is I=0b00111 & A=0 & B & C=1 & f & dd & cj { link(); if (!f) goto <skip>; jumpflags(B); <skip> goto [(B & 0xffffff) << 2]; }
+
+:b^cj^dd #jump_dest  is I=0b00100 & L & dd & cj [ jump_dest = inst_next + (L << 2); ] { goto [jump_dest:4]; }
+:bl^cj^dd #jump_dest  is I=0b00101 & L & dd & cj [ jump_dest = inst_next + (L << 2); ] { link(); call [jump_dest:4]; }
+
+# FIXME: Properly implement loops.
+:lp^cl^dd #jump_dest  is I=0b00110 & L & dd & cl [ jump_dest = inst_next + (L << 2); ] {
+	if (cl) goto <skip>;
+	goto [jump_dest:4];
+	<skip>
+	lp_end = jump_dest;
+	lp_start = inst_next;
+}
+
+:adc^fi   dest, B, #D     is I=0b01001 & dest & B & (C=61 | C=63) & fi & D { dest = B + D + zext(CY); if (!fi) goto <skip>; adcflags(dest, B, D:4); <skip> }
+:adc^fi   dest, #D, C     is I=0b01001 & dest & (B=61 | B=63) & C & fi & D { dest = D + C + zext(CY); if (!fi) goto <skip>; adcflags(dest, D:4, C); <skip> }
+:adc^cc^f dest, B, #Limm  is I=0b01001 & dest & B & C=62 & f & cc ; Limm { dest = B + Limm + zext(CY); if (!f) goto <skip>; adcflags(dest, B, Limm:4); <skip> }
+:adc^cc^f dest, #Limm, C  is I=0b01001 & dest & B=62 & C & f & cc ; Limm { dest = Limm + C + zext(CY); if (!f) goto <skip>; adcflags(dest, Limm:4, C); <skip> }
+:adc^cc^f dest, B, C      is I=0b01001 & dest & B & C & f & cc { dest = B + C + zext(CY); if (!f) goto <skip>; adcflags(dest, B, C); <skip> }
+
+:add^fi   dest, B, #D     is I=0b01000 & dest & B & (C=61 | C=63) & fi & D { dest = B + D; if (!fi) goto <skip>; addflags(dest, B, D:4); <skip> }
+:add^fi   dest, #D, C     is I=0b01000 & dest & (B=61 | B=63) & C & fi & D { dest = D + C; if (!fi) goto <skip>; addflags(dest, D:4, C); <skip> }
+:add^cc^f dest, B, #Limm  is I=0b01000 & dest & B & C=62 & f & cc ; Limm { dest = B + Limm; if (!f) goto <skip>; addflags(dest, B, Limm:4); <skip> }
+:add^cc^f dest, #Limm, C  is I=0b01000 & dest & B=62 & C & f & cc ; Limm { dest = Limm + C; if (!f) goto <skip>; addflags(dest, Limm:4, C); <skip> }
+:add^cc^f dest, B, C      is I=0b01000 & dest & B & C & f & cc { dest = B + C; if (!f) goto <skip>; addflags(dest, B, C); <skip> }
+
+:mov^fi   dest, #D        is I=0b01100 & dest & (B=61 | B=63) & (C=61 | C=63) & fi & D { dest = D; }
+:mov^cc^f dest, #Limm     is I=0b01100 & dest & B=62 & C=62 & f & cc ; Limm { dest = Limm; }
+
+:and^fi   dest, B, #D     is I=0b01100 & dest & B & (C=61 | C=63) & fi & D { dest = B & D; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:and^fi   dest, #D, C     is I=0b01100 & dest & (B=61 | B=63) & C & fi & D { dest = D & C; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:and^cc^f dest, B, #Limm  is I=0b01100 & dest & B & C=62 & f & cc ; Limm { dest = B & Limm; if (!f) goto <skip>; resultflags(dest); <skip> }
+:and^cc^f dest, #Limm, C  is I=0b01100 & dest & B=62 & C & f & cc ; Limm { dest = Limm & C; if (!f) goto <skip>; resultflags(dest); <skip> }
+:and^cc^f dest, B, C      is I=0b01100 & dest & B & C & f & cc { dest = B & C; if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:asl^fi   dest, B, #D     is I=0b10000 & dest & B & (C=61 | C=63) & fi & D { dest = B << D; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:asl^fi   dest, #D, C     is I=0b10000 & dest & (B=61 | B=63) & C & fi & D { dest = D << C; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:asl^cc^f dest, B, #Limm  is I=0b10000 & dest & B & C=62 & f & cc ; Limm { dest = B << Limm; if (!f) goto <skip>; resultflags(dest); <skip> }
+:asl^cc^f dest, #Limm, C  is I=0b10000 & dest & B=62 & C & f & cc ; Limm { dest = Limm << C; if (!f) goto <skip>; resultflags(dest); <skip> }
+:asl^cc^f dest, B, C      is I=0b10000 & dest & B & C & f & cc { dest = B << C; if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:asr^fi   dest, B, #D     is I=0b10010 & dest & B & (C=61 | C=63) & fi & D { dest = B s>> D; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:asr^fi   dest, #D, C     is I=0b10010 & dest & (B=61 | B=63) & C & fi & D { dest = D s>> C; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:asr^cc^f dest, B, #Limm  is I=0b10010 & dest & B & C=62 & f & cc ; Limm { dest = B s>> Limm; if (!f) goto <skip>; resultflags(dest); <skip> }
+:asr^cc^f dest, #Limm, C  is I=0b10010 & dest & B=62 & C & f & cc ; Limm { dest = Limm s>> C; if (!f) goto <skip>; resultflags(dest); <skip> }
+:asr^cc^f dest, B, C      is I=0b10010 & dest & B & C & f & cc { dest = B s>> C; if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:bic^fi   dest, B, #D     is I=0b01110 & dest & B & (C=61 | C=63) & fi & D { dest = B & ~D; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:bic^fi   dest, #D, C     is I=0b01110 & dest & (B=61 | B=63) & C & fi & D { dest = D & ~C; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:bic^cc^f dest, B, #Limm  is I=0b01110 & dest & B & C=62 & f & cc ; Limm { dest = B & ~Limm; if (!f) goto <skip>; resultflags(dest); <skip> }
+:bic^cc^f dest, #Limm, C  is I=0b01110 & dest & B=62 & C & f & cc ; Limm { dest = Limm & ~C; if (!f) goto <skip>; resultflags(dest); <skip> }
+:bic^cc^f dest, B, C      is I=0b01110 & dest & B & C & f & cc { dest = B & ~C; if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:lsr^fi   dest, B, #D     is I=0b10001 & dest & B & (C=61 | C=63) & fi & D { dest = B >> D; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:lsr^fi   dest, #D, C     is I=0b10001 & dest & (B=61 | B=63) & C & fi & D { dest = D >> C; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:lsr^cc^f dest, B, #Limm  is I=0b10001 & dest & B & C=62 & f & cc ; Limm { dest = B >> Limm; if (!f) goto <skip>; resultflags(dest); <skip> }
+:lsr^cc^f dest, #Limm, C  is I=0b10001 & dest & B=62 & C & f & cc ; Limm { dest = Limm >> C; if (!f) goto <skip>; resultflags(dest); <skip> }
+:lsr^cc^f dest, B, C      is I=0b10001 & dest & B & C & f & cc { dest = B >> C; if (!f) goto <skip>; resultflags(dest); <skip> }
+
+# TODO: Implement MAX instruction.
+
+# TODO: Implement MIN instruction.
+
+# FIXME: Semantics are guessed--confirm with old GCC sources.
+:mul16^fi   dest, B, #D     is I=0b10110 & dest & B & (C=61 | C=63) & fi & D { mulext(dest, B:2, D:2); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:mul16^fi   dest, #D, C     is I=0b10110 & dest & (B=61 | B=63) & C & fi & D { mulext(dest, D:2, C:2); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:mul16^cc^f dest, B, #Limm  is I=0b10110 & dest & B & C=62 & f & cc ; Limm { mulext(dest, B:2, Limm:2); if (!f) goto <skip>; resultflags(dest); <skip> }
+:mul16^cc^f dest, #Limm, C  is I=0b10110 & dest & B=62 & C & f & cc ; Limm { mulext(dest, Limm:2, C:2); if (!f) goto <skip>; resultflags(dest); <skip> }
+:mul16^cc^f dest, B, C      is I=0b10110 & dest & B & C & f & cc { mulext(dest, B:2, C:2); if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:or^fi   dest, B, #D     is I=0b01101 & dest & B & (C=61 | C=63) & fi & D { dest = B | D; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:or^fi   dest, #D, C     is I=0b01101 & dest & (B=61 | B=63) & C & fi & D { dest = D | C; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:or^cc^f dest, B, #Limm  is I=0b01101 & dest & B & C=62 & f & cc ; Limm { dest = B | Limm; if (!f) goto <skip>; resultflags(dest); <skip> }
+:or^cc^f dest, #Limm, C  is I=0b01101 & dest & B=62 & C & f & cc ; Limm { dest = Limm | C; if (!f) goto <skip>; resultflags(dest); <skip> }
+:or^cc^f dest, B, C      is I=0b01101 & dest & B & C & f & cc { dest = B | C; if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:ror^fi   dest, B, #D     is I=0b10011 & dest & B & (C=61 | C=63) & fi & D { rormultiple(dest, B, D:4); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:ror^fi   dest, #D, C     is I=0b10011 & dest & (B=61 | B=63) & C & fi & D { rormultiple(dest, D:4, C); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:ror^cc^f dest, B, #Limm  is I=0b10011 & dest & B & C=62 & f & cc ; Limm { rormultiple(dest, B, Limm:4); if (!f) goto <skip>; resultflags(dest); <skip> }
+:ror^cc^f dest, #Limm, C  is I=0b10011 & dest & B=62 & C & f & cc ; Limm { rormultiple(dest, Limm:4, C); if (!f) goto <skip>; resultflags(dest); <skip> }
+:ror^cc^f dest, B, C      is I=0b10011 & dest & B & C & f & cc { rormultiple(dest, B, C); if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:sbc^fi   dest, B, #D     is I=0b01011 & dest & B & (C=61 | C=63) & fi & D { dest = B - D - zext(CY); if (!fi) goto <skip>; sbcflags(dest, B, D:4); <skip> }
+:sbc^fi   dest, #D, C     is I=0b01011 & dest & (B=61 | B=63) & C & fi & D { dest = D - C - zext(CY); if (!fi) goto <skip>; sbcflags(dest, D:4, C); <skip> }
+:sbc^cc^f dest, B, #Limm  is I=0b01011 & dest & B & C=62 & f & cc ; Limm { dest = B - Limm - zext(CY); if (!f) goto <skip>; sbcflags(dest, B, Limm:4); <skip> }
+:sbc^cc^f dest, #Limm, C  is I=0b01011 & dest & B=62 & C & f & cc ; Limm { dest = Limm - C - zext(CY); if (!f) goto <skip>; sbcflags(dest, Limm:4, C); <skip> }
+:sbc^cc^f dest, B, C      is I=0b01011 & dest & B & C & f & cc { dest = B - C - zext(CY); if (!f) goto <skip>; sbcflags(dest, B, C); <skip> }
+
+:sub^fi   dest, B, #D     is I=0b01010 & dest & B & (C=61 | C=63) & fi & D { dest = B - D; if (!fi) goto <skip>; subflags(dest, B, D:4); <skip> }
+:sub^fi   dest, #D, C     is I=0b01010 & dest & (B=61 | B=63) & C & fi & D { dest = D - C; if (!fi) goto <skip>; subflags(dest, D:4, C); <skip> }
+:sub^cc^f dest, B, #Limm  is I=0b01010 & dest & B & C=62 & f & cc ; Limm { dest = B - Limm; if (!f) goto <skip>; subflags(dest, B, Limm:4); <skip> }
+:sub^cc^f dest, #Limm, C  is I=0b01010 & dest & B=62 & C & f & cc ; Limm { dest = Limm - C; if (!f) goto <skip>; subflags(dest, Limm:4, C); <skip> }
+:sub^cc^f dest, B, C      is I=0b01010 & dest & B & C & f & cc { dest = B - C; if (!f) goto <skip>; subflags(dest, B, C); <skip> }
+
+:xor^fi   dest, B, #D     is I=0b01111 & dest & B & (C=61 | C=63) & fi & D { dest = B ^ D; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:xor^fi   dest, #D, C     is I=0b01111 & dest & (B=61 | B=63) & C & fi & D { dest = D ^ C; if (!fi) goto <skip>; resultflags(dest); <skip> }
+:xor^cc^f dest, B, #Limm  is I=0b01111 & dest & B & C=62 & f & cc ; Limm { dest = B ^ Limm; if (!f) goto <skip>; resultflags(dest); <skip> }
+:xor^cc^f dest, #Limm, C  is I=0b01111 & dest & B=62 & C & f & cc ; Limm { dest = Limm ^ C; if (!f) goto <skip>; resultflags(dest); <skip> }
+:xor^cc^f dest, B, C      is I=0b01111 & dest & B & C & f & cc { dest = B ^ C; if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:asr^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=1 & fi & D { dest = D s>> 1; if (!fi) goto <skip>; rorflags(dest, D:4); <skip> }
+:asr^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=1 & f & cc ; Limm { dest = Limm s>> 1; if (!f) goto <skip>; rorflags(dest, Limm:4); <skip> }
+:asr^cc^f dest, B      is I=0b00011 & dest & B & C=1 & f & cc { dest = B s>> 1; if (!f) goto <skip>; rorflags(dest, B); <skip> }
+
+:extb^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=7 & fi & D { dest = zext(D:1); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:extb^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=7 & f & cc ; Limm { dest = zext(Limm:1); if (!f) goto <skip>; resultflags(dest); <skip> }
+:extb^cc^f dest, B      is I=0b00011 & dest & B & C=7 & f & cc { dest = zext(B:1); if (!f) goto <skip>; resultflags(dest); <skip> }
+:extw^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=8 & fi & D { dest = zext(D:2); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:extw^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=8 & f & cc ; Limm { dest = zext(Limm:2); if (!f) goto <skip>; resultflags(dest); <skip> }
+:extw^cc^f dest, B      is I=0b00011 & dest & B & C=8 & f & cc { dest = zext(B:2); if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:flag    #D     is I=0b00011 & A=61 & B=63 & C=0 & D               { set_flags(D:4); }
+:flag^cc #Limm  is I=0b00011 & A=61 & B=62 & C=0 & F=0 & cc ; Limm { set_flags(Limm:4); }
+:flag^cc B      is I=0b00011 & A=61 & B    & C=0 & F=0 & cc        { set_flags(B); }
+
+:lsr^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=2 & fi & D { dest = D >> 1; if (!fi) goto <skip>; rorflags(dest, D:4); <skip> }
+:lsr^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=2 & f & cc ; Limm { dest = Limm >> 1; if (!f) goto <skip>; rorflags(dest, Limm:4); <skip> }
+:lsr^cc^f dest, B      is I=0b00011 & dest & B & C=2 & f & cc { dest = B >> 1; if (!f) goto <skip>; rorflags(dest, B); <skip> }
+
+# TODO: Implement NORM instruction.
+
+:ror^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=3 & fi & D { roronce(dest, D); if (!fi) goto <skip>; rorflags(dest, D:4); <skip> }
+:ror^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=3 & f & cc ; Limm { roronce(dest, Limm); if (!f) goto <skip>; rorflags(dest, Limm:4); <skip> }
+:ror^cc^f dest, B      is I=0b00011 & dest & B & C=3 & f & cc { roronce(dest, B); if (!f) goto <skip>; rorflags(dest, B); <skip> }
+
+:sexb^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=5 & fi & D { dest = sext(D:1); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:sexb^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=5 & f & cc ; Limm { dest = sext(Limm:1); if (!f) goto <skip>; resultflags(dest); <skip> }
+:sexb^cc^f dest, B      is I=0b00011 & dest & B & C=5 & f & cc { dest = sext(B:1); if (!f) goto <skip>; resultflags(dest); <skip> }
+:sexw^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=6 & fi & D { dest = sext(D:2); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:sexw^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=6 & f & cc ; Limm { dest = sext(Limm:2); if (!f) goto <skip>; resultflags(dest); <skip> }
+:sexw^cc^f dest, B      is I=0b00011 & dest & B & C=6 & f & cc { dest = sext(B:2); if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:swap^fi   dest, #D     is I=0b00011 & dest & (B=61 | B=63) & C=9 & fi & D { swapwords(dest, D); if (!fi) goto <skip>; resultflags(dest); <skip> }
+:swap^cc^f dest, #Limm  is I=0b00011 & dest & B=62 & C=9 & f & cc ; Limm { swapwords(dest, Limm); if (!f) goto <skip>; resultflags(dest); <skip> }
+:swap^cc^f dest, B      is I=0b00011 & dest & B & C=9 & f & cc { swapwords(dest, B); if (!f) goto <skip>; resultflags(dest); <skip> }
+
+:st^st_a^st_di #C_D, [#B_D, #D]   is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B=63 & C=63 & D [ B_D = D + 0; C_D = D + 0; ] { *[ram]:4 (D:4 + D) = D; }
+:st^st_a^st_di #Limm, [#B_D, #D]  is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B=63 & C=62 & D ; Limm [ B_D = D + 0; ] { *[ram]:4 (D:4 + D) = Limm; }
+:st^st_a^st_di #C_D, [#Limm, #D]  is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B=62 & C=63 & D ; Limm [ C_D = D + 0; ] { *[ram]:4 (Limm:4 + D) = D; }
+:st^st_a^st_di C, [#B_D, #D]      is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B=63 & C & D [ B_D = D + 0; ] { *[ram]:4 (D:4 + D) = C; }
+:st^st_a^st_di C, [#Limm, #D]     is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B=62 & C & D ; Limm { *[ram]:4 (Limm:4 + D) = C; }
+:st^st_a^st_di #C_D, [B, #D]      is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B & C=63 & D [ C_D = D + 0; ] { *[ram]:4 (B + D) = D; writeback(B, B + D, st_a); }
+:st^st_a^st_di #Limm, [B, #D]     is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B & C=62 & D ; Limm { *[ram]:4 (B + D) = Limm; writeback(B, B + D, st_a); }
+:st^st_a^st_di C, [B, #D]         is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b00 & st_21=0 & B & C & D { *[ram]:4 (B + D) = C; writeback(B, B + D, st_a); }
+
+:stb^st_a^st_di #C_D, [#B_D, #D]   is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B=63 & C=63 & D [ B_D = D + 0; C_D = D + 0; ] { *[ram]:1 (D:4 + D) = D; }
+:stb^st_a^st_di #Limm, [#B_D, #D]  is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B=63 & C=62 & D ; Limm [ B_D = D + 0; ] { *[ram]:1 (D:4 + D) = Limm; }
+:stb^st_a^st_di #C_D, [#Limm, #D]  is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B=62 & C=63 & D ; Limm [ C_D = D + 0; ] { *[ram]:1 (Limm:4 + D) = D; }
+:stb^st_a^st_di C, [#B_D, #D]      is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B=63 & C & D [ B_D = D + 0; ] { *[ram]:1 (D:4 + D) = C; }
+:stb^st_a^st_di C, [#Limm, #D]     is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B=62 & C & D ; Limm { *[ram]:1 (Limm:4 + D) = C; }
+:stb^st_a^st_di #C_D, [B, #D]      is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B & C=63 & D [ C_D = D + 0; ] { *[ram]:1 (B + D) = D; writeback(B, B + D, st_a); }
+:stb^st_a^st_di #Limm, [B, #D]     is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B & C=62 & D ; Limm { *[ram]:1 (B + D) = Limm; writeback(B, B + D, st_a); }
+:stb^st_a^st_di C, [B, #D]         is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b01 & st_21=0 & B & C & D { *[ram]:1 (B + D) = C; writeback(B, B + D, st_a); }
+
+:stw^st_a^st_di #C_D, [#B_D, #D]   is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B=63 & C=63 & D [ B_D = D + 0; C_D = D + 0; ] { *[ram]:2 (D:4 + D) = D; }
+:stw^st_a^st_di #Limm, [#B_D, #D]  is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B=63 & C=62 & D ; Limm [ B_D = D + 0; ] { *[ram]:2 (D:4 + D) = Limm; }
+:stw^st_a^st_di #C_D, [#Limm, #D]  is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B=62 & C=63 & D ; Limm [ C_D = D + 0; ] { *[ram]:2 (Limm:4 + D) = D; }
+:stw^st_a^st_di C, [#B_D, #D]      is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B=63 & C & D [ B_D = D + 0; ] { *[ram]:2 (D:4 + D) = C; }
+:stw^st_a^st_di C, [#Limm, #D]     is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B=62 & C & D ; Limm { *[ram]:2 (Limm:4 + D) = C; }
+:stw^st_a^st_di #C_D, [B, #D]      is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B & C=63 & D [ C_D = D + 0; ] { *[ram]:2 (B + D) = D; writeback(B, B + D, st_a); }
+:stw^st_a^st_di #Limm, [B, #D]     is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B & C=62 & D ; Limm { *[ram]:2 (B + D) = Limm; writeback(B, B + D, st_a); }
+:stw^st_a^st_di C, [B, #D]         is I=0b00010 & st_di & st_25=0 & st_a & st_Z=0b10 & st_21=0 & B & C & D { *[ram]:2 (B + D) = C; writeback(B, B + D, st_a); }
+
+:sr #Limm, [ar_D]  is I=0b00010 & st_Di=0 & st_25=1 & st_A=0 & st_Z=0b00 & st_21=0 & B=63 & C=62 & ar_D ; Limm { ar_D = Limm; }
+:sr D, [#Limm]     is I=0b00010 & st_Di=0 & st_25=1 & st_A=0 & st_Z=0b00 & st_21=0 & B=62 & C=63 & D ; Limm { *[ram]:4 (Limm:4) = D; }
+:sr C, [ar_D]      is I=0b00010 & st_Di=0 & st_25=1 & st_A=0 & st_Z=0b00 & st_21=0 & B=63 & C & ar_D { ar_D = C; }
+:sr C, [#Limm]     is I=0b00010 & st_Di=0 & st_25=1 & st_A=0 & st_Z=0b00 & st_21=0 & B=62 & C ; Limm { *[ram]:4 (Limm:4) = C; }
+:sr D, [B]         is I=0b00010 & st_Di=0 & st_25=1 & st_A=0 & st_Z=0b00 & st_21=0 & B & C=63 & D { *[ram]:4 (B) = D; }
+:sr #Limm, [B]     is I=0b00010 & st_Di=0 & st_25=1 & st_A=0 & st_Z=0b00 & st_21=0 & B & C=62 ; Limm { *[ram]:4 (B) = Limm; }
+:sr C, [B]         is I=0b00010 & st_Di=0 & st_25=1 & st_A=0 & st_Z=0b00 & st_21=0 & B & C { *[ram]:4 (B) = C; }
+
+:ld^ldg_x^ldg_a^ldg_di  dest, [B, #Limm]  is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b00 & ldg_x & dest & B & C=62 ; Limm { dest = *[ram]:4 (B + Limm); }
+:ld^ldg_x^ldg_a^ldg_di  dest, [#Limm, C]  is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b00 & ldg_x & dest & B=62 & C ; Limm { dest = *[ram]:4 (Limm + C); }
+:ld^ldg_x^ldg_a^ldg_di  dest, [B, C]      is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b00 & ldg_x & dest & B & C { local old_B:4 = B; writeback(B, old_B + C, ldg_a); dest = *[ram]:4 (old_B + C); }
+
+:ldb^ldg_x^ldg_a^ldg_di  dest, [B, #Limm]  is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b01 & ldg_x & dest & B & C=62 ; Limm { ldext(dest, *[ram]:1 (B + Limm), ldg_x); }
+:ldb^ldg_x^ldg_a^ldg_di  dest, [#Limm, C]  is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b01 & ldg_x & dest & B=62 & C ; Limm { ldext(dest, *[ram]:1 (Limm + C), ldg_x); }
+:ldb^ldg_x^ldg_a^ldg_di  dest, [B, C]      is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b01 & ldg_x & dest & B & C { local old_B:4 = B; writeback(B, old_B + C, ldg_a); ldext(dest, *[ram]:1 (old_B + C), ldg_x); }
+
+:ldw^ldg_x^ldg_a^ldg_di  dest, [B, #Limm]  is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b10 & ldg_x & dest & B & C=62 ; Limm { ldext(dest, *[ram]:2 (B + Limm), ldg_x); }
+:ldw^ldg_x^ldg_a^ldg_di  dest, [#Limm, C]  is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b10 & ldg_x & dest & B=62 & C ; Limm { ldext(dest, *[ram]:2 (Limm + C), ldg_x); }
+:ldw^ldg_x^ldg_a^ldg_di  dest, [B, C]      is I=0b00000 & ldg_di & ldg_a & ldg_Z=0b10 & ldg_x & dest & B & C { local old_B:4 = B; writeback(B, old_B + C, ldg_a); ldext(dest, *[ram]:2 (old_B + C), ldg_x); }
+
+:ld^lds_x^lds_a^lds_di  dest, [#B_D, #D]   is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b00 & lds_x & dest & B=63 & D [ B_D = D + 0; ] { dest = *[ram]:4 (D:4 + D); }
+:ld^lds_x^lds_a^lds_di  dest, [#Limm, #D]  is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b00 & lds_x & dest & B=62 & D ; Limm { dest = *[ram]:4 (Limm:4 + D); }
+:ld^lds_x^lds_a^lds_di  dest, [B, #D]      is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b00 & lds_x & dest & B & D { local old_B:4 = B; writeback(B, old_B + D, lds_a); dest = *[ram]:4 (old_B + D); }
+
+:ldb^lds_x^lds_a^lds_di  dest, [#B_D, #D]   is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b01 & lds_x & dest & B=63 & D [ B_D = D + 0; ] { ldext(dest, *[ram]:1 (D:4 + D), lds_x); }
+:ldb^lds_x^lds_a^lds_di  dest, [#Limm, #D]  is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b01 & lds_x & dest & B=62 & D ; Limm { ldext(dest, *[ram]:1 (Limm:4 + D), lds_x); }
+:ldb^lds_x^lds_a^lds_di  dest, [B, #D]      is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b01 & lds_x & dest & B & D { local old_B:4 = B; writeback(B, old_B + D, lds_a); ldext(dest, *[ram]:1 (old_B + D), lds_x); }
+
+:ldw^lds_x^lds_a^lds_di  dest, [#B_D, #D]   is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b10 & lds_x & dest & B=63 & D [ B_D = D + 0; ] { ldext(dest, *[ram]:2 (D:4 + D), lds_x); }
+:ldw^lds_x^lds_a^lds_di  dest, [#Limm, #D]  is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b10 & lds_x & dest & B=62 & D ; Limm { ldext(dest, *[ram]:2 (Limm:4 + D), lds_x); }
+:ldw^lds_x^lds_a^lds_di  dest, [B, #D]      is I=0b00001 & lds_di & lds_13=0 & lds_a & lds_Z=0b10 & lds_x & dest & B & D { local old_B:4 = B; writeback(B, old_B + D, lds_a); ldext(dest, *[ram]:2 (old_B + D), lds_x); }
+
+:lr  dest, [ar_D]   is I=0b00001 & lds_Di=0 & lds_13=1 & lds_A=0 & lds_Z=0b00 & lds_X=0 & dest & B=63 & ar_D { dest = ar_D; }
+:lr  dest, [#Limm]  is I=0b00001 & lds_Di=0 & lds_13=1 & lds_A=0 & lds_Z=0b00 & lds_X=0 & dest & B=62 ; Limm { dest = *[auxregs]:4 (Limm:4); }
+:lr  dest, [B]      is I=0b00001 & lds_Di=0 & lds_13=1 & lds_A=0 & lds_Z=0b00 & lds_X=0 & dest & B { dest = *[auxregs]:4 (B); }

--- a/Ghidra/Processors/ARC/data/languages/ARC32_be.slaspec
+++ b/Ghidra/Processors/ARC/data/languages/ARC32_be.slaspec
@@ -1,0 +1,3 @@
+define endian=big;
+
+@include "ARC32.sinc"

--- a/Ghidra/Processors/ARC/data/languages/ARC32_le.slaspec
+++ b/Ghidra/Processors/ARC/data/languages/ARC32_le.slaspec
@@ -1,0 +1,3 @@
+define endian=little;
+
+@include "ARC32.sinc"


### PR DESCRIPTION
This PR adds support for the legacy, pre-ARCompact ARC ISA with 32-bit instructions. While similar to ARCompact in its programming model and instruction semantics, the instruction encoding is _completely different_ from that of the ARCompact ISA and its 16/32-bit instructions. Since this legacy instruction set tends to be referred to as just the "ARC" ISA in documentation and binutils/GCC, to avoid confusion with the modern ARC ISAs I've named this one "ARC32" in the language definitions.

The ISA manual for this instruction set can be found [here](http://me.bios.io/images/c/c6/ARC4._Programmers_reference.pdf).

As far as I can tell, this ISA was last used in the ARCtangent-A4 processor, which [was used for the Intel Management Engine in chipsets prior to the release of the Intel 5 Series (Ibex Peak) chipsets](https://recon.cx/2014/slides/Recon%202014%20Skochinsky.pdf#page=16). This ISA is also used in all versions of the [Broadcom Crystal HD](https://en.wikipedia.org/wiki/Broadcom_Crystal_HD) video decoder chip (whose firmware can be found [here](https://github.com/yeradis/crystalhd/tree/0d08f182397d732dec70099a6a0af835b677f8df/firmware/fwbin)). Hopefully this demonstrates that the core popular enough to justify inclusion in Ghidra.

Unfortunately, when it comes to C toolchains, support for this ISA was removed from GCC nearly a decade ago, and I have been unable to build the last version that supported it (4.5.4). Fortunately, there is a pre-built ARC toolchain (available [here](https://www.maintech.de/support/toolchains/)) that includes both binutils and GCC and can compile for both big-endian and little-endian ARC. In addition to the pre-built toolchain, binutils 2.25.1 (the last version to support this ISA) can still easily be built from source (without modification), and can be used to assemble and disassemble code for this architecture.

I've tested this processor module's disassembly of some of the libraries included in the pre-built toolchain, and compared the output to that of `objdump -d` from binutils 2.25.1 for the same libraries, and they seem to match, but it'd be nice to have some more automated testing of this, both to confirm that the disassembly listing is correct and to validate the p-code implementation of the instruction semantics. Unfortunately, I don't really understand how to enable these tests, so I'd appreciate some assistance with that.

This module is still missing support for some instructions (MAX, MIN, NORM, see TODOs) as well as semantics for some instructions (I have no idea how to implement LP or the "only execute the delay slot when jumping" for branch/jump instructions--see FIXMEs), so I'd appreciate some assistance here as well.

I had originally intended the directory for this processor module to contain all the variants of the ARC ISA, including ARC32, ARCompact, and later ARC ISAs. This is why I just named the directory "ARC" and not "ARC32", but that was before I discovered that someone else had already started adding support for ARCompact in PR #3006. At this point, I'm not sure if you'd rather I rename this module to ARC32, have #3006 rebase off of this PR and move their code under "ARC", or keep everything separate like it is now. I expect that fully implementing ARC32 will take some more time, so maybe it'd be best to keep ARC32 and ARCompact separate for now and only combine them later once they've both been merged into Ghidra. Or maybe we should just keep them separate indefinitely since their instruction encodings are so different.

I'm eager for any advice, suggestions, and comments that anyone might offer.