### PR TITLE
fix(objc2): don't attempt to process external categories

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Category.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Category.java
@@ -45,6 +45,8 @@ public class ObjectiveC2_Category implements StructConverter {
 
 		readName(reader);
 		readClass(reader);
+		if (cls.getISA() == null)
+			return;
 		readInstanceMethods(reader);
 		readClassMethods(reader);
 		readProtocols(reader);


### PR DESCRIPTION
The Objective-C 2 class analyzer crashes when encountering categories with an implementation in external binary.  
This commit stops the analyzer from attempting to parse these kinds of categories. 