### PR TITLE
Optimize Gradle build with focus on incremental build support and output caching

### DIFF
--- a/Ghidra/Debug/Framework-TraceModeling/build.gradle
+++ b/Ghidra/Debug/Framework-TraceModeling/build.gradle
@@ -21,6 +21,18 @@ apply from: "${rootProject.projectDir}/gradle/distributableGhidraModule.gradle"
 apply plugin: 'eclipse'
 eclipse.project.name = 'Debug Framework-TraceModeling'
 
+// The generation timestamp included in these help files
+// makes them different on every build which causes all consuming tasks to be re-executed every time
+// By excluding these files from crucial inputs using runtime classpath normalization, 
+// we are able to re-use build artifacts of this project on incremental builds
+normalization {
+    runtimeClasspath {
+        ignore '**/help/*_HelpSet.hs'
+        ignore '**/help/*_map.xml'
+        ignore '**/help/*_TOC.xml'
+    }
+}
+
 dependencies {
 	api project(':Generic')
 	api project(':SoftwareModeling')

--- a/Ghidra/Extensions/bundle_examples/build.gradle
+++ b/Ghidra/Extensions/bundle_examples/build.gradle
@@ -122,10 +122,5 @@ rootProject.createInstallationZip {
 			ZIP_DIR_PREFIX + "/Extensions/Ghidra"
 		}
 	}
-	doLast {
-		this.project.zipExtensions.outputs.each {
-			delete it
-		}
-	}
 }
 

--- a/Ghidra/Features/FunctionID/build.gradle
+++ b/Ghidra/Features/FunctionID/build.gradle
@@ -40,6 +40,16 @@ def fidDbFiles = fileTree(depsDir.exists() ? depsDir : binRepoDir) {
 }
 
 task unpackFidDatabases {
+    inputs.files(fidDbFiles.getFiles())
+			.withPropertyName("fidDbFiles")
+			.withPathSensitivity(PathSensitivity.RELATIVE)
+	// Adding task output to make use of Gradle's up-to-date check
+	// However, outputs in form of file trees are not supported by Gradle's build cache
+	// We would need to write these files to a separate folder if we'd like to enable caching 
+    outputs.files fileTree("$buildDir/data").matching {
+        include "*.fidbf"
+    }
+
 	doLast {
 		fidDbFiles.each { file ->
 		

--- a/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
+++ b/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
@@ -183,16 +183,44 @@ task buildExtension (type: Zip) {
 	}
 }
 
+// CommandLineArgumentProvider that supplies indexHelp task with relative help file paths
+// This allows build cache artifacts to be relocate-able across workspaces and machines.
+class HelpFilesPathProvider implements CommandLineArgumentProvider {
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    File helpFilePath
+
+    @Override
+    Iterable<String> asArguments() {
+        [helpFilePath.absolutePath]
+    }
+}
+
+// CommandLineArgumentProvider that supplies indexHelp task with the absolute path to the help output directory
+// This allows build cache artifacts to be relocate-able across workspaces and machines.
+class HelpOutputPathProvider implements CommandLineArgumentProvider {
+    @OutputDirectory
+    File helpOutputPath
+
+    @Override
+    Iterable<String> asArguments() {
+        ["-db ${helpOutputPath.absolutePath}".toString()]
+    }
+}
+
 // task for calling the java help indexer
-task indexHelp(type: JavaExec) {	
+task indexHelp(type: JavaExec) {
 	File helpRootDir = file('src/main/help')		// this the root dir for the help source
 	File outputFile = file("build/help/main/help/${project.name}_JavaHelpSearch")	
 	onlyIf {helpRootDir.exists()}
 
 	dependsOn configurations.helpPath
 
-	inputs.dir helpRootDir
+	inputs.dir(helpRootDir)
+			.withPropertyName('helpRootDir')
+			.withPathSensitivity(PathSensitivity.RELATIVE)
 	outputs.dir outputFile
+    outputs.cacheIf { true }
 
 	classpath = sourceSets.main.runtimeClasspath		// this modules runtime classpath (contains jhall.jar)
 	
@@ -200,7 +228,7 @@ task indexHelp(type: JavaExec) {
 
 	// tell the indexer where send its output
 	
-	args '-db', outputFile.absolutePath
+    argumentProviders.add(new HelpOutputPathProvider(helpOutputPath: outputFile))
 
 
 	// The index has a config file parameter.  The only thing we use in the config file
@@ -227,7 +255,7 @@ task indexHelp(type: JavaExec) {
 	doFirst {
 		// for each help file that was found, add it as an argument to the indexer
 		helpFiles.each { File file ->
-			args "${file.absolutePath}"
+            argumentProviders.add(new HelpFilesPathProvider(helpFilePath: file))
 		}	
 	}
 	

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/gradle/distributableGhidraExtension.gradle
+++ b/gradle/distributableGhidraExtension.gradle
@@ -32,10 +32,5 @@ rootProject.createInstallationZip {
 		into  {
 			ZIP_DIR_PREFIX + "/Extensions/Ghidra"
 		}
-	} 
-	doLast {
-		this.project.zipExtensions.outputs.each {
-			delete it
-		}
 	}
 }

--- a/gradle/distributableGhidraModule.gradle
+++ b/gradle/distributableGhidraModule.gradle
@@ -43,8 +43,8 @@ rootProject.assembleDistribution {
 	from (BIN_REPO + '/' + getGhidraRelativePath(p) + "/data") {
 		into { zipPath + "/data" }
 	}
-	
-	from (p.projectDir.toString() + "/build/LICENSE.txt") {
+
+	from (ip) {
 		into { zipPath }
 	}
 

--- a/gradle/externalGhidraExtension.gradle
+++ b/gradle/externalGhidraExtension.gradle
@@ -18,10 +18,5 @@ apply from: "$rootProject.projectDir/gradle/support/extensionCommon.gradle"
 
 rootProject.createExternalExtensions {
 	from (this.project.zipExtensions)
-	doLast {
-		this.project.zipExtensions.outputs.each {
-			delete it
-		}
-	}
 }
 

--- a/gradle/helpProject.gradle
+++ b/gradle/helpProject.gradle
@@ -63,9 +63,34 @@ dependencies {
 	helpIndexImplementation project(':Help')
 }
 
+// CommandLineArgumentProvider that supplies indexHelp task with relative help file paths
+// This allows build cache artifacts to be relocate-able across workspaces and machines.
+class HelpFilesPathProvider implements CommandLineArgumentProvider {
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    File helpFilePath
+
+    @Override
+    Iterable<String> asArguments() {
+        [helpFilePath.absolutePath]
+    }
+}
+
+// CommandLineArgumentProvider that supplies indexHelp task with the absolute path to the help output directory
+// This allows build cache artifacts to be relocate-able across workspaces and machines.
+class HelpOutputPathProvider implements CommandLineArgumentProvider {
+    @OutputDirectory
+    File helpOutputPath
+
+    @Override
+    Iterable<String> asArguments() {
+        ["-db ${helpOutputPath.absolutePath}".toString()]
+    }
+}
+
 // Task for calling the java help indexer, which creates a searchable index of the 
 // help contents.
-task indexHelp(type: JavaExec) {	
+task indexHelp(type: JavaExec) {
 
 	group "private"
 	description "indexes the helps files for this module.  [gradle/helpProject.gradle]"
@@ -76,15 +101,18 @@ task indexHelp(type: JavaExec) {
 
 	dependsOn configurations.helpPath
 
-	inputs.dir helpRootDir
+	inputs.dir(helpRootDir)
+			.withPropertyName('helpRootDir')
+			.withPathSensitivity(PathSensitivity.RELATIVE)
 	outputs.dir outputFile
+    outputs.cacheIf { true }
 	
 	classpath = sourceSets.helpIndex.runtimeClasspath
 	
 	mainClass = 'com.sun.java.help.search.Indexer'
 
 	// tell the indexer where send its output	
-	args '-db', outputFile.absolutePath
+    argumentProviders.add(new HelpOutputPathProvider(helpOutputPath: outputFile))
 
 	// The index has a config file parameter.  The only thing we use in the config file
 	// is a root directory path that should be stripped off all the help references to
@@ -114,7 +142,7 @@ task indexHelp(type: JavaExec) {
 		
 		// for each help file that was found, add it as an argument to the indexer
 		helpFiles.each { File file ->
-			args "${file.absolutePath}"
+            argumentProviders.add(new HelpFilesPathProvider(helpFilePath: file))
 		}	
 	}
 }

--- a/gradle/root/distribution.gradle
+++ b/gradle/root/distribution.gradle
@@ -468,6 +468,16 @@ def updateSlaFilesTimestamp(String distributionDirectoryPath, int timeOffsetMinu
 	println "updateSlaFilesTimestamp: Updated timestamps to $numFilesAdded .sla files."
 }
 
+String ghidraExtensionsDirPath = DISTRIBUTION_DIR.getPath() + "/" + ZIP_DIR_PREFIX + "/Ghidra/Extensions"
+task createGhidraExtensionsDir {
+    outputs.dir ghidraExtensionsDirPath
+    doLast {
+        // We always want the extensions directory to exist in the zip, even if there's nothing
+        // installed there.
+        new File(ghidraExtensionsDirPath).mkdirs()
+    }
+}
+
 /*********************************************************************************
  * 
  * Creates the local installation zip.
@@ -481,6 +491,7 @@ task createInstallationZip(type: Zip) { t ->
 	dependsOn assembleDistribution
 	dependsOn assembleSource
 	dependsOn "assembleDistribution_$currentPlatform"
+    dependsOn createGhidraExtensionsDir
 	
 	if (project.hasProperty("allPlatforms")) {
 		project.PLATFORMS.each { platform ->
@@ -504,11 +515,6 @@ task createInstallationZip(type: Zip) { t ->
 	}
 		
 	doFirst {
-		// We always want the extensions directory to exist in the zip, even if there's nothing
-		// installed there.
-		new File( DISTRIBUTION_DIR.getPath() + "/" + ZIP_DIR_PREFIX + "/Ghidra/Extensions").mkdirs()
-
-
 		// The dependent tasks copy the sla and slaspec files into "extractTo/<release name>/ghidra/"
 		// and then later to "extractTo/<release name>/dist/", which this zip task compresses. The copy 
 		// tasks do not preserve the file modification times. If slaspec timestamp > sla timestamp, 
@@ -516,10 +522,6 @@ task createInstallationZip(type: Zip) { t ->
 		// will ensure the zip archive has sla files newer than slaspec. Give new timestamp of now plus 
 		// two minutes.
 		updateSlaFilesTimestamp(DISTRIBUTION_DIR.getPath(), 2)
-	}
-	
-	doLast {
-		delete file(DISTRIBUTION_DIR.getPath() + "/" + ZIP_DIR_PREFIX)
 	}
 }
 

--- a/gradle/support/extensionCommon.gradle
+++ b/gradle/support/extensionCommon.gradle
@@ -110,8 +110,8 @@ task zipExtensions (type: Zip) {
 	from (p.projectDir.toString() + "/build/data") {
 		into { getBaseProjectName(p) + "/data" }
 	}
-	
-	from (p.projectDir.toString() + "/build/LICENSE.txt") {
+
+	from (ip) {
 		into { getBaseProjectName(p) }
 	}
 	

--- a/gradle/support/ip.gradle
+++ b/gradle/support/ip.gradle
@@ -31,7 +31,17 @@
 /*********************************************************************************
  * Defines the main ip task for each subproject
  *********************************************************************************/
-task ip { 
+task ip {
+
+    inputs.file(file("certification.manifest"))
+			.withPropertyName("ipCertificationFile")
+			.withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file(file("Module.manifest"))
+			.withPropertyName("ipModuleManifest")
+			.withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.cacheIf { true}
+    outputs.file file("$buildDir/LICENSE.txt")
+
 	doLast {
 		
 		// scans all the files in the module, reads ip from header, verifies ip, and creates mapping

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+rootProject.name = "ghidra"
 apply from: "gradle/support/settingsUtil.gradle"
 
 /*******************************************************************************************


### PR DESCRIPTION
## Summary
This PR proposes several optimizations to decrease Gradle build times which were discovered using [Gradle Enterprise](https://gradle.com/) tool. The main goals of the optimizations were to (1) minimize incremental build time and (2) increase build cache usage for all tasks and projects.

## Build Scan Links
The following Build Scan links provide empirical data to quantify the improvements in the build times:
- Initial build: [master](https://scans.gradle.com/s/u7sgq3tcdmu5i) vs [pshevche/ghidra/build-optimizations](https://scans.gradle.com/s/zzyoiz2s3k6ge)
- Incremental build: [master](https://scans.gradle.com/s/cke7wafvkm5zu) vs [pshevche/ghidra/build-optimizations](https://scans.gradle.com/s/47lokhr6slphk)
- Clean consecutive build in the same workspace: [master](https://scans.gradle.com/s/vxamwqrk2pjxi) vs [pshevche/ghidra/build-optimizations](https://scans.gradle.com/s/o3fc3v4ll46yc)
- Clean consecutive build in a different workspace: [master](https://scans.gradle.com/s/ssikgpsf35sik) vs [pshevche/ghidra/build-optimizations](https://scans.gradle.com/s/sglnrkjqwymou)

## Further Improvements
- **Improve cacheability by separating outputs of `indexHelp` and `buildHelp` tasks**: to fully utilize Gradle's build cache, all tasks should have exclusive access to the output folders which is not the case for these two tasks (saves appr. another 8s per build)
- **Improve cacheability by separating inputs and outputs of `sleighCompile` task**: similarly to the above comment, having exclusive output paths is crucial for build caching (saves appr. 2.5 min per build with remote cache).
