### PR TITLE
tricore: fix jl

### DIFF
--- a/Ghidra/Processors/tricore/data/languages/tricore.sinc
+++ b/Ghidra/Processors/tricore/data/languages/tricore.sinc
@@ -2918,7 +2918,7 @@ SC: [a10]const0815Z10zz is PCPMode=0 & a10 & const0815Z10zz & op0003=8 & op0404=
 {
 	#TODO  is this just a call w/o context switching?
 	a11 = inst_start + 4;
-	call [off24abs];
+	call off24abs;
 }
 
 @if defined(TRICORE_RIDER_B) || defined(TRICORE_RIDER_D) || defined(TRICORE_V2)

--- a/Ghidra/Processors/tricore/data/languages/tricore.sinc
+++ b/Ghidra/Processors/tricore/data/languages/tricore.sinc
@@ -2910,7 +2910,7 @@ SC: [a10]const0815Z10zz is PCPMode=0 & a10 & const0815Z10zz & op0003=8 & op0404=
 {
 	#TODO  is this just a call w/o context switching?
 	a11 = inst_start + 4;
-	call [off24pc];
+	call off24pc;
 }
 
 # JLA disp24 (B)


### PR DESCRIPTION
https://www.infineon.com/dgdl/tc1_6__architecture_vol2.pdf?fileId=db3a3043372d5cc801374ad9c0653ad9

```
JL
Jump and Link
Description
Store the address of the next instruction in A[11] (return address). Add the value specified by disp24, signextended and multiplied by 2, to the contents of PC and jump to that address.
A[11] = PC + 4;
PC = PC + sign_ext(disp24) * 2;
```