### PR TITLE
Return value isn't used.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/marker/MarkerSetImpl.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/marker/MarkerSetImpl.java
@@ -437,7 +437,7 @@ abstract class MarkerSetImpl implements MarkerSet {
 			BigInteger bigEndy = BigInteger.valueOf(y + MARKER_HEIGHT);
 			BigInteger numIndexes = map.getIndexCount();
 			BigInteger numIndexesMinus1 = numIndexes.subtract(BigInteger.ONE);
-			numIndexesMinus1.max(BigInteger.ZERO);
+			numIndexesMinus1 = numIndexesMinus1.max(BigInteger.ZERO);
 
 			BigInteger start = getIndex(bigStarty, bigHeight, numIndexes, numIndexesMinus1);
 			BigInteger end = getIndex(bigEndy, bigHeight, numIndexes, numIndexesMinus1);


### PR DESCRIPTION
numIndexesMinus1 should not be negative so we want the max(numIndexesMinus1, 0) but for that we need to use the return value from BigInteger.max().