### PR TITLE
Fix semantics for certain encodings of ARM vcvt

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMv8.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMv8.sinc
@@ -651,28 +651,28 @@ vcvt_56_128_dt: ".u32.f32"
 	is ((TMode=0 &        ARMcond=1 &     c2327=0b11101 &     c1921=0b111 &     c1011=0b10 &     c0607=0b11 &     c0404=0 &     c1618=0b100 &     c0809=0b10)
 	|   (TMode=1 & thv_c2831=0b1110 & thv_c2327=0b11101 & thv_c1921=0b111 & thv_c1011=0b10 & thv_c0607=0b11 & thv_c0404=0 & thv_c1618=0b100 & thv_c0809=0b10))
 	& COND & Sd & Sm
-	{ build COND; Sd = zext(round(Sm)); }
+	{ build COND; Sd = trunc(Sm); }
 
 # F6.1.57 p3356 A1 opc2==101 && size==10 (c1618, c0809)
 :vcvt^COND^".s32.f32"	Sd,Sm
 	is ((TMode=0 &        ARMcond=1 &     c2327=0b11101 &     c1921=0b111 &     c1011=0b10 &     c0607=0b11 &     c0404=0 &     c1618=0b101 &     c0809=0b10)
 	|   (TMode=1 & thv_c2831=0b1110 & thv_c2327=0b11101 & thv_c1921=0b111 & thv_c1011=0b10 & thv_c0607=0b11 & thv_c0404=0 & thv_c1618=0b101 & thv_c0809=0b10))
 	& COND & Sd & Sm
-	{ build COND; Sd = sext(round(Sm)); }
+	{ build COND; Sd = trunc(Sm); }
 
 # F6.1.57 p3356 A1 opc2==100 && size==11 (c1618, c0809)
 :vcvt^COND^".u32.f64"	Sd,Dm
 	is ((TMode=0 &        ARMcond=1 &     c2327=0b11101 &     c1921=0b111 &     c1011=0b10 &     c0607=0b11 &     c0404=0 &     c1618=0b100 &     c0809=0b11)
 	|   (TMode=1 & thv_c2831=0b1110 & thv_c2327=0b11101 & thv_c1921=0b111 & thv_c1011=0b10 & thv_c0607=0b11 & thv_c0404=0 & thv_c1618=0b100 & thv_c0809=0b11))
 	& COND & Sd & Dm
-	{ build COND; local tmp:8 = zext(round(Dm)); Sd = tmp:4; }
+	{ build COND; local tmp:8 = trunc(Dm); Sd = tmp:4; }
 
 # F6.1.57 p3356 A1 opc2==101 && size==11 (c1618, c0809)
 :vcvt^COND^".s32.f64"	Sd,Dm
 	is ((TMode=0 &        ARMcond=1 &     c2327=0b11101 &     c1921=0b111 &     c1011=0b10 &     c0607=0b11 &     c0404=0 &     c1618=0b101 &     c0809=0b11)
 	|   (TMode=1 & thv_c2831=0b1110 & thv_c2327=0b11101 & thv_c1921=0b111 & thv_c1011=0b10 & thv_c0607=0b11 & thv_c0404=0 & thv_c1618=0b101 & thv_c0809=0b11))
 	& COND & Sd & Dm
-	{ build COND; local tmp:8 = sext(round(Dm)); Sd = tmp:4; }
+	{ build COND; local tmp:8 = trunc(Dm); Sd = tmp:4; }
 
 # The rounding mode depends on c0707=0 => FPSCR else ZERO
 


### PR DESCRIPTION
Previously the encoding of the ARM VCVT instruction was lifted into pcode with `round`, however, per [Arm Architecture Reference Manual for ARMv8](https://developer.arm.com/documentation/ddi0487/latest), section F6.1.61, whose bit-pattern matches is handled by the ARMv8.sinc lines 650-675, is described as:

> Convert floating-point to integer with Round towards Zero converts a value in a register from floating-point to a 32-bit integer, using the Round towards Zero rounding mode, and places the result in a second register.

Importantly, the written register is rounded and converted to a {signed,unsigned} 32 bit integer, while previously it was only rounded and written as a floating point integer, leading to incorrect semantics of the instruction. This MR replaces the lifting to use `trunc` in these situations rather than `round`, since `trunc` handles the rounding to zero implicitly as well as the cast.

There is a correctness issue here around the unsigned cases, since `trunc` will convert from float -> signed integer, and in the unsigned cases this will be incorrect. After looking around at some other architecture's handling of this case (such as [RISC-V](https://github.com/NationalSecurityAgency/ghidra/blob/da94eb86bd2b89c8b0ab9bd89e9f0dc5a3157055/Ghidra/Processors/RISCV/data/languages/riscv.rv64d.sinc#L31)), it seems that this is an acceptable inaccuracy. 