### PR TITLE
Replace keySet().contains with faster and cleaner containsKey method

### DIFF
--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/java/agent/gdb/model/impl/GdbModelTargetModuleContainer.java
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/java/agent/gdb/model/impl/GdbModelTargetModuleContainer.java
@@ -107,7 +107,7 @@ public class GdbModelTargetModuleContainer
 	protected CompletableFuture<Void> doRefresh() {
 		return inferior.listModules().thenCompose(byName -> {
 			for (String modName : inferior.getKnownModules().keySet()) {
-				if (!byName.keySet().contains(modName)) {
+				if (!byName.containsKey(modName)) {
 					impl.deleteModelObject(byName.get(modName));
 				}
 			}

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/export/TraceViewXmlExporter.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/export/TraceViewXmlExporter.java
@@ -40,14 +40,14 @@ public class TraceViewXmlExporter extends XmlExporter {
 	public List<Option> getOptions(DomainObjectService domainObjectService) {
 		List<Option> options = super.getOptions(domainObjectService);
 		return options.stream()
-				.filter(o -> !hideOpts.keySet().contains(o.getName()))
+				.filter(o -> !hideOpts.containsKey(o.getName()))
 				.collect(Collectors.toList());
 	}
 
 	@Override
 	public void setOptions(List<Option> options) throws OptionException {
 		List<Option> opts = new ArrayList<>(options);
-		options.stream().filter(o -> !hideOpts.keySet().contains(o.getName())).forEach(opts::add);
+		options.stream().filter(o -> !hideOpts.containsKey(o.getName())).forEach(opts::add);
 		for (Map.Entry<String, Object> ent : hideOpts.entrySet()) {
 			opts.add(new Option(ent.getKey(), ent.getValue()));
 		}

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/TraceObjectManager.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/TraceObjectManager.java
@@ -232,7 +232,7 @@ public class TraceObjectManager {
 
 		Set<Class<? extends TargetObject>> interfaces = obj.getSchema().getInterfaces();
 		for (Class<? extends TargetObject> ifc : interfaces) {
-			if (handlerMapInit.keySet().contains(ifc)) {
+			if (handlerMapInit.containsKey(ifc)) {
 				return true;
 			}
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/merge/listing/FunctionTagListingMerger.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/merge/listing/FunctionTagListingMerger.java
@@ -171,7 +171,7 @@ public class FunctionTagListingMerger extends AbstractListingMerger {
 
 	@Override
 	public boolean hasConflict(Address addr) {
-		return conflictMap.keySet().contains(addr);
+		return conflictMap.containsKey(addr);
 	}
 
 	@Override

--- a/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RecoveredClass.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RecoveredClass.java
@@ -191,7 +191,7 @@ public class RecoveredClass {
 			return;
 		}
 
-		if (!classOffsetToVftableMap.keySet().contains(offset)) {
+		if (!classOffsetToVftableMap.containsKey(offset)) {
 
 			// error if try to add same address to different offset
 			if (classOffsetToVftableMap.values().contains(vftableAddress)) {
@@ -219,7 +219,7 @@ public class RecoveredClass {
 
 	public void addParentToBaseTypeMapping(RecoveredClass recoveredClass, Boolean isVirtualBase) {
 
-		if (!parentToBaseTypeMap.keySet().contains(recoveredClass)) {
+		if (!parentToBaseTypeMap.containsKey(recoveredClass)) {
 			parentToBaseTypeMap.put(recoveredClass, isVirtualBase);
 		}
 	}
@@ -658,7 +658,7 @@ public class RecoveredClass {
 	public void addClassHierarchyMapping(RecoveredClass recoveredClass,
 			List<RecoveredClass> recoveredClasses) {
 
-		if (!classHierarchyMap.keySet().contains(recoveredClass)) {
+		if (!classHierarchyMap.containsKey(recoveredClass)) {
 			classHierarchyMap.put(recoveredClass, recoveredClasses);
 		}
 	}

--- a/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RecoveredClassHelper.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RecoveredClassHelper.java
@@ -4322,7 +4322,7 @@ public class RecoveredClassHelper {
 				continue;
 			}
 
-			if (!functionOccuranceMap.keySet().contains(firstCalledFunction)) {
+			if (!functionOccuranceMap.containsKey(firstCalledFunction)) {
 				functionOccuranceMap.put(firstCalledFunction, 1);
 			}
 			else {


### PR DESCRIPTION
Obtaining the keySet just to call contains to see if it contains a key is slower than running containsKey directly, since the contains() method just calls containsKey() anyway, so let's call containsKey() directly when we can!