### PR TITLE
Support for the new iOS 15/macOS Monterey dyld_cache format

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheImage.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheImage.java
@@ -1,0 +1,36 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.macho.dyld;
+
+/**
+ * A convenience interface for getting the address and path of a DYLD Cache image
+ */
+public interface DyldCacheImage {
+
+	/**
+	 * Gets the address the start of the image
+	 * 
+	 * @return The address of the start of the image
+	 */
+	public long getAddress();
+
+	/**
+	 * Gets the path of the image
+	 * 
+	 * @return The path of the image
+	 */
+	public String getPath();
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheImageInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheImageInfo.java
@@ -29,7 +29,7 @@ import ghidra.util.exception.DuplicateNameException;
  * @see <a href="https://opensource.apple.com/source/dyld/dyld-852.2/dyld3/shared-cache/dyld_cache_format.h.auto.html">dyld3/shared-cache/dyld_cache_format.h</a> 
  */
 @SuppressWarnings("unused")
-public class DyldCacheImageInfo implements StructConverter {
+public class DyldCacheImageInfo implements DyldCacheImage, StructConverter {
 
 	private long address;
 	private long modTime;
@@ -55,20 +55,12 @@ public class DyldCacheImageInfo implements StructConverter {
 		path = reader.readAsciiString(pathFileOffset);
 	}
 
-	/**
-	 * Gets the address the start of the image.
-	 * 
-	 * @return The address of the start of the image
-	 */
+	@Override
 	public long getAddress() {
 		return address;
 	}
 
-	/**
-	 * Gets the path of the image.
-	 * 
-	 * @return The path of the image
-	 */
+	@Override
 	public String getPath() {
 		return path;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheImageTextInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheImageTextInfo.java
@@ -29,7 +29,7 @@ import ghidra.util.exception.DuplicateNameException;
  * @see <a href="https://opensource.apple.com/source/dyld/dyld-852.2/dyld3/shared-cache/dyld_cache_format.h.auto.html">dyld3/shared-cache/dyld_cache_format.h</a> 
  */
 @SuppressWarnings("unused")
-public class DyldCacheImageTextInfo implements StructConverter {
+public class DyldCacheImageTextInfo implements DyldCacheImage, StructConverter {
 
 	private byte[] uuid;
 	private long loadAddress;
@@ -52,12 +52,13 @@ public class DyldCacheImageTextInfo implements StructConverter {
 
 		path = reader.readAsciiString(pathOffset);
 	}
+	
+	@Override
+	public long getAddress() {
+		return loadAddress;
+	}
 
-	/**
-	 * Gets the path of the image text.
-	 * 
-	 * @return The path of the image text.
-	 */
+	@Override
 	public String getPath() {
 		return path;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheMappingInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheMappingInfo.java
@@ -106,6 +106,17 @@ public class DyldCacheMappingInfo implements StructConverter {
 		return (initProt & SegmentConstants.PROTECTION_X) != 0;
 	}
 
+	/**
+	 * Returns true if the mapping contains the given address
+	 * 
+	 * @param addr The address to check
+	 * @return True if the mapping contains the given address; otherwise, false
+	 */
+	public boolean contains(long addr) {
+		return Long.compareUnsigned(addr, address) >= 0 &&
+			Long.compareUnsigned(addr, address + size) < 0;
+	}
+
 	@Override
 	public DataType toDataType() throws DuplicateNameException, IOException {
 		StructureDataType struct = new StructureDataType("dyld_cache_mapping_info", 0);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/DyldCacheLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/DyldCacheLoader.java
@@ -18,9 +18,7 @@ package ghidra.app.util.opinion;
 import java.io.IOException;
 import java.util.*;
 
-import ghidra.app.util.MemoryBlockUtils;
-import ghidra.app.util.Option;
-import ghidra.app.util.OptionUtils;
+import ghidra.app.util.*;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.bin.format.macho.dyld.DyldArchitecture;
@@ -51,11 +49,19 @@ public class DyldCacheLoader extends AbstractLibrarySupportLoader {
 	static final boolean CREATE_DYLIB_SECTIONS_OPTION_DEFAULT = false;
 
 	/** Loader option to add relocation entries for each fixed chain pointer */
-	static final String ADD_RELOCATION_ENTRIES_OPTION_NAME = "Add relocation entries for fixed chain pointers";
+	static final String ADD_RELOCATION_ENTRIES_OPTION_NAME =
+		"Add relocation entries for fixed chain pointers";
 
 	/** Default value for loader option add relocation entries */
 	static final boolean ADD_RELOCATION_ENTRIES_OPTION_DEFAULT = false;
 	
+	/** Loader option to combine split DYLD Cache files (.1, .2, .symbol, etc) into one program */
+	static final String COMBINE_SPLIT_FILES_OPTION_NAME =
+		"Auto import and combine split DYLD Cache files";
+
+	/** Default value for loader option add relocation entries */
+	static final boolean COMBINE_SPLIT_FILES_OPTION_DEFAULT = true;
+
 	@Override
 	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
 		List<LoadSpec> loadSpecs = new ArrayList<>();
@@ -92,7 +98,8 @@ public class DyldCacheLoader extends AbstractLibrarySupportLoader {
 			DyldCacheProgramBuilder.buildProgram(program, provider,
 				MemoryBlockUtils.createFileBytes(program, provider, monitor),
 				shouldProcessSymbols(options), shouldCreateDylibSections(options),
-				shouldAddRelocationEntries(options), log, monitor);
+				shouldAddRelocationEntries(options), shouldCombineSplitFiles(options), log,
+				monitor);
 		}
 		catch (CancelledException e) {
 			return;
@@ -113,25 +120,35 @@ public class DyldCacheLoader extends AbstractLibrarySupportLoader {
 			list.add(
 				new Option(CREATE_DYLIB_SECTIONS_OPTION_NAME, CREATE_DYLIB_SECTIONS_OPTION_DEFAULT,
 					Boolean.class, Loader.COMMAND_LINE_ARG_PREFIX + "-createDylibSections"));
-			list.add(
-					new Option(ADD_RELOCATION_ENTRIES_OPTION_NAME, ADD_RELOCATION_ENTRIES_OPTION_DEFAULT,
-						Boolean.class, Loader.COMMAND_LINE_ARG_PREFIX + "-addRelocationEntries"));
+			list.add(new Option(ADD_RELOCATION_ENTRIES_OPTION_NAME,
+				ADD_RELOCATION_ENTRIES_OPTION_DEFAULT, Boolean.class,
+				Loader.COMMAND_LINE_ARG_PREFIX + "-addRelocationEntries"));
+			list.add(new Option(COMBINE_SPLIT_FILES_OPTION_NAME, COMBINE_SPLIT_FILES_OPTION_DEFAULT,
+				Boolean.class, Loader.COMMAND_LINE_ARG_PREFIX + "-combineSplitFiles"));
 		}
 		return list;
 	}
 
 	private boolean shouldProcessSymbols(List<Option> options) {
-		return OptionUtils.getOption(PROCESS_SYMBOLS_OPTION_NAME, options, PROCESS_SYMBOLS_OPTION_DEFAULT);
+		return OptionUtils.getOption(PROCESS_SYMBOLS_OPTION_NAME, options,
+			PROCESS_SYMBOLS_OPTION_DEFAULT);
 	}
 
 	private boolean shouldCreateDylibSections(List<Option> options) {
-		return OptionUtils.getOption(CREATE_DYLIB_SECTIONS_OPTION_NAME, options, CREATE_DYLIB_SECTIONS_OPTION_DEFAULT);
+		return OptionUtils.getOption(CREATE_DYLIB_SECTIONS_OPTION_NAME, options,
+			CREATE_DYLIB_SECTIONS_OPTION_DEFAULT);
 	}
 
 	private boolean shouldAddRelocationEntries(List<Option> options) {
-		return OptionUtils.getOption(ADD_RELOCATION_ENTRIES_OPTION_NAME, options, ADD_RELOCATION_ENTRIES_OPTION_DEFAULT);
+		return OptionUtils.getOption(ADD_RELOCATION_ENTRIES_OPTION_NAME, options,
+			ADD_RELOCATION_ENTRIES_OPTION_DEFAULT);
 	}
-	
+
+	private boolean shouldCombineSplitFiles(List<Option> options) {
+		return OptionUtils.getOption(COMBINE_SPLIT_FILES_OPTION_NAME, options,
+			COMBINE_SPLIT_FILES_OPTION_DEFAULT);
+	}
+
 	@Override
 	public String getName() {
 		return DYLD_CACHE_NAME;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/DyldCacheUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/DyldCacheUtils.java
@@ -15,13 +15,19 @@
  */
 package ghidra.app.util.opinion;
 
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.AccessMode;
+import java.util.*;
 
-import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.*;
 import ghidra.app.util.bin.format.macho.dyld.DyldArchitecture;
+import ghidra.app.util.bin.format.macho.dyld.DyldCacheHeader;
+import ghidra.app.util.importer.MessageLog;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.mem.MemoryAccessException;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.task.TaskMonitor;
 
 /**
  * Utilities methods for working with Mach-O DYLD shared cache binaries.
@@ -89,4 +95,124 @@ public class DyldCacheUtils {
 		return false;
 	}
 
+	/**
+	 * Class to store a "split" DYLD Cache, which is split across several files (base file, .1, .2,
+	 * .symbols, etc).
+	 */
+	public static class SplitDyldCache implements Closeable {
+
+		List<ByteProvider> providers = new ArrayList<>();
+		List<DyldCacheHeader> headers = new ArrayList<>();
+
+		/**
+		 * Creates a new {@link SplitDyldCache}
+		 * 
+		 * @param baseProvider The {@link ByteProvider} of the "base" DYLD Cache file
+		 * @param shouldProcessSymbols True if symbols should be processed; otherwise, false
+		 * @param shouldCombineSplitFiles True if split DYLD Cache files should be automatically 
+		 * @param log The log
+		 * @param monitor A cancelable task monitor
+		 * @throws IOException If there was an IO-related issue with processing the split DYLD Cache
+		 * @throws CancelledException If the user canceled the operation
+		 */
+		public SplitDyldCache(ByteProvider baseProvider, boolean shouldProcessSymbols,
+				boolean shouldCombineSplitFiles, MessageLog log, TaskMonitor monitor)
+				throws IOException, CancelledException {
+
+			// Setup "base" DYLD Cache
+			monitor.setMessage("Parsing " + baseProvider.getName() + " headers...");
+			providers.add(baseProvider);
+			DyldCacheHeader baseHeader = new DyldCacheHeader(new BinaryReader(baseProvider, true));
+			baseHeader.parseFromFile(shouldProcessSymbols, log, monitor);
+			headers.add(baseHeader);
+
+			// Setup additional "split" DYLD Caches (if applicable)
+			for (File splitFile : getSplitDyldCacheFiles(baseProvider, shouldCombineSplitFiles)) {
+				monitor.setMessage("Parsing " + splitFile.getName() + " headers...");
+				ByteProvider provider = new FileByteProvider(splitFile, null, AccessMode.READ);
+				if (!DyldCacheUtils.isDyldCache(provider)) {
+					continue;
+				}
+				providers.add(provider);
+				DyldCacheHeader splitHeader = new DyldCacheHeader(new BinaryReader(provider, true));
+				splitHeader.parseFromFile(shouldProcessSymbols, log, monitor);
+				headers.add(splitHeader);
+				log.appendMsg("Including split DYLD: " + splitFile.getName());
+			}
+		}
+
+		/**
+		 * Gets the i'th {@link ByteProvider} in the split DYLD Cache
+		 * 
+		 * @param i The index of the {@link ByteProvider} to get
+		 * @return The i'th {@link ByteProvider} in the split DYLD Cache
+		 */
+		public ByteProvider getProvider(int i) {
+			return providers.get(i);
+		}
+
+		/**
+		 * Gets the i'th {@link DyldCacheHeader} in the split DYLD Cache
+		 * 
+		 * @param i The index of the {@link DyldCacheHeader} to get
+		 * @return The i'th {@link DyldCacheHeader} in the split DYLD Cache
+		 */
+		public DyldCacheHeader getDyldCacheHeader(int i) {
+			return headers.get(i);
+		}
+
+		/**
+		 * Gets the number of split DYLD Cache files
+		 * 
+		 * @return The number of split DYLD Cache files
+		 */
+		public int size() {
+			return providers.size();
+		}
+
+		@Override
+		public void close() throws IOException {
+			// Assume someone else is responsible for closing the base providers that was passed
+			// in at construction
+			for (int i = 1; i < providers.size(); i++) {
+				providers.get(i).close();
+			}
+		}
+
+		/**
+		 * Gets a {@link List} of extra split DYLD Cache files to load, sorted by name (base 
+		 * DYLD Cache file not included)
+		 * 
+		 * @param baseProvider The base {@link ByteProvider} that contains the DYLD Cache bytes
+		 * @param shouldCombineSplitFiles True if split DYLD Cache files should be automatically 
+		 *   combined into one DYLD Cache; false if only the base file should be processed
+		 * @return A {@link List} of extra split DYLD Cache files to load, sorted by name (base 
+		 *   DYLD Cache file not included).
+		 */
+		private List<File> getSplitDyldCacheFiles(ByteProvider baseProvider,
+				boolean shouldCombineSplitFiles) {
+			File file = baseProvider.getFile();
+			if (file != null && shouldCombineSplitFiles) {
+				String baseName = file.getName();
+				File[] splitFiles = file.getParentFile().listFiles(f -> {
+					if (!f.getName().startsWith(baseName)) {
+						return false;
+					}
+					if (f.getName().equals(baseName)) {
+						return false;
+					}
+					if (f.getName().toLowerCase().endsWith(".map")) {
+						return false;
+					}
+					return true;
+				});
+				if (splitFiles != null) {
+					List<File> list = Arrays.asList(splitFiles);
+					Collections.sort(list);
+					return list;
+				}
+			}
+			return Collections.emptyList();
+		}
+	}
 }

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dyldcache/DyldCacheDylibExtractor.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dyldcache/DyldCacheDylibExtractor.java
@@ -23,6 +23,9 @@ import generic.continues.RethrowContinuesFactory;
 import ghidra.app.util.bin.*;
 import ghidra.app.util.bin.format.macho.*;
 import ghidra.app.util.bin.format.macho.commands.*;
+import ghidra.app.util.bin.format.macho.dyld.DyldCacheHeader;
+import ghidra.app.util.bin.format.macho.dyld.DyldCacheMappingInfo;
+import ghidra.app.util.opinion.DyldCacheUtils.SplitDyldCache;
 import ghidra.formats.gfilesystem.FSRL;
 import ghidra.util.*;
 import ghidra.util.exception.NotFoundException;
@@ -38,26 +41,29 @@ public class DyldCacheDylibExtractor {
 	 * DYLIB's header will be altered to account for its segment bytes being packed down.   
 	 * 
 	 * @param dylibOffset The offset of the DYLIB in the given provider
-	 * @param provider The DYLD
-	 * @param fsrl {@link FSRL} to assign to the resulting ByteProvider
+	 * @param splitDyldCache The {@link SplitDyldCache}
+	 * @param index The DYLIB's {@link SplitDyldCache} index
+	 * @param fsrl {@link FSRL} to assign to the resulting {@link ByteProvider}
 	 * @param monitor {@link TaskMonitor}
-	 * @return {@link ByteProvider} containing the bytes of the dylib
+	 * @return {@link ByteProvider} containing the bytes of the DYLIB
 	 * @throws IOException If there was an IO-related issue with extracting the DYLIB
 	 * @throws MachException If there was an error parsing the DYLIB headers
 	 */
-	public static ByteProvider extractDylib(long dylibOffset, ByteProvider provider, FSRL fsrl,
-			TaskMonitor monitor) throws IOException, MachException {
+	public static ByteProvider extractDylib(long dylibOffset, SplitDyldCache splitDyldCache,
+			int index, FSRL fsrl, TaskMonitor monitor) throws IOException, MachException {
 
 		// Make sure Mach-O header is valid
-		MachHeader header = MachHeader.createMachHeader(RethrowContinuesFactory.INSTANCE, provider,
-			dylibOffset, false);
-		header.parse();
+		MachHeader dylibHeader = MachHeader.createMachHeader(RethrowContinuesFactory.INSTANCE,
+			splitDyldCache.getProvider(index), dylibOffset, false);
+		dylibHeader.parse();
 
 		// Pack the DYLIB
-		PackedDylib packedDylib = new PackedDylib(header, dylibOffset, provider);
+		PackedDylib packedDylib = new PackedDylib(dylibHeader, dylibOffset, splitDyldCache, index);
+
+		// TODO: Fixup pointer chains
 
 		// Fixup indices, offsets, etc in the packed DYLIB's header
-		for (LoadCommand cmd : header.getLoadCommands()) {
+		for (LoadCommand cmd : dylibHeader.getLoadCommands()) {
 			if (monitor.isCancelled()) {
 				break;
 			}
@@ -203,17 +209,18 @@ public class DyldCacheDylibExtractor {
 		/**
 		 * Creates a new {@link PackedDylib} object
 		 * 
-		 * @param header The DYLD's DYLIB's Mach-O header
+		 * @param dylibHeader The DYLD's DYLIB's Mach-O header
 		 * @param dylibOffset The offset of the DYLIB in the given provider
-		 * @param provider The DYLD's bytes
+		 * @param splitDyldCache The {@link SplitDyldCache}
+		 * @param index The DYLIB's {@link SplitDyldCache} index
 		 * @throws IOException If there was an IO-related error
 		 */
-		public PackedDylib(MachHeader header, long dylibOffset, ByteProvider provider)
-				throws IOException {
-			reader = new BinaryReader(provider, true);
+		public PackedDylib(MachHeader dylibHeader, long dylibOffset, SplitDyldCache splitDyldCache,
+				int index) throws IOException {
+			reader = new BinaryReader(splitDyldCache.getProvider(index), true);
 			packedStarts = new HashMap<>();
 			int size = 0;
-			for (SegmentCommand segment : header.getAllSegments()) {
+			for (SegmentCommand segment : dylibHeader.getAllSegments()) {
 				packedStarts.put(segment, size);
 				size += segment.getFileSize();
 
@@ -224,14 +231,15 @@ public class DyldCacheDylibExtractor {
 				}
 			}
 			packed = new byte[size];
-			for (SegmentCommand segment : header.getAllSegments()) {
+			for (SegmentCommand segment : dylibHeader.getAllSegments()) {
 				long segmentSize = segment.getFileSize();
-				if (segment.getFileOffset() + segmentSize > provider.length()) {
-					segmentSize = provider.length() - segment.getFileOffset();
+				ByteProvider segmentProvider = getSegmentProvider(segment, splitDyldCache);
+				if (segment.getFileOffset() + segmentSize > segmentProvider.length()) {
+					segmentSize = segmentProvider.length() - segment.getFileOffset();
 					Msg.warn(this, segment.getSegmentName() +
 						" segment extends beyond end of file.  Truncating...");
 				}
-				byte[] bytes = provider.readBytes(segment.getFileOffset(), segmentSize);
+				byte[] bytes = segmentProvider.readBytes(segment.getFileOffset(), segmentSize);
 				System.arraycopy(bytes, 0, packed, packedStarts.get(segment), bytes.length);
 			}
 		}
@@ -281,6 +289,28 @@ public class DyldCacheDylibExtractor {
 			throw new NotFoundException(
 				"Failed to convert DYLD file offset to packed DYLIB offset: " +
 					Long.toHexString(fileOffset));
+		}
+
+		/**
+		 * Gets the {@link ByteProvider} that contains the given {@link SegmentCommand segment}
+		 * 
+		 * @param segment The {@link SegmentCommand segment}
+		 * @param splitDyldCache The {@link SplitDyldCache}
+		 * @return The {@link ByteProvider} that contains the given {@link SegmentCommand segment}
+		 * @throws IOException If a {@link ByteProvider} could not be found
+		 */
+		private ByteProvider getSegmentProvider(SegmentCommand segment,
+				SplitDyldCache splitDyldCache) throws IOException {
+			for (int i = 0; i < splitDyldCache.size(); i++) {
+				DyldCacheHeader header = splitDyldCache.getDyldCacheHeader(i);
+				for (DyldCacheMappingInfo mappingInfo : header.getMappingInfos()) {
+					if (mappingInfo.contains(segment.getVMaddress())) {
+						return splitDyldCache.getProvider(i);
+					}
+				}
+			}
+			throw new IOException(
+				"Failed to find provider for segment: " + segment.getSegmentName());
 		}
 
 		/**


### PR DESCRIPTION
Fixes #3345

- Now accounting for `imagesTextOffset` being used instead of `imagesOffset`
- New Loader option to automatically import and combine split files (.1, .2, .symbols, etc) into one program (on by default).  Only works when you import the "base" version of the split file.  