### PR TITLE
correct payload type in specification extension

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SpecExtensionPanel.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SpecExtensionPanel.java
@@ -323,7 +323,7 @@ public class SpecExtensionPanel extends JPanel {
 				if (injectLibrary.isOverride(fixupName, InjectPayload.CALLOTHERFIXUP_TYPE)) {
 					status = Status.EXTENSION_OVERRIDE;
 				}
-				if (injectLibrary.getPayload(InjectPayload.CALLFIXUP_TYPE, fixupName)
+				if (injectLibrary.getPayload(InjectPayload.CALLOTHERFIXUP_TYPE, fixupName)
 						.isErrorPlaceholder()) {
 					status = Status.EXTENSION_ERROR;
 				}


### PR DESCRIPTION
Corrects NullPointerExceptions when rendering the view of per-project Specification Extensions in the Code Browser tool. See #3502 for context.