### PR TITLE
Fix: ARM setStackMode() parameter

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -2837,7 +2837,7 @@ define pcodeop setStackMode;
 # TODO: not sure about the following semantics  
   b = isThreadMode();
   if (!b) goto inst_next;
-  stackMode:1 = isUsingMainStack() == 1:1;
+  stackMode:1 = (Rn0003 & 2) != 0;
   setStackMode(stackMode);
 # TODO: should we set sp ?
 }


### PR DESCRIPTION
Currently all changes to the stack mode of an ARM Cortex processor are completely ignored by Ghidra, because the register in the SLEIGH definition is not used for generating the parameter for the `setStackMode` function.
For example, the following assembly instructions: 
```
ef f3 14 83     mrs        r3,control
43 f0 02 03     orr        r3,r3,#0x2
83 f3 14 88     msr        control,r3
```
result in
```c
[...]
      cVar1 = isUsingMainStack();
      setStackMode(cVar1 == '\x01');
```

but I would expect a result that is similar to the usage described in the [ARM Documentation](https://developer.arm.com/documentation/dui0646/a/CHDBIBGJ#BABIFGGB).
The changes to this pull request will therefore result in the following code being generated:
```c
[...]
      setStackMode(1);
```