### PR TITLE
"Enabled" Compressed DWARF Section support

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/DWARFProgram.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/DWARFProgram.java
@@ -72,10 +72,8 @@ public class DWARFProgram implements Closeable {
 		switch (format) {
 			case ElfLoader.ELF_NAME:
 			case PeLoader.PE_NAME:
-				return BaseSectionProvider.hasDWARFSections(program) ||
-					ExternalDebugInfo.fromProgram(program) != null;
 			case MachoLoader.MACH_O_NAME:
-				return DSymSectionProvider.getDSYMForProgram(program) != null;
+				return DWARFSectionProviderFactory.createSectionProviderFor(program) != null;
 		}
 		return false;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/sectionprovider/DWARFSectionProviderFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/sectionprovider/DWARFSectionProviderFactory.java
@@ -41,7 +41,8 @@ public class DWARFSectionProviderFactory {
 	private static final List<Function<Program, DWARFSectionProvider>> sectionProviderFactoryFuncs =
 		List.of(
 			BaseSectionProvider::createSectionProviderFor,
-			DSymSectionProvider::createSectionProviderFor);
+			DSymSectionProvider::createSectionProviderFor,
+			CompressedSectionProvider::createSectionProviderFor);
 
 	/**
 	 * Iterates through the statically registered {@link #sectionProviderFactoryFuncs factory funcs},


### PR DESCRIPTION
The bytes skipped between `ZLIB` and the actual start of the data appear to be the size of the decompressed data. I'm not sure if it is usable or not though.