### PR TITLE
Remove deprecated Gradle features

### DIFF
--- a/Ghidra/Debug/Debugger-agent-dbgeng/build.gradle
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/build.gradle
@@ -69,7 +69,7 @@ task nodepJar(type: Jar) {
 	dependsOn(configureNodepJar)
 	dependsOn(jar)
 	
-	appendix = 'nodep'
+	archiveAppendix = 'nodep'
 	manifest {
 		attributes['Main-Class'] = 'agent.dbgeng.gadp.DbgEngGadpServer'
 	}

--- a/Ghidra/Debug/Debugger-agent-dbgmodel/build.gradle
+++ b/Ghidra/Debug/Debugger-agent-dbgmodel/build.gradle
@@ -64,7 +64,7 @@ task nodepJar(type: Jar) {
 	dependsOn(configureNodepJar)
 	dependsOn(jar)
 
-	appendix = 'nodep'
+	archiveAppendix = 'nodep'
 	manifest {
 		attributes['Main-Class'] = 'agent.dbgmodel.gadp.DbgModelGadpServer'
 	}

--- a/Ghidra/Debug/Debugger-agent-gdb/build.gradle
+++ b/Ghidra/Debug/Debugger-agent-gdb/build.gradle
@@ -67,7 +67,7 @@ task nodepJar(type: Jar) {
 	dependsOn(configureNodepJar)
 	dependsOn(jar)
 	
-	appendix = 'nodep'
+	archiveAppendix = 'nodep'
 	manifest {
 		attributes['Main-Class'] = 'agent.gdb.gadp.GdbGadpServer'
 	}

--- a/Ghidra/Debug/Debugger-agent-lldb/build.gradle
+++ b/Ghidra/Debug/Debugger-agent-lldb/build.gradle
@@ -64,7 +64,7 @@ task nodepJar(type: Jar) {
 	dependsOn(configureNodepJar)
 	dependsOn(jar)
 	
-	appendix = 'nodep'
+	archiveAppendix = 'nodep'
 	manifest {
 		attributes['Main-Class'] = 'agent.lldb.gadp.LldbGadpServer'
 	}

--- a/Ghidra/Debug/Framework-AsyncComm/build.gradle
+++ b/Ghidra/Debug/Framework-AsyncComm/build.gradle
@@ -32,7 +32,7 @@ task genTestPy(type: JavaExec) {
 	outputs.dir(outDir)
 	classpath(sourceSets["main"].runtimeClasspath)
 	classpath(sourceSets["test"].runtimeClasspath)
-	main = "ghidra.comm.util.pyexport.GeneratePython"
+	mainClass = "ghidra.comm.util.pyexport.GeneratePython"
 	args("ghidra.comm.tests.packet", outDir)
 	doLast {
 		println("NOTE: It is normal to see some export errors, since some classes are intentionally broken to test error detection")

--- a/Ghidra/Features/Base/build.gradle
+++ b/Ghidra/Features/Base/build.gradle
@@ -87,7 +87,7 @@ task buildCParser(type: JavaExec) {
 	outputs.dir file("${outputDir}")
 
 	classpath = configurations.javacc
-	main = 'javacc'
+	mainClass = 'javacc'
 	workingDir = "${srcDir}"
 	args "-OUTPUT_DIRECTORY=${outputDir}"
 	// args "-DEBUG_PARSER=true"
@@ -107,7 +107,7 @@ task buildCPPParser(type: JavaExec) {
 	outputs.dir file("${outputDir}")
 	
 	classpath = configurations.javacc	
-	main = 'javacc'
+	mainClass = 'javacc'
 	workingDir = "${srcDir}"
 	args "-OUTPUT_DIRECTORY=${outputDir}"
 	// args "-DEBUG_PARSER=true"

--- a/gradle/helpProject.gradle
+++ b/gradle/helpProject.gradle
@@ -81,7 +81,7 @@ task indexHelp(type: JavaExec) {
 	
 	classpath = sourceSets.helpIndex.runtimeClasspath
 	
-	main = 'com.sun.java.help.search.Indexer'		
+	mainClass = 'com.sun.java.help.search.Indexer'
 
 	// tell the indexer where send its output	
 	args '-db', outputFile.absolutePath
@@ -131,7 +131,7 @@ task buildHelp(type: JavaExec, dependsOn: indexHelp) {
 	inputs.dir helpRootDir
 	outputs.dir outputDir
 
-	main = 'help.GHelpBuilder'		
+	mainClass = 'help.GHelpBuilder'
 	
 	args '-n', "${project.name}"	 		// use the module's name for the help file name
 	
@@ -169,7 +169,7 @@ task findUnusedHelp(type: JavaExec) {
 
 	inputs.dir helpRootDir
 
-	main = 'help.validator.UnusedHelpImageFileFinder'		
+	mainClass = 'help.validator.UnusedHelpImageFileFinder'
 
 	// args '-debug' // print debug info
 

--- a/gradle/processorProject.gradle
+++ b/gradle/processorProject.gradle
@@ -164,7 +164,7 @@ task sleighCompile (type: JavaExec) {
 	 
 	// define standard parameters for JavaExec
 	classpath configurations.sleighConfig
-	main = 'ghidra.pcodeCPort.slgh_compile.SleighCompile'
+	mainClass = 'ghidra.pcodeCPort.slgh_compile.SleighCompile'
 	
 	// Delay adding the directory argument until the first part of the execution phase, so
 	// that any extra args added by a project override will be added to the arg list before

--- a/gradle/root/jacoco.gradle
+++ b/gradle/root/jacoco.gradle
@@ -104,11 +104,9 @@ task jacocoReport(type: JacocoReport, group: 'Coverage reports') {
   
    reports {
       html {
-         enabled true
+         required
          destination new File(rootDir.absolutePath + "/jacocoReport")
       }
-      xml {
-         enabled false
-      }
+      xml { }
    }
 }

--- a/gradle/root/svg.gradle
+++ b/gradle/root/svg.gradle
@@ -62,7 +62,7 @@ task rasterizeSvg(type: JavaExec) {
 			files.push(file.toString())
 		}
 						
-		main = MAIN_CLASS
+		mainClass = MAIN_CLASS
 			
 		// Set up the entire arg list, minus the input files.
 		def argsList = ["-scriptSecurityOff",


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/203261/138096316-53046395-73f4-4650-abab-6524a134c916.png)

## After
![image](https://user-images.githubusercontent.com/203261/138096394-f89980de-9416-4a21-b53e-03343a7abb67.png)

I tried to remove also the `JCenter` usage but some dependencies weren't available on Maven, it seems.

Partially addressing https://github.com/NationalSecurityAgency/ghidra/issues/3527
