### PR TITLE
C/CPP: Eliminate static state from generated parsers

### DIFF
--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
@@ -718,7 +718,7 @@ PARSER_END(CParser)
 
 TOKEN_MGR_DECLS :
 {
-    static int parenNesting = 0;
+    int parenNesting = 0;
 }
 
 SKIP :

--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/CPP/CPP.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/CPP/CPP.jj
@@ -437,7 +437,7 @@ public class PreProcessor {
 	private HashMap<String, Integer> alreadyDone;
 
 	// Toggle printing
-	private static int verboseLevel = 0;
+	private int verboseLevel = 0;
 
 	public int verboseLevel() {
 		int vl = verboseLevel;
@@ -1125,6 +1125,7 @@ public class PreProcessor {
 		this.pathList = parent.pathList;
 		this.shift = parent.shift;
 		this.alreadyDone = parent.alreadyDone;
+		this.verboseLevel = parent.verboseLevel;
 	}
 
 	public PreProcessor(String[] args) throws ParseException {
@@ -2174,7 +2175,7 @@ PPToken ValueExpression() :
 // LEXICAL SCANNER SECTION
 TOKEN_MGR_DECLS :
 {
-    static int parenNesting = 0;
+    int parenNesting = 0;
 }
 
 <DEFAULT>


### PR DESCRIPTION
This fixes issue #1421 by tracking the parenthesis depth per CPP tokenizer instead of globally across all instances. The former behavior allowed one failed parser run to break all subsequent parser runs until Ghidra was restarted. There is no reason this variable needs to be static, anyway, since it's a per-file piece of state.

Also make the same fix to the C tokenizer and to the CPP verbosity level, the only other static variables in either parser. Neither of those pieces of state should persist across parser runs either.