### PR TITLE
Issue #3453 fix. ghidraDev should lookup pydev pysrc directory by bundle path

### DIFF
--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/utils/PyDevUtils.java
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/utils/PyDevUtils.java
@@ -17,6 +17,8 @@ package ghidradev.ghidraprojectcreator.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,12 +30,15 @@ import java.util.stream.Stream;
 import javax.naming.OperationNotSupportedException;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 import ghidradev.Activator;
 
@@ -158,30 +163,25 @@ public class PyDevUtils {
 	 * @throws CoreException if there was a problem searching for the PyDev source directory.
 	 */
 	public static File getPyDevSrcDir() throws CoreException {
-		String eclipsePath = Platform.getInstallLocation().getURL().getFile();
-		
-		List<File> searchDirs = new ArrayList<>();
-		searchDirs.add(new File(eclipsePath, "plugins"));
-		searchDirs.add(new File(eclipsePath, "dropins"));
-		
-		for (File searchRoot : searchDirs) {
-			try (Stream<Path> paths = Files.walk(Paths.get(searchRoot.toURI()))) {
-				Optional<File> pysrcDir = paths.filter(
-					Files::isDirectory)
-						.filter(p -> p.endsWith("pysrc"))
-						.map(p -> p.toFile())
-						.filter(f -> f.getParentFile().getName().startsWith("org.python.pydev"))
-						.findFirst();
-				if (pysrcDir.isPresent()) {
-					return pysrcDir.get();
+		Bundle[] bundles = FrameworkUtil.getBundle(PyDevUtilsInternal.class).getBundleContext().getBundles();
+
+		Bundle pydevCoreBundle = Stream.of(bundles).filter(bundle -> bundle.getSymbolicName().contains("org.python.pydev.core")).findFirst().orElse(null);
+
+		if(pydevCoreBundle != null) {
+			try {
+				URL pydevDirUrl = FileLocator.toFileURL(pydevCoreBundle.getEntry("/"));
+				URI pydevDirUri = new URI(pydevDirUrl.getProtocol(), pydevDirUrl.getPath(), null).normalize();
+				Path pysrcDir = Paths.get(pydevDirUri).resolve("pysrc");
+				if (Files.exists(pysrcDir)) {
+					return pysrcDir.toFile();
 				}
 			}
-			catch (IOException e) {
+			catch (Exception e) {
 				throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID,
 					IStatus.ERROR, "Problem searching for PyDev source directory", e));
 			}
 		}
-		
+
 		return null;
 	}
 }


### PR DESCRIPTION
Fixes #3453
Since the user can choose where their pool is located, it I figured the solution is to get the location of the pydev bundle, and use that to find the pysrc directory. Seems like that would work for all cases, pool or no pool, plugin or dropin.

This fix works for me. I can try setting up eclipse in a linux VM to test it there too, if that is needed. Don't have any macos access.