### PR TITLE
More stringent size checks for Sleigh spaces.

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/antlr/ghidra/sleigh/grammar/SleighCompiler.g
+++ b/Ghidra/Framework/SoftwareModeling/src/main/antlr/ghidra/sleigh/grammar/SleighCompiler.g
@@ -404,9 +404,11 @@ contextdef
 spacedef
 	scope {
 		SpaceQuality quality;
+		boolean wordSizeSet;
 	}
 	@init {
 		$spacedef::quality = null;
+		$spacedef::wordSizeSet = false;
 	}
 	:	^(OP_SPACE n=unbound_identifier["space"] {
 			String name = "<parse error>";
@@ -447,14 +449,23 @@ typemod
 	;
 
 sizemod
-	:	^(OP_SIZE i=integer) {
-			$spacedef::quality.size = $i.value.intValue();
+	:	^(t=OP_SIZE i=integer) {
+			if ($spacedef::quality.size != 0) {
+				reportError(find(t), "space '" + $spacedef::quality.name + "' already has a size set");
+			} else {
+				$spacedef::quality.size = $i.value.intValue();
+			}
 		}
 	;
 
 wordsizemod
-	:	^(OP_WORDSIZE i=integer) {
-			$spacedef::quality.wordsize = $i.value.intValue();
+	:	^(t=OP_WORDSIZE i=integer) {
+			if ($spacedef::wordSizeSet) {
+				reportError(find(t), "space '" + $spacedef::quality.name + "' already has a word size set");
+			} else {
+				$spacedef::quality.wordsize = $i.value.intValue();
+				$spacedef::wordSizeSet = true;
+			}
 		}
 	;
 


### PR DESCRIPTION
This lets the Sleigh compiler report errors on duplicate size/wordsize entries in space definitions (ie. `define space X type=Y size=1 size=2 wordsize=1 wordsize=2`).  Right now the compiler silently uses the last value it encounters, which doesn't look right.

I couldn't find a compiler-specific test suite, but I successfully built all processors in the current source tree so it shouldn't break anything.

Same goes for `hex`, `dec`, and `signed` modifiers when defining token variables, but since `dec` is currently ignored and `hex` is the default, it doesn't make much sense to fix this right now.  If needed I can update the PR with that and squash it afterwards.
