### PR TITLE
Use return value from substring()

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliAbstractSig.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliAbstractSig.java
@@ -723,7 +723,7 @@ public abstract class CliAbstractSig extends CliBlob implements CliRepresentable
 				modsRep += mod.toString() + ", ";
 			}
 			if (customMods.size() > 0) {
-				modsRep.substring(0, modsRep.length() - 2); // Remove last comma+space
+				modsRep = modsRep.substring(0, modsRep.length() - 2); // Remove last comma+space
 			}
 			return String.format("SzArray %s %s", modsRep, typeRep);
 		}


### PR DESCRIPTION
The substring() method returns the desired result instead of modifying the current string.