### PR TITLE
add exclusions for object and depend files

### DIFF
--- a/gradle/support/ip.gradle
+++ b/gradle/support/ip.gradle
@@ -134,6 +134,8 @@ def Map<String, List<String>> getIpForModule(Project p) {
 		exclude "**/data/build.xml" // language build file (generated for dev only)
 		exclude "**/.vs/**"
 		exclude "**/*.vcxproj.user"
+		exclude "**/*.o"
+		exclude "**/depend"
 	}
 	tree.each { file ->
 			String ip = getIp(p.projectDir, file)


### PR DESCRIPTION
IP checks are mistakenly performed on some `.o` and `depend` files,
causing builds to fail. This change adds exclusions for these types
of files to prevent unnecessary failures.

This is intended to address #3566.