### PR TITLE
Fix bld and movmu instruction in SuperH arch

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -2332,7 +2332,7 @@ define pcodeop Sleep_Standby;
 :bld "#"imm3_00_02, rn_04_07
     is opcode_08_15=0b10000111 & rn_04_07 & opcode_03_03=0b1 & imm3_00_02
 {
-    local b = *:1 (rn_04_07);
+    local b = rn_04_07;
     $(T_FLAG) = ((b & (1 << imm3_00_02)) != 0);
 }
 

--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -754,46 +754,46 @@ MovMUReg1: MovMUReg1_15 is MovMUReg1_15 {
 
 MovMUReg2_0:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=0 {  loadRegister(r0,r15); }
 
-MovMUReg2_1:	MovMUReg2_0  	is MovMUReg2_0                         {  build MovMUReg2_0; loadRegister(pr,r15); }
+MovMUReg2_1:	MovMUReg2_0  	is MovMUReg2_0                         {  build MovMUReg2_0; loadRegister(r1,r15); }
 MovMUReg2_1:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=1 {  loadRegister(r1,r15); }
 
-MovMUReg2_2:	MovMUReg2_1  	is MovMUReg2_1                         {  build MovMUReg2_1; loadRegister(pr,r15); }
+MovMUReg2_2:	MovMUReg2_1  	is MovMUReg2_1                         {  build MovMUReg2_1; loadRegister(r2,r15); }
 MovMUReg2_2:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=2 {  loadRegister(r2,r15); }
 
-MovMUReg2_3:	MovMUReg2_2  	is MovMUReg2_2                         {  build MovMUReg2_2; loadRegister(pr,r15); }
+MovMUReg2_3:	MovMUReg2_2  	is MovMUReg2_2                         {  build MovMUReg2_2; loadRegister(r3,r15); }
 MovMUReg2_3:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=3 {  loadRegister(r3,r15); }
 
-MovMUReg2_4:	MovMUReg2_3  	is MovMUReg2_3                         {  build MovMUReg2_3; loadRegister(pr,r15); }
+MovMUReg2_4:	MovMUReg2_3  	is MovMUReg2_3                         {  build MovMUReg2_3; loadRegister(r4,r15); }
 MovMUReg2_4:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=4 {  loadRegister(r4,r15); }
 
-MovMUReg2_5:	MovMUReg2_4  	is MovMUReg2_4                         {  build MovMUReg2_4; loadRegister(pr,r15); }
+MovMUReg2_5:	MovMUReg2_4  	is MovMUReg2_4                         {  build MovMUReg2_4; loadRegister(r5,r15); }
 MovMUReg2_5:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=5 {  loadRegister(r5,r15); }
 
-MovMUReg2_6:	MovMUReg2_5  	is MovMUReg2_5                         {  build MovMUReg2_5; loadRegister(pr,r15); }
+MovMUReg2_6:	MovMUReg2_5  	is MovMUReg2_5                         {  build MovMUReg2_5; loadRegister(r6,r15); }
 MovMUReg2_6:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=6 {  loadRegister(r6,r15); }
 
-MovMUReg2_7:	MovMUReg2_6  	is MovMUReg2_6                         { build MovMUReg2_6; loadRegister(pr,r15); }
+MovMUReg2_7:	MovMUReg2_6  	is MovMUReg2_6                         { build MovMUReg2_6; loadRegister(r7,r15); }
 MovMUReg2_7:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=7 {  loadRegister(r7,r15); }
 
-MovMUReg2_8:	MovMUReg2_7  	is MovMUReg2_7                         {  build MovMUReg2_7; loadRegister(pr,r15); }
+MovMUReg2_8:	MovMUReg2_7  	is MovMUReg2_7                         {  build MovMUReg2_7; loadRegister(r8,r15); }
 MovMUReg2_8:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=8 {  loadRegister(r8,r15); }
 
-MovMUReg2_9:	MovMUReg2_8  	is MovMUReg2_8                         {  build MovMUReg2_8; loadRegister(pr,r15); }
+MovMUReg2_9:	MovMUReg2_8  	is MovMUReg2_8                         {  build MovMUReg2_8; loadRegister(r9,r15); }
 MovMUReg2_9:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=9 {  loadRegister(r9,r15); }
 
-MovMUReg2_10:	MovMUReg2_9  	is MovMUReg2_9                         {  build MovMUReg2_9; loadRegister(pr,r15); }
+MovMUReg2_10:	MovMUReg2_9  	is MovMUReg2_9                         {  build MovMUReg2_9; loadRegister(r10,r15); }
 MovMUReg2_10:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=10 {  loadRegister(r10,r15); }
 
-MovMUReg2_11:	MovMUReg2_10  	is MovMUReg2_10                         {  build MovMUReg2_10; loadRegister(pr,r15); }
+MovMUReg2_11:	MovMUReg2_10  	is MovMUReg2_10                         {  build MovMUReg2_10; loadRegister(r11,r15); }
 MovMUReg2_11:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=11 {  loadRegister(r11,r15); }
 
-MovMUReg2_12:	MovMUReg2_11  	is MovMUReg2_11                         {  build MovMUReg2_11; loadRegister(pr,r15); }
+MovMUReg2_12:	MovMUReg2_11  	is MovMUReg2_11                         {  build MovMUReg2_11; loadRegister(r12,r15); }
 MovMUReg2_12:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=12 {  loadRegister(r12,r15); }
 
-MovMUReg2_13:	MovMUReg2_12	is MovMUReg2_12                            {  build MovMUReg2_12; loadRegister(pr,r15); }
+MovMUReg2_13:	MovMUReg2_12	is MovMUReg2_12                            {  build MovMUReg2_12; loadRegister(r13,r15); }
 MovMUReg2_13:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=13 {  loadRegister(r13,r15); }
 
-MovMUReg2_14:	MovMUReg2_13	is MovMUReg2_13                            {  build MovMUReg2_13; loadRegister(pr,r15); }
+MovMUReg2_14:	MovMUReg2_13	is MovMUReg2_13                            {  build MovMUReg2_13; loadRegister(r14,r15); }
 MovMUReg2_14:	rm_imm_08_11     is rm_imm_08_11 & rm_08_11=14 {  loadRegister(r14,r15); }
 
 MovMUReg2_15:	MovMUReg2_14	is MovMUReg2_14                             {  build MovMUReg2_14; loadRegister(pr,r15); }


### PR DESCRIPTION
## Problem with  :bld "#"imm3_00_02, rn_04_07
It should use the value in Rn instead of using it as a pointer,
Ref: Page 110 or (94) of https://www.renesas.com/us/en/document/mah/sh-2a-sh2a-fpu-software-manual?language=en

## Problem with movmu
It should restore Rn to R0 from the stack instead of popping the stack and write all values to pr. 

Ref: Page 152 or (136) of https://www.renesas.com/us/en/document/mah/sh-2a-sh2a-fpu-software-manual?language=en