### PR TITLE
Fix script directory path expansion in analyzeHeadless.bat

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/support/analyzeHeadless.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/analyzeHeadless.bat
@@ -22,6 +22,9 @@ set DEBUG_ADDRESS=127.0.0.1:13002
 set VMARG_LIST=-XX:ParallelGCThreads=2
 set VMARG_LIST=%VMARG_LIST% -XX:CICompilerCount=2
 
+:: Store current path
+set "SCRIPT_DIR=%~dp0"
+
 :: Loop through parameters (if there aren't any, just continue) and store
 ::   in params variable.
 
@@ -49,4 +52,4 @@ goto Loop
 
 :cont
 
-call "%~dp0launch.bat" %LAUNCH_MODE% Ghidra-Headless "%MAXMEM%" "%VMARG_LIST%" ghidra.app.util.headless.AnalyzeHeadless %params%
+call "%SCRIPT_DIR%launch.bat" %LAUNCH_MODE% Ghidra-Headless "%MAXMEM%" "%VMARG_LIST%" ghidra.app.util.headless.AnalyzeHeadless %params%


### PR DESCRIPTION
This fixes a regression in analyzeHeadless.bat introduced by https://github.com/NationalSecurityAgency/ghidra/commit/7f50d8f4301cdee4a20636281295746557919d31.

The script contains a loop modifying parameters, which seems to also affect `%~dp0`. In my case (testing an extension), this resulted in the path pointing to the extension's script directory instead of the support directory, breaking the test script and CI (see https://github.com/mborgerson/ghidra-xbe/pull/31/checks?check_run_id=3138785871).

My fix is to re-introduce a variable that stores the path. This is how it was done before, and how the other scripts do it. I tested that it still reacts in the expected way when the path contains an exclamation mark, and it does indeed print the correct error message, while also fixing the regression.

The regression only affects Ghidra 10.0.1 afaict.