### PR TITLE
Corrected the first pair type inserted into recs

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
@@ -1229,7 +1229,7 @@ void ConsistencyChecker::examineVn(map<uintb,OptimizeRecord> &recs,
   if (vn->getOffset().getType() != ConstTpl::real) return;
 
   map<uintb,OptimizeRecord>::iterator iter;
-  iter = recs.insert( pair<uint4,OptimizeRecord>(vn->getOffset().getReal(),OptimizeRecord())).first;
+  iter = recs.insert({vn->getOffset().getReal(),OptimizeRecord()}).first;
   if (inslot>=0) {
     (*iter).second.readop = i;
     (*iter).second.readcount += 1;


### PR DESCRIPTION
I found this by removing the pragmas in `types.h` that are suppressing warnings. Suppressing warnings is always a bad idea.