### PR TITLE
Add letters A-Z for moving 10-35 items down in the menu list

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/menu/keys/MenuKeyProcessor.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/menu/keys/MenuKeyProcessor.java
@@ -39,6 +39,11 @@ public class MenuKeyProcessor {
 			menuHandlersByKeyStroke.put(keyStroke(Integer.toString(i)),
 				new NumberMenuKeyHandler(i));
 		}
+
+		for (char c = 'A'; c <= 'Z'; c++) {
+			menuHandlersByKeyStroke.put(keyStroke(Character.toString(c)),
+				new NumberMenuKeyHandler(10 + (int)c - (int)'A'));
+		}
 	}
 
 	/**


### PR DESCRIPTION
An addition to <https://github.com/NationalSecurityAgency/ghidra/issues/2811> that simply enables letters A-Z to be used to move the current menu selection down 10-35 items.  (Ghidra has some long menus!!)