### PR TITLE
Set Equate: show all matching names in each enum

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bean/SetEquateDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bean/SetEquateDialog.java
@@ -210,11 +210,8 @@ public class SetEquateDialog extends DialogComponentProvider {
 			.stream()
 			.filter(dt -> dt instanceof Enum)
 			.map(Enum.class::cast)
-			.filter(enoom -> enoom.getName(scalar.getValue()) != null)
-			.forEach(enoom -> {
-				String name = enoom.getName(scalar.getValue());
-				entries.add(new EquateRowObject(name, enoom));
-			});
+			.flatMap(enoom -> Arrays.stream(enoom.getNames(scalar.getValue())).map(name -> new EquateRowObject(name, enoom)))
+			.forEach(entries::add);
 		//@formatter:on
 
 		return entries;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumDB.java
@@ -163,6 +163,23 @@ class EnumDB extends DataTypeDB implements Enum {
 	}
 
 	@Override
+	public String[] getNames(long value) {
+		lock.acquire();
+		try {
+			checkIsValid();
+			initializeIfNeeded();
+			List<String> list = valueMap.get(value);
+			if (list == null) {
+				return new String[0];
+			}
+			return list.toArray(new String[0]);
+		}
+		finally {
+			lock.release();
+		}
+	}
+
+	@Override
 	public boolean hasLanguageDependantLength() {
 		return false;
 	}


### PR DESCRIPTION
This makes the Set Equate dialog show all names matching the given value, instead of just one per enum, which greatly limited its usefulness.

Warning: I have not yet been able to get a build environment working to be able to test this.