### PR TITLE
Replace C Style arrays to Java style arrays

### DIFF
--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/gadp/DbgEngGadpServer.java
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/gadp/DbgEngGadpServer.java
@@ -77,7 +77,7 @@ public interface DbgEngGadpServer extends AutoCloseable {
 		public DbgEngRunner() {
 		}
 
-		public void run(String args[])
+		public void run(String[] args)
 				throws IOException, InterruptedException, ExecutionException {
 			parseArguments(args);
 

--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/jna/dbgeng/WinNTExtra.java
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/jna/dbgeng/WinNTExtra.java
@@ -183,7 +183,7 @@ public class WinNTExtra {
 		public EXCEPTION_RECORD.ByReference ExceptionRecord;
 		public Pointer ExceptionAddress;
 		public DWORD NumberParameters;
-		public ULONG_PTR ExceptionInformation[] = new ULONG_PTR[15];
+		public ULONG_PTR[] ExceptionInformation = new ULONG_PTR[15];
 
 		@Override
 		protected List<String> getFieldOrder() {
@@ -206,7 +206,7 @@ public class WinNTExtra {
 		public DWORD ExceptionAddress;
 		public DWORD NumberParameters;
 		public DWORD __unusedAlignment;
-		public DWORD ExceptionInformation[] = new DWORD[15];
+		public DWORD[] ExceptionInformation = new DWORD[15];
 
 		@Override
 		protected List<String> getFieldOrder() {
@@ -229,7 +229,7 @@ public class WinNTExtra {
 		public DWORDLONG ExceptionAddress;
 		public DWORD NumberParameters;
 		public DWORD __unusedAlignment;
-		public DWORDLONG ExceptionInformation[] = new DWORDLONG[15];
+		public DWORDLONG[] ExceptionInformation = new DWORDLONG[15];
 
 		@Override
 		protected List<String> getFieldOrder() {

--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/manager/impl/DbgStackFrameImpl.java
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/manager/impl/DbgStackFrameImpl.java
@@ -38,7 +38,7 @@ public class DbgStackFrameImpl implements DbgStackFrame {
 	private long stackOffset;
 	private boolean virtual;
 
-	private long params[] = new long[4];
+	private long[] params = new long[4];
 
 	public DbgStackFrameImpl(DbgThreadImpl thread, int level, BigInteger addr, String func) {
 		this.manager = thread.manager;

--- a/Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/gadp/DbgModelGadpServer.java
+++ b/Ghidra/Debug/Debugger-agent-dbgmodel/src/main/java/agent/dbgmodel/gadp/DbgModelGadpServer.java
@@ -108,7 +108,7 @@ public interface DbgModelGadpServer extends DbgEngGadpServer {
 		}
 
 		@Override
-		public void run(String args[])
+		public void run(String[] args)
 				throws IOException, InterruptedException, ExecutionException {
 			parseArguments(args);
 

--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/java/agent/gdb/gadp/GdbGadpServer.java
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/java/agent/gdb/gadp/GdbGadpServer.java
@@ -48,7 +48,7 @@ public interface GdbGadpServer extends AutoCloseable {
 		private List<String> gdbArgs = new ArrayList<>();
 		private InetSocketAddress bindTo;
 
-		public void run(String args[])
+		public void run(String[] args)
 				throws IOException, InterruptedException, ExecutionException {
 			parseArguments(args);
 

--- a/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/gadp/LldbGadpServer.java
+++ b/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/gadp/LldbGadpServer.java
@@ -66,7 +66,7 @@ public interface LldbGadpServer extends AutoCloseable {
 		public LldbRunner() {
 		}
 
-		public void run(String args[])
+		public void run(String[] args)
 				throws IOException, InterruptedException, ExecutionException {
 			parseArguments(args);
 

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/memview/MemviewMapModel.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/memview/MemviewMapModel.java
@@ -38,7 +38,7 @@ class MemviewMapModel extends AbstractSortedTableModel<MemoryBox> {
 	private Map<String, MemoryBox> memMap = new HashMap<>();
 	private MemviewProvider provider;
 
-	private final static String COLUMN_NAMES[] =
+	private final static String[] COLUMN_NAMES =
 		{ NAME_COL, ASTART_COL, ASTOP_COL, TSTART_COL, TSTOP_COL };
 
 	public MemviewMapModel(MemviewProvider provider) {

--- a/Ghidra/Debug/Debugger/src/test/java/ghidra/app/plugin/core/debug/gui/copying/DebuggerCopyPlanTests.java
+++ b/Ghidra/Debug/Debugger/src/test/java/ghidra/app/plugin/core/debug/gui/copying/DebuggerCopyPlanTests.java
@@ -73,7 +73,7 @@ public class DebuggerCopyPlanTests extends AbstractGhidraHeadedDebuggerGUITest {
 		assertTrue(AllCopiers.BYTES.isAvailable(view, program));
 
 		Random r = new Random();
-		byte src[] = new byte[0x10000];
+		byte[] src = new byte[0x10000];
 		r.nextBytes(src);
 		try (UndoableTransaction tid = tb.startTransaction()) {
 			DBTraceMemoryManager memory = tb.trace.getMemoryManager();
@@ -92,7 +92,7 @@ public class DebuggerCopyPlanTests extends AbstractGhidraHeadedDebuggerGUITest {
 				TaskMonitor.DUMMY);
 		}
 
-		byte dst[] = new byte[0x10000];
+		byte[] dst = new byte[0x10000];
 		program.getMemory().getBytes(paddr, dst);
 
 		assertArrayEquals(src, dst);

--- a/Ghidra/Debug/Framework-Debugging/src/main/java/ghidra/dbg/util/TargetDataTypeConverter.java
+++ b/Ghidra/Debug/Framework-Debugging/src/main/java/ghidra/dbg/util/TargetDataTypeConverter.java
@@ -298,7 +298,7 @@ public class TargetDataTypeConverter {
 		 * space-separated token in its index. It can be the sole token, but the index must be
 		 * unique within the namespace.
 		 */
-		String parts[] = type.getIndex().split("\\s+");
+		String[] parts = type.getIndex().split("\\s+");
 		String name = parts[parts.length - 1];
 		switch (type.getTypeKind()) {
 			case ENUM:

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/symbol/DBTraceFunctionSymbolView.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/symbol/DBTraceFunctionSymbolView.java
@@ -221,7 +221,7 @@ public class DBTraceFunctionSymbolView
 	// TODO: Move this into a FunctionUtilities class?
 	public static Variable getReferencedVariable(Function function, Address instrAddr,
 			Address storageAddr, int size, boolean isRead, Language language) {
-		Variable variables[] = function.getAllVariables();
+		Variable[] variables = function.getAllVariables();
 
 		Parameter paramCandidate = null;
 		List<Variable> localCandidates = null;

--- a/Ghidra/Extensions/SleighDevTools/src/main/java/ghidra/app/util/disassemble/GNUExternalDisassembler.java
+++ b/Ghidra/Extensions/SleighDevTools/src/main/java/ghidra/app/util/disassemble/GNUExternalDisassembler.java
@@ -544,7 +544,7 @@ public class GNUExternalDisassembler implements ExternalDisassembler {
 		String endianString = gdisConfig.isBigEndian ? "0x00" : "0x01"; // 0x0 is big, 0x1 is little endian
 
 		// NOTE: valid target must be specified but has no effect on results
-		String cmds[] = { gdisConfig.gdisExecFile.getAbsolutePath(), "pef", gdisConfig.architecture,
+		String[] cmds = { gdisConfig.gdisExecFile.getAbsolutePath(), "pef", gdisConfig.architecture,
 			gdisConfig.machineId, endianString, "0x0",
 			gdisDataDirectory.getAbsolutePath() + File.separator,
 			GNUExternalDisassembler.READ_FROM_STDIN_PARAMETER };

--- a/Ghidra/Features/Base/ghidra_scripts/CompareAnalysisScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/CompareAnalysisScript.java
@@ -232,7 +232,7 @@ public class CompareAnalysisScript extends GhidraScript {
 			Symbol currentSym = currentSymIter.next();
 			Address switchAddress = currentSym.getAddress();
 			numSwitchesInCurrentProg++;
-			Symbol otherSyms[] = otherSymbolTable.getSymbols(switchAddress);
+			Symbol[] otherSyms = otherSymbolTable.getSymbols(switchAddress);
 			if (!isSwitch(otherSyms, "switchdataD_")) {
 				numMissingSwitches++;
 				println(numMissingSwitches + ": Missing switch table in " + otherProgramName +
@@ -249,7 +249,7 @@ public class CompareAnalysisScript extends GhidraScript {
 			Symbol otherSym = otherSymIter.next();
 			Address otherSwitchAddress = otherSym.getAddress();
 			numSwitchesInOtherProg++;
-			Symbol currentSyms[] = currentSymbolTable.getSymbols(otherSwitchAddress);
+			Symbol[] currentSyms = currentSymbolTable.getSymbols(otherSwitchAddress);
 			if (!isSwitch(currentSyms, "switchdataD_")) {
 				numMissingSwitches2++;
 				println(numMissingSwitches2 + ": Missing switch table in " + currentProgramName +

--- a/Ghidra/Features/Base/ghidra_scripts/FindImagesScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/FindImagesScript.java
@@ -118,7 +118,7 @@ public class FindImagesScript extends GhidraScript {
 
 	List<Address> scanForGIF87aImages() {
 
-		byte gifBytes[] = new byte[6];
+		byte[] gifBytes = new byte[6];
 		gifBytes[0] = (byte) 0x47;
 		gifBytes[1] = (byte) 0x49;
 		gifBytes[2] = (byte) 0x46;
@@ -132,7 +132,7 @@ public class FindImagesScript extends GhidraScript {
 
 	List<Address> scanForGIF89aImages() {
 
-		byte gifBytes[] = new byte[6];
+		byte[] gifBytes = new byte[6];
 		gifBytes[0] = (byte) 0x47;
 		gifBytes[1] = (byte) 0x49;
 		gifBytes[2] = (byte) 0x46;
@@ -146,7 +146,7 @@ public class FindImagesScript extends GhidraScript {
 
 	List<Address> scanForPNGs() {
 
-		byte pngBytes[] = new byte[8];
+		byte[] pngBytes = new byte[8];
 		pngBytes[0] = (byte) 0x89;
 		pngBytes[1] = (byte) 0x50;
 		pngBytes[2] = (byte) 0x4e;
@@ -165,7 +165,7 @@ public class FindImagesScript extends GhidraScript {
 		Memory memory = currentProgram.getMemory();
 		MemoryBlock[] blocks = memory.getBlocks();
 
-		byte maskBytes[] = null;
+		byte[] maskBytes = null;
 
 		List<Address> foundImages = new ArrayList<Address>();
 

--- a/Ghidra/Features/Base/ghidra_scripts/GenerateMaskedBitStringScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/GenerateMaskedBitStringScript.java
@@ -57,7 +57,7 @@ public class GenerateMaskedBitStringScript extends GhidraScript {
 		println("\nTotal count: " + count);
 	}
 
-	private String createMaskedBitString(byte values[], byte masks[]) {
+	private String createMaskedBitString(byte[] values, byte[] masks) {
 
 		String bitString = new String();
 

--- a/Ghidra/Features/Base/ghidra_scripts/RegisterTouchesPerFunction.java
+++ b/Ghidra/Features/Base/ghidra_scripts/RegisterTouchesPerFunction.java
@@ -81,7 +81,7 @@ public class RegisterTouchesPerFunction extends GhidraScript
         {
             inst = iIter.next();
 
-            Object o[] = inst.getResultObjects();
+            Object[] o = inst.getResultObjects();
             for (int i = 0; i < o.length; i++)
             {
                 if (o[i] instanceof Register)

--- a/Ghidra/Features/Base/ghidra_scripts/SearchForImageBaseOffsets.java
+++ b/Ghidra/Features/Base/ghidra_scripts/SearchForImageBaseOffsets.java
@@ -39,7 +39,7 @@ public class SearchForImageBaseOffsets extends GhidraScript {
 
 		long currentAddressIbo = imageBaseOffset ^ currentAddressOffset;
 
-		byte searchBytes[] = createLittleEndianByteArray(currentAddressIbo, 8);
+		byte[] searchBytes = createLittleEndianByteArray(currentAddressIbo, 8);
 		println("searching for possible ibo64 references to " + currentAddress.toString() + " ...");
 		searchForByteArray(searchBytes);
 
@@ -60,7 +60,7 @@ public class SearchForImageBaseOffsets extends GhidraScript {
 			throws CancelledException {
 
 
-		byte byteArray[] = new byte[numBytes];
+		byte[] byteArray = new byte[numBytes];
 
 		for (int i = 0; i < numBytes; i++) {
 			monitor.checkCanceled();

--- a/Ghidra/Features/Base/ghidra_scripts/SearchForImageBaseOffsetsScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/SearchForImageBaseOffsetsScript.java
@@ -56,7 +56,7 @@ public class SearchForImageBaseOffsetsScript extends GhidraScript {
 
 		long currentAddressIbo = currentAddressOffset - imageBaseOffset;
 
-		byte searchBytes[] =
+		byte[] searchBytes =
 			createSearchArray(currentAddressIbo, POINTER_BYTE_LEN_64BIT, isBigEndian);
 		println("searching for possible ibo64 references to " + currentAddress.toString() + " ...");
 		AddressSet ibo64refs = searchForByteArray(searchBytes);
@@ -99,7 +99,7 @@ public class SearchForImageBaseOffsetsScript extends GhidraScript {
 			throws CancelledException {
 
 
-		byte byteArray[] = new byte[numBytes];
+		byte[] byteArray = new byte[numBytes];
 
 		for (int i = 0; i < numBytes; i++) {
 			monitor.checkCanceled();
@@ -118,7 +118,7 @@ public class SearchForImageBaseOffsetsScript extends GhidraScript {
 	 */
 	private byte[] createBigEndianByteArray(long value, int numBytes) throws CancelledException {
 
-		byte byteArray[] = new byte[numBytes];
+		byte[] byteArray = new byte[numBytes];
 
 		for (int i = 0; i < numBytes; i++) {
 			monitor.checkCanceled();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CallDepthChangeInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CallDepthChangeInfo.java
@@ -794,7 +794,7 @@ public class CallDepthChangeInfo {
 		int offsetReg = 0;
 		Register offReg = null;
 		Scalar s = null;
-		Object obj[] = cu.getOpObjects(opIndex);
+		Object[] obj = cu.getOpObjects(opIndex);
 		for (int i = 0; obj != null && i < obj.length; i++) {
 			if (obj[i] instanceof Scalar) {
 				Scalar newsc = (Scalar) obj[i];
@@ -1014,7 +1014,7 @@ public class CallDepthChangeInfo {
 		FlowType fType = instr.getFlowType();
 		Address[] flows;
 		if (fType.isComputed()) {
-			Reference refs[] = instr.getReferencesFrom();
+			Reference[] refs = instr.getReferencesFrom();
 			flows = new Address[refs.length];
 			for (int ri = 0; ri < refs.length; ri++) {
 				Data data = program.getListing().getDataAt(refs[ri].getToAddress());

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/FunctionResultStateStackAnalysisCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/FunctionResultStateStackAnalysisCmd.java
@@ -141,7 +141,7 @@ public class FunctionResultStateStackAnalysisCmd extends BackgroundCommand {
 				while (iter.hasNext()) {
 					monitor.checkCanceled();
 					Address fromAddr = iter.next();
-					Reference refs[] =
+					Reference[] refs =
 						program.getReferenceManager().getFlowReferencesFrom(fromAddr);
 					for (Reference ref : refs) {
 						if (ref.getReferenceType().isCall()) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/FunctionStackAnalysisCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/FunctionStackAnalysisCmd.java
@@ -341,7 +341,7 @@ public class FunctionStackAnalysisCmd extends BackgroundCommand {
 			}
 		}
 		else {
-			Object results[] = instr.getResultObjects();
+			Object[] results = instr.getResultObjects();
 			if (results.length == 1 && results[0] instanceof Register) {
 				return ((Register) results[0]).getMinimumByteSize();
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/NewFunctionStackAnalysisCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/NewFunctionStackAnalysisCmd.java
@@ -560,7 +560,7 @@ public class NewFunctionStackAnalysisCmd extends BackgroundCommand {
 		int opIndex = 0;
 //		int opLocation = -1;
 		for (; opIndex < cu.getNumOperands(); opIndex++) {
-			Object obj[] = cu.getOpObjects(opIndex);
+			Object[] obj = cu.getOpObjects(opIndex);
 //	        if (obj.length <= 1) {
 //	        	continue;
 //	        }
@@ -707,7 +707,7 @@ public class NewFunctionStackAnalysisCmd extends BackgroundCommand {
 			}
 		}
 		else {
-			Object results[] = instr.getResultObjects();
+			Object[] results = instr.getResultObjects();
 			if (results.length == 1 && results[0] instanceof Register) {
 				return ((Register) results[0]).getMinimumByteSize();
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/merge/listing/CodeUnitMerger.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/merge/listing/CodeUnitMerger.java
@@ -285,7 +285,7 @@ class CodeUnitMerger extends AbstractListingMerger {
 		Listing latestListing = latestPgm.getListing();
 		Listing myListing = myPgm.getListing();
 		Listing originalListing = originalPgm.getListing();
-		Listing listings[] = new Listing[] { latestListing, myListing, originalListing };
+		Listing[] listings = new Listing[] { latestListing, myListing, originalListing };
 		// Create address ranges based on alignment between versions.
 		AddressRangeIterator iter = conflictSet.getAddressRanges();
 		while (iter.hasNext()) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisManager.java
@@ -1194,9 +1194,8 @@ public class AutoAnalysisManager implements DomainObjectListener, DomainObjectCl
 	 * @return an array of task names
 	 */
 	public String[] getTimedTasks() {
-		String values[] = new String[timedTasks.size()];
-		List<String> list = new ArrayList<>();
-		list.addAll(timedTasks.keySet());
+		String[] values = new String[timedTasks.size()];
+        List<String> list = new ArrayList<>(timedTasks.keySet());
 		Collections.sort(list);
 		return list.toArray(values);
 	}
@@ -1263,7 +1262,7 @@ public class AutoAnalysisManager implements DomainObjectListener, DomainObjectCl
 
 		taskTimesStringBuf.append("-----------------------------------------------------\n");
 
-		String taskNames[] = getTimedTasks();
+		String[] taskNames = getTimedTasks();
 		for (String element : taskNames) {
 			long taskTime = getTaskTime(timedTasks, element);
 			double totalTime = taskTime / 1000.00;
@@ -1300,7 +1299,7 @@ public class AutoAnalysisManager implements DomainObjectListener, DomainObjectCl
 
 		StoredAnalyzerTimes times = StoredAnalyzerTimes.getStoredAnalyzerTimes(program);
 
-		String taskNames[] = getTimedTasks();
+		String[] taskNames = getTimedTasks();
 		for (String element : taskNames) {
 			long taskTimeMSec = getTaskTime(timedTasks, element);
 			times.addTime(element, taskTimeMSec);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/CliMetadataTokenAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/CliMetadataTokenAnalyzer.java
@@ -218,7 +218,7 @@ public class CliMetadataTokenAnalyzer extends AbstractAnalyzer {
 
 	private CliAbstractTableRow getRowForMetadataToken(CliStreamMetadata metaStream,
 			Instruction inst) {
-		Object ops[] = inst.getOpObjects(0);
+		Object[] ops = inst.getOpObjects(0);
 		Scalar tableOp = (Scalar) ops[0];
 		Scalar indexOp = (Scalar) ops[1];
 		int table = (int) tableOp.getUnsignedValue();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/OperandReferenceAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/OperandReferenceAnalyzer.java
@@ -690,7 +690,7 @@ public class OperandReferenceAnalyzer extends AbstractAnalyzer {
 
 	private AddressSet getExecuteSet(Memory memory) {
 		AddressSet set = new AddressSet();
-		MemoryBlock blocks[] = memory.getBlocks();
+		MemoryBlock[] blocks = memory.getBlocks();
 		for (MemoryBlock block : blocks) {
 			if (block.isExecute()) {
 				set.addRange(block.getStart(), block.getEnd());
@@ -729,7 +729,7 @@ public class OperandReferenceAnalyzer extends AbstractAnalyzer {
 			return null;
 		}
 
-		Object opObjects[] = instr.getOpObjects(opIndex);
+		Object[] opObjects = instr.getOpObjects(opIndex);
 		// figure out the multiple away
 		long entryLen = 0;
 		for (Object opObject : opObjects) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ScalarOperandAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ScalarOperandAnalyzer.java
@@ -108,7 +108,7 @@ public class ScalarOperandAnalyzer extends AbstractAnalyzer {
 		// Check for scalar operands that are a valid address
 		//
 		for (int i = 0; i < instr.getNumOperands(); i++) {
-			Object objs[] = instr.getOpObjects(i);
+			Object[] objs = instr.getOpObjects(i);
 			for (int j = 0; j < objs.length; j++) {
 				if (!(objs[j] instanceof Scalar)) {
 					continue;
@@ -227,7 +227,7 @@ public class ScalarOperandAnalyzer extends AbstractAnalyzer {
 
 		//check that the target does not fall inside a defined function
 		if (checkOffcutFuncRef(program, addr)) {
-			Object objs[] = instr.getOpObjects(opIndex);
+			Object[] objs = instr.getOpObjects(opIndex);
 			checkForJumpTable(program, instr, opIndex, objs, addr);
 			return false;
 		}
@@ -246,8 +246,8 @@ public class ScalarOperandAnalyzer extends AbstractAnalyzer {
 		return true;
 	}
 
-	void checkForJumpTable(Program program, Instruction refInstr, int opIndex, Object opObjects[],
-			Address addr) {
+	void checkForJumpTable(Program program, Instruction refInstr, int opIndex, Object[] opObjects,
+                           Address addr) {
 		Instruction instr = program.getListing().getInstructionContaining(addr);
 
 		if (instr == null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompositeViewerModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompositeViewerModel.java
@@ -58,7 +58,7 @@ class CompositeViewerModel extends AbstractTableModel implements DataTypeManager
 
 	// The fields for each component.
 	/** The column headers for the component edit area. */
-	protected String headers[] =
+	protected String[] headers =
 		{ "Offset", "Length", "Mnemonic", "DataType", "FieldName", "Comment" };
 	private static final int OFFSET = 0;
 	private static final int LENGTH = 1;
@@ -1049,7 +1049,7 @@ class CompositeViewerModel extends AbstractTableModel implements DataTypeManager
 	 * @return true if a sub-component is in the indicated category.
 	 */
 	boolean hasSubDtInCategory(Composite parentDt, String catPath) {
-		DataTypeComponent components[] = parentDt.getDefinedComponents();
+		DataTypeComponent[] components = parentDt.getDefinedComponents();
 		// FUTURE Add a structure to keep track of which composites were searched so they aren't searched multiple times.
 		for (DataTypeComponent component : components) {
 			DataType subDt = component.getDataType();
@@ -1074,7 +1074,7 @@ class CompositeViewerModel extends AbstractTableModel implements DataTypeManager
 	 * @return true if the composite data type has the data type as a sub-component.
 	 */
 	protected boolean hasSubDt(Composite parentDt, DataTypePath dtPath) {
-		DataTypeComponent components[] = parentDt.getDefinedComponents();
+		DataTypeComponent[] components = parentDt.getDefinedComponents();
 		for (DataTypeComponent component : components) {
 			DataType subDt = component.getDataType();
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/CParserPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/CParserPlugin.java
@@ -288,7 +288,7 @@ public class CParserPlugin extends ProgramPlugin {
 			ghidra.app.util.cparser.CPP.ParseException {
 		String[] args = parseOptions(options);
 
-		DataTypeManager openDTmanagers[] = null;
+		DataTypeManager[] openDTmanagers = null;
 		DataTypeManagerService dtService = tool.getService(DataTypeManagerService.class);
 		if (dtService != null) {
 			openDTmanagers = dtService.getDataTypeManagers();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/data/CycleGroupAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/data/CycleGroupAction.java
@@ -143,7 +143,7 @@ public class CycleGroupAction extends DockingAction {
 			if (data == null) {
 				return;
 			}
-			int compPath[] = location.getComponentPath();
+			int[] compPath = location.getComponentPath();
 			if (compPath == null || compPath.length <= 0) {
 				DataType dt = cycleGroup.getNextDataType(data.getDataType(), true);
 				if (dt != null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTable.java
@@ -479,7 +479,7 @@ public class AddressTable {
 		if (flagNewCode && newCodeFound) {
 			// make sure we didn't get any references on the mnemonic
 			//  since more code must be found
-			Reference refs[] = start_inst.getMnemonicReferences();
+			Reference[] refs = start_inst.getMnemonicReferences();
 			for (Reference ref : refs) {
 				start_inst.removeMnemonicReference(ref.getToAddress());
 			}
@@ -536,7 +536,7 @@ public class AddressTable {
 	public void labelTable(Program program, Instruction start_inst,
 			ArrayList<AddLabelCmd> switchLabelList, AddLabelCmd tableNameLabel) {
 		// check if the table is already labeled
-		Symbol syms[] = program.getSymbolTable().getSymbols(getTopAddress());
+		Symbol[] syms = program.getSymbolTable().getSymbols(getTopAddress());
 		for (Symbol sym : syms) {
 			if (sym.getName(false).startsWith(tableNameLabel.getLabelName())) {
 				return;
@@ -587,7 +587,7 @@ public class AddressTable {
 		Symbol s = program.getSymbolTable().getGlobalSymbol(tableNameLabel.getLabelName(),
 			tableNameLabel.getLabelAddr());
 		for (int op = 0; op < start_inst.getNumOperands(); op++) {
-			Reference fromRefs[] = start_inst.getOperandReferences(op);
+			Reference[] fromRefs = start_inst.getOperandReferences(op);
 			for (Reference fromRef : fromRefs) {
 				if (fromRef.getToAddress().equals(tableNameLabel.getLabelAddr())) {
 					program.getReferenceManager().setAssociation(s, fromRef);
@@ -770,7 +770,7 @@ public class AddressTable {
 
 	private AddressSet getExecuteSet(Memory memory) {
 		AddressSet set = new AddressSet();
-		MemoryBlock blocks[] = memory.getBlocks();
+		MemoryBlock[] blocks = memory.getBlocks();
 		for (MemoryBlock block : blocks) {
 			if (block.isExecute()) {
 				set.addRange(block.getStart(), block.getEnd());

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTableAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTableAnalyzer.java
@@ -295,7 +295,7 @@ public class AddressTableAnalyzer extends AbstractAnalyzer {
 		// trim from the first offcut entry on
 		Address start = tableEntry.getTopAddress();
 		int tableLen = tableEntry.getNumberAddressEntries();
-		Address addrs[] = tableEntry.getTableElements();
+		Address[] addrs = tableEntry.getTableElements();
 		for (int i = 0; i < tableLen; i++) {
 			Address tableEntryAddr = start.add(i * 4);
 			Address targetAddr = addrs[i];

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/entropy/EntropyCalculate.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/entropy/EntropyCalculate.java
@@ -21,7 +21,7 @@ import ghidra.program.model.mem.MemoryBlock;
 
 public class EntropyCalculate {
 	private MemoryBlock block;
-	private int entropy[];				// Quantized entropy statistic for each chunk
+	private int[] entropy;				// Quantized entropy statistic for each chunk
 	private int chunksize;
 	private int[] histo;				// histogram of a chunk (reused for each chunk)
 	private byte[] chunk;				// chunk of bytes

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapModel.java
@@ -75,7 +75,7 @@ class MemoryMapModel extends AbstractSortedTableModel<MemoryBlock> {
 	private ArrayList<MemoryBlock> memList;
 	private MemoryMapProvider provider;
 
-	private final static String COLUMN_NAMES[] =
+	private final static String[] COLUMN_NAMES =
 		{ NAME_COL, START_COL, END_COL, LENGTH_COL, READ_COL, WRITE_COL, EXECUTE_COL, VOLATILE_COL,
 			OVERLAY_COL, BLOCK_TYPE_COL, INIT_COL, BYTE_SOURCE_COL, SOURCE_COL, COMMENT_COL };
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapProvider.java
@@ -535,7 +535,7 @@ class MemoryMapProvider extends ComponentProviderAdapter {
 			return;
 		}
 		ArrayList<MemoryBlock> delBlocks = new ArrayList<>();
-		int delRows[] = memTable.getSelectedRows();
+		int[] delRows = memTable.getSelectedRows();
 		for (int element : delRows) {
 			MemoryBlock block = mapModel.getBlockAt(element);
 			delBlocks.add(block);
@@ -640,7 +640,7 @@ class MemoryMapProvider extends ComponentProviderAdapter {
 	 */
 	private void mergeBlocks() {
 		ArrayList<MemoryBlock> blocks = new ArrayList<>();
-		int rows[] = memTable.getSelectedRows();
+		int[] rows = memTable.getSelectedRows();
 		for (int element : rows) {
 			MemoryBlock block = mapModel.getBlockAt(element);
 			blocks.add(block);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/processors/InstructionInfoProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/processors/InstructionInfoProvider.java
@@ -322,7 +322,7 @@ class InstructionInfoProvider extends ComponentProviderAdapter implements Domain
 		}
 	}
 
-	private String getString(String strs[]) {
+	private String getString(String[] strs) {
 		if (strs == null) {
 			return "-none-";
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/mask/MnemonicSearchPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/mask/MnemonicSearchPlugin.java
@@ -214,7 +214,7 @@ public class MnemonicSearchPlugin extends Plugin {
 	/*
 	 * Returns a single string based on the masked bits
 	 */
-	private String createMaskedBitString(byte values[], byte masks[]) {
+	private String createMaskedBitString(byte[] values, byte[] masks) {
 
 		String bitString = new String();
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/select/programtree/ProgramTreeSelectionPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/select/programtree/ProgramTreeSelectionPlugin.java
@@ -76,7 +76,7 @@ public class ProgramTreeSelectionPlugin extends ProgramPlugin {
 
 		JTree tree = node.getTree();
 		int count = tree.getSelectionCount();
-		TreePath paths[] = node.getTree().getSelectionPaths();
+		TreePath[] paths = node.getTree().getSelectionPaths();
 		for (int i = 0; i < count; i++) {
 			TreePath path = paths[i];
 			ProgramNode pNode = (ProgramNode) path.getLastPathComponent();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/AggressiveInstructionFinderAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/AggressiveInstructionFinderAnalyzer.java
@@ -335,7 +335,7 @@ public class AggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 								if (ftype.isTerminal()) {
 									return true;
 								}
-								Address flows[] = instr.getFlows();
+								Address[] flows = instr.getFlows();
 								if (flows != null && flows.length > 0) {
 
 									if (!curProgram.getMemory().contains(flows[0])) {
@@ -414,7 +414,7 @@ public class AggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 		// check if there is a block marked unexec
 
 		AddressSet execSet = new AddressSet();
-		MemoryBlock blocks[] = program.getMemory().getBlocks();
+		MemoryBlock[] blocks = program.getMemory().getBlocks();
 		for (MemoryBlock block : blocks) {
 			if (block.isExecute()) {
 				execSet.addRange(block.getStart(), block.getEnd());

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/ArmAggressiveInstructionFinderAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/ArmAggressiveInstructionFinderAnalyzer.java
@@ -260,7 +260,7 @@ public class ArmAggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 		pseudoContext.setValue(tmodeReg, entry, curValue);
 		AddressSet body =
 			pseudo.followSubFlows(entry, pseudoContext, 1000, new PseudoFlowProcessor() {
-				Object lastResults[] = null;
+				Object[] lastResults = null;
 				Instruction lastInstr = null;
 				int duplicateCount = 0;
 
@@ -299,7 +299,7 @@ public class ArmAggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 					if (ftype.isComputed() && ftype.isJump()) {
 						return true;
 					}
-					Address flows[] = instr.getFlows();
+					Address[] flows = instr.getFlows();
 					if (flows != null && flows.length > 0) {
 
 						if (!curProgram.getMemory().contains(flows[0])) {
@@ -357,7 +357,7 @@ public class ArmAggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 				private boolean validTerminator(PseudoInstruction instr) {
 					// for load multiple, one better be the stack to be a return
 					if (instr.getMnemonicString().startsWith("ldm")) {
-						Object inObjs[] = instr.getInputObjects();
+						Object[] inObjs = instr.getInputObjects();
 						if (inObjs != null) {
 							for (int i = 0; i < inObjs.length; i++) {
 								if (inObjs[i] instanceof Register &&
@@ -486,7 +486,7 @@ public class ArmAggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 		// check if there is a block marked unexec
 
 		AddressSet execSet = new AddressSet();
-		MemoryBlock blocks[] = program.getMemory().getBlocks();
+		MemoryBlock[] blocks = program.getMemory().getBlocks();
 		for (int i = 0; i < blocks.length; i++) {
 			if (blocks[i].isExecute()) {
 				execSet.addRange(blocks[i].getStart(), blocks[i].getEnd());

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/ObfuscatedInputStream.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/ObfuscatedInputStream.java
@@ -88,7 +88,7 @@ public class ObfuscatedInputStream extends InputStream {
 		try (InputStream is = new ObfuscatedInputStream(new FileInputStream(obfuscatedInputFile));
 				OutputStream os = new FileOutputStream(plainTextOutputFile)) {
 
-			byte buffer[] = new byte[4096];
+			byte[] buffer = new byte[4096];
 			int bytesRead;
 			while ((bytesRead = is.read(buffer)) > 0) {
 				os.write(buffer, 0, bytesRead);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/expression/DWARFExpression.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/expression/DWARFExpression.java
@@ -30,7 +30,7 @@ import ghidra.util.NumericUtilities;
  * Use a {@link DWARFExpressionEvaluator} to execute a {@link DWARFExpression}.
  */
 public class DWARFExpression {
-	static long EMPTY_OPERANDS_VALUE[] = {};
+	static long[] EMPTY_OPERANDS_VALUE = {};
 
 	private final List<DWARFExpressionOperation> operations;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/expression/DWARFExpressionOperation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/expression/DWARFExpressionOperation.java
@@ -27,7 +27,7 @@ class DWARFExpressionOperation {
 	protected final int offset;
 	protected final int opcode;
 	protected final DWARFExpressionOperandType[] operandTypes;
-	protected final long operands[];
+	protected final long[] operands;
 	protected final byte[] blob;
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/DWARFDataTypeManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/DWARFDataTypeManager.java
@@ -65,11 +65,11 @@ public class DWARFDataTypeManager {
 	private DataType baseDataTypeBool;
 	private DataType baseDataTypeChar;
 	private DataType baseDataTypeUchar;
-	private DataType baseDataTypeFloats[];
-	private DataType baseDataTypeSignedInts[];
-	private DataType baseDataTypeUnsignedInts[];
-	private DataType baseDataTypeUntyped[];
-	private DataType baseDataTypeChars[];
+	private DataType[] baseDataTypeFloats;
+	private DataType[] baseDataTypeSignedInts;
+	private DataType[] baseDataTypeUnsignedInts;
+	private DataType[] baseDataTypeUntyped;
+	private DataType[] baseDataTypeChars;
 	private DataType baseDataTypeUndefined1;
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DyldChainedImports.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DyldChainedImports.java
@@ -34,7 +34,7 @@ public class DyldChainedImports implements StructConverter {
 	private int imports_count;
 	private int imports_format;
 	private long imports_offset;
-	private DyldChainedImport chainedImports[];
+	private DyldChainedImport[] chainedImports;
 
 	static DyldChainedImports createDyldChainedImports(FactoryBundledWithBinaryReader reader,
 			DyldChainedFixupHeader cfh) throws IOException {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DyldChainedStartsInImage.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DyldChainedStartsInImage.java
@@ -32,9 +32,9 @@ import ghidra.util.exception.DuplicateNameException;
 public class DyldChainedStartsInImage implements StructConverter {
 
 	private int seg_count;         // count of segment chain starts
-	private int seg_info_offset[];
+	private int[] seg_info_offset;
 
-	private DyldChainedStartsInSegment chainedStarts[];
+	private DyldChainedStartsInSegment[] chainedStarts;
 
 	static DyldChainedStartsInImage createDyldChainedStartsInImage(
 			FactoryBundledWithBinaryReader reader) throws IOException {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DyldChainedStartsInSegment.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DyldChainedStartsInSegment.java
@@ -36,8 +36,8 @@ public class DyldChainedStartsInSegment implements StructConverter {
 	private long segment_offset;    // offset in memory to start of segment
 	private int max_valid_pointer;  // for 32-bit OS, any value beyond this is not a pointer
 	private short page_count;       // how many pages are in array
-	private short page_starts[];    // each entry is offset in each page of first element in chain
-	private short chain_starts[];   // TODO: used for some 32-bit formats with multiple starts per page 
+	private short[] page_starts;    // each entry is offset in each page of first element in chain
+	private short[] chain_starts;   // TODO: used for some 32-bit formats with multiple starts per page
 
 	static DyldChainedStartsInSegment createDyldChainedFixupHeader(
 			FactoryBundledWithBinaryReader reader) throws IOException {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/dyld/AbstractClassicProcessor.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/dyld/AbstractClassicProcessor.java
@@ -74,7 +74,7 @@ public abstract class AbstractClassicProcessor {
 
 		int fileType = header.getFileType();
 
-		byte originalBytes[] = new byte[0];
+		byte[] originalBytes = new byte[0];
 
 		switch (fileType) {
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo1.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo1.java
@@ -44,8 +44,8 @@ public class DyldCacheSlideInfo1 extends DyldCacheSlideInfoCommon {
 	private int entries_count;
 	private int entries_size;
 
-	private short toc[];
-	private byte bits[][];
+	private short[] toc;
+	private byte[][] bits;
 
 	public int getTocOffset() {
 		return toc_offset;
@@ -138,7 +138,7 @@ public class DyldCacheSlideInfo1 extends DyldCacheSlideInfoCommon {
 
 		List<Address> unchainedLocList = new ArrayList<>(1024);
 
-		byte origBytes[] = new byte[8];
+		byte[] origBytes = new byte[8];
 
 		monitor.setMessage("Fixing V1 chained data page pointers...");
 
@@ -156,7 +156,7 @@ public class DyldCacheSlideInfo1 extends DyldCacheSlideInfoCommon {
 				continue;
 			}
 
-			byte entry[] = bits[entryIndex];
+			byte[] entry = bits[entryIndex];
 
 			long page = dataPageStart + (4096L * tocIndex);
 			for (int pageEntriesIndex = 0; pageEntriesIndex < 128; ++pageEntriesIndex) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo2.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo2.java
@@ -48,8 +48,8 @@ public class DyldCacheSlideInfo2 extends DyldCacheSlideInfoCommon {
 	private int page_extras_count;
 	private long delta_mask;
 	private long value_add;
-	private short page_starts_entries[];
-	private short page_extras_entries[];
+	private short[] page_starts_entries;
+	private short[] page_extras_entries;
 
 	public long getPageSize() {
 		return Integer.toUnsignedLong(page_size);
@@ -212,7 +212,7 @@ public class DyldCacheSlideInfo2 extends DyldCacheSlideInfoCommon {
 		Memory memory = program.getMemory();
 		List<Address> unchainedLocList = new ArrayList<>(1024);
 
-		byte origBytes[] = new byte[8];
+		byte[] origBytes = new byte[8];
 
 		long valueMask = 0xffffffffffffffffL >>> (64 - deltaShift);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo3.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo3.java
@@ -43,7 +43,7 @@ public class DyldCacheSlideInfo3 extends DyldCacheSlideInfoCommon {
 	private int page_size;
 	private int page_starts_count;
 	private long auth_value_add;
-	private short page_starts[];
+	private short[] page_starts;
 
 	public int getPageSize() {
 		return page_size;
@@ -172,7 +172,7 @@ public class DyldCacheSlideInfo3 extends DyldCacheSlideInfoCommon {
 
 		List<Address> unchainedLocList = new ArrayList<>(1024);
 
-		byte origBytes[] = new byte[8];
+		byte[] origBytes = new byte[8];
 
 		long delta = -1;
 		while (delta != 0) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo4.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheSlideInfo4.java
@@ -52,8 +52,8 @@ public class DyldCacheSlideInfo4 extends DyldCacheSlideInfoCommon {
 	private long delta_mask;         // which (contiguous) set of bits contains the delta to the next rebase location (0xC0000000)
 	private long value_add;          // base address of cache
 
-	private short page_starts[];
-	private short page_extras[];
+	private short[] page_starts;
+	private short[] page_extras;
 
 	public int getPageSize() {
 		return page_size;
@@ -225,7 +225,7 @@ public class DyldCacheSlideInfo4 extends DyldCacheSlideInfoCommon {
 
 		List<Address> unchainedLocList = new ArrayList<Address>(1024);
 
-		byte origBytes[] = new byte[4];
+		byte[] origBytes = new byte[4];
 
 		int valueMask = 0xffffffff >>> (32 - deltaShift);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliAbstractSig.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliAbstractSig.java
@@ -434,7 +434,7 @@ public abstract class CliAbstractSig extends CliBlob implements CliRepresentable
 		private long dataOffset;
 
 		private CliRetType retType;
-		private CliParam params[];
+		private CliParam[] params;
 		private int sizeOfCount;
 		private byte flags;
 		private int genericParamCount;
@@ -1182,12 +1182,12 @@ public abstract class CliAbstractSig extends CliBlob implements CliRepresentable
 		private int rankBytes;
 		private int numSizes;
 		private int numSizesBytes;
-		private int size[];
-		private int sizeBytes[];
+		private int[] size;
+		private int[] sizeBytes;
 		private int numLoBounds;
 		private int numLoBoundsBytes;
-		private int loBound[];
-		private int loBoundBytes[];
+		private int[] loBound;
+		private int[] loBoundBytes;
 
 		public CliArrayShape(BinaryReader reader) throws IOException {
 			long origIndex = reader.getPointerIndex();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigLocalVar.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigLocalVar.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliSigLocalVar extends CliAbstractSig {
 	private int sizeOfCount;
-	private CliParam types[];
+	private CliParam[] types;
 
 	private static final int CLISIGLOCALVAR_PROLOG = 0x07;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodDef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodDef.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 public class CliSigMethodDef extends CliAbstractSig {
 
 	private CliRetType retType;
-	private CliParam params[];
+	private CliParam[] params;
 	private int sizeOfCount;
 	private int genericParamCount;
 	private byte flags;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodRef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodRef.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 public class CliSigMethodRef extends CliAbstractSig {
 	private long dataOffset;
 	private CliRetType retType;
-	private CliParam params[];
+	private CliParam[] params;
 	private int sizeOfCount;
 	private byte flags;
 	private int genericParamCount;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodSpec.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodSpec.java
@@ -26,7 +26,7 @@ import ghidra.util.exception.InvalidInputException;
 public class CliSigMethodSpec extends CliAbstractSig {
 	private int genArgCount;
 	private int genArgCountBytes;
-	private CliSigType types[];
+	private CliSigType[] types;
 
 	private static final byte CLISIGMETHODSPEC_PROLOG = 0x0A;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigProperty.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigProperty.java
@@ -27,7 +27,7 @@ public class CliSigProperty extends CliAbstractSig {
 	private int sizeOfCount;
 	private byte flags;
 	private CliRetType returnType;
-	private CliParam params[];
+	private CliParam[] params;
 
 	private final int CLISIGPROPERTY_PROLOG = 0x08;
 	private final int CLISIGPROPERTY_FLAGS_HASTHIS = 0x20;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigStandAloneMethod.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigStandAloneMethod.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 public class CliSigStandAloneMethod extends CliAbstractSig {
 
 	private CliRetType retType;
-	private CliParam params[];
+	private CliParam[] params;
 	private byte flags;
 	private int sizeOfCount;
 	private int sentinelIndex; // SENTINEL is before the parameter index in this field

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/CliTableMethodDef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/CliTableMethodDef.java
@@ -135,7 +135,7 @@ public class CliTableMethodDef extends CliAbstractTable {
 				paramsStr = "";
 			}
 			else {
-				String params[] = new String[this.nextRowParamIndex - this.paramIndex];
+				String[] params = new String[this.nextRowParamIndex - this.paramIndex];
 				for (int i = 0; i < params.length; i++) {
 					params[i] = getRowRepresentationSafe(CliTypeTable.Param, paramIndex + i);
 				}
@@ -169,7 +169,7 @@ public class CliTableMethodDef extends CliAbstractTable {
 				paramsStr = "";
 			}
 			else {
-				String params[] = new String[this.nextRowParamIndex - this.paramIndex];
+				String[] params = new String[this.nextRowParamIndex - this.paramIndex];
 				for (int i = 0; i < params.length; i++) {
 					params[i] = getRowShortRepSafe(CliTypeTable.Param, paramIndex + i);
 				}
@@ -301,7 +301,7 @@ public class CliTableMethodDef extends CliAbstractTable {
 
 			int maxSequence = 0;
 			int stackOffset = 0;
-			CliParam paramTypes[] = methodSig.getParamTypes();
+			CliParam[] paramTypes = methodSig.getParamTypes();
 			int paramCount = paramTypes.length;
 			CliTableParam paramTable = (CliTableParam) metadataStream.getTable(CliTypeTable.Param);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliCodedIndexUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliCodedIndexUtils.java
@@ -24,7 +24,7 @@ import ghidra.program.model.data.*;
 import ghidra.util.exception.InvalidInputException;
 
 public class CliCodedIndexUtils {	
-	public static DataType toDataType(CliStreamMetadata stream, int bitsUsed, CliTypeTable tables[]) {
+	public static DataType toDataType(CliStreamMetadata stream, int bitsUsed, CliTypeTable[] tables) {
 		int maxForWord = (1 << (WordDataType.dataType.getLength()*8 - bitsUsed)) - 1;
 		for (CliTypeTable table : tables) {
 			if (table != null && stream.getNumberRowsForTable(table) > maxForWord)
@@ -33,7 +33,7 @@ public class CliCodedIndexUtils {
 		return WordDataType.dataType;
 	}
 	
-	public static CliTypeTable getTableName(int codedIndex, int bitsUsed, CliTypeTable tables[]) throws InvalidInputException {
+	public static CliTypeTable getTableName(int codedIndex, int bitsUsed, CliTypeTable[] tables) throws InvalidInputException {
 		int mask = (2 << (bitsUsed - 1)) - 1; // 2 << (bitsUsed-1) == 2^(bitsUsed)
 		int tableBits = codedIndex & mask;
 		if (tableBits >= tables.length)
@@ -45,7 +45,7 @@ public class CliCodedIndexUtils {
 		return codedIndex >> bitsUsed;
 	}
 	
-	public static int readCodedIndex(BinaryReader reader, CliStreamMetadata stream, int bitsUsed, CliTypeTable tables[]) throws IOException {
+	public static int readCodedIndex(BinaryReader reader, CliStreamMetadata stream, int bitsUsed, CliTypeTable[] tables) throws IOException {
 		if (toDataType(stream, bitsUsed, tables).getLength() == WordDataType.dataType.getLength()) {
 			return reader.readNextShort();
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexCustomAttributeType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexCustomAttributeType.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexCustomAttributeType {
 	private static final int bitsUsed = 3;
-	private static final CliTypeTable tables[] = { null, null, CliTypeTable.MethodDef, CliTypeTable.MemberRef };
+	private static final CliTypeTable[] tables = { null, null, CliTypeTable.MethodDef, CliTypeTable.MemberRef };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasConstant.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasConstant.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexHasConstant {
 	private static final int bitsUsed = 2;
-	private static final CliTypeTable tables[] = { CliTypeTable.Field, CliTypeTable.Param, CliTypeTable.Property };
+	private static final CliTypeTable[] tables = { CliTypeTable.Field, CliTypeTable.Param, CliTypeTable.Property };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasCustomAttribute.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasCustomAttribute.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexHasCustomAttribute {
 	private static final int bitsUsed = 5;
-	private static final CliTypeTable tables[] = { CliTypeTable.MethodDef, CliTypeTable.Field, CliTypeTable.TypeRef, CliTypeTable.TypeDef, CliTypeTable.Param, 
+	private static final CliTypeTable[] tables = { CliTypeTable.MethodDef, CliTypeTable.Field, CliTypeTable.TypeRef, CliTypeTable.TypeDef, CliTypeTable.Param,
 		CliTypeTable.InterfaceImpl, CliTypeTable.MemberRef, CliTypeTable.Module, null, CliTypeTable.Property, CliTypeTable.Event, CliTypeTable.StandAloneSig,
 		CliTypeTable.ModuleRef, CliTypeTable.TypeSpec, CliTypeTable.Assembly, CliTypeTable.AssemblyRef, CliTypeTable.File, CliTypeTable.ExportedType, 
 		CliTypeTable.ManifestResource }; // TODO: null should be TableName.Permission, but this is not well-described in the standard

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasDeclSecurity.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasDeclSecurity.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexHasDeclSecurity {
 	private static final int bitsUsed = 2;
-	private static final CliTypeTable tables[] = { CliTypeTable.TypeDef, CliTypeTable.MethodDef, CliTypeTable.Assembly };
+	private static final CliTypeTable[] tables = { CliTypeTable.TypeDef, CliTypeTable.MethodDef, CliTypeTable.Assembly };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasFieldMarshall.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasFieldMarshall.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexHasFieldMarshall {
 	private static final int bitsUsed = 1;
-	private static final CliTypeTable tables[] = { CliTypeTable.Field, CliTypeTable.Param };
+	private static final CliTypeTable[] tables = { CliTypeTable.Field, CliTypeTable.Param };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasSemantics.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexHasSemantics.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexHasSemantics {
 	private static final int bitsUsed = 1;
-	private static final CliTypeTable tables[] = { CliTypeTable.Event, CliTypeTable.Property };
+	private static final CliTypeTable[] tables = { CliTypeTable.Event, CliTypeTable.Property };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexImplementation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexImplementation.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexImplementation {
 	private static final int bitsUsed = 2;
-	private static final CliTypeTable tables[] = { CliTypeTable.File, CliTypeTable.AssemblyRef, CliTypeTable.ExportedType };
+	private static final CliTypeTable[] tables = { CliTypeTable.File, CliTypeTable.AssemblyRef, CliTypeTable.ExportedType };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexMemberForwarded.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexMemberForwarded.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexMemberForwarded {
 	private static final int bitsUsed = 1;
-	private static final CliTypeTable tables[] = { CliTypeTable.Field, CliTypeTable.MethodDef };
+	private static final CliTypeTable[] tables = { CliTypeTable.Field, CliTypeTable.MethodDef };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexMemberRefParent.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexMemberRefParent.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexMemberRefParent extends CliCodedIndexUtils {
 	private static final int bitsUsed = 3;
-	private static final CliTypeTable tables[] = { CliTypeTable.TypeDef, CliTypeTable.TypeRef, CliTypeTable.ModuleRef, CliTypeTable.MethodDef, CliTypeTable.TypeSpec };
+	private static final CliTypeTable[] tables = { CliTypeTable.TypeDef, CliTypeTable.TypeRef, CliTypeTable.ModuleRef, CliTypeTable.MethodDef, CliTypeTable.TypeSpec };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexMethodDefOrRef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexMethodDefOrRef.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexMethodDefOrRef {
 	private static final int bitsUsed = 1;
-	private static final CliTypeTable tables[] = { CliTypeTable.MethodDef, CliTypeTable.MemberRef };
+	private static final CliTypeTable[] tables = { CliTypeTable.MethodDef, CliTypeTable.MemberRef };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexResolutionScope.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexResolutionScope.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexResolutionScope {
 	private static final int bitsUsed = 2;
-	private static final CliTypeTable tables[] = { CliTypeTable.Module, CliTypeTable.ModuleRef, CliTypeTable.AssemblyRef, CliTypeTable.TypeRef };
+	private static final CliTypeTable[] tables = { CliTypeTable.Module, CliTypeTable.ModuleRef, CliTypeTable.AssemblyRef, CliTypeTable.TypeRef };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexTypeDefOrRef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexTypeDefOrRef.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexTypeDefOrRef {
 	private static final int bitsUsed = 2;
-	private static final CliTypeTable tables[] = { CliTypeTable.TypeDef, CliTypeTable.TypeRef, CliTypeTable.TypeSpec };
+	private static final CliTypeTable[] tables = { CliTypeTable.TypeDef, CliTypeTable.TypeRef, CliTypeTable.TypeSpec };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexTypeOrMethodDef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/indexes/CliIndexTypeOrMethodDef.java
@@ -25,7 +25,7 @@ import ghidra.util.exception.InvalidInputException;
 
 public class CliIndexTypeOrMethodDef {
 	private static final int bitsUsed = 1;
-	private static final CliTypeTable tables[] = { CliTypeTable.TypeDef, CliTypeTable.MethodDef };
+	private static final CliTypeTable[] tables = { CliTypeTable.TypeDef, CliTypeTable.MethodDef };
 	
 	public static DataType toDataType(CliStreamMetadata stream) {
 		return CliCodedIndexUtils.toDataType(stream, bitsUsed, tables);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/BoundedBufferedReader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/BoundedBufferedReader.java
@@ -22,7 +22,7 @@ public class BoundedBufferedReader extends Reader {
 
 	private Reader in;
 
-	private char cb[];
+	private char[] cb;
 	private int nChars, nextChar;
 
 	private static final int INVALIDATED = -2;
@@ -101,7 +101,7 @@ public class BoundedBufferedReader extends Reader {
 					dst = delta;
 				} else {
 					/* Reallocate buffer to accommodate read-ahead limit */
-					char ncb[] = new char[readAheadLimit];
+					char[] ncb = new char[readAheadLimit];
 					System.arraycopy(cb, markedChar, ncb, 0, delta);
 					cb = ncb;
 					markedChar = 0;
@@ -239,7 +239,7 @@ public class BoundedBufferedReader extends Reader {
 	 * @exception IOException
 	 *                If an I/O error occurs
 	 */
-	public int read(char cbuf[], int off, int len) throws IOException {
+	public int read(char[] cbuf, int off, int len) throws IOException {
 		synchronized (lock) {
 			ensureOpen();
 			if ((off < 0) || (off > cbuf.length) || (len < 0)

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/LibrarySymbolTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/LibrarySymbolTable.java
@@ -119,7 +119,7 @@ class LibrarySymbolTable {
 			}
 
 			// assumes that Ordinal_# name comes right before the actual name
-			Symbol symbolsAt[] = symTab.getSymbols(symAddr);
+			Symbol[] symbolsAt = symTab.getSymbols(symAddr);
 			for (int i = 0; i < symbolsAt.length; i++) {
 				if (symbolsAt[i].getName().equals(sym.getName())) {
 					if (i + 1 < symbolsAt.length) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MachoPrelinkProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MachoPrelinkProgramBuilder.java
@@ -368,7 +368,7 @@ public class MachoPrelinkProgramBuilder extends MachoProgramBuilder {
 		long imageBaseOffset = program.getImageBase().getOffset();
 		Address chainStart = memory.getProgram().getLanguage().getDefaultSpace().getAddress(page);
 
-		byte origBytes[] = new byte[8];
+		byte[] origBytes = new byte[8];
 
 		long next = -1;
 		boolean start = true;
@@ -520,7 +520,7 @@ public class MachoPrelinkProgramBuilder extends MachoProgramBuilder {
 		}
 
 		// Add entry to relocation table for the pointer fixup
-		byte origBytes[] = new byte[8];
+		byte[] origBytes = new byte[8];
 		memory.getBytes(pointerAddr, origBytes);
 		program.getRelocationTable()
 				.add(pointerAddr, (int) fixedPointerType, new long[] { fixedPointerValue },

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/options/OptionsGui.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/options/OptionsGui.java
@@ -338,7 +338,7 @@ public class OptionsGui extends JPanel {
 		JPanel panel1 = new JPanel(new FlowLayout());
 
 		GraphicsEnvironment gEnv = GraphicsEnvironment.getLocalGraphicsEnvironment();
-		String envfonts[] = gEnv.getAvailableFontFamilyNames();
+		String[] envfonts = gEnv.getAvailableFontFamilyNames();
 		fontNameField = new GComboBox<>(envfonts);
 		fontNameField.setBackground(Color.white);
 		fontNameField.setRenderer(new FontRenderer());

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FSUtilities.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FSUtilities.java
@@ -360,7 +360,7 @@ public class FSUtilities {
 	 */
 	public static long streamCopy(InputStream is, OutputStream os, TaskMonitor monitor)
 			throws IOException, CancelledException {
-		byte buffer[] = new byte[FileUtilities.IO_BUFFER_SIZE];
+		byte[] buffer = new byte[FileUtilities.IO_BUFFER_SIZE];
 		int bytesRead;
 		long totalBytesCopied = 0;
 		while ((bytesRead = is.read(buffer)) > 0) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/MultiAddressIterator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/MultiAddressIterator.java
@@ -26,9 +26,9 @@ import ghidra.program.model.address.AddressIterator;
  */
 public class MultiAddressIterator {
 	/** the code unit iterators */
-	AddressIterator	iters[];
+	AddressIterator[] iters;
 	/** the current code units */
-	Address			addrs[];
+	Address[] addrs;
 	boolean			forward;
 
 	/**
@@ -85,7 +85,7 @@ public class MultiAddressIterator {
 
 		// Find next address.
 		Address addrNext = null;
-		boolean next[] = new boolean[iters.length];
+		boolean[] next = new boolean[iters.length];
 		for (int i = 0; i < iters.length; i++) {
 			if (addrs[i] == null) {
 				continue;
@@ -137,7 +137,7 @@ public class MultiAddressIterator {
 
 		// Find next address.
 		Address addrNext = null;
-		boolean next[] = new boolean[iters.length];
+		boolean[] next = new boolean[iters.length];
 		for (int i = 0; i < iters.length; i++) {
 			if (addrs[i] == null) {
 				continue;
@@ -162,7 +162,7 @@ public class MultiAddressIterator {
 		}
 
 		// Load array with all addresses that have same address as next. Others are null.
-		Address nextAddr[] = new Address[iters.length];
+		Address[] nextAddr = new Address[iters.length];
 		for (int i = 0; i < iters.length; i++) {
 			if (next[i]) {
 				nextAddr[i] = addrs[i];

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/MultiAddressRangeIterator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/MultiAddressRangeIterator.java
@@ -24,8 +24,8 @@ import ghidra.program.model.address.*;
  * as determined from all the iterators.
  */
 public class MultiAddressRangeIterator {
-	AddressRangeIterator	iters[];
-	AddressRange			addrRanges[];
+	AddressRangeIterator[] iters;
+	AddressRange[] addrRanges;
 	boolean			forward;
 	Address min = null;
 	Address max = null;

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/MultiCodeUnitIterator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/MultiCodeUnitIterator.java
@@ -28,9 +28,9 @@ import ghidra.program.model.listing.*;
  */
 public class MultiCodeUnitIterator {
 	/** the code unit iterators */
-	CodeUnitIterator	iter[];
+	CodeUnitIterator[] iter;
 	/** the current code units */
-	CodeUnit			cu[];
+	CodeUnit[] cu;
 	boolean				forward;
 
 	/**
@@ -97,7 +97,7 @@ public class MultiCodeUnitIterator {
 
 		// Find next code unit.
 		CodeUnit cuNext = null;
-		boolean next[] = new boolean[iter.length];
+		boolean[] next = new boolean[iter.length];
 		for (int i = 0; i < iter.length; i++) {
 			if (cu[i] == null) {
 				continue;
@@ -122,7 +122,7 @@ public class MultiCodeUnitIterator {
 		}
 
 		// Load array with all code units that have same address as next. Others are null.
-		CodeUnit nextCU[] = new CodeUnit[iter.length];
+		CodeUnit[] nextCU = new CodeUnit[iter.length];
 		for (int i = 0; i < iter.length; i++) {
 			if (next[i]) {
 				nextCU[i] = cu[i];

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/ProgramMemoryUtil.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/ProgramMemoryUtil.java
@@ -352,7 +352,7 @@ public class ProgramMemoryUtil {
 				}
 				else {
 					// handle any addrSize the hard way
-					byte dest[] = new byte[addrSize / 8];
+					byte[] dest = new byte[addrSize / 8];
 					int num = memory.getBytes(a, dest);
 					if (num != dest.length) {
 						continue; // insufficient bytes
@@ -661,7 +661,7 @@ public class ProgramMemoryUtil {
 	private static void findBytePattern(Memory memory, AddressRange memoryRange, byte[] bytePattern,
 			int alignment, Set<Address> foundList, TaskMonitor monitor) throws CancelledException {
 
-		byte maskBytes[] = null;
+		byte[] maskBytes = null;
 
 		MemoryBlock[] blocks = memory.getBlocks();
 		for (MemoryBlock block : blocks) {
@@ -698,7 +698,7 @@ public class ProgramMemoryUtil {
 	private static void findBytePattern(Memory memory, List<MemoryBlock> blocks, byte[] bytePattern,
 			int alignment, Set<Address> foundList, TaskMonitor monitor) throws CancelledException {
 
-		byte maskBytes[] = null;
+		byte[] maskBytes = null;
 
 		if (blocks == null) {
 			blocks = Arrays.asList(memory.getBlocks());

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/SymbolicPropogator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/SymbolicPropogator.java
@@ -532,7 +532,7 @@ public class SymbolicPropogator {
 				// if the instruction changed it's type to a call, need to handle the call side effects
 				FlowType instrFlow = instr.getFlowType();
 				if (!originalFlowType.equals(instrFlow) && instrFlow.isCall()) {
-					Address targets[] = getInstructionFlows(instr);
+					Address[] targets = getInstructionFlows(instr);
 					for (Address target : targets) {
 						handleFunctionSideEffects(instr, target, monitor);
 					}
@@ -548,7 +548,7 @@ public class SymbolicPropogator {
 				// follow flow, except for call flow
 				boolean doFallThruLast = false;
 				if (!simpleFlow) {
-					Address flows[] = getInstructionFlows(instr);
+					Address[] flows = getInstructionFlows(instr);
 					if (flows != null && flows.length > 0) {
 						// if already hit another flow, don't continue past any type of branching instruction
 						if (hitOtherFlow) {
@@ -702,7 +702,7 @@ public class SymbolicPropogator {
 	}
 
 	private PcodeOp[] getInstructionPcode(Instruction instruction) {
-		PcodeOp ops[] = pcodeCache.get(instruction.getMinAddress());
+		PcodeOp[] ops = pcodeCache.get(instruction.getMinAddress());
 		if (ops == null) {
 			ops = instruction.getPcode(true);
 			pcodeCache.put(instruction.getMinAddress(), ops);
@@ -1487,7 +1487,7 @@ public class SymbolicPropogator {
 			}
 
 			// clear out settings for any return variables
-			Varnode returnVarnodes[] = context.getReturnVarnode(targetFunc);
+			Varnode[] returnVarnodes = context.getReturnVarnode(targetFunc);
 			if (returnVarnodes != null) {
 				for (Varnode varnode : returnVarnodes) {
 					context.putValue(varnode, context.createBadVarnode(), false);

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/MultiComparableArrayIterator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/MultiComparableArrayIterator.java
@@ -111,7 +111,7 @@ public class MultiComparableArrayIterator<T extends Comparable<T>> {
 
 		// Find next variable.
 		T compNext = null;
-		boolean next[] = new boolean[comps.length];
+		boolean[] next = new boolean[comps.length];
 //		for (int i = (forward ? 0 : comps.length-1); 
 //				(forward ? (i < comps.length) : (i >= 0)); 
 //				i=(forward ? i+1 : i-1)) {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/datamgr/CreateEnumFromSelectionTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/datamgr/CreateEnumFromSelectionTest.java
@@ -174,7 +174,7 @@ public class CreateEnumFromSelectionTest extends AbstractGhidraHeadedIntegration
 		assertNotNull(newEnumNode);
 
 		Enum newEnum = (Enum) newEnumNode.getDataType();
-		long values[] = newEnum.getValues();
+		long[] values = newEnum.getValues();
 
 		assertEquals(values.length, 6);
 

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/string/StringTableSearchTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/string/StringTableSearchTest.java
@@ -1254,7 +1254,7 @@ public class StringTableSearchTest extends AbstractGhidraHeadedIntegrationTest {
 		// make sure new label is made primary and second label is still there as secondary one
 		sym = program.getSymbolTable().getPrimarySymbol(addr(0x40503c));
 		assertEquals("s_String2", sym.getName());
-		Symbol symArray[] = program.getSymbolTable().getSymbols(addr(0x40503c));
+		Symbol[] symArray = program.getSymbolTable().getSymbols(addr(0x40503c));
 		assertEquals(2, symArray.length);
 		assertEquals("s_String2", symArray[0].getName());
 		assertEquals("testLabel", symArray[1].getName());

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/program/database/function/StackFrameTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/program/database/function/StackFrameTest.java
@@ -103,7 +103,7 @@ public class StackFrameTest extends AbstractGhidraHeadedIntegrationTest {
 		boolean growsNeg = frame.growsNegative();
 		DataType dt = new ByteDataType();
 
-		String names[] = new String[16];
+		String[] names = new String[16];
 
 		for (int i = 0; i < 16; i++) {
 			int offset = i - 8;

--- a/Ghidra/Features/Base/src/test/java/ghidra/program/model/address/AddressObjectMapTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/program/model/address/AddressObjectMapTest.java
@@ -230,9 +230,9 @@ public class AddressObjectMapTest extends AbstractGenericTest {
 	}
 
 	private boolean testContains(AddressObjectMap testMap, AddressSet set, Address addr) {
-		Object objs[] = testMap.getObjects(addr);
-		for (int i = 0; i < objs.length; i++) {
-			if (objs[i].equals(set)) {
+		Object[] objs = testMap.getObjects(addr);
+		for (Object obj : objs) {
+			if (obj.equals(set)) {
 				return true;
 			}
 		}

--- a/Ghidra/Features/Base/src/test/java/ghidra/test/JavaCompiler.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/test/JavaCompiler.java
@@ -51,7 +51,7 @@ public class JavaCompiler {
 		if (javaLoc.endsWith("jre")) {
 			javaLoc = javaLoc.substring(0, javaLoc.indexOf("jre")-1);
 		}
-		String argV[] = new String[6];
+		String[] argV = new String[6];
 		argV[0] = javaLoc + File.separator + "bin" + File.separator +"javac";
 		argV[1] = "-classpath";
 		argV[2] = classpath;

--- a/Ghidra/Features/BytePatterns/src/main/java/ghidra/bitpatterns/info/FunctionBitPatternInfo.java
+++ b/Ghidra/Features/BytePatterns/src/main/java/ghidra/bitpatterns/info/FunctionBitPatternInfo.java
@@ -133,7 +133,7 @@ public class FunctionBitPatternInfo {
 		}
 		numPreBytes = Math.max(numPreBytes, params.getNumPreBytes());
 
-		byte preByteArray[] = getBytesAgainstFlow(numPreBytes, mem, adjustedAddress);
+		byte[] preByteArray = getBytesAgainstFlow(numPreBytes, mem, adjustedAddress);
 		if (preByteArray != null) {
 			this.preBytes = getBytesAsString(preByteArray);
 		}

--- a/Ghidra/Features/Decompiler/ghidra_scripts/ShowCCallsScript.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/ShowCCallsScript.java
@@ -68,7 +68,7 @@ public class ShowCCallsScript extends GhidraScript {
 	        // call decompiler for all refs to current function
 	        Symbol sym = this.getSymbolAt(func.getEntryPoint());
 	
-	        Reference refs[] = sym.getReferences(null);
+	        Reference[] refs = sym.getReferences(null);
 	
 	        for (int i = 0; i < refs.length; i++) {
 	            if (monitor.isCancelled()) {

--- a/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RTTIWindowsClassRecoverer.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RTTIWindowsClassRecoverer.java
@@ -812,7 +812,7 @@ public class RTTIWindowsClassRecoverer extends RTTIClassRecoverer {
 		// this currently will workn only if there is a created reference
 		// TODO: get ibo bytes and figure out what the ibo ref address would be
 		if (addressSize == 64) {
-			Reference refs[] = extendedFlatAPI.getReferencesFrom(address);
+			Reference[] refs = extendedFlatAPI.getReferencesFrom(address);
 			if (refs.length == 0) {
 				return null;
 			}

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/cmd/function/DecompilerSwitchAnalysisCmd.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/cmd/function/DecompilerSwitchAnalysisCmd.java
@@ -220,7 +220,7 @@ public class DecompilerSwitchAnalysisCmd extends BackgroundCommand {
 			new AddLabelCmd(table.getSwitchAddress(), "switchD", SourceType.ANALYSIS);
 
 		// check if the table is already labeled
-		Symbol syms[] = program.getSymbolTable().getSymbols(table.getSwitchAddress());
+		Symbol[] syms = program.getSymbolTable().getSymbols(table.getSwitchAddress());
 		for (Symbol sym : syms) {
 			if (sym.getName(false).startsWith(tableNameLabel.getLabelName())) {
 				return;
@@ -269,7 +269,7 @@ public class DecompilerSwitchAnalysisCmd extends BackgroundCommand {
 			}
 		}
 
-		JumpTable.LoadTable loadtable[] = table.getLoadTables();
+		JumpTable.LoadTable[] loadtable = table.getLoadTables();
 		for (LoadTable element : loadtable) {
 			labelLoadTable(element, switchCases, caseSymbols, space, monitor);
 		}
@@ -377,7 +377,7 @@ public class DecompilerSwitchAnalysisCmd extends BackgroundCommand {
 
 		String dataName = "switchdataD_" + loadtable.getAddress();
 		// check if the table is already labeled
-		Symbol syms[] = program.getSymbolTable().getSymbols(tableAddr);
+		Symbol[] syms = program.getSymbolTable().getSymbols(tableAddr);
 		for (Symbol sym : syms) {
 			if (sym.getName(false).startsWith(dataName)) {
 				return;

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
@@ -574,7 +574,7 @@ public class DecompileCallback {
 			curspace = curspace.getParentNamespace();
 			curId = curspace.getID();
 		}
-		long path[] = new long[pathSize];
+		long[] path = new long[pathSize];
 		curspace = namespace;
 		path[0] = startId;
 		for (int i = 1; i < pathSize; ++i) {
@@ -1086,7 +1086,7 @@ public class DecompileCallback {
 			containedFunc.getBody());
 		while (iter.hasNext()) {
 			Address changeAddr = iter.next();
-			Reference refs[] =
+			Reference[] refs =
 				func.getProgram().getReferenceManager().getFlowReferencesFrom(changeAddr);
 			for (Reference element : refs) {
 				if (element.getToAddress().equals(addr)) {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/LimitedByteBuffer.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/LimitedByteBuffer.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
  *
  */
 public class LimitedByteBuffer {
-	byte value[];
+	byte[] value;
 	int count;			// Current number of characters
 	int absmax;			// Absolute maximum number of characters
 	

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ConvertConstantAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ConvertConstantAction.java
@@ -111,7 +111,7 @@ public abstract class ConvertConstantAction extends AbstractDecompilerAction {
 	 * @param values is an array of the given values
 	 * @return the Scalar and
 	 */
-	private ScalarMatch findScalarInInstruction(Instruction instr, long values[]) {
+	private ScalarMatch findScalarInInstruction(Instruction instr, long[] values) {
 		int numOperands = instr.getNumOperands();
 		ScalarMatch scalarMatch = null;
 		for (int i = 0; i < numOperands; i++) {
@@ -154,7 +154,7 @@ public abstract class ConvertConstantAction extends AbstractDecompilerAction {
 		if (constVn.getSize() < 8) {
 			mask = mask >>> (8 - constVn.getSize()) * 8;
 		}
-		long values[] = new long[4];
+		long[] values = new long[4];
 		values[0] = value;
 		values[1] = (value - 1) & mask;
 		values[2] = (value + 1) & mask;

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/FillOutStructureCmd.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/FillOutStructureCmd.java
@@ -251,7 +251,7 @@ public class FillOutStructureCmd extends BackgroundCommand {
 				return null;
 			}
 		}
-		DataType typeList[] = new DataType[slot + 1];
+		DataType[] typeList = new DataType[slot + 1];
 		typeList[0] = DataType.DEFAULT;		// Default function return data-type
 		for (int i = 1; i < slot + 1; ++i) {
 			typeList[i] = inputs[i].getHigh().getDataType();

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/DataTypeDependencyOrderer.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/DataTypeDependencyOrderer.java
@@ -261,19 +261,19 @@ public class DataTypeDependencyOrderer {
 			}
 			else if (dataType instanceof Structure) {
 				Structure struct = (Structure) dataType;
-				DataTypeComponent dtcomps[] = struct.getDefinedComponents();
+				DataTypeComponent[] dtcomps = struct.getDefinedComponents();
 				for (DataTypeComponent dtcomp : dtcomps) {
 					addDependent(entry, dtcomp.getDataType());
 				}
 			}
 			else if (dataType instanceof Composite) {
-				DataTypeComponent dtcomps[] = ((Composite) dataType).getComponents();
+				DataTypeComponent[] dtcomps = ((Composite) dataType).getComponents();
 				for (DataTypeComponent dtcomp : dtcomps) {
 					addDependent(entry, dtcomp.getDataType());
 				}
 			}
 			else if (dataType instanceof FunctionDefinition) {
-				ParameterDefinition paramDefs[] = ((FunctionDefinition) dataType).getArguments();
+				ParameterDefinition[] paramDefs = ((FunctionDefinition) dataType).getArguments();
 				addDependent(entry, ((FunctionDefinition) dataType).getReturnType());
 				for (ParameterDefinition paramDef : paramDefs) {
 					addDependent(entry, paramDef.getDataType());

--- a/Ghidra/Features/Decompiler/src/test.slow/java/ghidra/app/plugin/core/decompile/EquateTest.java
+++ b/Ghidra/Features/Decompiler/src/test.slow/java/ghidra/app/plugin/core/decompile/EquateTest.java
@@ -134,7 +134,7 @@ public class EquateTest extends AbstractDecompilerTest {
 		boolean foundHash = false;
 		if (ref.getDynamicHashValue() == 0) {
 			Instruction instr = program.getListing().getInstructionAt(ref.getAddress());
-			long values[] = DynamicHash.calcConstantHash(instr, equate.getValue());
+			long[] values = DynamicHash.calcConstantHash(instr, equate.getValue());
 			for (long value : values) {
 				if (value == dynEntry.getHash()) {
 					foundHash = true;

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/Ext4Analyzer.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/Ext4Analyzer.java
@@ -97,7 +97,7 @@ public class Ext4Analyzer extends FileFormatAnalyzer {
 		long groupDescOffset = groupStart + blockSize;
 		Address groupDescAddress = toAddr(program, groupDescOffset);
 		reader.setPointerIndex(groupDescOffset);
-		Ext4GroupDescriptor groupDescriptors[] = new Ext4GroupDescriptor[numGroups];
+		Ext4GroupDescriptor[] groupDescriptors = new Ext4GroupDescriptor[numGroups];
 		monitor.setMessage("Creating group descriptors...");
 		monitor.setMaximum(numGroups);
 		for( int i = 0; i < numGroups; i++ ) {
@@ -122,7 +122,7 @@ public class Ext4Analyzer extends FileFormatAnalyzer {
 			Ext4GroupDescriptor[] groupDescriptors, boolean is64Bit, TaskMonitor monitor) throws DuplicateNameException, Exception {
 		
 		int inodeCount = superBlock.getS_inodes_count();
-		Ext4Inode inodes[] = new Ext4Inode[inodeCount];
+		Ext4Inode[] inodes = new Ext4Inode[inodeCount];
 
 		for( int i = 0; i < groupDescriptors.length; i++ ) {
 			monitor.checkCanceled();

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/NewExt4Analyzer.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/NewExt4Analyzer.java
@@ -131,7 +131,7 @@ public class NewExt4Analyzer extends FileFormatAnalyzer {
 			long groupDescOffset = groupStart + blockSize;
 			Address groupDescAddress = toAddr( program, groupDescOffset );
 			reader.setPointerIndex( groupDescOffset );
-			Ext4GroupDescriptor groupDescriptors[] = new Ext4GroupDescriptor [ numGroups ];
+			Ext4GroupDescriptor[] groupDescriptors = new Ext4GroupDescriptor [ numGroups ];
 			monitor.setMessage( "Creating group descriptors..." );
 			monitor.setMaximum( numGroups );
 			for ( int i = 0; i < numGroups; i++ ) {

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dmg/DmgDecryptorStream.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dmg/DmgDecryptorStream.java
@@ -157,7 +157,7 @@ public class DmgDecryptorStream extends InputStream {
 	}
 
 	@Override
-	public int read(byte b[], int off, int len) throws IOException {
+	public int read(byte[] b, int off, int len) throws IOException {
 		if (buffer != null && bufferposition >= buffer.length) {
 			nextBuffer();
 		}

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dmg/DmgServerProcessManager.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/dmg/DmgServerProcessManager.java
@@ -235,7 +235,7 @@ class DmgServerProcessManager implements Closeable {
 		String classPath = buildClasspath();
 
 		// library path setup
-		String envp[] = buildEnvironmentVariables();
+		String[] envp = buildEnvironmentVariables();
 
 		String java =
 			System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/lzss/LzssCodec.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/lzss/LzssCodec.java
@@ -82,9 +82,9 @@ public class LzssCodec {
 		}
 
 		/* These constitute binary search trees */
-		int lchild[] = new int[N + 1];
-		int rchild[] = new int[N + 257];
-		int parent[] = new int[N + 1];
+		int[] lchild = new int[N + 1];
+		int[] rchild = new int[N + 257];
+		int[] parent = new int[N + 1];
 
 		/* Ring buffer of size N, with extra F-1 bytes to aid string comparison */
 		ByteBuffer textBuf = ByteBuffer.allocate(N + F - 1);

--- a/Ghidra/Features/MicrosoftCodeAnalyzer/ghidra_scripts/FixUpRttiAnalysisScript.java
+++ b/Ghidra/Features/MicrosoftCodeAnalyzer/ghidra_scripts/FixUpRttiAnalysisScript.java
@@ -623,7 +623,7 @@ public class FixUpRttiAnalysisScript extends GhidraScript {
 		// this currently will workn only if there is a created reference
 		// TODO: get ibo bytes and figure out what the ibo ref address would be
 		if (addressSize == 64) {
-			Reference refs[] = getReferencesFrom(address);
+			Reference[] refs = getReferencesFrom(address);
 			if (refs.length == 0) {
 				return null;
 			}

--- a/Ghidra/Features/PDB/developer_scripts/DeveloperDumpAllTypesScript.java
+++ b/Ghidra/Features/PDB/developer_scripts/DeveloperDumpAllTypesScript.java
@@ -80,7 +80,7 @@ public class DeveloperDumpAllTypesScript extends GhidraScript {
 		PluginTool tool = state.getTool();
 		DataTypeManagerService service = tool.getService(DataTypeManagerService.class);
 		DataTypeManager[] dataTypeManagers = service.getDataTypeManagers();
-		String names[] = new String[dataTypeManagers.length];
+		String[] names = new String[dataTypeManagers.length];
 		String initialDtmChoice = names[0];
 		try {
 			initialDtmChoice = currentProgram.getDataTypeManager().getName();

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/RegisterName.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/RegisterName.java
@@ -22,7 +22,7 @@ import java.util.*;
  */
 public class RegisterName extends AbstractParsableItem {
 
-	private static final String regX86[] = { "None", "al", "cl", "dl", "bl", "ah", "ch", "dh", "bh",
+	private static final String[] regX86 = { "None", "al", "cl", "dl", "bl", "ah", "ch", "dh", "bh",
 		"ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "eax", "ecx", "edx", "ebx", "esp", "ebp",
 		"esi", "edi", "es", "cs", "ss", "ds", "fs", "gs", "ip", "flags", "eip", "eflags", "???",
 		"???", "???", "???", "???", "temp", "temph", "quote", "pcdr3", "pcdr4", "pcdr5", "pcdr6",
@@ -35,7 +35,7 @@ public class RegisterName extends AbstractParsableItem {
 		"???", "???", "???", "st(0)", "st(1)", "st(2)", "st(3)", "st(4)", "st(5)", "st(6)", "st(7)",
 		"ctrl", "stat", "tag", "fpip", "fpcs", "fpdo", "fpds", "fpeip", "fped0" };
 
-	private static final String regAmd64[] = { "None", "al", "cl", "dl", "bl", "ah", "ch", "dh",
+	private static final String[] regAmd64 = { "None", "al", "cl", "dl", "bl", "ah", "ch", "dh",
 		"bh", "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "eax", "ecx", "edx", "ebx", "esp",
 		"ebp", "esi", "edi", "es", "cs", "ss", "ds", "fs", "gs", "flags", "rip", "eflags", "???",
 		"???", "???", "???", "???", "???", "???", "???", "???", "???", "???", "???", "???", "???",
@@ -71,7 +71,7 @@ public class RegisterName extends AbstractParsableItem {
 		"r11w", "r12w", "r13w", "r14w", "r15w", "r8d", "r9d", "r10d", "r11d", "r12d", "r13d",
 		"r14d", "r15d" };
 
-	private static final String regMips[] = { "None", "???", "???", "???", "???", "???", "???",
+	private static final String[] regMips = { "None", "???", "???", "???", "???", "???", "???",
 		"???", "???", "???", "zero", "at", "v0", "v1", "a0", "a1", "a2", "a3", "t0", "t1", "t2",
 		"t3", "t4", "t5", "t6", "t7", "s0", "s1", "t2", "s3", "s4", "s5", "s6", "s7", "t8", "t9",
 		"k0", "k1", "gp", "sp", "s8", "ra", "lo", "hi", "???", "???", "???", "???", "???", "???",
@@ -82,14 +82,14 @@ public class RegisterName extends AbstractParsableItem {
 
 	// Indices 41-48 are actually:
 	//   R68_MMUSR030, R68_MMUSR, R68_URP, R68_DTT0, R68_DTT1, R68_ITT0, R68_ITT1
-	private static final String reg68k[] = { "CCR", "SR", "SUP", "MSP", "SFC", "DFC", "CACR", "VBR",
+	private static final String[] reg68k = { "CCR", "SR", "SUP", "MSP", "SFC", "DFC", "CACR", "VBR",
 		"CARR", "ISP", "PC", "???", "FPCR", "FPSR", "FPIAR", "???", "FPO", "FP1", "FP2", "FP3",
 		"FP4", "FP5", "FP6", "FP7", "???", "???", "???", "???", "???", "???", "???", "???", "???",
 		"???", "???", "PSR", "PCSR", "VAL", "CRP", "SRP", "DRP", "TC", "AC", "SCC", "CAL", "TT0",
 		"TT1", "???", "BAD0", "BAD1", "BAD2", "BAD3", "BAD4", "BAD5", "BAD6", "BAD7", "BAC0",
 		"BAC1", "BAC2", "BAC3", "BAC4", "BAC5", "BAC6", "BAC7", };
 
-	private static final String regAlpha[] = { "None", "???", "???", "???", "???", "???", "???",
+	private static final String[] regAlpha = { "None", "???", "???", "???", "???", "???", "???",
 		"???", "???", "???", "$f0", "$f1", "$f2", "$f3", "$f4", "$f5", "$f6", "$f7", "$f8", "$f9",
 		"$f10", "$f11", "$f12", "$f13", "$f14", "$f15", "$f16", "$f17", "$f18", "$f19", "$f20",
 		"$f21", "$f22", "$f23", "$f24", "$f25", "$f26", "$f27", "$f28", "$f29", "$f30", "$f31",
@@ -97,7 +97,7 @@ public class RegisterName extends AbstractParsableItem {
 		"fp", "a0", "a1", "a2", "a3", "a4", "a5", "t8", "t9", "t10", "t11", "ra", "t12", "at", "gp",
 		"sp", "zero", "Fpcr", "Fir", "Psr", "FltFsr" };
 
-	private static final String regPpc[] =
+	private static final String[] regPpc =
 		{ "None", "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12",
 			"r13", "r14", "r15", "r16", "r17", "r18", "r19", "r20", "r21", "r22", "r23", "r24",
 			"r25", "r26", "r27", "r28", "r29", "r30", "r31", "cr", "cr0", "cr1", "cr2", "cr3",
@@ -105,7 +105,7 @@ public class RegisterName extends AbstractParsableItem {
 			"f10", "f11", "f12", "f13", "f14", "f15", "f16", "f17", "f18", "f19", "f20", "f21",
 			"f22", "f23", "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31", "Fpscr", "Msr" };
 
-	private static final String regSh[] = { "None", "???", "???", "???", "???", "???", "???", "???",
+	private static final String[] regSh = { "None", "???", "???", "???", "???", "???", "???", "???",
 		"???", "???", "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
 		"r12", "r13", "fp", "sp", "???", "???", "???", "???", "???", "???", "???", "???", "???",
 		"???", "???", "???", "gbr", "pr", "mach", "macl", "???", "???", "???", "???", "???", "???",

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/pdb/pdbapplicator/PdbResearch.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/pdb/pdbapplicator/PdbResearch.java
@@ -837,7 +837,7 @@ public class PdbResearch {
 		int indexNumber = pdb.getTypeProgramInterface().getTypeIndexMin();
 		int indexLimit = pdb.getTypeProgramInterface().getTypeIndexMaxExclusive();
 		int num = indexLimit - indexNumber;
-		boolean covered[] = new boolean[indexLimit];
+		boolean[] covered = new boolean[indexLimit];
 
 		monitor.initialize(num);
 		monitor.setMessage("Study: NAMES_START " + (indexLimit - indexNumber));

--- a/Ghidra/Features/PDB/src/test/java/ghidra/app/util/pdb/pdbapplicator/CppCompositeTypeTest.java
+++ b/Ghidra/Features/PDB/src/test/java/ghidra/app/util/pdb/pdbapplicator/CppCompositeTypeTest.java
@@ -224,7 +224,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 
 			@Override
 			public int getInt(Address addr) throws MemoryAccessException {
-				byte bytes[] = new byte[4];
+				byte[] bytes = new byte[4];
 				int num = getBytes(addr, bytes, 0, 4);
 				assertEquals(num, 4);
 				return LittleEndianDataConverter.INSTANCE.getInt(bytes);
@@ -232,7 +232,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 
 			@Override
 			public long getLong(Address addr) throws MemoryAccessException {
-				byte bytes[] = new byte[8];
+				byte[] bytes = new byte[8];
 				int num = getBytes(addr, bytes, 0, 8);
 				assertEquals(num, 8);
 				return LittleEndianDataConverter.INSTANCE.getLong(bytes);

--- a/Ghidra/Features/ProgramGraph/src/main/java/ghidra/graph/program/BlockModelGraphDisplayListener.java
+++ b/Ghidra/Features/ProgramGraph/src/main/java/ghidra/graph/program/BlockModelGraphDisplayListener.java
@@ -129,7 +129,7 @@ public class BlockModelGraphDisplayListener extends AddressBasedGraphDisplayList
 			return;
 		}
 
-		CodeBlock blocks[] = null;
+		CodeBlock[] blocks = null;
 		if (blockModel != null) {
 			CodeBlock block = blockModel.getCodeBlockAt(blockAddr, TaskMonitor.DUMMY);
 			if (block != null) {

--- a/Ghidra/Framework/Docking/src/main/java/docking/DialogComponentProvider.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/DialogComponentProvider.java
@@ -325,7 +325,7 @@ public class DialogComponentProvider
 		if (component instanceof Container) {
 			Container c = (Container) component;
 			c.addContainerListener(popupHandler);
-			Component comps[] = c.getComponents();
+			Component[] comps = c.getComponents();
 			for (Component comp : comps) {
 				installMouseListener(comp);
 			}
@@ -343,7 +343,7 @@ public class DialogComponentProvider
 		if (comp instanceof Container) {
 			Container c = (Container) comp;
 			c.removeContainerListener(popupHandler);
-			Component comps[] = c.getComponents();
+			Component[] comps = c.getComponents();
 			for (Component comp2 : comps) {
 				uninstallMouseListener(comp2);
 			}

--- a/Ghidra/Framework/Docking/src/main/java/docking/DockableComponent.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/DockableComponent.java
@@ -322,7 +322,7 @@ public class DockableComponent extends JPanel implements ContainerListener {
 		if (comp instanceof Container) {
 			Container c = (Container) comp;
 			c.addContainerListener(this);
-			Component comps[] = c.getComponents();
+			Component[] comps = c.getComponents();
 			for (Component comp2 : comps) {
 				initializeComponents(comp2);
 			}
@@ -345,7 +345,7 @@ public class DockableComponent extends JPanel implements ContainerListener {
 		if (comp instanceof Container) {
 			Container c = (Container) comp;
 			c.removeContainerListener(this);
-			Component comps[] = c.getComponents();
+			Component[] comps = c.getComponents();
 			for (Component comp2 : comps) {
 				deinitializeComponents(comp2);
 			}

--- a/Ghidra/Framework/Docking/src/main/java/docking/GenericHeader.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/GenericHeader.java
@@ -119,7 +119,7 @@ public class GenericHeader extends JPanel {
 	private void installMouseListener(Component comp) {
 		if (comp instanceof Container) {
 			Container c = (Container) comp;
-			Component comps[] = c.getComponents();
+			Component[] comps = c.getComponents();
 			for (Component element : comps) {
 				installMouseListener(element);
 			}

--- a/Ghidra/Framework/Docking/src/main/java/docking/options/editor/FontPropertyEditor.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/options/editor/FontPropertyEditor.java
@@ -159,7 +159,7 @@ public class FontPropertyEditor extends PropertyEditorSupport {
 
 			GraphicsEnvironment gEnv = GraphicsEnvironment.getLocalGraphicsEnvironment();
 
-			String envfonts[] = gEnv.getAvailableFontFamilyNames();
+			String[] envfonts = gEnv.getAvailableFontFamilyNames();
 			List<FontWrapper> list = new ArrayList<>(envfonts.length);
 			for (String envfont : envfonts) {
 				list.add(new FontWrapper(envfont));

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/DataFileHandle.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/DataFileHandle.java
@@ -40,7 +40,7 @@ public interface DataFileHandle {
      *               all the bytes.
      * @exception  IOException   if an I/O error occurs.       
      */
-    public void read(byte b[]) throws IOException;
+    public void read(byte[] b) throws IOException;
 
     /**
      * Reads exactly <code>len</code> bytes from this file into the byte 
@@ -56,7 +56,7 @@ public interface DataFileHandle {
      *               all the bytes.
      * @exception  IOException   if an I/O error occurs.
      */
-    public void read(byte b[], int off, int len) throws IOException;
+    public void read(byte[] b, int off, int len) throws IOException;
 
     /**
      * Attempts to skip over <code>n</code> bytes of input discarding the 
@@ -92,7 +92,7 @@ public interface DataFileHandle {
      * @param      b   the data.
      * @exception  IOException  if an I/O error occurs.
      */
-    public void write(byte b[]) throws IOException;
+    public void write(byte[] b) throws IOException;
 
     /**
      * Writes <code>len</code> bytes from the specified byte array 
@@ -103,7 +103,7 @@ public interface DataFileHandle {
      * @param      len   the number of bytes to write.
      * @exception  IOException  if an I/O error occurs.
      */
-    public void write(byte b[], int off, int len) throws IOException;
+    public void write(byte[] b, int off, int len) throws IOException;
 
     /**
      * Sets the file-pointer offset, measured from the beginning of this 

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/util/HashUtilities.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/util/HashUtilities.java
@@ -200,7 +200,7 @@ public class HashUtilities {
 	 * @return hex character representation of data
 	 */
 	public static char[] hexDump(byte[] data) {
-		char buf[] = new char[data.length * 2];
+		char[] buf = new char[data.length * 2];
 		for (int i = 0; i < data.length; i++) {
 			String b = Integer.toHexString(data[i] & 0xFF);
 			if (b.length() < 2) {

--- a/Ghidra/Framework/Generic/src/main/java/generic/algorithms/CRC64.java
+++ b/Ghidra/Framework/Generic/src/main/java/generic/algorithms/CRC64.java
@@ -19,7 +19,7 @@ package generic.algorithms;
 public class CRC64 {
 
 	private static final long poly = 0xC96C5795D7870F42L;
-	private static final long crcTable[] = new long[256];
+	private static final long[] crcTable = new long[256];
 
 	private long crc = -1;
 

--- a/Ghidra/Framework/Generic/src/main/java/generic/hash/SimpleCRC32.java
+++ b/Ghidra/Framework/Generic/src/main/java/generic/hash/SimpleCRC32.java
@@ -17,7 +17,7 @@
 package generic.hash;
 
 public final class SimpleCRC32 {
-	public static final int crc32tab[] = {
+	public static final int[] crc32tab = {
 		0,1996959894,-301047508,-1727442502,124634137,
 		1886057615,-379345611,-1637575261,249268274,2044508324,
 		-522852066,-1747789432,162941995,2125561021,-407360249,

--- a/Ghidra/Framework/Generic/src/main/java/generic/lsh/vector/WeightFactory.java
+++ b/Ghidra/Framework/Generic/src/main/java/generic/lsh/vector/WeightFactory.java
@@ -22,8 +22,8 @@ import ghidra.xml.XmlElement;
 import ghidra.xml.XmlPullParser;
 
 public class WeightFactory {
-	private double idfweight[] = new double[512];		// Weights associated with (normalized) idf counts
-	private double tfweight[] = new double[64];			// Weights associated with tf (term frequency) counts
+	private double[] idfweight = new double[512];		// Weights associated with (normalized) idf counts
+	private double[] tfweight = new double[64];			// Weights associated with tf (term frequency) counts
 	private double weightnorm;		// Scale to which idf weights are normalized = -log2( probability of 1000th most common hash)
 	private double probflip0;		// Hash flipping probability in causal model, param0
 	private double probflip1;		// Hash flipping probability in causal model, param1

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/options/PropertySelector.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/options/PropertySelector.java
@@ -38,7 +38,7 @@ public class PropertySelector extends JComboBox<String> implements ItemListener 
 	 */
 	public PropertySelector(PropertyEditor pe) {
 		propertyEditor = pe;
-		String tags[] = propertyEditor.getTags();
+		String[] tags = propertyEditor.getTags();
 		for (String tag : tags) {
 			addItem(tag);
 		}

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/ColorUtils.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/ColorUtils.java
@@ -33,7 +33,7 @@ public class ColorUtils {
 	public static final float HUE_PINK = 11.0f / 12;
 
 	public static Color deriveBackground(Color src, float hue, float sfact, float bfact) {
-		float vals[] = new float[3];
+		float[] vals = new float[3];
 		Color.RGBtoHSB(src.getRed(), src.getGreen(), src.getBlue(), vals);
 		// Assign the requested hue without modification
 		vals[0] = hue;
@@ -174,8 +174,8 @@ public class ColorUtils {
 		if (c2 == null) {
 			return c1;
 		}
-		float rgb1[] = new float[3];
-		float rgb2[] = new float[3];
+		float[] rgb1 = new float[3];
+		float[] rgb2 = new float[3];
 		c1.getColorComponents(rgb1);
 		c2.getColorComponents(rgb2);
 

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/MonitoredInputStream.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/MonitoredInputStream.java
@@ -100,7 +100,7 @@ public class MonitoredInputStream extends InputStream {
 	 * @see        java.io.FilterInputStream#read(byte[], int, int)
 	 */
 	@Override
-	public int read(byte b[]) throws IOException {
+	public int read(byte[] b) throws IOException {
 		return read(b, 0, b.length);
 	}
 
@@ -121,7 +121,7 @@ public class MonitoredInputStream extends InputStream {
 	 * @exception  IOException  if an I/O error occurs.
 	 */
 	@Override
-	public int read(byte b[], int off, int len) throws IOException {
+	public int read(byte[] b, int off, int len) throws IOException {
 		if (monitor.isCancelled()) {
 			throw new IOCancelledException();
 		}

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/graph/DirectedGraph.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/graph/DirectedGraph.java
@@ -1193,7 +1193,7 @@ public class DirectedGraph {
 	protected void copyEdgeAttributeValues(Edge newe, Edge e, DirectedGraph other) {
 
 		AttributeManager<Edge> aman = other.edgeAttributes();
-		String vamNames[] = aman.getAttributeNames();
+		String[] vamNames = aman.getAttributeNames();
 		for (int i = 0; i < vamNames.length; i++) {
 			ObjectAttribute<Edge> att = (ObjectAttribute<Edge>) aman.getAttribute(vamNames[i]);
 			if (!this.edgeAttributes().hasAttributeNamed(vamNames[i])) {
@@ -1238,7 +1238,7 @@ public class DirectedGraph {
 	protected void copyVertexAttributeValues(Vertex vert, DirectedGraph other) {
 
 		AttributeManager<Vertex> aman = other.vertexAttributes();
-		String vamNames[] = aman.getAttributeNames();
+		String[] vamNames = aman.getAttributeNames();
 		for (int i = 0; i < vamNames.length; i++) {
 			ObjectAttribute<Vertex> att = (ObjectAttribute<Vertex>) aman.getAttribute(vamNames[i]);
 			if (!this.vertexAttributes().hasAttributeNamed(vamNames[i])) {

--- a/Ghidra/Framework/Project/src/main/java/ghidra/app/util/FileOpenDropHandler.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/app/util/FileOpenDropHandler.java
@@ -115,7 +115,7 @@ public class FileOpenDropHandler implements DropTargetHandler, Droppable, Contai
 		if (comp instanceof Container) {
 			Container c = (Container) comp;
 			c.addContainerListener(this);
-			Component comps[] = c.getComponents();
+			Component[] comps = c.getComponents();
 			for (Component element : comps) {
 				initializeComponents(element);
 			}
@@ -134,7 +134,7 @@ public class FileOpenDropHandler implements DropTargetHandler, Droppable, Contai
 		if (comp instanceof Container) {
 			Container c = (Container) comp;
 			c.removeContainerListener(this);
-			Component comps[] = c.getComponents();
+			Component[] comps = c.getComponents();
 			for (Component element : comps) {
 				deinitializeComponents(element);
 			}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/core/data/ProgramStructureProviderContext.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/core/data/ProgramStructureProviderContext.java
@@ -33,7 +33,7 @@ public class ProgramStructureProviderContext implements DataTypeProviderContext 
 	public ProgramStructureProviderContext(Program program, ProgramLocation loc) {
 		this.program = program;
 
-		int dataPath[] = loc.getComponentPath();
+		int[] dataPath = loc.getComponentPath();
 		Data data = program.getListing().getDefinedDataContaining(loc.getAddress());
 		data = data.getComponent(dataPath);
 		this.addr = data.getMinAddress();

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/generic/OpTemplate.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/generic/OpTemplate.java
@@ -54,7 +54,7 @@ public class OpTemplate implements Serializable {
 		Varnode out = null;
 		if (output != null)
 			out = output.resolve(handles, position, off);
-		Varnode in[] = new Varnode[numInputs];
+		Varnode[] in = new Varnode[numInputs];
 		for (int i = 0; i < numInputs; i++)
 			in[i] = input[i].resolve(handles, position, off);
 		

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/OpTplWalker.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/OpTplWalker.java
@@ -29,7 +29,7 @@ public class OpTplWalker {
 	private ConstructState point;		// The current node being visited
 	private OpTpl[] oparray;			// current array of ops being traversed
 	private int depth;					// Depth of current node within the tree
-	private int breadcrumb[];			// Path of operands from the root
+	private int[] breadcrumb;			// Path of operands from the root
 	private int maxsize;				// Maximum number of directives for this point
 	private int sectionnum;
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/ParserWalker.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/ParserWalker.java
@@ -40,7 +40,7 @@ public class ParserWalker {
 	private SleighParserContext cross_context;		// If in the midst of cross-build, the context from the original instruction
 	private ConstructState point;		// The current node being visited
 	private int depth;					// Depth of current node within the tree
-	private int breadcrumb[];			// Path of operands from the root
+	private int[] breadcrumb;			// Path of operands from the root
 
 	public ParserWalker(SleighParserContext c) {
 		context = c;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoCodeUnit.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoCodeUnit.java
@@ -575,7 +575,7 @@ abstract class PseudoCodeUnit implements CodeUnit {
 	 *             if this object is no longer valid.
 	 */
 	@Override
-	public void setCommentAsArray(int commentType, String comment[]) {
+	public void setCommentAsArray(int commentType, String[] comment) {
 		setComment(commentType, comment[0]);
 		//throw new UnsupportedOperationException();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoDisassembler.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoDisassembler.java
@@ -188,7 +188,7 @@ public class PseudoDisassembler {
 	 * @throws UnknownInstructionException
 	 * @throws UnknownContextException
 	 */
-	public PseudoInstruction disassemble(Address addr, byte bytes[])
+	public PseudoInstruction disassemble(Address addr, byte[] bytes)
 			throws InsufficientBytesException, UnknownInstructionException,
 			UnknownContextException {
 
@@ -210,8 +210,8 @@ public class PseudoDisassembler {
 	 * @throws UnknownInstructionException
 	 * @throws UnknownContextException
 	 */
-	public PseudoInstruction disassemble(Address addr, byte bytes[],
-			PseudoDisassemblerContext disassemblerContext) throws InsufficientBytesException,
+	public PseudoInstruction disassemble(Address addr, byte[] bytes,
+                                         PseudoDisassemblerContext disassemblerContext) throws InsufficientBytesException,
 			UnknownInstructionException, UnknownContextException {
 
 		MemBuffer memBuffer = new ByteMemBufferImpl(addr, bytes, language.isBigEndian());
@@ -491,7 +491,7 @@ public class PseudoDisassembler {
 					else if (instr.getFlowType().isJump()) {
 						// if this is a jump, and jumps forward only some number of bytes
 						//    make that the new target.
-						Address flows[] = instr.getFlows();
+						Address[] flows = instr.getFlows();
 						if (flows != null) {
 							for (Address address : flows) {
 								if (!body.contains(address)) {
@@ -510,7 +510,7 @@ public class PseudoDisassembler {
 				// if this is a jump, add it's targets to list of valid
 				//   forward reference continuation points.
 				if (instr.getFlowType().isJump()) {
-					Address flows[] = instr.getFlows();
+					Address[] flows = instr.getFlows();
 					if (flows != null) {
 						for (Address address : flows) {
 							targetList.add(address);
@@ -704,7 +704,7 @@ public class PseudoDisassembler {
 						// if this is a jump, and jumps forward only some number
 						// of bytes
 						// make that the new target.
-						Address flows[] = instr.getFlows();
+						Address[] flows = instr.getFlows();
 						if (flows != null) {
 							for (Address address : flows) {
 								if (!body.contains(address)) {
@@ -724,7 +724,7 @@ public class PseudoDisassembler {
 				// if this is a jump, add it's targets to list of valid
 				// forward reference continuation points.
 				if (flowType.isJump()) {
-					Address flows[] = instr.getFlows();
+					Address[] flows = instr.getFlows();
 					if (flows != null && flows.length > 0) {
 						for (Address address : flows) {
 							// if jump target is the same as the fallthru
@@ -753,7 +753,7 @@ public class PseudoDisassembler {
 					}
 				}
 				if (flowType.isCall() || (flowType.isJump() && flowType.isComputed())) {
-					Address flows[] = instr.getFlows();
+					Address[] flows = instr.getFlows();
 					if (flows == null || flows.length == 0) {
 						Reference[] refsFrom = instr.getReferencesFrom();
 						if (refsFrom != null && refsFrom.length > 0) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoInstruction.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoInstruction.java
@@ -159,7 +159,7 @@ public class PseudoInstruction extends PseudoCodeUnit implements Instruction, In
 		}
 		Reference ref = new MemReferenceImpl(address, toAddr, getOperandRefType(opIndex),
 			SourceType.DEFAULT, opIndex, false);
-		Reference refArray[] = new Reference[1];
+		Reference[] refArray = new Reference[1];
 		refArray[0] = ref;
 		return refArray;
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/BigFloat.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/BigFloat.java
@@ -478,7 +478,7 @@ public strictfp class BigFloat implements Comparable<BigFloat> {
 		int lshift = fracbits + 2 + other.unscaled.bitLength() - this.unscaled.bitLength();
 		this.upscale(lshift);
 
-		BigInteger qr[] = this.unscaled.divideAndRemainder(other.unscaled);
+		BigInteger[] qr = this.unscaled.divideAndRemainder(other.unscaled);
 		BigInteger q = qr[0];
 		BigInteger r = qr[1];
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/opcodes/OpCode.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/opcodes/OpCode.java
@@ -193,7 +193,7 @@ public enum OpCode {
 		return false;
 	}
 
-	static final String opcode_name[] = { "BLANK", "COPY", "LOAD", "STORE", "BRANCH", "CBRANCH",
+	static final String[] opcode_name = { "BLANK", "COPY", "LOAD", "STORE", "BRANCH", "CBRANCH",
 		"BRANCHIND", "CALL", "CALLIND", "CALLOTHER", "RETURN", "INT_EQUAL", "INT_NOTEQUAL",
 		"INT_SLESS", "INT_SLESSEQUAL", "INT_LESS", "INT_LESSEQUAL", "INT_ZEXT", "INT_SEXT",
 		"INT_ADD", "INT_SUB", "INT_CARRY", "INT_SCARRY", "INT_SBORROW", "INT_2COMP", "INT_NEGATE",
@@ -209,7 +209,7 @@ public enum OpCode {
 		return opcode_name[op.ordinal()];
 	}
 
-	static final int opcode_indices[] = { 0, 39, 37, 40, 38, 4, 6, 60, 7, 8, 9, 64, 5, 57, 1, 68, 66,
+	static final int[] opcode_indices = { 0, 39, 37, 40, 38, 4, 6, 60, 7, 8, 9, 64, 5, 57, 1, 68, 66,
 			61, 71, 55, 52, 47, 48, 41, 43, 44, 49, 46, 51, 42, 53, 50, 58, 70, 54, 24, 19, 27, 21,
 			33, 11, 29, 15, 16, 32, 25, 12, 28, 35, 30, 23, 22, 34, 18, 13, 14, 36, 31, 20, 26, 17,
 			65, 2, 69, 62, 72, 10, 59, 67, 3, 63, 56, 45 };

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/function/FunctionManagerDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/function/FunctionManagerDB.java
@@ -777,7 +777,7 @@ public class FunctionManagerDB implements FunctionManager {
 	 */
 	private VariableStorage checkDynamicStorageConversion(DataType returnDataType,
 			Parameter[] currentParams, int paramOffset, PrototypeModel callingConvention) {
-		DataType types[] = new DataType[currentParams.length - paramOffset + 1];
+		DataType[] types = new DataType[currentParams.length - paramOffset + 1];
 		types[0] = returnDataType;
 		int index = 1;
 		for (int i = paramOffset; i < currentParams.length; ++i) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/EquateDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/EquateDB.java
@@ -80,7 +80,7 @@ public class EquateDB extends DatabaseObject implements Equate {
 			}
 			else {
 				long value = record.getLongValue(EquateDBAdapter.VALUE_COL);
-				long hashArray[] = DynamicHash.calcConstantHash(instr, value);
+				long[] hashArray = DynamicHash.calcConstantHash(instr, value);
 				if (hashArray.length != 1) {
 					dynamicHash = 0;
 				}
@@ -116,7 +116,7 @@ public class EquateDB extends DatabaseObject implements Equate {
 			return -1;
 		}
 		long value = record.getLongValue(EquateDBAdapter.VALUE_COL);
-		long checkHash[] = DynamicHash.calcConstantHash(instr, value);
+		long[] checkHash = DynamicHash.calcConstantHash(instr, value);
 		for (long element : checkHash) {
 			if (element == dynamicHash) {
 				return findScalarOpIndex(instr);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/address/AddressObjectMap.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/address/AddressObjectMap.java
@@ -68,7 +68,7 @@ public class AddressObjectMap {
      */
     public Object[] getObjects(Address addr) {
 
-        Object objarray[] = getObj(addrMap.getKey(addr));
+        Object[] objarray = getObj(addrMap.getKey(addr));
         return objarray;
     }
 
@@ -397,7 +397,7 @@ class Mark implements Serializable {
     static final int END = 2;
     static final int SINGLE = 3;
 
-    private final static Object emptyArray[] = new Object[0];
+    private final static Object[] emptyArray = new Object[0];
 
     Object obj;
     int type;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockCache.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockCache.java
@@ -61,7 +61,7 @@ class CodeBlockCache extends AddressObjectMap {
         Object[] blocks = getObjects(addr);
         for (int i=0; i < blocks.length; i++) {
             CodeBlock block = (CodeBlock) blocks[i];
-            Address starts[] = block.getStartAddresses();
+            Address[] starts = block.getStartAddresses();
             for (int j=0; j < starts.length; j++) {
                 if (starts[j].equals(addr)) {
                     return block;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockImpl.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockImpl.java
@@ -35,7 +35,7 @@ import ghidra.util.task.TaskMonitorAdapter;
 public class CodeBlockImpl implements CodeBlock {
 
 	private CodeBlockModel model; // model that produced this block
-	private Address starts[]; // entry points into block.  Addresses are stored
+	private Address[] starts; // entry points into block.  Addresses are stored
 	// in natural sorted order.
 	private AddressSetView set; // set of addresses that make up this block
 
@@ -47,7 +47,7 @@ public class CodeBlockImpl implements CodeBlock {
 	 * be used to identify this block within the model that produced it.
 	 * @param body the address set which makes-up the body of this block.
 	 */
-	public CodeBlockImpl(CodeBlockModel model, Address starts[], AddressSetView body) {
+	public CodeBlockImpl(CodeBlockModel model, Address[] starts, AddressSetView body) {
 		if (starts != null) {
 			this.starts = starts.clone();
 			Arrays.sort(this.starts); // store start Addresses in natural sorted order

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/SimpleBlockModel.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/SimpleBlockModel.java
@@ -108,7 +108,7 @@ public class SimpleBlockModel implements CodeBlockModel {
 	public CodeBlock getCodeBlockAt(Address addr, TaskMonitor monitor) throws CancelledException {
 
 		// First check out the Block cache
-		Object blocks[] = foundBlockMap.getObjects(addr);
+		Object[] blocks = foundBlockMap.getObjects(addr);
 		if (blocks.length > 0) {
 			CodeBlock block = (CodeBlock) blocks[0];
 			Address[] entryPts = block.getStartAddresses();
@@ -313,7 +313,7 @@ public class SimpleBlockModel implements CodeBlockModel {
 			return null;
 		}
 		// First check out the Block cache
-		Object blocks[] = foundBlockMap.getObjects(addr);
+		Object[] blocks = foundBlockMap.getObjects(addr);
 		if (blocks.length > 0) {
 			return (CodeBlock) blocks[0];
 		}
@@ -417,7 +417,7 @@ public class SimpleBlockModel implements CodeBlockModel {
 	 */
 	protected boolean isBlockStart(Address addr) {
 		// First check out the Block cache
-		Object blocks[] = foundBlockMap.getObjects(addr);
+		Object[] blocks = foundBlockMap.getObjects(addr);
 		if (blocks.length > 0) {
 			CodeBlock block = (CodeBlock) blocks[0];
 			if (block.getFirstStartAddress().equals(addr)) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/SimpleDestReferenceIterator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/SimpleDestReferenceIterator.java
@@ -246,7 +246,7 @@ public class SimpleDestReferenceIterator implements CodeBlockReferenceIterator {
     	if (primitive != null) {
 
 			// Follow pointer - could have multiple references 			
-			Reference refs[] = primitive.getReferencesFrom();
+			Reference[] refs = primitive.getReferencesFrom();
 			for (int i = 0; i < refs.length; i++) {
 				
 				monitor.checkCanceled();

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/PrototypeModel.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/PrototypeModel.java
@@ -246,7 +246,7 @@ public class PrototypeModel {
 			// customized storage has been used
 		}
 
-		DataType arr[] = new DataType[argIndex + 2];
+		DataType[] arr = new DataType[argIndex + 2];
 		arr[0] = VoidDataType.dataType;				// Assume the return type is void
 		for (int i = 0; i < argIndex; ++i) {
 			if (params != null && i < params.length) {
@@ -258,7 +258,7 @@ public class PrototypeModel {
 		}
 		arr[argIndex + 1] = dataType;
 
-		VariableStorage res[] = getStorageLocations(program, arr, false);
+		VariableStorage[] res = getStorageLocations(program, arr, false);
 		return res[res.length - 1];
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/DynamicHash.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/DynamicHash.java
@@ -40,7 +40,7 @@ public class DynamicHash {
 
 	// Table for how to hash opcodes, lumps certain operators (i.e. AND SUB PTRADD PTRSUB) into one hash
 	// zero indicates the operator should be skipped
-	public final static int transtable[] = { 0, PcodeOp.COPY, PcodeOp.LOAD, PcodeOp.STORE,
+	public final static int[] transtable = { 0, PcodeOp.COPY, PcodeOp.LOAD, PcodeOp.STORE,
 		PcodeOp.BRANCH, PcodeOp.CBRANCH, PcodeOp.BRANCHIND,
 
 		PcodeOp.CALL,

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/JumpTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/JumpTable.java
@@ -118,9 +118,9 @@ public class JumpTable {
 	private Address opAddress;
 
 	// Address corresponds to label entries.  If DEFAULT_VALUE, then entry is the default guard case, not a jump target.
-	private Address addressTable[];
-	private Integer labelTable[];
-	private LoadTable loadTable[];
+	private Address[] addressTable;
+	private Integer[] labelTable;
+	private LoadTable[] loadTable;
 	private BasicOverride override;
 
 	public JumpTable(AddressSpace preferredSpace) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/LocalSymbolMap.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/LocalSymbolMap.java
@@ -154,7 +154,7 @@ public class LocalSymbolMap {
 	public void grabFromFunction(boolean includeDefaultNames) {
 		ArrayList<String> mergeNames = null;
 		Function dbFunction = func.getFunction();
-		Variable locals[] = dbFunction.getLocalVariables();
+		Variable[] locals = dbFunction.getLocalVariables();
 		for (Variable local : locals) {
 			if (!local.isValid()) {
 				// exclude locals which don't have valid storage
@@ -519,7 +519,7 @@ public class LocalSymbolMap {
 						if (instr == null) {
 							continue;
 						}
-						long hash[] = DynamicHash.calcConstantHash(instr, eqValue);
+						long[] hash = DynamicHash.calcConstantHash(instr, eqValue);
 						if (hash.length == 0) {
 							continue;
 						}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/Varnode.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/Varnode.java
@@ -33,7 +33,7 @@ import ghidra.xml.XmlPullParser;
  * A raw varnode is said to be free, it is not attached to any variable.
  */
 public class Varnode {
-	private static final long masks[] = { 0L, 0xffL, 0xffffL, 0xffffffL, 0xffffffffL, 0xffffffffffL,
+	private static final long[] masks = { 0L, 0xffL, 0xffffL, 0xffffffL, 0xffffffffL, 0xffffffffffL,
 		0xffffffffffffL, 0xffffffffffffffL, 0xffffffffffffffffL };
 
 	private Address address;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/InstructionUtils.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/InstructionUtils.java
@@ -207,7 +207,7 @@ public class InstructionUtils {
 		return buf.toString();
 	}
 
-	private static String getString(String strs[], boolean multiline) {
+	private static String getString(String[] strs, boolean multiline) {
 		if (multiline) {
 			List<String> list = Arrays.asList(strs);
 			return getString(list, true);

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/util/HashingOutputStream.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/util/HashingOutputStream.java
@@ -46,12 +46,12 @@ public class HashingOutputStream extends OutputStream {
 		out.write(b);
 	}
 
-	public void write(byte b[]) throws IOException {
+	public void write(byte[] b) throws IOException {
 		messageDigest.update(b);
 		out.write(b, 0, b.length);
 	}
 
-	public void write(byte b[], int off, int len) throws IOException {
+	public void write(byte[] b, int off, int len) throws IOException {
 		messageDigest.update(b, off, len);
 		out.write(b, off, len);
 	}

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/util/MonitoredOutputStream.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/util/MonitoredOutputStream.java
@@ -82,7 +82,7 @@ public class MonitoredOutputStream extends OutputStream {
 	 * @see        java.io.FilterOutputStream#write(byte[], int, int)
 	 */
 	@Override
-	public void write(byte b[]) throws IOException {
+	public void write(byte[] b) throws IOException {
 		write(b, 0, b.length);
 	}
 
@@ -107,7 +107,7 @@ public class MonitoredOutputStream extends OutputStream {
 	 * @see        java.io.FilterOutputStream#write(int)
 	 */
 	@Override
-	public void write(byte b[], int off, int len) throws IOException {
+	public void write(byte[] b, int off, int len) throws IOException {
 		out.write(b, off, len);
 		smallCount += len;
 

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/util/NullOutputStream.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/util/NullOutputStream.java
@@ -31,11 +31,11 @@ public class NullOutputStream extends OutputStream {
 		// nada
 	}
 
-	public void write(byte b[]) throws IOException {
+	public void write(byte[] b) throws IOException {
 		// nada
 	}
 
-	public void write(byte b[], int off, int len) throws IOException {
+	public void write(byte[] b, int off, int len) throws IOException {
 		// nada
 	}
 

--- a/Ghidra/Processors/Dalvik/src/main/java/ghidra/dalvik/dex/inject/ConstantPoolDex.java
+++ b/Ghidra/Processors/Dalvik/src/main/java/ghidra/dalvik/dex/inject/ConstantPoolDex.java
@@ -146,7 +146,7 @@ public class ConstantPoolDex extends ConstantPool {
 				paramDef.add(pDef);
 			}
 		}
-		ParameterDefinition finalDefs[] = new ParameterDefinition[paramDef.size()];
+		ParameterDefinition[] finalDefs = new ParameterDefinition[paramDef.size()];
 		paramDef.toArray(finalDefs);
 		funcDef.setArguments(finalDefs);
 	}

--- a/Ghidra/Processors/PIC/src/main/java/ghidra/app/util/bin/format/elf/extend/PIC30_ElfExtension.java
+++ b/Ghidra/Processors/PIC/src/main/java/ghidra/app/util/bin/format/elf/extend/PIC30_ElfExtension.java
@@ -262,7 +262,7 @@ public class PIC30_ElfExtension extends ElfExtension {
 		}
 
 		@Override
-		public int read(byte b[], int off, int len) throws IOException {
+		public int read(byte[] b, int off, int len) throws IOException {
 			if (b == null) {
 				throw new NullPointerException();
 			}

--- a/Ghidra/Processors/tricore/src/main/java/ghidra/program/emulation/TRICOREEmulateInstructionStateModifier.java
+++ b/Ghidra/Processors/tricore/src/main/java/ghidra/program/emulation/TRICOREEmulateInstructionStateModifier.java
@@ -141,7 +141,7 @@ public class TRICOREEmulateInstructionStateModifier extends EmulateInstructionSt
 	
 	// Helper functions
 	private int copyRegisterToArray(Register reg, int len, MemoryState memoryState, byte[] outBytes, int i) {
-		byte vBytes[] = new byte[len];
+		byte[] vBytes = new byte[len];
 		int nread = memoryState.getChunk(vBytes, reg.getAddressSpace(), reg.getOffset(), len, false);
 		System.arraycopy(vBytes, 0, outBytes, i, len);
 		return nread;

--- a/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/program/disassemble/DisassemblerLargeSetTest.java
+++ b/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/program/disassemble/DisassemblerLargeSetTest.java
@@ -36,7 +36,7 @@ public class DisassemblerLargeSetTest extends AbstractGhidraHeadlessIntegrationT
 
 	private static final long NUMCASES = MEMORY_SIZE / CASESIZE;
 
-	private static byte disBlock[] = { (byte) 0xf5, 0x0c, 0x03, 0x04, (byte) 0xf4, 0x00,
+	private static byte[] disBlock = { (byte) 0xf5, 0x0c, 0x03, 0x04, (byte) 0xf4, 0x00,
 		(byte) 0xdf, 0x34, (byte) 0xf4, 0x00, (byte) 0xf4, 0x00 };
 
 	private ToyProgramBuilder programBuilder;// Instructions are 2-byte aligned 

--- a/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/server/remote/ServerTestUtil.java
+++ b/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/server/remote/ServerTestUtil.java
@@ -827,7 +827,7 @@ public class ServerTestUtil {
 		System.arraycopy(users, 0, userArray, 1, users.length);
 		createUsers(dirPath, userArray);
 
-		String keys[] = SSHKeyUtil.generateSSHKeys();
+		String[] keys = SSHKeyUtil.generateSSHKeys();
 		addSSHKeys(dirPath, keys[0], "test.key", keys[1], "test.pub");
 
 		LocalFileSystem repoFilesystem = createRepository(dirPath, "Test", ADMIN_USER + "=ADMIN",

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidrasymbollookup/SocketSetupRunnable.java
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidrasymbollookup/SocketSetupRunnable.java
@@ -95,7 +95,7 @@ public class SocketSetupRunnable implements Runnable {
 
 	private String init() {
 		String projectName = GhidraSymbolLookupPreferences.getSymbolLookupProjectName();
-		final String errorMessageContainer[] = { "" };
+		final String[] errorMessageContainer = { "" };
 		Display.getDefault().syncExec(() -> {
 			while (!isInitialized) {
 				if (projectName == null) {


### PR DESCRIPTION
Standard Java dictates the brackets go after the type, not after the variable name.