### PR TITLE
SuperH: Fix trapa to use call instead of goto

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -1979,14 +1979,13 @@ define pcodeop Sleep_Standby;
 
 :trapa  imm_00_07  is opcode_08_15=0b11000011 & imm_00_07
 {
-    r15 = r15 -4;
+    r15 = r15 - 4;
     *r15 = sr;
 
-    r15 = r15- 4;
+    r15 = r15 - 4;
     *r15 = pc + 2;
 
-    pc = *(vbr + (imm_00_07 * 4));
-    goto [pc];
+    call [vbr + (imm_00_07 * 4)];
 }
 
 @if defined(FPU)


### PR DESCRIPTION
Correct trapa to use call instead of goto. Fix by waterfuell. 