### PR TITLE
Fix error where win user dir has space in it

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/support/launch.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/launch.bat
@@ -39,7 +39,7 @@ set "SUPPORT_DIR=%~dp0"
 set "SUPPORT_DIR=%SUPPORT_DIR:~0,-1%"
 
 :: Ensure Ghidra path doesn't contain illegal characters
-if not "%SUPPORT_DIR:!=%"=="%SUPPORT_DIR%" (
+ECHO.%SUPPORT_DIR%| FIND /I "!">Nul && ( 
 	echo Ghidra path cannot contain a "!" character.
 	set ERRORLEVEL=1
 	goto exit1


### PR DESCRIPTION
The launch script would error out for me when running giving me this:
```
C:\Users\Lillian Armes\Downloads\ghidra_10.0.1_PUBLIC>ghidraRun.bat
Armes\Downloads\ghidra_10.0.1_PUBLIC\support==C:\Users\Lillian was unexpected at this time.
```