### PR TITLE
Fix emulator's FilteredMemoryState write filter triggering after write

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/FilteredMemoryState.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/FilteredMemoryState.java
@@ -34,8 +34,12 @@ class FilteredMemoryState extends MemoryState {
 		int readLen = super.getChunk(res, spc, off, size, stopOnUnintialized);
 		if (filterEnabled && filter != null) {
 			filterEnabled = false;
-			filter.filterRead(spc, off, readLen, res);
-			filterEnabled = true;
+			try {
+				filter.filterRead(spc, off, readLen, res);
+			}
+			finally {
+				filterEnabled = true;
+			}
 		}
 		return readLen;
 	}
@@ -44,8 +48,12 @@ class FilteredMemoryState extends MemoryState {
 	public void setChunk(byte[] res, AddressSpace spc, long off, int size) {
 		if (filterEnabled && filter != null) {
 			filterEnabled = false;
-			filter.filterWrite(spc, off, size, res);
-			filterEnabled = true;
+			try {
+				filter.filterWrite(spc, off, size, res);
+			}
+			finally {
+				filterEnabled = true;
+			}
 		}
 		super.setChunk(res, spc, off, size);
 	}


### PR DESCRIPTION
FilteredMemoryState allows the user to add a MemoryAccessFilter callback, which gets called on reads and writes to a MemoryState. There are two issues:

FilteredMemoryState uses try/finally around the filter's callback calls. This makes it near-impossible for the user to debug the filter implementation, since they do not get exceptions from their code. These should be removed. If there is an exception in the MemoryAccessFilter, then it should be dealt with by the implementer and not suppressed here.

FilteredMemoryState currently calls the filter's write callback after already executing the write with setChunk(). This makes it impossible for the MemoryAccessFilter to know what the previous value at that address was, since it gets overwritten before the callback is called. The easy fix for this is to call the filter's callback before actually executing the write. That way, the filter can get the old value if it wants to.