### PR TITLE
fix loading of RUNTIME_FUNCTION structures from x64 PEs

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
@@ -413,7 +413,7 @@ public class FileHeader implements StructConverter {
 
 		long oldIndex = reader.getPointerIndex();
 
-		int start = irfeHeader.getPointerToRawData();
+		int start = ntHeader.rvaToPointer(irfeHeader.getVirtualAddress());
 		reader.setPointerIndex(start);
 
 		ImageRuntimeFunctionEntries entries =


### PR DESCRIPTION
This fixes loading of RUNTIME_FUNCTION structures from x64 PE files when loaded using SectionLayout.MEMORY.

Currently if you try to use `PortableExecutable.createPortableExecutable()` with an in-memory section layout, the `processImageRuntimeFunctionEntries` function will use the physical address of the start of the `.pdata` section instead of the virtual address. This works fine when importing x64 PEs but will cause exceptions in scripts that perform PE parsing after a binary has already been imported, eg. PortableExecutableRichPrintScript.java.

The patch uses `rvaToPointer` to account for the section layout specified when loading the PE.