### PR TITLE
Update 6502.pspec - remove motorola 6805 symbols

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.pspec
+++ b/Ghidra/Processors/6502/data/languages/6502.pspec
@@ -8,32 +8,6 @@
   </volatile>
   
   <default_symbols>
-    <symbol name="PORTA" address="0"/>
-    <symbol name="PORTB" address="1"/>
-    <symbol name="PORTC" address="2"/>
-    <symbol name="PORTD" address="3"/>
-    <symbol name="DDRA" address="4"/>
-    <symbol name="DDRB" address="5"/>
-    <symbol name="DDRC" address="6"/>
-    <symbol name="DDRD" address="7"/>
-    <symbol name="SPCR" address="A"/>
-    <symbol name="SPSR" address="B"/>
-    <symbol name="SPDR" address="C"/>
-    <symbol name="BAUD" address="D"/>
-    <symbol name="SCCR1" address="E"/>
-    <symbol name="SCCR2" address="F"/>
-    <symbol name="SCSR" address="10"/>
-    <symbol name="SCDAT" address="11"/>
-    <symbol name="TCR" address="12"/>
-    <symbol name="TSR" address="13"/>
-    <symbol name="ICHR" address="14"/>
-    <symbol name="ICLR" address="15"/>
-    <symbol name="OCHR" address="16"/>
-    <symbol name="OCLR" address="17"/>
-    <symbol name="CHR" address="18"/>
-    <symbol name="CLR" address="19"/>
-    <symbol name="ACHR" address="1A"/>
-    <symbol name="ACLR" address="1B"/>
     <symbol name="NMI" address="FFFA" entry="true" type="code_ptr"/>
     <symbol name="RES" address="FFFC" entry="true" type="code_ptr"/>
     <symbol name="IRQ" address="FFFE" entry="true" type="code_ptr"/>


### PR DESCRIPTION
The symbols such as SPDR, BAUD, SCCR1, SCDAT do not exist for MOS Technology 6502 processor family, 
those symbols were likely copied from Motorola 6805 or 68HC11 processor by mistake, which is a completely different CPU.

see (Ghidra/Processors/6805/data/languages/6805.pspec)

