### PR TITLE
Fix VLE register in PowerPC emulation (See issue #3428)

### DIFF
--- a/Ghidra/Processors/PowerPC/src/main/java/ghidra/program/emulation/PPCEmulateInstructionStateModifier.java
+++ b/Ghidra/Processors/PowerPC/src/main/java/ghidra/program/emulation/PPCEmulateInstructionStateModifier.java
@@ -24,15 +24,28 @@ import ghidra.pcode.emulate.callother.OpBehaviorOther;
 import ghidra.pcode.memstate.MemoryState;
 import ghidra.pcodeCPort.error.LowlevelError;
 import ghidra.program.model.pcode.Varnode;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.lang.Register;
+import ghidra.program.model.lang.RegisterValue;
+import ghidra.program.model.pcode.PcodeOp;
 
 public class PPCEmulateInstructionStateModifier extends EmulateInstructionStateModifier {
+
+	private Register VLEModeReg;
+	private RegisterValue vleMode;
+	private RegisterValue ppcMode;
 
 	public PPCEmulateInstructionStateModifier(Emulate emu) {
 		super(emu);
 
+		VLEModeReg = language.getRegister("vle");
 		registerPcodeOpBehavior("countLeadingZeros", new CountLeadingZerosOpBehavior());
 		registerPcodeOpBehavior("vectorPermute", new vectorPermuteOpBehavior());
 
+		if (VLEModeReg != null) {
+			vleMode = new RegisterValue(VLEModeReg, BigInteger.ONE);
+			ppcMode = new RegisterValue(VLEModeReg, BigInteger.ZERO);
+		}
 	}
 
 	private class vectorPermuteOpBehavior implements OpBehaviorOther {
@@ -107,5 +120,52 @@ public class PPCEmulateInstructionStateModifier extends EmulateInstructionStateM
 		int destStartIndex = byteLength - copyCount; // adjust if too few bytes provided
 		System.arraycopy(srcBytes, srcStartIndex, result, destStartIndex, copyCount);
 		return result;
+	}
+
+	/**
+	 * Initialize VLE register based upon context-register state before first instruction is executed.
+	 */
+	@Override
+	public void initialExecuteCallback(Emulate emulate, Address current_address, RegisterValue contextRegisterValue) throws LowlevelError {
+		if (VLEModeReg == null) {
+			return; // VLE mode not supported
+		}
+		BigInteger vleModeValue = BigInteger.ZERO;
+		if (contextRegisterValue != null) {
+			vleModeValue =
+				contextRegisterValue.getRegisterValue(VLEModeReg).getUnsignedValueIgnoreMask();
+		}
+		if (!BigInteger.ZERO.equals(vleModeValue)) {
+			vleModeValue = BigInteger.ONE;
+		}
+		emu.getMemoryState().setValue(VLEModeReg, vleModeValue);
+	}
+
+	/**
+	 * Language should properly preserve the context register during the flow of execution, but it doesn't.
+	 */
+	@Override
+	public void postExecuteCallback(Emulate emulate, Address lastExecuteAddress,
+			PcodeOp[] lastExecutePcode, int lastPcodeIndex, Address currentAddress)
+			throws LowlevelError {
+		if (VLEModeReg == null) {
+			return; // VLE mode not supported
+		}
+		if (lastPcodeIndex < 0) {
+			// ignore fall-through condition
+			return;
+		}
+		int lastOp = lastExecutePcode[lastPcodeIndex].getOpcode();
+		if (lastOp != PcodeOp.BRANCH && lastOp != PcodeOp.CBRANCH && lastOp != PcodeOp.BRANCHIND &&
+			lastOp != PcodeOp.CALL && lastOp != PcodeOp.CALLIND && lastOp != PcodeOp.RETURN) {
+			// only concerned with Branch, Call or Return ops
+			return;
+		}
+		long vle = emu.getMemoryState().getValue(VLEModeReg);
+		if (vle == 1) {
+			emu.setContextRegisterValue(vleMode);
+		} else if (vle == 0) {
+			emu.setContextRegisterValue(ppcMode);
+		}
 	}
 }


### PR DESCRIPTION
This fixes issue #3428 .

The code is mostly copied from the [ARM thumb emulator](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Processors/ARM/src/main/java/ghidra/program/emulation/ARMEmulateInstructionStateModifier.java).

I tested the VLE emulator with the following hex file:
```
:020000040800F2
:10000000C0432A04E20670B9E2FF1CA5BABEE805A7
:1000100070BBE6AE1CA5BEEFD05344004400E80020
:00000001FF
```
And it correctly preserves the VLE register after jumps.
I also checked that the normal PowerPC emulator still works.

I'm not 100% sure this is the correct way to fix it, reviews are welcome.