### PR TITLE
Added TypeDef support

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -2207,7 +2207,6 @@ int4 ActionSetCasts::castOutput(PcodeOp *op,Funcdata &data,CastStrategy *castStr
   Datatype *outct,*ct,*tokenct;
   Varnode *vn,*outvn;
   PcodeOp *newop;
-  bool force=false;
 
   tokenct = op->getOpcode()->getOutputToken(op,castStrategy);
   outvn = op->getOut();
@@ -2222,14 +2221,10 @@ int4 ActionSetCasts::castOutput(PcodeOp *op,Funcdata &data,CastStrategy *castStr
       if ((meta!=TYPE_ARRAY)&&(meta!=TYPE_STRUCT))
 	outvn->updateType(tokenct,false,false); // Otherwise ignore it in favor of the token type
     }
-    if (outvn->getType() != tokenct)
-      force=true;		// Make sure not to drop pointer type
   }
-  if (!force) {
-    outct = outvn->getHigh()->getType();	// Type of result
-    ct = castStrategy->castStandard(outct,tokenct,false,true);
-    if (ct == (Datatype *)0) return 0;
-  }
+  outct = outvn->getHigh()->getType();	// Type of result
+  ct = castStrategy->castStandard(outct,tokenct,false,true);
+  if (ct == (Datatype *)0) return 0;
 				// Generate the cast op
   vn = data.newUnique(op->getOut()->getSize());
   vn->updateType(tokenct,false,false);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/grammar.y
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/grammar.y
@@ -1037,7 +1037,7 @@ Datatype *CParse::newStruct(const string &ident,vector<TypeDeclarator *> *declis
     sublist.back().offset = -1;	// Let typegrp figure out offset
   }
 
-  if (!glb->types->setFields(sublist,res,-1,0)) {
+  if (!glb->types->setFields(move(sublist),res,-1,0)) {
     setError("Bad structure definition");
     glb->types->destroyType(res);
     return (Datatype *)0;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -1578,6 +1578,9 @@ void PrintC::pushConstant(uintb val,const Datatype *ct,
   case TYPE_FLOAT:
     push_float(val,ct->getSize(),vn,op);
     return;
+  case TYPE_ALIAS:
+    pushConstant(val, ((const TypeAlias *)ct)->getDatatype(), vn, op);
+    return;
   case TYPE_SPACEBASE:
   case TYPE_CODE:
   case TYPE_ARRAY:

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
@@ -127,6 +127,7 @@ public:
   void saveXmlBasic(ostream &s) const;	///< Save basic data-type properties
   void saveXmlRef(ostream &s) const;	///< Write an XML reference of \b this to stream
   bool isPtrsubMatching(uintb offset) const;	///< Is this data-type suitable as input to a CPUI_PTRSUB op
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const { return id == reqtype->id; }
 };
 
 /// \brief Specifies subfields of a structure or what a pointer points to
@@ -175,6 +176,7 @@ public:
   /// Construct TypeBase from a size, meta-type, and name
   TypeBase(int4 s,type_metatype m,const string &n) : Datatype(s,m,n) {}
   virtual Datatype *clone(void) const { return new TypeBase(*this); }
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const;
 };
 
 /// \brief Base type for character data-types: i.e. char
@@ -222,6 +224,7 @@ public:
   TypeVoid(void) : Datatype(0,TYPE_VOID,"void") { flags |= Datatype::coretype; }
   virtual Datatype *clone(void) const { return new TypeVoid(*this); }
   virtual void saveXml(ostream &s) const;
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const { return reqtype->getMetatype()==TYPE_VOID; }
 };
 
 /// \brief Datatype object representing a pointer
@@ -248,6 +251,7 @@ public:
   virtual int4 compareDependency(const Datatype &op) const; // For tree structure
   virtual Datatype *clone(void) const { return new TypePointer(*this); }
   virtual void saveXml(ostream &s) const;
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const;
   virtual TypePointer *downChain(uintb &off,bool allowArrayWrap,TypeFactory &typegrp);
 };
 
@@ -278,6 +282,7 @@ public:
   virtual int4 compareDependency(const Datatype &op) const; // For tree structure
   virtual Datatype *clone(void) const { return new TypeArray(*this); }
   virtual void saveXml(ostream &s) const;
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const;
 };
 
 /// \brief An enumerated Datatype object: an integer with named values.
@@ -305,6 +310,7 @@ public:
   virtual int4 compareDependency(const Datatype &op) const;
   virtual Datatype *clone(void) const { return new TypeEnum(*this); }
   virtual void saveXml(ostream &s) const;
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const;
 };
 
 /// \brief A composite Datatype object: A "structure" with component "fields"
@@ -331,6 +337,7 @@ public:
   virtual int4 compareDependency(const Datatype &op) const; // For tree structure
   virtual Datatype *clone(void) const { return new TypeStruct(*this); }
   virtual void saveXml(ostream &s) const;
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const;
 };
 
 class FuncProto;		// Forward declaration
@@ -361,6 +368,7 @@ public:
   virtual int4 compareDependency(const Datatype &op) const;
   virtual Datatype *clone(void) const { return new TypeCode(*this); }
   virtual void saveXml(ostream &s) const;
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const;
 };
 
 /// \brief Special Datatype object used to describe pointers that index into the symbol table
@@ -391,6 +399,7 @@ public:
   virtual int4 compareDependency(const Datatype &op) const; // For tree structure
   virtual Datatype *clone(void) const { return new TypeSpacebase(*this); }
   virtual void saveXml(ostream &s) const;
+  virtual bool isEquivalent(const Datatype *reqtype,bool care_uint_int,bool care_ptr_uint) const;
 };
 
 /// \brief Container class for all Datatype objects in an Architecture

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/utils.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/utils.hh
@@ -1,0 +1,75 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// \file utils.hh
+/// \brief Generic utilities
+
+#ifndef __UTILS__
+#define __UTILS__
+
+#include <string>
+#include <type_traits>
+
+template <typename T>
+inline T to_number(const std::string &s, size_t *idx = nullptr, int base = 0)
+
+{
+  static_assert(std::is_integral<T>::value, "no instance of function template \"to_number\" matches the argument list");
+  return to_number<std::decay<int4>::type>(s, idx, base);
+}
+
+template <typename T>
+inline T to_hex_number(const std::string &s, size_t *idx = nullptr)
+
+{
+  return to_number<T>(s, idx, 16);
+}
+
+template<>
+inline int to_number<int>(const std::string &s, size_t *idx, int base)
+
+{
+  return std::stoi(s, idx, base);
+}
+
+template<>
+inline long to_number<long>(const std::string &s, size_t *idx, int base)
+
+{
+  return std::stol(s, idx, base);
+}
+
+template<>
+inline long long to_number<long long>(const std::string &s, size_t *idx, int base)
+
+{
+  return std::stoll(s, idx, base);
+}
+
+template<>
+inline unsigned long to_number<unsigned long>(const std::string &s, size_t *idx, int base)
+
+{
+  return std::stoul(s, idx, base);
+}
+
+template<>
+inline unsigned long long to_number<unsigned long long>(const std::string &s, size_t *idx, int base)
+
+{
+  return std::stoull(s, idx, base);
+}
+
+#endif


### PR DESCRIPTION
This isn't fully complete and requires/contains #3301.

The last function I debugged is as follows. You can see that `FILE *` is still being cast which the whole purpose of this is to prevent. This function was able to decompile in the decompiler without a problem but gets stuck in an infinite loop in Ghidra and I have yet to figure out why. One thing I was not 100% sure about is the type ordering and how to properly handle the `CompareDependency` for `TypeAlias`.

```c
void _lock_file(FILE *_File)

{
  __crt_stdio_stream *this;
  __crt_stdio_stream_data *p_Var1;
  __crt_stdio_stream local_18 [24];
  
  this = __crt_stdio_stream::__crt_stdio_stream(local_18,(_iobuf *)_File);
  p_Var1 = __crt_stdio_stream::operator->(this);
  EnterCriticalSection((LPCRITICAL_SECTION)(p_Var1 + 0x30));
  return;
}
``` 

The class is named `TypeAlias` because `TypeTypedef` or `TypeTypeDef` was just 🤮 