### PR TITLE
Unable to load into Ghidra a Mozi sample which runs on Linux

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -898,19 +898,20 @@ public class ElfHeader implements StructConverter, Writeable {
 		}
 
 		parsedSectionHeaders = true;
-        try{
-            sectionHeaders = new ElfSectionHeader[e_shnum];
-            for (int i = 0; i < e_shnum; ++i) {
-                long index = e_shoff + (i * e_shentsize);
-                reader.setPointerIndex(index);
-                sectionHeaders[i] = ElfSectionHeader.createElfSectionHeader(reader, this);
-            }
-        } catch(Exception e) {
-            e_shnum = 0;
-            sectionHeaders = new ElfSectionHeader[e_shnum];
-            Msg.warn(ElfHeader.class, "There was an error creating the ElfSectionHeader: " + e.getMessage());
-            Msg.info(ElfHeader.class, "A dummy ElfSectionHeader containing 0 section header entries was created.");
-        }
+		try {
+			sectionHeaders = new ElfSectionHeader[e_shnum];
+			for (int i = 0; i < e_shnum; ++i) {
+				long index = e_shoff + (i * e_shentsize);
+				reader.setPointerIndex(index);
+				sectionHeaders[i] = ElfSectionHeader.createElfSectionHeader(reader, this);
+			}
+		}
+		catch (EOFException e) {
+			e_shnum = 0;
+			sectionHeaders = new ElfSectionHeader[e_shnum];
+			Msg.warn(ElfHeader.class, "There was an error creating the ElfSectionHeader: " + e.getMessage());
+			Msg.info(ElfHeader.class, "A dummy ElfSectionHeader containing 0 section header entries was created.");
+		}
 
 		//note: we cannot retrieve all the names
 		//until after we have read all the section headers.

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -898,12 +898,19 @@ public class ElfHeader implements StructConverter, Writeable {
 		}
 
 		parsedSectionHeaders = true;
-		sectionHeaders = new ElfSectionHeader[e_shnum];
-		for (int i = 0; i < e_shnum; ++i) {
-			long index = e_shoff + (i * e_shentsize);
-			reader.setPointerIndex(index);
-			sectionHeaders[i] = ElfSectionHeader.createElfSectionHeader(reader, this);
-		}
+        try{
+            sectionHeaders = new ElfSectionHeader[e_shnum];
+            for (int i = 0; i < e_shnum; ++i) {
+                long index = e_shoff + (i * e_shentsize);
+                reader.setPointerIndex(index);
+                sectionHeaders[i] = ElfSectionHeader.createElfSectionHeader(reader, this);
+            }
+        } catch(Exception e) {
+            e_shnum = 0;
+            sectionHeaders = new ElfSectionHeader[e_shnum];
+            Msg.warn(ElfHeader.class, "There was an error creating the ElfSectionHeader: " + e.getMessage());
+            Msg.info(ElfHeader.class, "A dummy ElfSectionHeader containing 0 section header entries was created.");
+        }
 
 		//note: we cannot retrieve all the names
 		//until after we have read all the section headers.


### PR DESCRIPTION
Hello,

  **Ghidra is not able to load ELF files, [like this Mozi sample](https://www.virustotal.com/gui/file/26d093799d06023a3e2356ed2ff6ca14c21995fe8d68151542adea15bff31edc), which has a bad section_header_table offset.**
  I mean, in the case of the mentioned file, e_shoff field in the elf_header points out of the file. Therefore, Ghidra tries to read an invalid offset and [fails while loading the file](https://github.com/NationalSecurityAgency/ghidra/blob/4920bc6d744ea4e765bed3215ae57405e05eb665/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/RandomAccessByteProvider.java#L143).
  **The important thing here I want to remark is that Linux loads this file and runs it without problem** so, I fixed it by treating section_header_table errors as if the file had a section_header_table of 0 section header entries such that it doesn't cause invalid offset reading errors.

Regards, D.