### PR TITLE
Adds TLS SNI to ghidra client connections

### DIFF
--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/GhidraSSLClientSocket.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/GhidraSSLClientSocket.java
@@ -1,0 +1,44 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.framework.client;
+
+import java.io.IOException;
+import java.net.*;
+import java.util.*;
+
+import javax.net.ssl.*;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+
+/**
+ * <code>GhidraSSLClientSocket</code> facilitates ability to impose client authentication
+ * for SSL server sockets used with Ghidra Server RMI connection.
+ */
+public class GhidraSSLClientSocket extends SslRMIClientSocketFactory {
+	/**
+	 * Creates an SSLSocket on a given port
+	 *
+	 * @throws IOException if an error occurs on socket creation.
+	 */
+	public Socket createSocket(String host, int port) throws IOException
+	{
+		SSLSocket sslSocket = (SSLSocket) super.createSocket(host, port);
+		List<SNIServerName> serverNames = Arrays.asList(new SNIHostName(host));
+		SSLParameters params = sslSocket.getSSLParameters();
+		params.setServerNames(serverNames);
+		sslSocket.setSSLParameters(params);
+		return sslSocket;
+	}
+}

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
-import javax.rmi.ssl.SslRMIClientSocketFactory;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.PasswordCallback;
@@ -163,7 +162,7 @@ class ServerConnectTask extends Task {
 			}
 			catch (IOException e) {
 				reg = LocateRegistry.getRegistry(server.getServerName(), server.getPortNumber(),
-					new SslRMIClientSocketFactory());
+					new GhidraSSLClientSocket());
 				checkServerBindNames(reg);
 			}
 
@@ -321,7 +320,7 @@ class ServerConnectTask extends Task {
 	private static void testServerSSLConnection(ServerInfo server) throws IOException {
 
 		RMIServerPortFactory portFactory = new RMIServerPortFactory(server.getPortNumber());
-		SslRMIClientSocketFactory factory = new SslRMIClientSocketFactory();
+		GhidraSSLClientSocket factory = new GhidraSSLClientSocket();
 		String serverName = server.getServerName();
 		int sslRmiPort = portFactory.getRMISSLPort();
 


### PR DESCRIPTION
This PR adds the SNI extension to the TLS requests, which enables proxying by domain.  It should be ignored/unused for direct connections, since the Ghidra server-side doesn't look at SNI.

- Adds SNI to RMI sockets (13100 and 13101)
- Adds SNI to Block Stream socket