### PR TITLE
Unicode function is wrongly specified for Windows

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/filemanage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/filemanage.cc
@@ -102,7 +102,7 @@ void FileManage::addCurrentDir(void)
 bool FileManage::isDirectory(const string &path)
 
 {
-  DWORD attribs = GetFileAttributes(path.c_str());
+  DWORD attribs = GetFileAttributesA(path.c_str());
   if (attribs == INVALID_FILE_ATTRIBUTES) return false;
   return ((attribs & FILE_ATTRIBUTE_DIRECTORY)!=0);
 }


### PR DESCRIPTION
Compiling with MSVC correctly yields the following error since ASCII is not defined and UNICODE can easily default:

```
1>D:\Source\Repos\GhidraDec\decompile\filemanage.cc(105,49): error C2664: 'DWORD GetFileAttributesW(LPCWSTR)': cannot convert argument 1 from 'const _Elem *' to 'LPCWSTR'
1>        with
1>        [
1>            _Elem=char
1>        ]
```

This is clearly a bug anyway as FindFirstFileA, FindNextFileA and GetCurrentDirectoryA are correctly used in the file.