### PR TITLE
Fix all major typos

### DIFF
--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/DebuggerResources.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/DebuggerResources.java
@@ -295,8 +295,8 @@ public interface DebuggerResources {
 	String MARKER_NAME_BREAKPOINT_DISABLED = "Disabled Breakpoint";
 	String MARKER_NAME_BREAKPOINT_INEFFECTIVE_E = "Ineffective Enabled Breakpoint";
 	String MARKER_NAME_BREAKPOINT_INEFFECTIVE_D = "Ineffective Disabled Breakpoint";
-	String MARKER_NAME_BREAKPOINT_MIXED_ED = "Mixed Enabled-Disabled Breakpont";
-	String MARKER_NAME_BREAKPOINT_MIXED_DE = "Mixed Disabled-Enabled Breakpont";
+	String MARKER_NAME_BREAKPOINT_MIXED_ED = "Mixed Enabled-Disabled Breakpoint";
+	String MARKER_NAME_BREAKPOINT_MIXED_DE = "Mixed Disabled-Enabled Breakpoint";
 	int PRIORITY_BREAKPOINT_ENABLED_MARKER = MarkerService.BREAKPOINT_PRIORITY;
 	int PRIORITY_BREAKPOINT_DISABLED_MARKER = MarkerService.BREAKPOINT_PRIORITY;
 	int PRIORITY_BREAKPOINT_INEFFECTIVE_E_MARKER = MarkerService.BREAKPOINT_PRIORITY;
@@ -1862,7 +1862,7 @@ public interface DebuggerResources {
 
 	interface ForceFullViewAction {
 		String NAME = "Force Full View";
-		String DESCRIPTION = "Ignore regions and fiew full address spaces";
+		String DESCRIPTION = "Ignore regions and view full address spaces";
 		String GROUP = GROUP_GENERAL;
 		String HELP_ANCHOR = "force_full_view";
 

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/memory/DebuggerRegionsProvider.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/memory/DebuggerRegionsProvider.java
@@ -427,7 +427,7 @@ public class DebuggerRegionsProvider extends ComponentProviderAdapter {
 	protected void promptRegionProposal(Collection<RegionMapEntry> proposal) {
 		if (proposal.isEmpty()) {
 			Msg.showInfo(this, getComponent(), "Map Regions",
-				"Could not formulate a propsal for any selection region." +
+				"Could not formulate a proposal for any selection region." +
 					" You may need to import and/or open the destination images first.");
 			return;
 		}

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/memview/DebuggerMemviewPlugin.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/memview/DebuggerMemviewPlugin.java
@@ -28,7 +28,7 @@ import ghidra.program.model.listing.Program;
 
 @PluginInfo( //
 		shortDescription = "Displays memory vs time", //
-		description = "Provides visualiztion/navigation across time/address axes", //
+		description = "Provides visualization/navigation across time/address axes", //
 		category = PluginCategoryNames.DEBUGGER, //
 		packageName = DebuggerPluginPackage.NAME, //
 		status = PluginStatus.RELEASED, //

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/objects/DebuggerObjectsProvider.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/objects/DebuggerObjectsProvider.java
@@ -100,7 +100,7 @@ public class DebuggerObjectsProvider extends ComponentProviderAdapter
 	private final AutoService.Wiring autoServiceWiring;
 
 	public static final String OPTION_NAME_DEFAULT_FOREGROUND_COLOR = "Object Colors.Default";
-	public static final String OPTION_NAME_MODIFIED_FOREGROUND_COLOR = "Object Colors.Modifed";
+	public static final String OPTION_NAME_MODIFIED_FOREGROUND_COLOR = "Object Colors.Modified";
 	public static final String OPTION_NAME_SUBSCRIBED_FOREGROUND_COLOR = "Object Colors.Subscribed";
 	public static final String OPTION_NAME_INVISIBLE_FOREGROUND_COLOR =
 		"Object Colors.Invisible (when toggled on)";
@@ -921,7 +921,7 @@ public class DebuggerObjectsProvider extends ComponentProviderAdapter
 	
 		groupTargetIndex++;
 
-		actionToggleHideIntrinsics = new ToggleActionBuilder("Hide Intrinsic Atributes", plugin.getName())
+		actionToggleHideIntrinsics = new ToggleActionBuilder("Hide Intrinsic Attributes", plugin.getName())
 			.menuPath("Maintenance","&Hide Intrinsic Attributes")
 			.menuGroup(DebuggerResources.GROUP_TARGET, "M" + groupTargetIndex)
 			.helpLocation(new HelpLocation(plugin.getName(), "hide_intrinsic_attributes"))

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/watch/WatchRow.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/watch/WatchRow.java
@@ -234,7 +234,7 @@ public class WatchRow {
 		Language newLanguage = trace.getBaseLanguage();
 		if (language != newLanguage) {
 			if (!(newLanguage instanceof SleighLanguage)) {
-				error = new RuntimeException("Not a sleigh-based langauge");
+				error = new RuntimeException("Not a sleigh-based language");
 				return;
 			}
 			language = (SleighLanguage) newLanguage;

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/DefaultThreadRecorder.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/DefaultThreadRecorder.java
@@ -138,7 +138,7 @@ public class DefaultThreadRecorder implements ManagedThreadRecorder {
 				}
 			}
 		}).exceptionally(ex -> {
-			Msg.error(this, "Could not intialize register mapper", ex);
+			Msg.error(this, "Could not initialize register mapper", ex);
 			return null;
 		});
 	}
@@ -153,7 +153,7 @@ public class DefaultThreadRecorder implements ManagedThreadRecorder {
 		return initRegMapper(descs).thenAccept(__ -> {
 			recorder.getListeners().fire.registerBankMapped(recorder);
 		}).exceptionally(ex -> {
-			Msg.error(this, "Could not intialize register mapper", ex);
+			Msg.error(this, "Could not initialize register mapper", ex);
 			return null;
 		});
 	}

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/TraceObjectManager.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/TraceObjectManager.java
@@ -356,7 +356,7 @@ public class TraceObjectManager {
 			}
 			//listenerForRecord.retroOfferMemMapperDependents();
 		}).exceptionally(ex -> {
-			Msg.error(this, "Could not intialize memory mapper", ex);
+			Msg.error(this, "Could not initialize memory mapper", ex);
 			return null;
 		});
 	}

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/launch/AbstractDebuggerProgramLaunchOffer.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/model/launch/AbstractDebuggerProgramLaunchOffer.java
@@ -172,7 +172,7 @@ public abstract class AbstractDebuggerProgramLaunchOffer implements DebuggerProg
 							e);
 					}
 					Msg.error(this,
-						"Saved launcher args are corrup, or launcher parameters changed. Defaulting.",
+						"Saved launcher args are corrupt, or launcher parameters changed. Defaulting.",
 						e);
 				}
 			}

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/workflow/ShowInterpreterDebuggerBot.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/workflow/ShowInterpreterDebuggerBot.java
@@ -30,7 +30,7 @@ import ghidra.util.Swing;
 @DebuggerBotInfo( //
 	description = "Show debugger interpreters", //
 	details = "Listens for new debuggers supporting the interpreter interface," +
-		" and when found, displays that interpeter.", //
+		" and when found, displays that interpreter.", //
 	help = @HelpInfo(anchor = "show_interpreter"), //
 	enabledByDefault = true //
 )

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/pcode/exec/trace/TraceSleighUtils.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/pcode/exec/trace/TraceSleighUtils.java
@@ -77,7 +77,7 @@ public enum TraceSleighUtils {
 		SleighLanguage language = expr.getLanguage();
 		if (trace.getBaseLanguage() != language) {
 			throw new IllegalArgumentException(
-				"This expression can only be evaulated on traces with language " + language);
+				"This expression can only be evaluated on traces with language " + language);
 		}
 		PcodeExecutor<byte[]> executor = buildByteExecutor(trace, snap, thread, frame);
 		return expr.evaluate(executor);
@@ -95,7 +95,7 @@ public enum TraceSleighUtils {
 		SleighLanguage language = expr.getLanguage();
 		if (trace.getBaseLanguage() != language) {
 			throw new IllegalArgumentException(
-				"This expression can only be evaulated on traces with language " +
+				"This expression can only be evaluated on traces with language " +
 					language);
 		}
 		PcodeExecutor<Pair<byte[], TraceMemoryState>> executor =

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/language/DBTraceGuestLanguageMappedMemory.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/language/DBTraceGuestLanguageMappedMemory.java
@@ -330,7 +330,7 @@ public class DBTraceGuestLanguageMappedMemory implements Memory {
 	}
 
 	@Override
-	public MemoryBlock convertToInitialized(MemoryBlock unitializedBlock, byte initialValue)
+	public MemoryBlock convertToInitialized(MemoryBlock uninitializedBlock, byte initialValue)
 			throws LockException, MemoryBlockException, NotFoundException {
 		throw new UnsupportedOperationException();
 	}

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/listing/DBTraceData.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/listing/DBTraceData.java
@@ -37,7 +37,7 @@ public class DBTraceData extends AbstractDBTraceCodeUnit<DBTraceData>
 		implements DBTraceDefinedDataAdapter {
 	private static final String TABLE_NAME = "Data";
 
-	static final String LANGUAGE_COLUMN_NAME = "Langauge";
+	static final String LANGUAGE_COLUMN_NAME = "Language";
 	static final String DATATYPE_COLUMN_NAME = "DataType";
 
 	@DBAnnotatedColumn(LANGUAGE_COLUMN_NAME)
@@ -75,7 +75,7 @@ public class DBTraceData extends AbstractDBTraceCodeUnit<DBTraceData>
 		}
 		language = space.manager.languageManager.getLanguageByKey(langKey);
 		if (language == null) {
-			throw new IOException("Data table is corrupt. Missing langauge: " + langKey);
+			throw new IOException("Data table is corrupt. Missing language: " + langKey);
 		}
 		dataType = space.dataTypeManager.getDataType(dataTypeID);
 		if (dataType == null) {

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/AbstractDBTraceProgramViewMemory.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/AbstractDBTraceProgramViewMemory.java
@@ -250,7 +250,7 @@ public abstract class AbstractDBTraceProgramViewMemory
 	}
 
 	@Override
-	public MemoryBlock convertToInitialized(MemoryBlock unitializedBlock, byte initialValue)
+	public MemoryBlock convertToInitialized(MemoryBlock uninitializedBlock, byte initialValue)
 			throws LockException, MemoryBlockException, NotFoundException {
 		throw new UnsupportedOperationException();
 	}

--- a/Ghidra/Debug/ProposedUtils/src/main/java/ghidra/util/database/DBCachedObjectStoreFactory.java
+++ b/Ghidra/Debug/ProposedUtils/src/main/java/ghidra/util/database/DBCachedObjectStoreFactory.java
@@ -329,7 +329,7 @@ public class DBCachedObjectStoreFactory {
 				return null;
 			}
 			if (enc.length % 8 != 0) {
-				Msg.warn(this, "Database record for long[] has remaning bytes");
+				Msg.warn(this, "Database record for long[] has remaining bytes");
 			}
 			int len = enc.length / 8;
 			ByteBuffer bytes = ByteBuffer.wrap(enc);

--- a/Ghidra/Extensions/sample/src/main/java/ghidra/examples/SampleProgramTreePlugin.java
+++ b/Ghidra/Extensions/sample/src/main/java/ghidra/examples/SampleProgramTreePlugin.java
@@ -211,7 +211,7 @@ public class SampleProgramTreePlugin extends ProgramPlugin {
 			}
 			catch (NotFoundException e) {
 				Msg.error(this,
-					"couln't find addresses for fragment " + fragmentName + " : " + start, e);
+					"couldn't find addresses for fragment " + fragmentName + " : " + start, e);
 			}
 			return frag;
 		}

--- a/Ghidra/Features/Base/developer_scripts/RangeDisassemblerScript.java
+++ b/Ghidra/Features/Base/developer_scripts/RangeDisassemblerScript.java
@@ -62,7 +62,7 @@ public class RangeDisassemblerScript extends GhidraScript {
 			return;
 		}
 
-		Msg.info(this, "Disassmbly Output File: " + outFile.getAbsolutePath());
+		Msg.info(this, "Disassembly Output File: " + outFile.getAbsolutePath());
 
 		PrintWriter out = new PrintWriter(outFile);
 		try {

--- a/Ghidra/Features/Base/ghidra_scripts/AssembleCheckDevScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/AssembleCheckDevScript.java
@@ -24,7 +24,7 @@ import ghidra.program.model.listing.Instruction;
 public class AssembleCheckDevScript extends AssemblyThrasherDevScript {
 	@Override
 	protected void run() throws Exception {
-		monitor.setMessage("Constructing Assember");
+		monitor.setMessage("Constructing Assembler");
 		AllMatchByTextSelector checker = new AllMatchByTextSelector();
 		Assembler asm = Assemblers.getAssembler(currentProgram, checker);
 		Instruction ins = currentProgram.getListing().getInstructionAt(currentAddress);

--- a/Ghidra/Features/Base/ghidra_scripts/AssembleScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/AssembleScript.java
@@ -28,7 +28,7 @@ import ghidra.program.model.listing.Instruction;
 public class AssembleScript extends GhidraScript {
 	@Override
 	public void run() throws Exception {
-		monitor.setMessage("Constructing Assember");
+		monitor.setMessage("Constructing Assembler");
 		// First, obtain an assembler bound to the current program.
 		// If a suitable assembler has not yet been build, this will take some time to build it.
 		Assembler asm = Assemblers.getAssembler(currentProgram);

--- a/Ghidra/Features/Base/ghidra_scripts/AutoRenameSimpleLabels.java
+++ b/Ghidra/Features/Base/ghidra_scripts/AutoRenameSimpleLabels.java
@@ -20,7 +20,7 @@
 //For instance a simple return function will be labeled ret_XXXX, where XXXX is the address
 //Also, a function that branches to another label will be renamed to dest_branch_XXXX, where dest is
 //destination label and XXXX is the address
-//Repeatable comments from these functions are propogated up from destination functions.
+//Repeatable comments from these functions are propagated up from destination functions.
 //
 //Symbols are replaced if they are DEFAULT or ANALYSIS only (they are not replaced if the symbol is
 //USER_DEFINED or IMPORTED).
@@ -145,7 +145,7 @@ public class AutoRenameSimpleLabels extends GhidraScript {
 					}
 				}
 
-				// now also propogate the repeatable comment up as well
+				// now also propagate the repeatable comment up as well
 
 				String comment = currentProgram.getListing().getComment(CodeUnit.REPEATABLE_COMMENT,
 					operand_addr);

--- a/Ghidra/Features/Base/ghidra_scripts/CountAndSaveStrings.java
+++ b/Ghidra/Features/Base/ghidra_scripts/CountAndSaveStrings.java
@@ -40,7 +40,7 @@ public class CountAndSaveStrings extends GhidraScript {
 			println("File " + saveFile + " was not found");
 			return;
 		}
-		println(stringsFound + " strings were writtin to " + saveFile.getName());
+		println(stringsFound + " strings were written to " + saveFile.getName());
 	}
 
 	private File getSaveFile() throws Exception {

--- a/Ghidra/Features/Base/ghidra_scripts/DeleteEmptyPlateCommentsScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/DeleteEmptyPlateCommentsScript.java
@@ -50,7 +50,7 @@ public class DeleteEmptyPlateCommentsScript extends GhidraScript {
 		}
 		if (updateCount > 0) {
 			String cmt = updateCount > 1? "comments" : "comment";
-			println("Removed " + updateCount + " emtpy plate " + cmt + ".");
+			println("Removed " + updateCount + " empty plate " + cmt + ".");
 		}
 		else {
 			println("Did not find any empty plate comments.");

--- a/Ghidra/Features/Base/ghidra_scripts/Mips_Fix_T9_PositionIndependentCode.java
+++ b/Ghidra/Features/Base/ghidra_scripts/Mips_Fix_T9_PositionIndependentCode.java
@@ -106,7 +106,7 @@ public class Mips_Fix_T9_PositionIndependentCode extends GhidraScript {
 				this.runScript("PropagateConstantReferences.java", newState);
 			}
 			catch (Exception e) {
-				println("Couldn't Run Propogate script");
+				println("Couldn't Run Propagate script");
 				e.printStackTrace();
 			}
 

--- a/Ghidra/Features/Base/ghidra_scripts/MultiInstructionMemReference.java
+++ b/Ghidra/Features/Base/ghidra_scripts/MultiInstructionMemReference.java
@@ -64,7 +64,7 @@ import ghidra.program.model.symbol.SourceType;
 import ghidra.program.util.ContextEvaluator;
 import ghidra.program.util.ContextEvaluatorAdapter;
 import ghidra.program.util.OperandFieldLocation;
-import ghidra.program.util.SymbolicPropogator;
+import ghidra.program.util.SymbolicPropagator;
 import ghidra.program.util.VarnodeContext;
 import ghidra.util.exception.CancelledException;
 
@@ -359,7 +359,7 @@ public class MultiInstructionMemReference extends GhidraScript {
 					}
 				}
 
-				SymbolicPropogator symEval = new SymbolicPropogator(currentProgram);
+				SymbolicPropagator symEval = new SymbolicPropagator(currentProgram);
 				symEval.setParamRefCheck(false);
 				symEval.setReturnRefCheck(false);
 				symEval.setStoredRefCheck(false);

--- a/Ghidra/Features/Base/ghidra_scripts/PropagateConstantReferences.java
+++ b/Ghidra/Features/Base/ghidra_scripts/PropagateConstantReferences.java
@@ -28,7 +28,7 @@ import ghidra.program.model.address.AddressSet;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.FunctionIterator;
 import ghidra.program.util.ContextEvaluator;
-import ghidra.program.util.SymbolicPropogator;
+import ghidra.program.util.SymbolicPropagator;
 
 public class PropagateConstantReferences extends GhidraScript {
 
@@ -72,7 +72,7 @@ public class PropagateConstantReferences extends GhidraScript {
 			// use context to fill out addresses on certain instructions 
 			ContextEvaluator eval = new ConstantPropagationContextEvaluator(true);
 
-			SymbolicPropogator symEval = new SymbolicPropogator(currentProgram);
+			SymbolicPropagator symEval = new SymbolicPropagator(currentProgram);
 
 			symEval.flowConstants(start, func.getBody(), eval, true, monitor);
 		}

--- a/Ghidra/Features/Base/ghidra_scripts/PropagateExternalParametersScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/PropagateExternalParametersScript.java
@@ -156,7 +156,7 @@ public class PropagateExternalParametersScript extends GhidraScript {
 						if (checkEnoughPushes(cuIt, params.length)) {
 							CodeUnitIterator codeUnitsToRef =
 								getCodeUnitsFromFunctionStartToRef(thunkRefFunc, thunkRefAddr);
-							propogateParams(params, codeUnitsToRef, extFunc.getName());
+							propagateParams(params, codeUnitsToRef, extFunc.getName());
 							println("Processing external function: " + extFuncName + " at " +
 								thunkRefAddr.toString());
 						}
@@ -169,7 +169,7 @@ public class PropagateExternalParametersScript extends GhidraScript {
 				if (checkEnoughPushes(cuIt, params.length)) {
 					CodeUnitIterator codeUnitsToRef =
 						getCodeUnitsFromFunctionStartToRef(calledFromFunc, refAddr);
-					propogateParams(params, codeUnitsToRef, extFunc.getName());
+					propagateParams(params, codeUnitsToRef, extFunc.getName());
 					println("Processing external function: " + extFuncName + " at " +
 						refAddr.toString());
 				}
@@ -264,7 +264,7 @@ public class PropagateExternalParametersScript extends GhidraScript {
 		return false; // not enough params between ref and top of function
 	}
 
-	void propogateParams(Parameter[] params, CodeUnitIterator cuIt, String extFuncName) {
+	void propagateParams(Parameter[] params, CodeUnitIterator cuIt, String extFuncName) {
 
 		int index = 0;
 		int numSkips = 0;

--- a/Ghidra/Features/Base/ghidra_scripts/PropagateX86ConstantReferences.java
+++ b/Ghidra/Features/Base/ghidra_scripts/PropagateX86ConstantReferences.java
@@ -37,7 +37,7 @@ import ghidra.program.model.listing.*;
 import ghidra.program.model.pcode.Varnode;
 import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.symbol.*;
-import ghidra.program.util.SymbolicPropogator;
+import ghidra.program.util.SymbolicPropagator;
 import ghidra.program.util.VarnodeContext;
 import ghidra.util.exception.*;
 
@@ -136,7 +136,7 @@ public class PropagateX86ConstantReferences extends GhidraScript {
 					}
 				};
 
-			SymbolicPropogator symEval = new SymbolicPropogator(currentProgram);
+			SymbolicPropagator symEval = new SymbolicPropagator(currentProgram);
 			symEval.setParamRefCheck(true);
 			symEval.setReturnRefCheck(true);
 			symEval.setStoredRefCheck(true);

--- a/Ghidra/Features/Base/ghidra_scripts/ResolveX86orX64LinuxSyscallsScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/ResolveX86orX64LinuxSyscallsScript.java
@@ -38,8 +38,8 @@ import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.program.model.pcode.PcodeOp;
 import ghidra.program.model.symbol.*;
 import ghidra.program.util.ContextEvaluator;
-import ghidra.program.util.SymbolicPropogator;
-import ghidra.program.util.SymbolicPropogator.Value;
+import ghidra.program.util.SymbolicPropagator;
+import ghidra.program.util.SymbolicPropagator.Value;
 import ghidra.util.Msg;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
@@ -278,7 +278,7 @@ public class ResolveX86orX64LinuxSyscallsScript extends GhidraScript {
 		for (Function func : funcsToCalls.keySet()) {
 			Address start = func.getEntryPoint();
 			ContextEvaluator eval = new ConstantPropagationContextEvaluator(true);
-			SymbolicPropogator symEval = new SymbolicPropogator(program);
+			SymbolicPropagator symEval = new SymbolicPropagator(program);
 			symEval.flowConstants(start, func.getBody(), eval, true, tMonitor);
 			for (Address callSite : funcsToCalls.get(func)) {
 				Value val = symEval.getRegisterValue(callSite, syscallReg);

--- a/Ghidra/Features/Base/ghidra_scripts/VersionControl_ResetAll.java
+++ b/Ghidra/Features/Base/ghidra_scripts/VersionControl_ResetAll.java
@@ -73,7 +73,7 @@ public class VersionControl_ResetAll extends GhidraScript {
 		}
 		long end_ts = System.currentTimeMillis();
 
-		println("Finished reseting to base rev for folder: " + rootFolder.getPathname());
+		println("Finished resetting to base rev for folder: " + rootFolder.getPathname());
 		println("Total files: " + filesProcessed);
 		println("Total time: " + (end_ts - start_ts));
 	}

--- a/Ghidra/Features/Base/src/main/help/help/topics/AutoAnalysisPlugin/AutoAnalysis.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/AutoAnalysisPlugin/AutoAnalysis.htm
@@ -356,7 +356,7 @@
 
         <P>Applying type information recovered by the decompiler can be extremely useful if you
         have type information for library functions. You can apply function signatures to your
-        library functions, and as code is disassembled, type information will be propogated from
+        library functions, and as code is disassembled, type information will be propagated from
         the library functions up into the parameters and local variables of the functions calling
         them.<BR>
         </P>
@@ -653,4 +653,4 @@
      <BR>
   </BODY>
 </HTML>
-
+

--- a/Ghidra/Features/Base/src/main/help/help/topics/MemoryMapPlugin/Memory_Map.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/MemoryMapPlugin/Memory_Map.htm
@@ -247,7 +247,7 @@
             <UL>
 				<LI><B>Initialized</B> - Specify a value and a new block will be created
 					using that value for every byte in the block. </LI>
-				<LI><B>Uninitialized</B> - An unitialized block will be created.</LI>
+				<LI><B>Uninitialized</B> - An uninitialized block will be created.</LI>
 				<LI><B>File Bytes</B> - Select from a list of imported files and enter
 				a starting offset for that file.  Those bytes will be the initial value for the block.</LI>
 				<P><I><IMG src="../../shared/note.png" border="0"> You can use the "Add To Program"

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/analyzers/CondenseFillerBytesAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/analyzers/CondenseFillerBytesAnalyzer.java
@@ -45,7 +45,7 @@ public class CondenseFillerBytesAnalyzer extends AbstractAnalyzer {
 
 	public CondenseFillerBytesAnalyzer() {
 		super(NAME, DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.after().after().after().after().after());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.after().after().after().after().after());
 		setPrototype();
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CallDepthChangeInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CallDepthChangeInfo.java
@@ -27,7 +27,7 @@ import ghidra.program.model.symbol.FlowType;
 import ghidra.program.model.symbol.Reference;
 import ghidra.program.model.util.*;
 import ghidra.program.util.*;
-import ghidra.program.util.SymbolicPropogator.Value;
+import ghidra.program.util.SymbolicPropagator.Value;
 import ghidra.util.Msg;
 import ghidra.util.exception.*;
 import ghidra.util.task.TaskMonitor;
@@ -72,7 +72,7 @@ public class CallDepthChangeInfo {
 	private Register stackReg = null;
 	private Register frameReg = null;
 
-	SymbolicPropogator symEval = null;
+	SymbolicPropagator symEval = null;
 
 	private int stackPurge = Function.UNKNOWN_STACK_DEPTH_CHANGE;
 
@@ -159,7 +159,7 @@ public class CallDepthChangeInfo {
 		depthMap = new DefaultIntPropertyMap("depth");
 		trans = new VarnodeTranslator(program);
 
-		symEval = new SymbolicPropogator(program);
+		symEval = new SymbolicPropagator(program);
 		symEval.setParamRefCheck(false);
 		symEval.setReturnRefCheck(false);
 		symEval.setStoredRefCheck(false);
@@ -627,7 +627,7 @@ public class CallDepthChangeInfo {
 		}
 
 		//		if (processTerminal) {
-		//			backPropogateStackDepth(program, func, badStackSet, this,
+		//			backPropagateStackDepth(program, func, badStackSet, this,
 		// procContext, terminalPoints, monitor);
 		//		}
 
@@ -993,7 +993,7 @@ public class CallDepthChangeInfo {
 		}
 
 		//		if (processTerminal) {
-		//			backPropogateStackDepth(program, func, badStackSet, this,
+		//			backPropagateStackDepth(program, func, badStackSet, this,
 		// procContext, terminalPoints, monitor);
 		//		}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CreateThunkFunctionCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/CreateThunkFunctionCmd.java
@@ -419,7 +419,7 @@ public class CreateThunkFunctionCmd extends BackgroundCommand {
 		// NOTE: Assumption, we have found all flows leading to the switch that might split the basic block
 
 		final AtomicInteger foundCount = new AtomicInteger(0);
-		SymbolicPropogator prop = new SymbolicPropogator(program);
+		SymbolicPropagator prop = new SymbolicPropagator(program);
 
 		prop.flowConstants(jumpBlockAt.getFirstStartAddress(), jumpBlockAt,
 			new ContextEvaluatorAdapter() {
@@ -429,7 +429,7 @@ public class CreateThunkFunctionCmd extends BackgroundCommand {
 					// go ahead and place the reference, since it is a constant.
 					if (refType.isComputed() && refType.isFlow() &&
 						program.getMemory().contains(address)) {
-						propogateCodeMode(context, address);
+						propagateCodeMode(context, address);
 						foundCount.incrementAndGet();
 						return true;
 					}
@@ -441,7 +441,7 @@ public class CreateThunkFunctionCmd extends BackgroundCommand {
 					return true;
 				}
 
-				private void propogateCodeMode(VarnodeContext context, Address addr) {
+				private void propagateCodeMode(VarnodeContext context, Address addr) {
 					// get CodeModeRegister and flow it to destination, if it is set here
 
 					if (isaModeSwitchRegister == null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/NewFunctionStackAnalysisCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/NewFunctionStackAnalysisCmd.java
@@ -252,7 +252,7 @@ public class NewFunctionStackAnalysisCmd extends BackgroundCommand {
 		// Add stack variables with undefined types to map to simplify merging
 		addFunctionStackVariablesToSortedList(func, sortedVariables);
 
-		SymbolicPropogator symEval = new SymbolicPropogator(program);
+		SymbolicPropagator symEval = new SymbolicPropagator(program);
 		symEval.setParamRefCheck(false);
 		symEval.setReturnRefCheck(false);
 		symEval.setStoredRefCheck(false);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AbstractDemanglerAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AbstractDemanglerAnalyzer.java
@@ -48,7 +48,7 @@ public abstract class AbstractDemanglerAnalyzer extends AbstractAnalyzer {
 
 	public AbstractDemanglerAnalyzer(String name, String description) {
 		super(name, description, AnalyzerType.BYTE_ANALYZER);
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.before().before().before());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.before().before().before());
 		setSupportsOneTimeAnalysis();
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ConstantPropagationAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ConstantPropagationAnalyzer.java
@@ -30,7 +30,7 @@ import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.symbol.*;
 import ghidra.program.model.util.CodeUnitInsertionException;
 import ghidra.program.util.ContextEvaluator;
-import ghidra.program.util.SymbolicPropogator;
+import ghidra.program.util.SymbolicPropagator;
 import ghidra.util.Msg;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
@@ -63,7 +63,7 @@ public class ConstantPropagationAnalyzer extends AbstractAnalyzer {
 
 	protected static final String MINKNOWNREFADDRESS_OPTION_NAME = "Min absolute reference";
 	protected static final String MINKNOWNREFADDRESS_OPTION_DESCRIPTION =
-		"Minimum address for calcuated constant store/load references";
+		"Minimum address for calculated constant store/load references";
 	protected static final int MINKNOWNREFADDRESS_OPTION_DEFAULT_VALUE = 4;
 
 	protected static final String MINSPECULATIVEREFADDRESS_OPTION_NAME =
@@ -75,7 +75,7 @@ public class ConstantPropagationAnalyzer extends AbstractAnalyzer {
 	protected static final String MAXSPECULATIVEREFADDRESS_OPTION_NAME =
 		"Speculative reference max";
 	protected static final String MAXSPECULATIVEREFADDRESS_OPTION_DESCRIPTION =
-		"Maxmimum speculative reference address offset from the end of memory for offsets and parameters";
+		"Maximum speculative reference address offset from the end of memory for offsets and parameters";
 	protected static final int MAXSPECULATIVEREFADDRESS_OPTION_DEFAULT_VALUE = 256;
 
 	protected final static int NOTIFICATION_INTERVAL = 100;
@@ -390,7 +390,7 @@ public class ConstantPropagationAnalyzer extends AbstractAnalyzer {
 			flowStart = func.getEntryPoint();
 		}
 
-		SymbolicPropogator symEval = new SymbolicPropogator(program);
+		SymbolicPropagator symEval = new SymbolicPropagator(program);
 		symEval.setParamRefCheck(checkParamRefsOption);
 		symEval.setReturnRefCheck(checkParamRefsOption);
 		symEval.setStoredRefCheck(checkStoredRefsOption);
@@ -411,7 +411,7 @@ public class ConstantPropagationAnalyzer extends AbstractAnalyzer {
 	 * @throws CancelledException
 	 */
 	public AddressSetView flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
 		ContextEvaluator eval = new ConstantPropagationContextEvaluator(trustWriteMemOption,

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ConstantPropagationContextEvaluator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ConstantPropagationContextEvaluator.java
@@ -23,7 +23,7 @@ import ghidra.program.util.ContextEvaluatorAdapter;
 import ghidra.program.util.VarnodeContext;
 
 /** 
- * The ConstantPropogatorEvaluator is used as the evaluator for the SymbolicPropagator when finding constant
+ * The ConstantPropagatorEvaluator is used as the evaluator for the SymbolicPropagator when finding constant
  * references and laying them down for a generic processor.  Extend this class to add additional checks
  * and behaviors necessary for a unique processor such as the PowerPC.
  * 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/FindNoReturnFunctionsAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/FindNoReturnFunctionsAnalyzer.java
@@ -381,7 +381,7 @@ public class FindNoReturnFunctionsAnalyzer extends AbstractAnalyzer {
 					// if function only calls non-returning functions
 					if (targetOnlyCallsNoReturn(cp, target, noReturnSet)) {
 						NoReturnLocations location =
-							new NoReturnLocations(target, null, "Calls only non-returing function");
+							new NoReturnLocations(target, null, "Calls only non-returning functions");
 						reasonList.add(location);
 						noReturnSet.add(target);
 						continue;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/OperandReferenceAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/OperandReferenceAnalyzer.java
@@ -612,7 +612,7 @@ public class OperandReferenceAnalyzer extends AbstractAnalyzer {
 		// TODO: we could get corroborating information from other means
 		//          (function right above, starts like a function, etc...)
 		//
-//		mgr.createFunction(functionStarts, false, AnalysisPriority.DATA_TYPE_PROPOGATION.getNext());
+//		mgr.createFunction(functionStarts, false, AnalysisPriority.DATA_TYPE_PROPAGATION.getNext());
 	}
 
 	private boolean shouldBeValidFunction(Program program, Instruction targetInstr) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/PefDebugAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/PefDebugAnalyzer.java
@@ -40,7 +40,7 @@ public class PefDebugAnalyzer extends AbstractAnalyzer {
 	public PefDebugAnalyzer() {
 		super(NAME, DESCRIPTION, AnalyzerType.FUNCTION_ANALYZER);
 		setDefaultEnablement(true);
-		setPriority(new AnalysisPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.priority() * 2));
+		setPriority(new AnalysisPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.priority() * 2));
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/BitFieldEditorPanel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/BitFieldEditorPanel.java
@@ -535,7 +535,7 @@ public class BitFieldEditorPanel extends JPanel {
 		}
 		if (bitfieldDtc != null) {
 			if (!bitfieldDtc.isBitFieldComponent()) {
-				throw new IllegalArgumentException("unsupport data type component");
+				throw new IllegalArgumentException("unsupported data type component");
 			}
 			initialFieldName = bitfieldDtc.getFieldName();
 			initialComment = bitfieldDtc.getComment();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompEditorModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompEditorModel.java
@@ -808,7 +808,7 @@ public abstract class CompEditorModel extends CompositeEditorModel {
 			dtc.setFieldName(oldDtc.getFieldName());
 		}
 		catch (DuplicateNameException e) {
-			Msg.showError(this, null, "Unexcected Exception", "Exception applying field name", e);
+			Msg.showError(this, null, "Unexpected Exception", "Exception applying field name", e);
 		}
 		dtc.setComment(oldDtc.getComment());
 		fixSelection();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/util/DataTypeTreeCopyMoveTask.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/util/DataTypeTreeCopyMoveTask.java
@@ -599,7 +599,7 @@ public class DataTypeTreeCopyMoveTask extends Task {
 				dtMgr.replaceDataType(existingDt, replacementDt, true);
 			}
 			catch (DataTypeDependencyException e) {
-				errors.add("Replace failed.  Existing type " + existingDt + "; replacment type " +
+				errors.add("Replace failed.  Existing type " + existingDt + "; replacement type " +
 					replacementDt + ". " + e.getMessage());
 			}
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTableAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTableAnalyzer.java
@@ -38,7 +38,7 @@ public class AddressTableAnalyzer extends AbstractAnalyzer {
 	private static final String OPTION_NAME_PTR_ALIGNMENT = "Pointer Alignment";
 	private static final String OPTION_NAME_AUTO_LABEL_TABLE = "Auto Label Table";
 	private static final String OPTION_NAME_MIN_POINTER_ADDR = "Minimum Pointer Address";
-	private static final String OPTION_NAME_MAX_POINTER_DIFF = "Maxmimum Pointer Distance";
+	private static final String OPTION_NAME_MAX_POINTER_DIFF = "Maximum Pointer Distance";
 	private static final String OPTION_NAME_RELOCATION_GUIDE = "Relocation Table Guide";
 	private static final String OPTION_NAME_ALLOW_OFFCUT_REFERENCES = "Allow Offcut References";
 
@@ -92,7 +92,7 @@ public class AddressTableAnalyzer extends AbstractAnalyzer {
 
 	public AddressTableAnalyzer() {
 		super("Create Address Tables", DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.before());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.before());
 		setSupportsOneTimeAnalysis();
 
 		// The analyzer should be off by default (as stated in its description)
@@ -216,13 +216,13 @@ public class AddressTableAnalyzer extends AbstractAnalyzer {
 					// disassemble valid code
 					if (!validCodeSet.isEmpty()) {
 						mgr.disassemble(validCodeSet,
-							AnalysisPriority.DATA_TYPE_PROPOGATION.before());
+							AnalysisPriority.DATA_TYPE_PROPAGATION.before());
 					}
 					// if valid functions, schedule much later, so switch table analysis can pick it up.
 					if (!validFuncSet.isEmpty()) {
 						//  For Now, Never make functions from address tables, Could later be an option
 						//		mgr.createFunction(validFuncSet, true,
-						//		AnalysisPriority.DATA_TYPE_PROPOGATION.getNext());
+						//		AnalysisPriority.DATA_TYPE_PROPAGATION.getNext());
 					}
 				}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/DisassemblerPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/DisassemblerPlugin.java
@@ -148,7 +148,7 @@ public class DisassemblerPlugin extends Plugin {
 		}
 		Options options = program.getOptions(Program.DISASSEMBLER_PROPERTIES);
 		options.registerOption(Disassembler.MARK_BAD_INSTRUCTION_PROPERTY, true, null,
-			"Place ERROR Bookmark at locations where disassembly could not be perfomed.");
+			"Place ERROR Bookmark at locations where disassembly could not be performed.");
 		options.registerOption(Disassembler.MARK_UNIMPL_PCODE_PROPERTY, true, null,
 			"Place WARNING Bookmark at locations where a disassembled instruction has unimplemented pcode.");
 		options.registerOption(Disassembler.RESTRICT_DISASSEMBLY_TO_EXECUTE_MEMORY_PROPERTY, false,
@@ -267,7 +267,7 @@ public class DisassemblerPlugin extends Plugin {
 				cmd = new DisassembleCommand(addr, restrictedSet, true);
 			}
 			catch (MemoryAccessException e) {
-				tool.setStatusInfo("Can't disassemble unitialized memory!", true);
+				tool.setStatusInfo("Can't disassemble uninitialized memory!", true);
 			}
 		}
 		if (cmd != null) {
@@ -332,7 +332,7 @@ public class DisassemblerPlugin extends Plugin {
 				cmd = new ArmDisassembleCommand(addr, null, thumbMode);
 			}
 			catch (MemoryAccessException e) {
-				tool.setStatusInfo("Can't disassemble unitialized memory!", true);
+				tool.setStatusInfo("Can't disassemble uninitialized memory!", true);
 			}
 		}
 		if (cmd != null) {
@@ -356,7 +356,7 @@ public class DisassemblerPlugin extends Plugin {
 				cmd = new Hcs12DisassembleCommand(addr, null, xgMode);
 			}
 			catch (MemoryAccessException e) {
-				tool.setStatusInfo("Can't disassemble unitialized memory!", true);
+				tool.setStatusInfo("Can't disassemble uninitialized memory!", true);
 			}
 		}
 		if (cmd != null) {
@@ -380,7 +380,7 @@ public class DisassemblerPlugin extends Plugin {
 				cmd = new MipsDisassembleCommand(addr, null, mips16);
 			}
 			catch (MemoryAccessException e) {
-				tool.setStatusInfo("Can't disassemble unitialized memory!", true);
+				tool.setStatusInfo("Can't disassemble uninitialized memory!", true);
 			}
 		}
 		if (cmd != null) {
@@ -404,7 +404,7 @@ public class DisassemblerPlugin extends Plugin {
 				cmd = new PowerPCDisassembleCommand(addr, null, vle);
 			}
 			catch (MemoryAccessException e) {
-				tool.setStatusInfo("Can't disassemble unitialized memory!", true);
+				tool.setStatusInfo("Can't disassemble uninitialized memory!", true);
 			}
 		}
 		if (cmd != null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/exporter/ExporterDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/exporter/ExporterDialog.java
@@ -62,7 +62,7 @@ import ghidra.util.task.*;
 public class ExporterDialog extends DialogComponentProvider implements AddressFactoryService {
 
 	private static final String XML_WARNING =
-		"   Warning: XML is lossy and intended only for transfering data to external tools. GZF is the recommended format for saving and sharing program data.";
+		"   Warning: XML is lossy and intended only for transferring data to external tools. GZF is the recommended format for saving and sharing program data.";
 
 	private static String lastUsedExporterName = "Ghidra Zip File";  // default to GZF first time
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/fallthrough/FallThroughPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/fallthrough/FallThroughPlugin.java
@@ -40,7 +40,7 @@ import ghidra.program.util.AddressFieldLocation;
 	description = "Provides actions for changing an instructions \"fall-through\" address.  " +
 			"Normally an instructions \"fall-through\" address is the address of the " +
 			"instruction that immediately follows it (except for jmp).  This plugin allows " +
-			"a user to overide this behaviour on specific situations.",
+			"a user to override this behaviour on specific situations.",
 	eventsConsumed = { ProgramLocationPluginEvent.class, ProgramActivatedPluginEvent.class, ProgramSelectionPluginEvent.class }
 )
 //@formatter:on

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/AnalyzeStackRefsAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/AnalyzeStackRefsAction.java
@@ -90,7 +90,7 @@ class AnalyzeStackRefsAction extends ListingContextAction {
 		Options options = program.getOptions(Program.ANALYSIS_PROPERTIES).getOptions("Stack");
 		options.registerOption(GhidraLanguagePropertyKeys.USE_NEW_FUNCTION_STACK_ANALYSIS,
 			doNewStackAnalysis, null,
-			"Use General Stack Reference Propogator (This works best on most processors)");
+			"Use General Stack Reference Propagator (This works best on most processors)");
 
 		options.registerOption("Create Local Variables", doLocalAnalysis, null,
 			"Create Function Local stack variables and references");

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/StackVariableAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/StackVariableAnalyzer.java
@@ -36,7 +36,7 @@ public class StackVariableAnalyzer extends AbstractAnalyzer {
 
 	public StackVariableAnalyzer() {
 		super(NAME, DESCRIPTION, AnalyzerType.FUNCTION_ANALYZER);
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.after().after().after());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.after().after().after());
 		setDefaultEnablement(true);
 		setSupportsOneTimeAnalysis();
 	}
@@ -71,7 +71,7 @@ public class StackVariableAnalyzer extends AbstractAnalyzer {
 	public void registerOptions(Options options, Program program) {
 		options.registerOption(GhidraLanguagePropertyKeys.USE_NEW_FUNCTION_STACK_ANALYSIS,
 			!useOldStackAnalysisByDefault(program), null,
-			"Use General Stack Reference Propogator (This works best on most processors)");
+			"Use General Stack Reference Propagator (This works best on most processors)");
 
 		options.registerOption("Create Local Variables", doLocalAnalysis, null,
 			"Create Function Local stack variables and references");

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/editor/FunctionEditorDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/editor/FunctionEditorDialog.java
@@ -565,7 +565,7 @@ public class FunctionEditorDialog extends DialogComponentProvider implements Mod
 			callingConventionComboBox.setSelectedItem(callingConventionName);
 			if (!callingConventionComboBox.getSelectedItem().equals(callingConventionName)) {
 				setStatusText(
-					"Invalid Callinging Convention '" + callingConventionName + "' ignored!");
+					"Invalid Calling Convention '" + callingConventionName + "' ignored!");
 			}
 		}
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/tags/FunctionTagProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/tags/FunctionTagProvider.java
@@ -454,7 +454,7 @@ public class FunctionTagProvider extends ComponentProviderAdapter
 		if (!dropped.isEmpty()) {
 			String text = StringUtils.join(dropped, ", ");
 			Msg.showInfo(this, tool.getActiveWindow(), "Duplicate Tag Names",
-				"Tags aleady exist.  Ignoring the following tags: " + text);
+				"Tags already exist.  Ignoring the following tags: " + text);
 		}
 
 		Swing.runLater(() -> tagInputField.setText(""));

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/highlight/SetHighlightPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/highlight/SetHighlightPlugin.java
@@ -41,7 +41,7 @@ import ghidra.program.util.ProgramSelection;
 	packageName = CorePluginPackage.NAME,
 	category = PluginCategoryNames.CODE_VIEWER,
 	shortDescription = "Set Highlight From Selection",
-	description = "Provides actions for setting a highlight from a selection or setting a selection from a hightlight",
+	description = "Provides actions for setting a highlight from a selection or setting a selection from a highlight",
 	eventsConsumed = { ProgramHighlightPluginEvent.class }
 )
 //@formatter:on

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/instructionsearch/model/InstructionSearchData.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/instructionsearch/model/InstructionSearchData.java
@@ -441,7 +441,7 @@ public class InstructionSearchData extends Observable {
 		}
 		catch (MemoryAccessException e) {
 			throw new InvalidInputException("Error reading bytes at: " +
-				codeUnit.getAddressString(false, false) + " (possibly unititialized data?)");
+				codeUnit.getAddressString(false, false) + " (possibly uninitialized data?)");
 		}
 
 		return createInstructionMetadata(codeUnit, mask, value, false);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/AddBlockDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/AddBlockDialog.java
@@ -79,7 +79,7 @@ class AddBlockDialog extends DialogComponentProvider implements ChangeListener {
 
 	private final static String MAPPED = "Mapped";
 	private final static String UNMAPPED = "Unmapped";
-	private static final String UNITIALIZED = "UNITIALIZED";
+	private static final String UNINITIALIZED = "UNINITIALIZED";
 	private static final String INITIALIZED = "INITIALIZED";
 	private static final String FILE_BYTES = "FILE_BYTES";
 	private JPanel inializedTypePanel;
@@ -246,7 +246,7 @@ class AddBlockDialog extends DialogComponentProvider implements ChangeListener {
 		initializedTypeCardLayout = new CardLayout();
 
 		inializedTypePanel = new JPanel(initializedTypeCardLayout);
-		inializedTypePanel.add(new JPanel(), UNITIALIZED);
+		inializedTypePanel.add(new JPanel(), UNINITIALIZED);
 		inializedTypePanel.add(buildInitalValuePanel(), INITIALIZED);
 		inializedTypePanel.add(buildFileBytesPanel(), FILE_BYTES);
 		return inializedTypePanel;
@@ -312,7 +312,7 @@ class AddBlockDialog extends DialogComponentProvider implements ChangeListener {
 		commentField.setText("");
 		initialValueField.setValue(Long.valueOf(0));
 		model.setBlockType(MemoryBlockType.DEFAULT);
-		model.setInitializedType(AddBlockModel.InitializedType.UNITIALIZED);
+		model.setInitializedType(AddBlockModel.InitializedType.UNINITIALIZED);
 		model.setInitialValue(0);
 
 		readCB.setSelected(model.isRead());
@@ -353,8 +353,8 @@ class AddBlockDialog extends DialogComponentProvider implements ChangeListener {
 			initializedTypeCardLayout.show(inializedTypePanel, INITIALIZED);
 		}
 		else if (uninitializedRB.isSelected()) {
-			model.setInitializedType(InitializedType.UNITIALIZED);
-			initializedTypeCardLayout.show(inializedTypePanel, UNITIALIZED);
+			model.setInitializedType(InitializedType.UNINITIALIZED);
+			initializedTypeCardLayout.show(inializedTypePanel, UNINITIALIZED);
 		}
 		else if (initializedFromFileBytesRB.isSelected()) {
 			model.setInitializedType(InitializedType.INITIALIZED_FROM_FILE_BYTES);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/AddBlockModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/AddBlockModel.java
@@ -61,7 +61,7 @@ class AddBlockModel {
 	private long fileBytesOffset = -1;
 
 	enum InitializedType {
-		UNITIALIZED, INITIALIZED_FROM_VALUE, INITIALIZED_FROM_FILE_BYTES;
+		UNINITIALIZED, INITIALIZED_FROM_VALUE, INITIALIZED_FROM_FILE_BYTES;
 	}
 
 	AddBlockModel(PluginTool tool, Program program) {
@@ -127,7 +127,7 @@ class AddBlockModel {
 		isOverlay = false;
 		schemeDestByteCount = blockType == MemoryBlockType.BIT_MAPPED ? 8 : 1;
 		schemeSrcByteCount = 1;
-		initializedType = InitializedType.UNITIALIZED;
+		initializedType = InitializedType.UNINITIALIZED;
 		validateInfo();
 		listener.stateChanged(null);
 	}
@@ -275,7 +275,7 @@ class AddBlockModel {
 			case INITIALIZED_FROM_VALUE:
 				return new AddInitializedMemoryBlockCmd(blockName, comment, source, startAddr,
 					length, isRead, isWrite, isExecute, isVolatile, (byte) initialValue, isOverlay);
-			case UNITIALIZED:
+			case UNINITIALIZED:
 				return new AddUninitializedMemoryBlockCmd(blockName, comment, source, startAddr,
 					length, isRead, isWrite, isExecute, isVolatile, isOverlay);
 			default:

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapModel.java
@@ -349,7 +349,7 @@ class MemoryMapModel extends AbstractSortedTableModel<MemoryBlock> {
 					if (blockType == MemoryBlockType.BIT_MAPPED ||
 						blockType == MemoryBlockType.BYTE_MAPPED) {
 
-						showMessage("Cannot change intialized memory state of a mapped Block");
+						showMessage("Cannot change initialized memory state of a mapped Block");
 						return;
 					}
 					provider.setStatusText("");
@@ -358,7 +358,7 @@ class MemoryMapModel extends AbstractSortedTableModel<MemoryBlock> {
 						initializeBlock(block);
 					}
 					else {
-						revertBlockToUnitialized(block);
+						revertBlockToUninitialized(block);
 					}
 					return;
 
@@ -392,9 +392,9 @@ class MemoryMapModel extends AbstractSortedTableModel<MemoryBlock> {
 		}
 	}
 
-	private void revertBlockToUnitialized(MemoryBlock block) {
+	private void revertBlockToUninitialized(MemoryBlock block) {
 		int result = OptionDialog.showYesNoDialog(provider.getComponent(),
-			"Confirm Setting Block To Unitialized",
+			"Confirm Setting Block To Uninitialized",
 			"Are you sure you want to remove the bytes from this block? \n\n" +
 				"This will result in removing all functions, instructions, data,\n" +
 				"and outgoing references from the block!");

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/UninitializedBlockCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/UninitializedBlockCmd.java
@@ -32,7 +32,7 @@ public class UninitializedBlockCmd extends BackgroundCommand {
 	private Program program;
 
 	public UninitializedBlockCmd(Program program, MemoryBlock block) {
-		super("Unitialize Memory Block", false, true, true);
+		super("Uninitialized Memory Block", false, true, true);
 		this.program = program;
 		this.block = block;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/navigation/NextPreviousDifferentByteAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/navigation/NextPreviousDifferentByteAction.java
@@ -108,7 +108,7 @@ public class NextPreviousDifferentByteAction extends AbstractNextPreviousAction 
 			catch (MemoryAccessException e) {
 				// should not happen as we are only iterating over "initialized memory"
 				throw new AssertException(
-					"Got MemoryAccessException when iterating over intialized memeory!");
+					"Got MemoryAccessException when iterating over initialized memory!");
 			}
 		}
 		return null;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/BundleStatusComponentProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/BundleStatusComponentProvider.java
@@ -390,7 +390,7 @@ public class BundleStatusComponentProvider extends ComponentProviderAdapter {
 					buff.append(Path.toPathString(bundle.getFile()) + "\n");
 				}
 				Msg.showWarn(this, BundleStatusComponentProvider.this.getComponent(),
-					"Unabled to remove", "System bundles cannot be removed:\n" + buff.toString());
+					"Unable to remove", "System bundles cannot be removed:\n" + buff.toString());
 			}
 			bundleHost.remove(bundles.get(false));
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/overview/addresstype/AddressTypeOverviewColorService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/overview/addresstype/AddressTypeOverviewColorService.java
@@ -282,7 +282,7 @@ public class AddressTypeOverviewColorService
 		options.registerOption("Undefined Color", DEFAULT_UNDEFINED_COLOR, help,
 			"Color for undefined bytes");
 		options.registerOption("Uninitialized Color", DEFAULT_UNINITIALIZED_COLOR, help,
-			"Color for uninitialize memory");
+			"Color for uninitialized memory");
 		options.registerOption("External Reference Color", DEFAULT_EXTERNAL_REF_COLOR, help,
 			"Color for external references");
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/progmgr/ProgramManagerPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/progmgr/ProgramManagerPlugin.java
@@ -466,7 +466,7 @@ public class ProgramManagerPlugin extends Plugin implements ProgramManager {
 	public void openProgram(final Program program, final int state) {
 		if (locked) {
 			throw new IllegalStateException(
-				"Progam manager is locked and cannot accept a new program");
+				"Program manager is locked and cannot accept a new program");
 		}
 
 		Runnable r = () -> {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/programtree/ProgramTreeModularizationPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/programtree/ProgramTreeModularizationPlugin.java
@@ -49,7 +49,7 @@ import docking.action.MenuData;
 	packageName = CorePluginPackage.NAME,
 	category = PluginCategoryNames.TREE,
 	shortDescription = "Program Tree Modularization Plugin",
-	description = "Provides actions for orgainizing a program tree into modules or fragments.  " +
+	description = "Provides actions for organizing a program tree into modules or fragments.  " +
 			"Currently there are two organizations, dominance and complexity depth",
 	servicesRequired = { BlockModelService.class }
 )

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/reloc/RelocationTablePlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/reloc/RelocationTablePlugin.java
@@ -35,7 +35,7 @@ import ghidra.util.table.actions.MakeProgramSelectionAction;
 	packageName = CorePluginPackage.NAME,
 	category = PluginCategoryNames.CODE_VIEWER,
 	shortDescription = "Displays relocation information",
-	description = "This plugin provides a component for displaying the reloction table. "
+	description = "This plugin provides a component for displaying the relocation table. "
 			+ "The table can be used to navigate in the code browser.",
 	servicesRequired = { GoToService.class },
 	eventsProduced = { ProgramLocationPluginEvent.class },

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchDialog.java
@@ -593,7 +593,7 @@ class MemSearchDialog extends DialogComponentProvider {
 		loadedBlocks.setToolTipText(HTMLUtilities.toHTML(
 			"Only searches memory blocks that are loaded in a running executable.\n  " +
 				"Ghidra now includes memory blocks for other data such as section headers.\n" +
-				"This option exludes these OTHER (non loaded) blocks."));
+				"This option excludes these OTHER (non loaded) blocks."));
 		allBlocks.setToolTipText(
 			"Searches all memory blocks including blocks that are not actually loaded in a running executable");
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchPlugin.java
@@ -381,7 +381,7 @@ public class MemSearchPlugin extends Plugin implements OptionsChangeListener,
 			"Initializes memory search byte sequence from " +
 				"the current selection provided the selection is less than 10 bytes.");
 		opt.registerOption(PluginConstants.AUTO_RESTRICT_SELECTION, true, null,
-			"Automactically adjusts memory searches restricted" +
+			"Automatically adjusts memory searches restricted" +
 				" to the current selection, as selections comes and goes");
 		opt.registerOption(GhidraOptions.OPTION_SEARCH_LIMIT, DEFAULT_SEARCH_LIMIT, null,
 			"Number of search hits found before stopping");

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/SearchTextDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/SearchTextDialog.java
@@ -283,7 +283,7 @@ class SearchTextDialog extends DialogComponentProvider {
 		commentsCB.setToolTipText(HTMLUtilities.toHTML("Search in any of the comment fields"));
 
 		labelsCB = new GCheckBox("Labels");
-		labelsCB.setToolTipText(HTMLUtilities.toHTML("Search in the Lable field"));
+		labelsCB.setToolTipText(HTMLUtilities.toHTML("Search in the Label field"));
 
 		mnemonicsCB = new GCheckBox("Instruction Mnemonics");
 		mnemonicsCB.setToolTipText(
@@ -410,7 +410,7 @@ class SearchTextDialog extends DialogComponentProvider {
 		loadedBlocksButton.setToolTipText(HTMLUtilities.toHTML(
 			"Only searches memory blocks that are loaded in a running executable.\n  " +
 				"Ghidra now includes memory blocks for other data such as section headers.\n" +
-				"This option exludes these OTHER (non loaded) blocks."));
+				"This option excludes these OTHER (non loaded) blocks."));
 		allBlocksButton.setToolTipText(
 			"Searches all memory blocks including blocks that are not actually loaded in a running executable");
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/select/RestoreSelectionPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/select/RestoreSelectionPlugin.java
@@ -43,7 +43,7 @@ import docking.tool.ToolConstants;
 	category = PluginCategoryNames.SELECTION,
 	shortDescription = "Restore Selection",
 	description = "This plugin provides the ability to restore the previous selection. " +
-	        "This is useful if you accidently lose you selection; for example, by clicking in " +
+	        "This is useful if you accidentally lose you selection; for example, by clicking in " +
 	        " the CodeBrowser.  Clicking thusly will clear any selection, which can be restored by " +
 	        "performing the " + RestoreSelectionPlugin.RESTORE_SELECTION_ACTION_NAME + " action."
 )

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/string/SearchStringDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/string/SearchStringDialog.java
@@ -276,7 +276,7 @@ public class SearchStringDialog extends DialogComponentProvider {
 		loadedBlocksRB.setToolTipText(HTMLUtilities.toHTML(
 			"Only searches memory blocks that are loaded in a running executable.\n  " +
 				"Ghidra now includes memory blocks for other data such as section headers.\n" +
-				"This option exludes these other (non-loaded) blocks."));
+				"This option excludes these other (non-loaded) blocks."));
 		allBlocksRB.setToolTipText(
 			"Searches all memory blocks including blocks that are not actually loaded in a running executable");
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/string/StringsAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/string/StringsAnalyzer.java
@@ -191,7 +191,7 @@ public class StringsAnalyzer extends AbstractAnalyzer {
 		super(NAME, DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
 		setDefaultEnablement(true);
 		setSupportsOneTimeAnalysis();
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.after().after().after().after().after());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.after().after().after().after().after());
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/debug/JavaHelpPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/debug/JavaHelpPlugin.java
@@ -145,7 +145,7 @@ public class JavaHelpPlugin extends Plugin implements FrontEndable {
 			List<HelpInfoObject> helpInfos = new ArrayList<>(map.size());
 
 			monitor.initialize(map.size());
-			monitor.setMessage("Procesing actions...");
+			monitor.setMessage("Processing actions...");
 			iter = map.keySet().iterator();
 			int i = 1;
 			while (iter.hasNext()) {
@@ -159,7 +159,7 @@ public class JavaHelpPlugin extends Plugin implements FrontEndable {
 				monitor.initialize(1);
 			}
 
-			if (helpInfos.size() == 0) {
+			if (helpInfos.isEmpty()) {
 				Msg.showInfo(this, tool.getToolFrame(), "Help Validation Complete",
 					"No items missing help were found");
 				return;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/match/ExactBytesFunctionHasher.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/match/ExactBytesFunctionHasher.java
@@ -52,7 +52,7 @@ public class ExactBytesFunctionHasher extends AbstractFunctionHasher {
 				codeUnit.getBytesInCodeUnit(buffer, offset);
 			}
 			catch (MemoryAccessException e) {
-				Msg.warn(this, "Could not get code unit bvtes at " + codeUnit.getAddress());
+				Msg.warn(this, "Could not get code unit bytes at " + codeUnit.getAddress());
 			}
 			offset += codeUnit.getLength();
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/AggressiveInstructionFinderAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/AggressiveInstructionFinderAnalyzer.java
@@ -77,7 +77,7 @@ public class AggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 		super(NAME, DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
 		setPrototype();
 		setSupportsOneTimeAnalysis();
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.after());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.after());
 		setDefaultEnablement(false);
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/ArmAggressiveInstructionFinderAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/prototype/analysis/ArmAggressiveInstructionFinderAnalyzer.java
@@ -60,7 +60,7 @@ public class ArmAggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 	public ArmAggressiveInstructionFinderAnalyzer() {
 		super(NAME, DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
 		setPrototype();
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.after());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.after());
 		setSupportsOneTimeAnalysis();
 	}
 
@@ -468,7 +468,7 @@ public class ArmAggressiveInstructionFinderAnalyzer extends AbstractAnalyzer {
 			todoSet = todoSet.subtract(cmd.getDisassembledAddressSet());
 			BookmarkEditCmd bcmd =
 				new BookmarkEditCmd(entry, BookmarkType.ANALYSIS,
-					"ARM Aggressive Intruction Finder", "Found code");
+					"ARM Aggressive Instruction Finder", "Found code");
 			bcmd.applyTo(curProgram);
 			return true;
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/script/GhidraScript.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/script/GhidraScript.java
@@ -1442,7 +1442,7 @@ public abstract class GhidraScript extends FlatProgramAPI {
 				case CUSTOM_TYPE:
 				case FILE_TYPE:
 					changeFailedMessage +=
-						"Not allowed to change settings usings strings for type: " + optionType;
+						"Not allowed to change settings using strings for type: " + optionType;
 
 				case NO_TYPE:
 				default:
@@ -1468,7 +1468,7 @@ public abstract class GhidraScript extends FlatProgramAPI {
 		Enum enumm = options.getEnum(analysisOption, null);
 		if (enumm == null) {
 			throw new IllegalStateException(
-				"Attempted to set an Enum option without an " + "existing enum value alreday set.");
+				"Attempted to set an Enum option without an existing enum value already set.");
 		}
 
 		@SuppressWarnings({ "rawtypes" })

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/services/AnalysisPriority.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/services/AnalysisPriority.java
@@ -118,8 +118,8 @@ public class AnalysisPriority {
 	 * Data type propogation analysis should hapen as late as possible so that all basic code
 	 * recovery, reference analysis, etc... has taken place.
 	 */
-	public final static AnalysisPriority DATA_TYPE_PROPOGATION =
-		FUNCTION_ID_ANALYSIS.getNext("DATA TYPE PROPOGATION");
+	public final static AnalysisPriority DATA_TYPE_PROPAGATION =
+		FUNCTION_ID_ANALYSIS.getNext("DATA TYPE PROPAGATION");
 
 	public static final AnalysisPriority LOW_PRIORITY = new AnalysisPriority("LOW", 10000);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/AoutHeaderMIPS.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/coff/AoutHeaderMIPS.java
@@ -37,7 +37,7 @@ public class AoutHeaderMIPS extends AoutHeader {
 		gp_value    = reader.readNextInt();
 	}
 
-	public int getUnitializedDataStart() {
+	public int getUninitializedDataStart() {
 		return bss_start;
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DIEAggregate.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DIEAggregate.java
@@ -779,7 +779,7 @@ public class DIEAggregate {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("DIEAgregrate of: ");
+		sb.append("DIEAggregate of: ");
 		for (DebugInfoEntry die : fragments) {
 			sb.append("DIE [").append(Long.toHexString(die.getOffset())).append("], ");
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheAccelerateInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheAccelerateInfo.java
@@ -337,7 +337,7 @@ public class DyldCacheAccelerateInfo implements StructConverter {
 		}
 		catch (CodeUnitInsertionException e) {
 			log.appendMsg(DyldCacheAccelerateInfo.class.getSimpleName(),
-				"Failed to markup dependences.");
+				"Failed to markup dependencies.");
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldCacheHeader.java
@@ -692,7 +692,7 @@ public class DyldCacheHeader implements StructConverter {
 		if (accelerateInfoAddr == 0) {
 			return;
 		}
-		monitor.setMessage("Parsing DYLD accelerateor info...");
+		monitor.setMessage("Parsing DYLD accelerator info...");
 		monitor.initialize(imagesTextCount);
 		try {
 			Address addr = space.getAddress(accelerateInfoAddr);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
@@ -129,9 +129,9 @@ public class FileHeader implements StructConverter {
 	private final static int LORDPE_NUMBER_OF_SYMBOLS = 0x5D455064;
 
 	public final static String[] CHARACTERISTICS = { "Relocation info stripped from file",
-		"File is executable  (i.e. no unresolved externel references)",
-		"Line nunbers stripped from file", "Local symbols stripped from file",
-		"Agressively trim working set", "App can handle >2gb addresses",
+		"File is executable  (i.e. no unresolved external references)",
+		"Line numbers stripped from file", "Local symbols stripped from file",
+		"Aggressively trim working set", "App can handle >2gb addresses",
 		"Bytes of machine word are reversed", "32 bit word machine",
 		"Debugging info stripped from file in .DBG file",
 		"If Image is on removable media, copy and run from the swap file",

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliAbstractSig.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliAbstractSig.java
@@ -510,7 +510,7 @@ public abstract class CliAbstractSig extends CliBlob implements CliRepresentable
 
 			if (genericParamCount > 0) {
 				struct.add(getDataTypeForBytes(sizeOfGenericCount), "GenParamCount",
-					"Number of generic paramameters for the method");
+					"Number of generic parameters for the method");
 			}
 			struct.add(getDataTypeForBytes(sizeOfCount), "ParamCount",
 				"Number of parameter types to follow RetType");

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliBlobCustomAttrib.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliBlobCustomAttrib.java
@@ -432,7 +432,7 @@ public class CliBlobCustomAttrib extends CliBlob {
 
 					default:
 						Msg.info(this,
-							"A CustomAttrib with an unprocessed element type was deteceted: " +
+							"A CustomAttrib with an unprocessed element type was detected: " +
 								param.getRepresentation());
 				}
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodDef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodDef.java
@@ -88,7 +88,7 @@ public class CliSigMethodDef extends CliAbstractSig {
 		struct.add(BYTE, "Flags", "ORed VARARG/GENERIC/HASTHIS/EXPLICITTHIS"); // TODO: enum
 		if (genericParamCount > 0) {
 			struct.add(getDataTypeForBytes(sizeOfGenericCount), "GenParamCount",
-				"Number of generic paramameters for the method");
+				"Number of generic parameters for the method");
 		}
 		struct.add(getDataTypeForBytes(sizeOfCount), "Count",
 			"Number of parameter types to follow RetType");

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodRef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/blobs/CliSigMethodRef.java
@@ -95,7 +95,7 @@ public class CliSigMethodRef extends CliAbstractSig {
 		struct.add(BYTE, "Flags", "ORed VARARG/GENERIC/HASTHIS/EXPLICITTHIS");
 		if (genericParamCount > 0) {
 			struct.add(getDataTypeForBytes(sizeOfGenericCount), "GenParamCount",
-				"Number of generic paramameters for the method");
+				"Number of generic parameters for the method");
 		}
 		struct.add(getDataTypeForBytes(sizeOfCount), "ParamCount",
 			"Number of parameter types to follow RetType");

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/flags/CliFlags.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/cli/tables/flags/CliFlags.java
@@ -129,7 +129,7 @@ public class CliFlags {
 			add(prefix+"Contravariant", 0x0002);
 			add(prefix+"ReferenceTypeConstraint", 0x0004);
 			add(prefix+"NotNullableValueTypeConstraint", 0x0008);
-			add(prefix+"DefaultConstructorContstraint", 0x0010);
+			add(prefix+"DefaultConstructorConstraint", 0x0010);
 		}
 	}
 	

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/ContainerHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/ContainerHeader.java
@@ -97,7 +97,7 @@ public class ContainerHeader implements StructConverter {
 			SectionHeader section = new SectionHeader(_reader);
 			if (section.getSectionKind() == SectionKind.Loader) {
 				if (_loader != null) {
-					throw new PefException("Multple loader sections exist!");
+					throw new PefException("Multiple loader sections exist!");
 				}
 				_loader = new LoaderInfoHeader(_reader, section);
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/demangler/CharacterIterator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/demangler/CharacterIterator.java
@@ -220,6 +220,6 @@ public class CharacterIterator {
 
 	@Override
 	public String toString() {
-		return "currnt = " + peek() + "; next = " + peek(1);
+		return "current = " + peek() + "; next = " + peek(1);
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/html/HTMLDataTypeRepresentation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/html/HTMLDataTypeRepresentation.java
@@ -257,7 +257,7 @@ public abstract class HTMLDataTypeRepresentation {
 			commentLines = commentLines.subList(0, maxLines - 1);
 			// use the last line to indicate there is more content that could not be displayed
 			commentLines.add(MIDDLE_COMMENT + "<i>" + (origCommentLineCount - maxLines + 1) +
-				" lines ommitted...</i>" + BR);
+				" lines omitted...</i>" + BR);
 		}
 
 		List<TextLine> newList = new ArrayList<>();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/navigation/GoToAddressLabelDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/navigation/GoToAddressLabelDialog.java
@@ -218,7 +218,7 @@ public class GoToAddressLabelDialog extends DialogComponentProvider implements G
 		inner.add(caseSensitiveBox, gbc);
 
 		includeDynamicBox = new GCheckBox("Dynamic labels", true);
-		includeDynamicBox.setToolTipText("Include dynamic lables in the search (slower)");
+		includeDynamicBox.setToolTipText("Include dynamic labels in the search (slower)");
 		gbc.gridx = 1;
 		inner.add(includeDynamicBox, gbc);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
@@ -186,7 +186,7 @@ public class ElfLoaderOptionsFactory {
 			space.getAddress(Long.parseUnsignedLong(value, 16), true);// verify valid address
 		}
 		catch (NumberFormatException e) {
-			return "Invalid " + name + " - expecting hexidecimal address offset";
+			return "Invalid " + name + " - expecting hexadecimal address offset";
 		}
 		catch (AddressOutOfBoundsException e) {
 			return "Invalid " + name + " - " + e.getMessage();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/BytesFieldFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/BytesFieldFactory.java
@@ -95,7 +95,7 @@ public class BytesFieldFactory extends FieldFactory {
 		fieldOptions.registerOption(MAX_DISPLAY_LINES_MSG, 3, hl,
 			"The maximum number of lines used to display bytes.");
 		fieldOptions.registerOption(BYTE_GROUP_SIZE_MSG, 1, hl,
-			"The number of bytes to group together without delimeters in the bytes field.");
+			"The number of bytes to group together without delimiters in the bytes field.");
 		fieldOptions.registerOption(DISPLAY_UCASE_MSG, false, hl,
 			"Displays the hex digits in upper case in the bytes field");
 		fieldOptions.registerOption(REVERSE_INSTRUCTION_BYTE_ORDERING, false, hl,

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/OptionsBasedDataTypeDisplayOptions.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/OptionsBasedDataTypeDisplayOptions.java
@@ -47,7 +47,7 @@ public class OptionsBasedDataTypeDisplayOptions implements DataTypeDisplayOption
 				"operand references (e.g., STR_01234567)");
 		options.registerOption(MAXIMUM_DEFAULT_LABEL_LENGTH,
 			DataTypeDisplayOptions.MAX_LABEL_STRING_LENGTH, null,
-			"Sets the maximumn number of characters from a String to include in dynamic " +
+			"Sets the maximum number of characters from a String to include in dynamic " +
 				"String labels in operand references");
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/listingpanel/DualListingGoToService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/listingpanel/DualListingGoToService.java
@@ -147,14 +147,14 @@ class DualListingGoToService implements GoToService {
 	@Override
 	public boolean goToExternalLocation(ExternalLocation extLoc, boolean checkNavigationOption) {
 		throw new UnsupportedOperationException(
-			"Connot Go To an external address from a dual listing view.");
+			"Cannot Go To an external address from a dual listing view.");
 	}
 
 	@Override
 	public boolean goToExternalLocation(Navigatable navigatable, ExternalLocation extLoc,
 			boolean checkNavigationOption) {
 		throw new UnsupportedOperationException(
-			"Connot Go To an external address from a dual listing view.");
+			"Cannot Go To an external address from a dual listing view.");
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FSUtilities.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FSUtilities.java
@@ -514,7 +514,7 @@ public class FSUtilities {
 
 		Objects.requireNonNull(path);
 		if (extLevel < 1) {
-			throw new IllegalArgumentException("Bad extention level: " + extLevel);
+			throw new IllegalArgumentException("Bad extension level: " + extLevel);
 		}
 
 		for (int i = path.length() - 1; i >= 0; i--) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemRef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemRef.java
@@ -77,7 +77,7 @@ public class FileSystemRef implements Closeable {
 	@Override
 	public void finalize() {
 		if (!refClosed) {
-			Msg.warn(this, "Unclosed FilesytemRef: " + fs.toString());
+			Msg.warn(this, "Unclosed FileSystemRef: " + fs.toString());
 		}
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemRefManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemRefManager.java
@@ -166,7 +166,7 @@ public class FileSystemRefManager {
 		// where instances are created and thrown away without a close() to probe
 		// filesystem container files.
 		if (fs != null && !(fs instanceof GFileSystemBase)) {
-			Msg.warn(this, "Unclosed FilesytemRefManager for filesystem: " + fs.getClass() + ", " +
+			Msg.warn(this, "Unclosed FileSytemRefManager for filesystem: " + fs.getClass() + ", " +
 				fs.getName());
 		}
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
@@ -733,7 +733,7 @@ public class FileSystemService {
 
 		String fsType = fsFactoryMgr.getFileSystemType(fsClass);
 		if (fsType == null) {
-			Msg.error(this, "Specific file system implemention " + fsClass.getName() +
+			Msg.error(this, "Specific file system implementation " + fsClass.getName() +
 				" not registered correctly in file system factory.");
 			return null;
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/factory/FileSystemFactoryMgr.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/factory/FileSystemFactoryMgr.java
@@ -81,7 +81,7 @@ public class FileSystemFactoryMgr {
 			Msg.error(this,
 				"GFileSystem type '" + fsir.getType() + "' registered more than one time: " +
 					fsClass.getName() + ", " + prevFSI.getFSClass().getName() +
-					", ommitting second instance.");
+					", omitting second instance.");
 			return;
 		}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/fileinfo/FileAttributeTypeGroup.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/fileinfo/FileAttributeTypeGroup.java
@@ -26,7 +26,7 @@ public enum FileAttributeTypeGroup {
 	PERMISSION_INFO("Permission Info"),
 	ENCRYPTION_INFO("Encryption Info"),
 	MISC_INFO("Misc"),
-	ADDITIONAL_INFO("Addional Info");
+	ADDITIONAL_INFO("Additional Info");
 
 	private final String descriptiveName;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/graph/CodeFlowGraphType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/graph/CodeFlowGraphType.java
@@ -19,7 +19,7 @@ public class CodeFlowGraphType extends ProgramGraphType {
 
 	public CodeFlowGraphType() {
 		super("Code Flow Graph",
-			"Shows code block flow (similar to Block Flow graph type, but shows the code in each veretx)");
+			"Shows code block flow (similar to Block Flow graph type, but shows the code in each vertex)");
 	}
 
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/plugins/importer/tasks/ImportBatchTask.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugins/importer/tasks/ImportBatchTask.java
@@ -137,7 +137,7 @@ public class ImportBatchTask extends Task {
 			LoadSpec loadSpec = batchLoadConfig.getLoadSpec(selectedBatchGroupLoadSpec);
 			if (loadSpec == null) {
 				Msg.error(this,
-					"Failed to get load spec from application that matches choosen batch load spec " +
+					"Failed to get load spec from application that matches chosen batch load spec " +
 						selectedBatchGroupLoadSpec);
 				return;
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/ContextEvaluator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/ContextEvaluator.java
@@ -21,7 +21,7 @@ import ghidra.program.model.pcode.Varnode;
 import ghidra.program.model.symbol.RefType;
 
 /**
- * ContextEvaluator provides a callback mechanism for the SymbolicPropogator as code is evaluated.
+ * ContextEvaluator provides a callback mechanism for the SymbolicPropagator as code is evaluated.
  * 
  */
 public interface ContextEvaluator {

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/ContextEvaluatorAdapter.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/ContextEvaluatorAdapter.java
@@ -21,7 +21,7 @@ import ghidra.program.model.pcode.Varnode;
 import ghidra.program.model.symbol.RefType;
 
 /**
- * Default behavior implementation of ContextEvaluator passed to SymbolicPropogator
+ * Default behavior implementation of ContextEvaluator passed to SymbolicPropagator
  * 
  * Override methods to inspect context.
  * 

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/ELFExternalSymbolResolver.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/ELFExternalSymbolResolver.java
@@ -104,7 +104,7 @@ public class ELFExternalSymbolResolver {
 				}
 				catch (VersionException e) {
 					messageLog.appendMsg(
-						"Referenced external program requires updgrade, unable to consider symbols: " +
+						"Referenced external program requires upgrade, unable to consider symbols: " +
 							libPath);
 				}
 				finally {

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/SymbolicPropagator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/SymbolicPropagator.java
@@ -39,7 +39,7 @@ import ghidra.util.Msg;
 import ghidra.util.exception.*;
 import ghidra.util.task.TaskMonitor;
 
-public class SymbolicPropogator {
+public class SymbolicPropagator {
 	private static int LRU_SIZE = 4096;
 	// QUESTIONS
 	// 1. How are "register-relative" varnodes distinguished based upon target space ?  Not sure how we handle wrapping/truncation concerns.
@@ -91,7 +91,7 @@ public class SymbolicPropogator {
 	// Cache instructions looked up by containing
 	Map<Address, Instruction> instructionContainingCache = new LRUMap<>(LRU_SIZE);
 
-	public SymbolicPropogator(Program program) {
+	public SymbolicPropagator(Program program) {
 		this.program = program;
 
 		Language language = program.getLanguage();
@@ -252,7 +252,7 @@ public class SymbolicPropogator {
 
 	/**
 	 * <code>Value</code> corresponds to a constant value or register relative value.
-	 * @see SymbolicPropogator#getRegisterValue(Address, Register)
+	 * @see SymbolicPropagator#getRegisterValue(Address, Register)
 	 */
 	public class Value {
 		final Register relativeRegister;
@@ -361,7 +361,7 @@ public class SymbolicPropogator {
 		int spaceID = context.getAddressSpace(stackReg.getName());
 		Varnode vnode = context.createVarnode(0, spaceID, stackReg.getBitLength() / 8);
 		context.putValue(context.getRegisterVarnode(stackReg), vnode, false);
-		context.propogateResults(false);
+		context.propagateResults(false);
 		context.flowEnd(addr);
 	}
 
@@ -857,8 +857,8 @@ public class SymbolicPropogator {
 						catch (NotFoundException e) {
 							// constant not found, ignore
 						}
-						// even though we don't know the destination, propogate the flow to attached destinations
-						vContext.propogateResults(false);
+						// even though we don't know the destination, propagate the flow to attached destinations
+						vContext.propagateResults(false);
 						Reference[] flowRefs = instruction.getReferencesFrom();
 						for (Reference flowRef : flowRefs) {
 							RefType referenceType = flowRef.getReferenceType();
@@ -928,7 +928,7 @@ public class SymbolicPropogator {
 
 						if (target != null) {
 							if (target.isMemoryAddress()) {
-								vContext.propogateResults(false);
+								vContext.propagateResults(false);
 								vContext.mergeToFutureFlowState(minInstrAddress, target);
 							}
 							func = prog.getFunctionManager().getFunctionAt(target);
@@ -1005,7 +1005,7 @@ public class SymbolicPropogator {
 							throw new AssertException("Not a valid Address on instruction at " +
 								instruction.getAddress());
 						}
-						vContext.propogateResults(false);
+						vContext.propagateResults(false);
 						vContext.mergeToFutureFlowState(minInstrAddress, in[0].getAddress());
 						pcodeIndex = ops.length; // break out of the processing
 						break;
@@ -1016,14 +1016,14 @@ public class SymbolicPropogator {
 						if (internalBranch) {
 							int sequenceOffset = (int) in[0].getOffset();
 							if ((pcodeIndex + sequenceOffset) >= ops.length) {
-								vContext.propogateResults(false);
+								vContext.propagateResults(false);
 								vContext.mergeToFutureFlowState(minInstrAddress,
 									instruction.getFallThrough());
 							}
 						}
 						else if (in[0].isAddress()) {
 							vt = in[0];
-							vContext.propogateResults(false);
+							vContext.propagateResults(false);
 							vContext.mergeToFutureFlowState(minInstrAddress, in[0].getAddress());
 						}
 
@@ -1063,7 +1063,7 @@ public class SymbolicPropogator {
 								if (i == sequenceOffset) {
 									if (fallThru != null) {
 										// we don't know what will happen from here on, but anything before should in theory propagate
-										vContext.propogateResults(true);
+										vContext.propagateResults(true);
 										vContext.mergeToFutureFlowState(minInstrAddress,
 											instruction.getFallThrough());
 									}
@@ -1432,7 +1432,7 @@ public class SymbolicPropogator {
 			}
 		}
 
-		vContext.propogateResults(true);
+		vContext.propagateResults(true);
 
 		Address fallthru = instruction.getFallThrough();
 		if (ptype == PcodeOp.BRANCH || ptype == PcodeOp.RETURN || ptype == PcodeOp.BRANCHIND) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/VarnodeContext.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/VarnodeContext.java
@@ -744,13 +744,13 @@ public class VarnodeContext implements ProcessorContext {
 	}
 
 	/**
-	 * Propogate any results that are in the value cache.
+	 * Propagate any results that are in the value cache.
 	 * 
 	 * @param clearContext  true if the cache should be cleared.
 	 *                      The propogation could be for flow purposes, and the
 	 *                      processing of the instruction is finished, so it's effects should be kept.
 	 */
-	public void propogateResults(boolean clearContext) {
+	public void propagateResults(boolean clearContext) {
 		Iterator<Entry<Varnode, Varnode>> iter = tempVals.entrySet().iterator();
 
 		while (iter.hasNext()) {
@@ -772,7 +772,7 @@ public class VarnodeContext implements ProcessorContext {
 				val = null;
 			}
 			if (val != null) {
-				propogateValue(reg, node, val, offsetContext.getAddress());
+				propagateValue(reg, node, val, offsetContext.getAddress());
 			}
 			else {
 				if (debug) {
@@ -790,7 +790,7 @@ public class VarnodeContext implements ProcessorContext {
 		}
 	}
 
-	public void propogateValue(Register reg, Varnode node, Varnode val, Address address) {
+	public void propagateValue(Register reg, Varnode node, Varnode val, Address address) {
 		if (debug) {
 			Msg.info(this, "   " + reg.getName() + "<-" + val.toString() + " at " +
 				offsetContext.getAddress());
@@ -1446,7 +1446,7 @@ public class VarnodeContext implements ProcessorContext {
 	public void setValue(Register register, BigInteger value) {
 		Varnode regVnode = trans.getVarnode(register);
 		putValue(regVnode, createConstantVarnode(value.longValue(), regVnode.getSize()), false);
-		propogateResults(false);
+		propagateResults(false);
 	}
 
 	public boolean isSymbol(Varnode node) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/EmulatorTestRunner.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/EmulatorTestRunner.java
@@ -476,7 +476,7 @@ public class EmulatorTestRunner {
 					// enter printf function
 					printfCallAddr = lastAddress;
 					memoryFilter.enabled = false;
-					executionListener.log(testGroup, "printf invocation (log supressed) ...");
+					executionListener.log(testGroup, "printf invocation (log suppressed) ...");
 				}
 				else if (printfCallAddr != null && isPrintfReturn(executeAddr, printfCallAddr)) {
 					// return from printf function 

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/state/ResultsState.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/state/ResultsState.java
@@ -599,7 +599,7 @@ public class ResultsState {
 		Varnode output = pcodeOp.getOutput();
 		Varnode result;
 		if (!values[0].isConstant()) {
-			throw new AssertException("Expected constatnt address space ID");
+			throw new AssertException("Expected constant address space ID");
 		}
 		int spaceId = (int) values[0].getOffset();
 		AddressSpace addressSpace = addrFactory.getAddressSpace(spaceId);
@@ -698,7 +698,7 @@ public class ResultsState {
 
 			case PcodeOp.STORE:
 				if (!values[0].isConstant()) {
-					throw new AssertException("Expected constatnt address space ID");
+					throw new AssertException("Expected constant address space ID");
 				}
 				int spaceId = (int) values[0].getOffset();
 				AddressSpace addressSpace = addrFactory.getAddressSpace(spaceId);
@@ -1246,7 +1246,7 @@ public class ResultsState {
 				if (values[1].isConstant() && values[0].isConstant()) {
 					if (values[1].getOffset() == 0) {
 						Msg.warn(ResultsState.class,
-							"Divide by zero encounteerd during emulation at " +
+							"Divide by zero encountered during emulation at " +
 								pcodeOp.getSeqnum().getTarget());
 					}
 					else {
@@ -1264,7 +1264,7 @@ public class ResultsState {
 				if (values[1].isConstant() && values[0].isConstant()) {
 					if (values[1].getOffset() == 0) {
 						Msg.warn(ResultsState.class,
-							"Divide by zero encounteerd during emulation at " +
+							"Divide by zero encountered during emulation at " +
 								pcodeOp.getSeqnum().getTarget());
 					}
 					else {
@@ -1279,7 +1279,7 @@ public class ResultsState {
 				if (values[1].isConstant() && values[0].isConstant()) {
 					if (values[1].getOffset() == 0) {
 						Msg.warn(ResultsState.class,
-							"Divide by zero encounteerd during emulation at " +
+							"Divide by zero encountered during emulation at " +
 								pcodeOp.getSeqnum().getTarget());
 					}
 					else {
@@ -1297,7 +1297,7 @@ public class ResultsState {
 				if (values[1].isConstant() && values[0].isConstant()) {
 					if (values[1].getOffset() == 0) {
 						Msg.warn(ResultsState.class,
-							"Divide by zero encounteerd during emulation at " +
+							"Divide by zero encountered during emulation at " +
 								pcodeOp.getSeqnum().getTarget());
 					}
 					else {

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/table/actions/DeleteTableRowAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/table/actions/DeleteTableRowAction.java
@@ -109,7 +109,7 @@ public class DeleteTableRowAction extends DockingAction {
 		TableModel model = table.getModel();
 		if (!(model instanceof RowObjectTableModel)) {
 			throw new AssertException("This action cannot delete rows for the given table model." +
-				"You can override this method to peform the delete action yourself.");
+				"You can override this method to perform the delete action yourself.");
 		}
 
 		if (checkForBusy(model)) {
@@ -138,7 +138,7 @@ public class DeleteTableRowAction extends DockingAction {
 
 		if (!(model instanceof ThreadedTableModel)) {
 			throw new AssertException("This action cannot delete rows for the given table model." +
-				"You can override this method to peform the delete action yourself.");
+				"You can override this method to perform the delete action yourself.");
 		}
 
 		ThreadedTableModel<Object, Object> threadedModel =

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/table/field/FunctionInlineSettingsDefinition.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/table/field/FunctionInlineSettingsDefinition.java
@@ -26,7 +26,7 @@ public class FunctionInlineSettingsDefinition implements BooleanSettingsDefiniti
 	private static final String INLINE = "Show inline";
 	private static final String NAME = INLINE;
 	private static final String DESCRIPTION =
-		"On siganls to show the inline " + "function attribute when present";
+		"On signals to show the inline function attribute when present";
 	private static final boolean DEFAULT = false;
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/table/field/FunctionThunkSettingsDefinition.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/table/field/FunctionThunkSettingsDefinition.java
@@ -25,7 +25,7 @@ public class FunctionThunkSettingsDefinition implements BooleanSettingsDefinitio
 	private static final String THUNK = "Show thunk";
 	private static final String NAME = THUNK;
 	private static final String DESCRIPTION =
-		"On siganls to show the thunk " + "function attribute when present";
+		"On signals to show the thunk function attribute when present";
 	private static final boolean DEFAULT = true;
 
 	@Override

--- a/Ghidra/Features/Base/src/test.slow/java/docking/action/KeyEntryDialogTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/docking/action/KeyEntryDialogTest.java
@@ -244,7 +244,7 @@ public class KeyEntryDialogTest extends AbstractGhidraHeadedIntegrationTest {
 			(Map<KeyStroke, DockingKeyBindingAction>) getInstanceField("dockingKeyMap", kbm);
 		KeyStroke ks = KeyStroke.getKeyStroke(KeyEvent.VK_F4, 0);
 		DockingKeyBindingAction dockingAction = dockingKeyMap.get(ks);
-		DockingAction f4Action = (DockingAction) getInstanceField("docakbleAction", dockingAction);
+		DockingAction f4Action = (DockingAction) getInstanceField("dockableAction", dockingAction);
 		return f4Action;
 	}
 

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/merge/tree/ProgramTreeMergeManager3Test.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/merge/tree/ProgramTreeMergeManager3Test.java
@@ -817,7 +817,7 @@ public class ProgramTreeMergeManager3Test extends AbstractProgramTreeMergeManage
 					root.removeChild("Strings");
 				}
 				catch (NotEmptyException e) {
-					Assert.fail("Got Not Empty exeception!");
+					Assert.fail("Got Not Empty exception!");
 				}
 				finally {
 					program.endTransaction(transactionID, true);
@@ -873,7 +873,7 @@ public class ProgramTreeMergeManager3Test extends AbstractProgramTreeMergeManage
 						root.removeChild(".text");
 					}
 					catch (NotEmptyException e) {
-						Assert.fail("Got Not Empty exeception!");
+						Assert.fail("Got Not Empty exception!");
 					}
 				}
 				finally {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/AutoAnalysisWorkerTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/AutoAnalysisWorkerTest.java
@@ -103,9 +103,9 @@ public class AutoAnalysisWorkerTest extends AbstractGhidraHeadedIntegrationTest 
 			// Can't invoke action since we are in background task here
 
 			Options list = p.getOptions("TEST");
-			assertTrue("Higher priorty analysis task failed to run first",
+			assertTrue("Higher priority analysis task failed to run first",
 				list.getBoolean("p0", false));
-			assertTrue("Lower priorty analysis task failed to run last",
+			assertTrue("Lower priority analysis task failed to run last",
 				!list.getBoolean("p1", false));
 
 			cb.goToField(addr("0x1001100"), "Operands", 0, 0);

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/disassembler/DisassembledViewPluginTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/disassembler/DisassembledViewPluginTest.java
@@ -251,7 +251,7 @@ public class DisassembledViewPluginTest extends AbstractGhidraHeadedIntegrationT
 		Font currentFont = opt.getFont(optionToChange, (Font) optionsMap.get("font"));
 		opt.setFont(optionToChange, currentFont.deriveFont((float) currentFont.getSize() + 1));
 
-		// now make sure that the changes have been propogated
+		// now make sure that the changes have been propagated
 		for (int i = 0; i < fieldNames.length; i++) {
 
 			Object newValue = getInstanceField(fieldNames[i], componentProvider);

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/equate/EquatePlugin1Test.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/equate/EquatePlugin1Test.java
@@ -782,9 +782,9 @@ public class EquatePlugin1Test extends AbstractEquatePluginTest {
 		assertFalse("Couldn't find equate", et.getEquates(addr3, 0).isEmpty());
 
 		// These are not 0x2 values in the selection that should not have been converted.
-		assertTrue("Equate should't have been made", et.getEquates(addr2, 1).isEmpty());
-		assertTrue("Equate should't have been made", et.getEquates(addr4, 0).isEmpty());
-		assertTrue("Equate should't have been made", et.getEquates(addr5, 0).isEmpty());
+		assertTrue("Equate shouldn't have been made", et.getEquates(addr2, 1).isEmpty());
+		assertTrue("Equate shouldn't have been made", et.getEquates(addr4, 0).isEmpty());
+		assertTrue("Equate shouldn't have been made", et.getEquates(addr5, 0).isEmpty());
 	}
 
 	@Test

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/label/AddEditDialoglTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/label/AddEditDialoglTest.java
@@ -746,7 +746,7 @@ public class AddEditDialoglTest extends AbstractGhidraHeadedIntegrationTest {
 		String nsName = functionName;
 		setText(nsName + Namespace.DELIMITER + functionName);
 		pressOk();
-		assertFalse("Rename unsuccesful", dialog.isShowing());
+		assertFalse("Rename unsuccessful", dialog.isShowing());
 
 		Symbol newFunction = getSymbol(functionName);
 		Namespace parentNs = newFunction.getParentNamespace();

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/memory/AddBlockModelTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/memory/AddBlockModelTest.java
@@ -236,7 +236,7 @@ public class AddBlockModelTest extends AbstractGhidraHeadedIntegrationTest
 		model.setStartAddress(getAddr(0x100));
 		model.setLength(100);
 		model.setBlockType(MemoryBlockType.BIT_MAPPED);
-		assertEquals(InitializedType.UNITIALIZED, model.getInitializedType());
+		assertEquals(InitializedType.UNINITIALIZED, model.getInitializedType());
 		model.setBaseAddress(getAddr(0x2000));
 
 		assertTrue(model.execute());
@@ -251,7 +251,7 @@ public class AddBlockModelTest extends AbstractGhidraHeadedIntegrationTest
 		model.setStartAddress(getAddr(0x100));
 		model.setLength(100);
 		model.setBlockType(MemoryBlockType.BYTE_MAPPED);
-		assertEquals(InitializedType.UNITIALIZED, model.getInitializedType());
+		assertEquals(InitializedType.UNINITIALIZED, model.getInitializedType());
 		model.setBaseAddress(getAddr(0x2000));
 
 		assertTrue(model.execute());

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/memory/MemoryMapProvider1Test.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/memory/MemoryMapProvider1Test.java
@@ -482,7 +482,7 @@ public class MemoryMapProvider1Test extends AbstractGhidraHeadedIntegrationTest 
 	@Test
 	public void testSortBlockType() throws Exception {
 
-		// add a bit overlay block, live block, and an unitialized block
+		// add a bit overlay block, live block, and an uninitialized block
 		int transactionID = program.startTransaction("test");
 		memory.createBitMappedBlock(".Bit", getAddr(0), getAddr(0x01001000), 0x100, false);
 		memory.createUninitializedBlock(".Uninit", getAddr(0x3000), 0x200, false);
@@ -508,7 +508,7 @@ public class MemoryMapProvider1Test extends AbstractGhidraHeadedIntegrationTest 
 
 	@Test
 	public void testSortBlockTypeDescending() throws Exception {
-		// add a bit overlay block, live block, and an unitialized block
+		// add a bit overlay block, live block, and an uninitialized block
 		int transactionID = program.startTransaction("test");
 		memory.createBitMappedBlock(".Bit", getAddr(0), getAddr(0x01001000), 0x100, false);
 		memory.createUninitializedBlock(".Uninit", getAddr(0x3000), 0x200, false);

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/processors/ShowInstructionInfoPluginTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/processors/ShowInstructionInfoPluginTest.java
@@ -160,7 +160,7 @@ public class ShowInstructionInfoPluginTest extends AbstractGhidraHeadedIntegrati
 		assertNull("The current Instruction is not null as expected.", currentInstruction);
 		assertTrue(
 			"The tables of the component provider have data even " +
-				"though there is not Instruction selected in the proram.",
+				"though there is not Instruction selected in the program.",
 			!componentProviderTablesHaveData());
 
 		// change to a valid instruction        
@@ -233,7 +233,7 @@ public class ShowInstructionInfoPluginTest extends AbstractGhidraHeadedIntegrati
 		// make sure there are no contents in the display
 		assertTrue(
 			"The tables of the component provider have data even " +
-				"though there is not Instruction selected in the proram.",
+				"though there is not Instruction selected in the program.",
 			!componentProviderTablesHaveData());
 
 		// decompile at the location

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/script/GhidraScriptAskMethodsTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/script/GhidraScriptAskMethodsTest.java
@@ -138,7 +138,7 @@ public class GhidraScriptAskMethodsTest extends AbstractGhidraHeadedIntegrationT
 				container[0] = script.askProgram("Test - Pick Program");
 			}
 			catch (Exception ioe) {
-				failWithException("Caught unexepected during askProgram()", ioe);
+				failWithException("Caught unexpected during askProgram()", ioe);
 			}
 		}, false);
 

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/MemoryBlockUtilTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/MemoryBlockUtilTest.java
@@ -94,7 +94,7 @@ public class MemoryBlockUtilTest extends AbstractGhidraHeadedIntegrationTest {
 	}
 
 	@Test
-	public void testGetByteOnUnitializedBlock() {
+	public void testGetByteOnUninitializedBlock() {
 		MemoryBlock block = MemoryBlockUtils.createUninitializedBlock(prog, false, "a",
 			space.getAddress(3000), 1000, "Acomment", "Asource", true, true, true, log);
 		try {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/viewer/field/XRefFieldFactoryTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/viewer/field/XRefFieldFactoryTest.java
@@ -498,7 +498,7 @@ public class XRefFieldFactoryTest extends AbstractGhidraHeadedIntegrationTest {
 			}
 		}
 
-		fail("Uanble to find text at " + Long.toHexString(addrOffset) + "; text: '" + text + "'");
+		fail("Unable to find text at " + Long.toHexString(addrOffset) + "; text: '" + text + "'");
 	}
 
 	private String getRowText(ListingTextField tf, int row) {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/framework/main/datatree/FrontEndPluginActionsTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/framework/main/datatree/FrontEndPluginActionsTest.java
@@ -793,7 +793,7 @@ public class FrontEndPluginActionsTest extends AbstractGhidraHeadedIntegrationTe
 
 	private void assertProgramName(GTable table, String programName) {
 		int row = getRow(table, programName);
-		assertTrue("No row exsists for '" + programName + "'", row != -1);
+		assertTrue("No row exists for '" + programName + "'", row != -1);
 	}
 
 	private int getRow(GTable table, String programName) {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/framework/plugintool/dialog/KeyBindingsTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/framework/plugintool/dialog/KeyBindingsTest.java
@@ -107,8 +107,8 @@ public class KeyBindingsTest extends AbstractGhidraHeadedIntegrationTest {
 		String escaped = description.replaceAll("&", "&amp;");
 		assertTrue(
 			"Description is not updated for action '" + action1.getName() + "'; instead the " +
-				"description is '" + actualText + "'\n\tDescrption: " + escaped,
-			actualText.indexOf(escaped) != -1);
+				"description is '" + actualText + "'\n\tDescription: " + escaped,
+				actualText.contains(escaped));
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class KeyBindingsTest extends AbstractGhidraHeadedIntegrationTest {
 		for (DockingActionIf action : list) {
 			if (!ignoreAction(action)) {
 				boolean inTable = actionInKeyBindingsTable(action);
-				assertTrue("Action should be in the key bindingds table: " + action.getFullName(),
+				assertTrue("Action should be in the key bindings table: " + action.getFullName(),
 					inTable);
 			}
 		}

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/framework/project/tool/ConnectToolsTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/framework/project/tool/ConnectToolsTest.java
@@ -98,7 +98,7 @@ public class ConnectToolsTest extends AbstractGhidraHeadedIntegrationTest {
 		}
 		if (tc.isConnected(BAD_EVENT_NAME)) {
 			Assert.fail("Connect Tools Failed: " + producer.getName() + " and " +
-				consumer.getName() + " conncted for BAD EVENT");
+				consumer.getName() + " connected for BAD EVENT");
 		}
 
 		//

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/program/database/ObjectCacheTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/program/database/ObjectCacheTest.java
@@ -44,7 +44,7 @@ public class ObjectCacheTest extends AbstractGhidraHeadedIntegrationTest {
 		obj1.setInvalid();
 		try {
 			obj1.setValue(10);
-			fail("Should have thrown a concurrent modification excption here.");
+			fail("Should have thrown a concurrent modification exception here.");
 		}
 		catch (ConcurrentModificationException e) {
 			// expected
@@ -57,7 +57,7 @@ public class ObjectCacheTest extends AbstractGhidraHeadedIntegrationTest {
 		cache.delete(1);
 		try {
 			obj1.setValue(10);
-			fail("Should have thrown a concurrent modification excption here.");
+			fail("Should have thrown a concurrent modification exception here.");
 		}
 		catch (ConcurrentModificationException e) {
 			// expected

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/program/model/data/StructureFactoryTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/program/model/data/StructureFactoryTest.java
@@ -202,7 +202,7 @@ public class StructureFactoryTest extends AbstractGhidraHeadedIntegrationTest {
 			StructureFactory.createStructureDataType(program, structureAddress, structureLength,
 				null, true);
 
-			Assert.fail("Did not receive an exception when passing a dupicate name.");
+			Assert.fail("Did not receive an exception when passing a duplicate name.");
 		}
 		catch (IllegalArgumentException iae) {
 			// good, expected

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/util/bean/opteditor/OptionsDialogTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/util/bean/opteditor/OptionsDialogTest.java
@@ -429,7 +429,7 @@ public class OptionsDialogTest extends AbstractGhidraHeadedIntegrationTest {
 		restoreDefaults();
 
 		KeyStroke currentBinding = getKeyBinding(actionName);
-		assertEquals("Key binding not restored after a call to restore defautls", defaultKeyStroke,
+		assertEquals("Key binding not restored after a call to restore defaults", defaultKeyStroke,
 			currentBinding);
 		assertOptionsKeyStroke(actionName, pluginName, defaultKeyStroke);
 	}
@@ -455,7 +455,7 @@ public class OptionsDialogTest extends AbstractGhidraHeadedIntegrationTest {
 		restoreDefaults();
 
 		KeyStroke currentBinding = getKeyBinding(actionName);
-		assertEquals("Key binding not restored after a call to restore defautls", defaultKeyStroke,
+		assertEquals("Key binding not restored after a call to restore defaults", defaultKeyStroke,
 			currentBinding);
 		assertOptionsKeyStroke(actionName, pluginName, defaultKeyStroke);
 	}

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/plugin/core/checksums/MyTestMemory.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/plugin/core/checksums/MyTestMemory.java
@@ -179,7 +179,7 @@ public class MyTestMemory extends AddressSet implements Memory {
 	}
 
 	@Override
-	public MemoryBlock convertToInitialized(MemoryBlock unitializedBlock, byte initialValue)
+	public MemoryBlock convertToInitialized(MemoryBlock uninitializedBlock, byte initialValue)
 			throws MemoryBlockException, NotFoundException {
 		throw new UnsupportedOperationException();
 	}

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/util/bin/format/dwarf4/expression/DWARFExpressionEvaluatorTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/util/bin/format/dwarf4/expression/DWARFExpressionEvaluatorTest.java
@@ -379,7 +379,7 @@ public class DWARFExpressionEvaluatorTest {
 			evaluator.setMaxStepCount(Integer.MAX_VALUE);
 			evaluator.evaluate(expr);
 			fail(
-				"DWARFExpressionEvaluator should have thrown an exception because it recieved an interrupt, " +
+				"DWARFExpressionEvaluator should have thrown an exception because it received an interrupt, " +
 					"but you are probably not reading this message because junit can't get here because of the endless loop in the expr.");
 		}
 		catch (DWARFExpressionException dee) {

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/util/cparser/C/CParserUtilsTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/util/cparser/C/CParserUtilsTest.java
@@ -58,7 +58,7 @@ public class CParserUtilsTest extends AbstractGenericTest {
 		catch (Throwable t) {
 			return t;
 		}
-		Assert.fail("Funcion text did not trigger a parse problem: " + function);
+		Assert.fail("Function text did not trigger a parse problem: " + function);
 		return null;// can't get here
 	}
 }

--- a/Ghidra/Features/Base/src/test/java/ghidra/plugins/fsbrowser/ImageManagerTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/plugins/fsbrowser/ImageManagerTest.java
@@ -47,7 +47,7 @@ public class ImageManagerTest extends AbstractGenericTest {
 				}
 			}
 		}
-		Assert.assertTrue("Some icons failed to load or misconfigured: " + failedIcons.toString(),
+		Assert.assertTrue("Some icons failed to load or were misconfigured: " + failedIcons.toString(),
 			failedIcons.isEmpty());
 	}
 }

--- a/Ghidra/Features/Base/src/test/java/ghidra/program/model/data/UnionDataTypeTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/program/model/data/UnionDataTypeTest.java
@@ -509,7 +509,7 @@ public class UnionDataTypeTest extends AbstractGTest {
 		try {
 			union.add(typeDef);
 			Assert.fail(
-				"Shouldn't be able to add a typedef of a strucutre, which contains this union, to this union.");
+				"Shouldn't be able to add a typedef of a structure, which contains this union, to this union.");
 		}
 		catch (IllegalArgumentException e) {
 			// Should get an exception from adding the structure typedef to the union.

--- a/Ghidra/Features/BytePatterns/src/main/java/ghidra/app/analyzers/FunctionStartDataPostAnalyzer.java
+++ b/Ghidra/Features/BytePatterns/src/main/java/ghidra/app/analyzers/FunctionStartDataPostAnalyzer.java
@@ -27,7 +27,7 @@ public class FunctionStartDataPostAnalyzer extends FunctionStartAnalyzer {
 	public FunctionStartDataPostAnalyzer() {
 		super(NAME + " After Data", AnalyzerType.DATA_ANALYZER);
 		setSupportsOneTimeAnalysis(false);
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.before().before());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.before().before());
 	}
 
 	@Override

--- a/Ghidra/Features/BytePatterns/src/main/java/ghidra/app/analyzers/FunctionStartPostAnalyzer.java
+++ b/Ghidra/Features/BytePatterns/src/main/java/ghidra/app/analyzers/FunctionStartPostAnalyzer.java
@@ -27,7 +27,7 @@ public class FunctionStartPostAnalyzer extends FunctionStartAnalyzer {
 	public FunctionStartPostAnalyzer() {
 		super(NAME + " After Code", AnalyzerType.INSTRUCTION_ANALYZER);
 		setSupportsOneTimeAnalysis(false);
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.before().before());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.before().before());
 	}
 
 	@Override

--- a/Ghidra/Features/BytePatterns/src/main/java/ghidra/bitpatterns/gui/FunctionBitPatternsMainProvider.java
+++ b/Ghidra/Features/BytePatterns/src/main/java/ghidra/bitpatterns/gui/FunctionBitPatternsMainProvider.java
@@ -409,7 +409,7 @@ public class FunctionBitPatternsMainProvider extends ComponentProviderAdapter
 			};
 		evaluateSelectedAction.setPopupMenuData(
 			new MenuData(new String[] { "Evaluate Selected Patterns" }));
-		evaluateSelectedAction.setDescription("Evalute Selected Patterns");
+		evaluateSelectedAction.setDescription("Evaluate Selected Patterns");
 		evaluateSelectedAction.setHelpLocation(
 			new HelpLocation("FunctionBitPatternsExplorerPlugin", "Evaluating_Patterns"));
 		tool.addLocalAction(this, evaluateSelectedAction);

--- a/Ghidra/Features/ByteViewer/src/main/java/ghidra/app/plugin/core/byteviewer/ByteViewerPlugin.java
+++ b/Ghidra/Features/ByteViewer/src/main/java/ghidra/app/plugin/core/byteviewer/ByteViewerPlugin.java
@@ -36,7 +36,7 @@ import ghidra.util.SystemUtilities;
 	category = PluginCategoryNames.BYTE_VIEWER,
 	shortDescription = "Displays bytes in memory",
 	description = "Provides a component for showing the bytes in memory.  " +
-		"Additional plugins provide capabilites for this plugin" +
+		"Additional plugins provide capabilities for this plugin" +
 		" to show the bytes in various formats (e.g., hex, octal, decimal)." +
 		"  The hex format plugin is loaded by default when this plugin is loaded.",
 	servicesRequired = {

--- a/Ghidra/Features/Decompiler/ghidra_scripts/ApplyClassFunctionDefinitionUpdatesScript.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/ApplyClassFunctionDefinitionUpdatesScript.java
@@ -50,7 +50,7 @@ public class ApplyClassFunctionDefinitionUpdatesScript extends GhidraScript {
 		Namespace classNamespace = classHelper.getClassNamespace(currentAddress);
 		if (classNamespace == null) {
 			println(
-				"Either cannot retrieve class namespace or cursor is not in a member of a class namepace");
+				"Either cannot retrieve class namespace or cursor is not in a member of a class namespace");
 			return;
 		}
 

--- a/Ghidra/Features/Decompiler/ghidra_scripts/ApplyClassFunctionSignatureUpdatesScript.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/ApplyClassFunctionSignatureUpdatesScript.java
@@ -50,7 +50,7 @@ public class ApplyClassFunctionSignatureUpdatesScript extends GhidraScript {
 		Namespace classNamespace = classHelper.getClassNamespace(currentAddress);
 		if (classNamespace == null) {
 			println(
-				"Either cannot retrieve class namespace or cursor is not in a member of a class namepace");
+				"Either cannot retrieve class namespace or cursor is not in a member of a class namespace");
 			return;
 		}
 

--- a/Ghidra/Features/Decompiler/ghidra_scripts/RecoverClassesFromRTTIScript.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/RecoverClassesFromRTTIScript.java
@@ -1083,7 +1083,7 @@ public class RecoverClassesFromRTTIScript extends GhidraScript {
 
 		println("Total fixed incorrect FID functions: " +
 			recoverClassesFromRTTI.getBadFIDFunctions().size());
-		println("Total resolved functions that had multiple FID possiblities: " +
+		println("Total resolved functions that had multiple FID possibilities: " +
 			recoverClassesFromRTTI.getResolvedFIDFunctions().size());
 		println("Total fixed functions that had incorrect data types due to incorrect FID: " +
 			recoverClassesFromRTTI.getFixedFIDFunctions().size());

--- a/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/ExtendedFlatProgramAPI.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/ExtendedFlatProgramAPI.java
@@ -507,7 +507,7 @@ public class ExtendedFlatProgramAPI extends FlatProgramAPI {
 			return false;
 		}
 		catch (CancelledException e) {
-			// FIXME: this should not be caught by this method and should propogate 
+			// FIXME: this should not be caught by this method and should propagate 
 			return false;
 		}
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
@@ -2677,7 +2677,7 @@ ProtoStoreSymbol::~ProtoStoreSymbol(void)
 
 /// Retrieve the specified ProtoParameter object, making sure it is a ParameterSymbol.
 /// If it doesn't exist, or if the object in the specific slot is not a ParameterSymbol,
-/// allocate an (unitialized) parameter.
+/// allocate an (uninitialized) parameter.
 /// \param i is the specified input slot
 /// \return the corresponding parameter
 ParameterSymbol *ProtoStoreSymbol::getSymbolBacked(int4 i)

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/analysis/DecompilerFunctionAnalyzer.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/analysis/DecompilerFunctionAnalyzer.java
@@ -65,7 +65,7 @@ public class DecompilerFunctionAnalyzer extends AbstractAnalyzer {
 
 	public DecompilerFunctionAnalyzer() {
 		super(NAME, DESCRIPTION, AnalyzerType.FUNCTION_ANALYZER);
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.after().after());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.after().after());
 		setSupportsOneTimeAnalysis();
 	}
 

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/analysis/DecompilerSwitchAnalyzer.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/analysis/DecompilerSwitchAnalyzer.java
@@ -346,7 +346,7 @@ public class DecompilerSwitchAnalyzer extends AbstractAnalyzer {
 			// NOTE: Assumption, we have found all flows leading to the switch that might split the basic block
 
 			final AtomicInteger foundCount = new AtomicInteger(0);
-			SymbolicPropogator prop = new SymbolicPropogator(program);
+			SymbolicPropagator prop = new SymbolicPropagator(program);
 			prop.flowConstants(jumpBlockAt.getFirstStartAddress(), jumpBlockAt,
 				new ContextEvaluatorAdapter() {
 					@Override
@@ -355,14 +355,14 @@ public class DecompilerSwitchAnalyzer extends AbstractAnalyzer {
 						// go ahead and place the reference, since it is a constant.
 						if (refType.isComputed() && refType.isFlow() &&
 							program.getMemory().contains(address)) {
-							propogateCodeMode(context, address);
+							propagateCodeMode(context, address);
 							foundCount.incrementAndGet();
 							return true;
 						}
 						return false;
 					}
 
-					private void propogateCodeMode(VarnodeContext context, Address addr) {
+					private void propagateCodeMode(VarnodeContext context, Address addr) {
 						// get CodeModeRegister and flow it to destination, if it is set here
 
 						if (isaModeSwitchRegister == null) {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeFieldAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeFieldAction.java
@@ -97,7 +97,7 @@ public class RetypeFieldAction extends AbstractDecompilerAction {
 		DataType originalDataType = comp != null ? comp.getDataType() : DataType.DEFAULT;
 		if (originalDataType instanceof BitFieldDataType) {
 			Msg.showError(this, tool.getToolFrame(), "Retype Failed",
-				"Retype of defind bit-field is not supported.");
+				"Retype of defined bit-field is not supported.");
 			return;
 		}
 

--- a/Ghidra/Features/Decompiler/src/test.slow/java/ghidra/app/decompiler/component/DecompilerClangTest.java
+++ b/Ghidra/Features/Decompiler/src/test.slow/java/ghidra/app/decompiler/component/DecompilerClangTest.java
@@ -2144,7 +2144,7 @@ public class DecompilerClangTest extends AbstractDecompilerTest {
 
 		TokenHighlights providerHighlights =
 			getHighligtedTokens(theProvider, decompilerHighlighter);
-		assertNotNull("No highligts for highlighter in the given provider", providerHighlights);
+		assertNotNull("No highlights for highlighter in the given provider", providerHighlights);
 		Map<ClangToken, Color> matchingTokens = spyMatcher.getMatchingTokens();
 
 		for (Map.Entry<ClangToken, Color> entry : matchingTokens.entrySet()) {

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/eclipse/AndroidProjectCreator.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/eclipse/AndroidProjectCreator.java
@@ -209,7 +209,7 @@ public class AndroidProjectCreator {
 		}
 		catch (IOException ioe) {
 			Msg.info(this,
-				"XML file " + containerFile.getPath() + " is not AndriodXmlFileSystem compatible",
+				"XML file " + containerFile.getPath() + " is not AndroidXmlFileSystem compatible",
 				ioe);
 		}
 	}

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/CrushedPNGUtil.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/CrushedPNGUtil.java
@@ -271,7 +271,7 @@ public class CrushedPNGUtil {
 			int y = 0;
 			while (y < (ihdrChunk.getBytesPerLine() * ihdrChunk.getImgHeight() + ihdrChunk.getRowFilterBytes())) {
 				if (decompressedResult[y] > 4) {
-					throw new PNGFormatException("Unkown row filter type " + decompressedResult[y]);
+					throw new PNGFormatException("Unknown row filter type " + decompressedResult[y]);
 				}
 
 				//skip row filter byte

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/iso9660/ISO9660VolumeDescriptor.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/iso9660/ISO9660VolumeDescriptor.java
@@ -150,7 +150,7 @@ public class ISO9660VolumeDescriptor extends ISO9660BaseVolume {
 		struc.add(DWORD, "Logical block Size", "Size of the logical block");
 		struc.add(QWORD, "Path Table Size", "Size of the path table");
 		struc.add(DWORD, "Location of Type-L Path Dable",
-			"LBA location of the path table containing only litle-endian values");
+			"LBA location of the path table containing only little-endian values");
 		struc.add(DWORD, "Location of Optional Type-L Path Table",
 			"LBA location of the optional path table containing only little-endian values");
 		struc.add(DWORD, "Location of Type-M Path Table",
@@ -174,7 +174,7 @@ public class ISO9660VolumeDescriptor extends ISO9660BaseVolume {
 			"Filename of file that contains abstract information on volume set");
 		struc.add(new ArrayDataType(BYTE, bibliographicFileIdentifier.length, 1),
 			"Bibliographic File Identifier",
-			"Filename of file that contians bibliographic information on volume set");
+			"Filename of file that contains bibliographic information on volume set");
 		struc.add(new ArrayDataType(BYTE, volumeCreationDateTime.length, 1),
 			"Volume Creation Date and Time", "Date and time volume was created");
 		struc.add(new ArrayDataType(BYTE, volumeModifyDateTime.length, 1),
@@ -231,7 +231,7 @@ public class ISO9660VolumeDescriptor extends ISO9660BaseVolume {
 		buff.append("Copyright File Identifier: " + new String(copyrightFileIdentifier).trim() +
 			"\n");
 		buff.append("Abstract File Identifier: " + new String(abstractFileIdentifier).trim() + "\n");
-		buff.append("Biliographic File Identifier: " + new String(bibliographicFileIdentifier) +
+		buff.append("Bibliographic File Identifier: " + new String(bibliographicFileIdentifier) +
 			"\n");
 		buff.append("Volume Creation Date/Time: " + createDateTimeString(volumeCreationDateTime) +
 			"\n");

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/sparseimage/SparseImageDecompressor.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/sparseimage/SparseImageDecompressor.java
@@ -102,7 +102,7 @@ public class SparseImageDecompressor {
 				totalBlocks += chunkSize;
 			}
 			else {
-				throw new IOException("Unkown chunk type: " + chunkType);
+				throw new IOException("Unknown chunk type: " + chunkType);
 			}
 			monitor.incrementProgress(1);
 		}

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/plugins/fileformats/FileFormatsPlugin.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/plugins/fileformats/FileFormatsPlugin.java
@@ -133,7 +133,7 @@ public class FileFormatsPlugin extends Plugin implements FrontEndable {
 							chooserEclipse = new GhidraFileChooser(null);
 						}
 						chooserEclipse.setFileSelectionMode(GhidraFileChooserMode.DIRECTORIES_ONLY);
-						chooserEclipse.setTitle("Select Eclipe Project Directory");
+						chooserEclipse.setTitle("Select Eclipse Project Directory");
 						chooserEclipse.setApproveButtonText("SELECT");
 						chooserEclipse.setSelectedFile(null);
 						File outputDirectory = chooserEclipse.getSelectedFile();

--- a/Ghidra/Features/FunctionGraph/src/main/java/ghidra/app/plugin/core/functiongraph/mvc/FunctionGraphOptions.java
+++ b/Ghidra/Features/FunctionGraph/src/main/java/ghidra/app/plugin/core/functiongraph/mvc/FunctionGraphOptions.java
@@ -197,14 +197,14 @@ public class FunctionGraphOptions extends VisualGraphOptions {
 
 		options.registerOption(EDGE_CONDITIONAL_JUMP_HIGHLIGHT_COLOR_KEY,
 			conditionalJumpEdgeHighlightColor, help,
-			"Conditional jump edge color when highlighting the reachablity of a vertex");
+			"Conditional jump edge color when highlighting the reachability of a vertex");
 
 		options.registerOption(EDGE_UNCONDITIONAL_JUMP_HIGHLIGHT_COLOR_KEY,
 			unconditionalJumpEdgeHighlightColor, help,
-			"Unconditional jump edge color when highlighting the reachablity of a vertex");
+			"Unconditional jump edge color when highlighting the reachability of a vertex");
 
 		options.registerOption(EDGE_FALLTHROUGH_HIGHLIGHT_COLOR_KEY, fallthroughEdgeHighlightColor,
-			help, "Fallthrough edge color when highlighting the reachablity of a vertex");
+			help, "Fallthrough edge color when highlighting the reachability of a vertex");
 
 	}
 

--- a/Ghidra/Features/FunctionGraph/src/main/java/ghidra/app/plugin/core/functiongraph/util/job/UngroupAllVertexFunctionGraphJob.java
+++ b/Ghidra/Features/FunctionGraph/src/main/java/ghidra/app/plugin/core/functiongraph/util/job/UngroupAllVertexFunctionGraphJob.java
@@ -50,7 +50,7 @@ public class UngroupAllVertexFunctionGraphJob implements GraphJob {
 
 	@Override
 	public void shortcut() {
-		throw new UnsupportedOperationException("Cannot shortct job: " + this);
+		throw new UnsupportedOperationException("Cannot shortcut job: " + this);
 	}
 
 	@Override

--- a/Ghidra/Features/FunctionGraph/src/test/java/ghidra/app/plugin/core/functiongraph/FunctionGraphPlugin2Test.java
+++ b/Ghidra/Features/FunctionGraph/src/test/java/ghidra/app/plugin/core/functiongraph/FunctionGraphPlugin2Test.java
@@ -319,7 +319,7 @@ public class FunctionGraphPlugin2Test extends AbstractFunctionGraphTest {
 		Color mostRecentColor = controller.getMostRecentColor();
 
 		Assert.assertNotEquals(
-			"Test environment not setup correctly--should have default backgrond " +
+			"Test environment not setup correctly--should have default background " +
 				"colors applied",
 			startBackgroundColor, mostRecentColor);
 

--- a/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/DefaultFidPopulateResultReporter.java
+++ b/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/DefaultFidPopulateResultReporter.java
@@ -67,7 +67,7 @@ public class DefaultFidPopulateResultReporter implements FidPopulateResultReport
 			buffer.append('\n');
 		}
 		TextAreaDialog dialog =
-			new TextAreaDialog("FidDb Popluate Results", buffer.toString(), true);
+			new TextAreaDialog("FidDb Populate Results", buffer.toString(), true);
 		DockingWindowManager.showDialog(dialog);
 	}
 

--- a/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidServiceLibraryIngest.java
+++ b/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidServiceLibraryIngest.java
@@ -195,7 +195,7 @@ class FidServiceLibraryIngest {
 		this.linkLibraries = linkLibraries;
 		this.monitor = monitor;
 		if (languageId == null) {
-			throw new IllegalArgumentException("LanugageID can't be null"); // null used to be allowed, so add special check
+			throw new IllegalArgumentException("LanguageID can't be null"); // null used to be allowed, so add special check
 		}
 	}
 

--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/remote/GhidraServer.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/remote/GhidraServer.java
@@ -649,7 +649,7 @@ public class GhidraServer extends UnicastRemoteObject implements GhidraServerHan
 					System.exit(-1);
 				}
 				else if (defaultPasswordExpiration == 0) {
-					System.out.println("Default password expiration has been disbaled.");
+					System.out.println("Default password expiration has been disabled.");
 				}
 			}
 			else if (s.startsWith("-jaas")) {

--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/remote/RepositoryHandleImpl.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/remote/RepositoryHandleImpl.java
@@ -116,7 +116,7 @@ public class RepositoryHandleImpl extends UnicastRemoteObject implements RemoteR
 			return;
 		}
 		try {
-			repository.log(null, "Clearning " + transientCheckouts.size() + " transiet checkouts",
+			repository.log(null, "Cleaning " + transientCheckouts.size() + " transient checkouts",
 				currentUser);
 			for (String pathname : transientCheckouts.keySet()) {
 				int index = pathname.lastIndexOf(FileSystem.SEPARATOR_CHAR);

--- a/Ghidra/Features/GnuDemangler/ghidra_scripts/DemangleElfWithOptionScript.java
+++ b/Ghidra/Features/GnuDemangler/ghidra_scripts/DemangleElfWithOptionScript.java
@@ -62,6 +62,6 @@ public class DemangleElfWithOptionScript extends GhidraScript {
 			return;
 		}
 
-		println("Succesfully demangled " + mangled + " to " + demangledObject);
+		println("Successfully demangled " + mangled + " to " + demangledObject);
 	}
 }

--- a/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplay.java
+++ b/Ghidra/Features/GraphServices/src/main/java/ghidra/graph/visualization/DefaultGraphDisplay.java
@@ -1361,7 +1361,7 @@ public class DefaultGraphDisplay implements GraphDisplay {
 	public void addAction(DockingActionIf action) {
 
 		if (containsAction(action)) {
-			Msg.warn(this, "Action with same name and owner already exixts in graph: " +
+			Msg.warn(this, "Action with same name and owner already exists in graph: " +
 				action.getFullName());
 			return;
 		}

--- a/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/PropagateExternalParametersAnalyzer.java
+++ b/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/PropagateExternalParametersAnalyzer.java
@@ -44,7 +44,7 @@ public class PropagateExternalParametersAnalyzer extends AbstractAnalyzer {
 	public PropagateExternalParametersAnalyzer() {
 		super(NAME, DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
 		setSupportsOneTimeAnalysis();
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION.after().after().after().after().after());
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION.after().after().after().after().after());
 		//	setPrototype();
 
 	}
@@ -70,7 +70,7 @@ public class PropagateExternalParametersAnalyzer extends AbstractAnalyzer {
 				if (hasEnoughPushes(it, params.length)) {
 					CodeUnitIterator codeUnitsToRef =
 						getCodeUnitsFromFunctionStartToRef(callingFunction, fromAddr);
-					propogateParams(params, codeUnitsToRef, externalFunctionName);
+					propagateParams(params, codeUnitsToRef, externalFunctionName);
 				}
 			}
 		}
@@ -95,7 +95,7 @@ public class PropagateExternalParametersAnalyzer extends AbstractAnalyzer {
 			if (hasEnoughPushes(cuIt, params.length)) {
 				CodeUnitIterator codeUnitsToRef =
 					getCodeUnitsFromFunctionStartToRef(thunk, thunkAddr);
-				propogateParams(params, codeUnitsToRef, externalFunction.getName());
+				propagateParams(params, codeUnitsToRef, externalFunction.getName());
 			}
 		}
 	}
@@ -179,7 +179,7 @@ public class PropagateExternalParametersAnalyzer extends AbstractAnalyzer {
 		return numPushes >= numParams;
 	}
 
-	private void propogateParams(Parameter[] params, CodeUnitIterator iterator,
+	private void propagateParams(Parameter[] params, CodeUnitIterator iterator,
 			String externalFunctionName) {
 
 		int index = 0;

--- a/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/WindowsResourceReferenceAnalyzer.java
+++ b/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/plugin/prototype/MicrosoftCodeAnalyzerPlugin/WindowsResourceReferenceAnalyzer.java
@@ -53,7 +53,7 @@ public class WindowsResourceReferenceAnalyzer extends AbstractAnalyzer {
 	public WindowsResourceReferenceAnalyzer() {
 		super(NAME, DESCRIPTION, AnalyzerType.INSTRUCTION_ANALYZER);
 		setSupportsOneTimeAnalysis();
-		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION);
+		setPriority(AnalysisPriority.DATA_TYPE_PROPAGATION);
 		setDefaultEnablement(true);
 	}
 

--- a/Ghidra/Features/MicrosoftDemangler/developer_scripts/MicrosoftDemanglerScript.java
+++ b/Ghidra/Features/MicrosoftDemangler/developer_scripts/MicrosoftDemanglerScript.java
@@ -95,6 +95,6 @@ public class MicrosoftDemanglerScript extends GhidraScript {
 
 	private void demangle(String mangled) throws Exception {
 		DemangledObject demangled = demangler.demangle(mangled);
-		printf("magled %s\ndemangled %s", mangled, demangled);
+		printf("mangled %s\ndemangled %s", mangled, demangled);
 	}
 }

--- a/Ghidra/Features/MicrosoftDmang/src/main/java/mdemangler/datatype/modifier/MDCVMod.java
+++ b/Ghidra/Features/MicrosoftDmang/src/main/java/mdemangler/datatype/modifier/MDCVMod.java
@@ -331,7 +331,7 @@ public class MDCVMod extends MDParsableItem {
 	public void checkInvalidSymbol() throws MDException {
 		if (isFunction && (foundManagedProperty || (prefixList.size() != 0))) {
 			throw new MDException(
-				"EFI and Managed Properies not permitted for function pointer/reference");
+				"EFI and Managed Properties not permitted for function pointer/reference");
 		}
 		// if (isFunction &&
 		// !((modType == cvModifierType.functionpointer) || (modType ==

--- a/Ghidra/Features/MicrosoftDmang/src/main/java/mdemangler/datatype/modifier/MDModifiedTypeParser.java
+++ b/Ghidra/Features/MicrosoftDmang/src/main/java/mdemangler/datatype/modifier/MDModifiedTypeParser.java
@@ -291,7 +291,7 @@ public class MDModifiedTypeParser {
 	public void checkInvalidSymbol() throws MDException {
 		if (isFunction && (foundManagedProperty || (prefixList.size() != 0))) {
 			throw new MDException(
-				"EFI and Managed Properies not permitted for function pointer/reference");
+				"EFI and Managed Properties not permitted for function pointer/reference");
 		}
 		// if (isFunction &&
 		// !((modType == cvModifierType.functionpointer) || (modType ==

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/DefaultCompositeMember.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/DefaultCompositeMember.java
@@ -206,7 +206,7 @@ public class DefaultCompositeMember extends CompositeMember {
 				name += parent.getOrdinal(oldMemberName);
 			}
 			catch (NotFoundException e) {
-				Msg.error(this, "Failed to rename anonymous compsite: " + getDataTypeName());
+				Msg.error(this, "Failed to rename anonymous composite: " + getDataTypeName());
 			}
 		}
 		else {

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/AbstractCompile2MsSymbol.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/AbstractCompile2MsSymbol.java
@@ -247,7 +247,7 @@ public abstract class AbstractCompile2MsSymbol extends AbstractMsSymbol {
 		builder.append(
 			"\n   Compiled for edit and continue: " + (compiledForEditAndContinue ? "yes" : "no"));
 		builder.append(
-			"\n   Compiled withoug debugging info: " + (notCompiledWithDebugInfo ? "yes" : "no"));
+			"\n   Compiled without debugging info: " + (notCompiledWithDebugInfo ? "yes" : "no"));
 		builder.append(
 			"\n   Compiled with LTCG: " + (compiledWithLinkTimeCodeGeneration ? "yes" : "no"));
 		builder.append(

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/Compile3MsSymbol.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/Compile3MsSymbol.java
@@ -277,7 +277,7 @@ public class Compile3MsSymbol extends AbstractMsSymbol {
 		builder.append(
 			"\n   Compiled for edit and continue: " + (compiledForEditAndContinue ? "yes" : "no"));
 		builder.append(
-			"\n   Compiled withoug debugging info: " + (notCompiledWithDebugInfo ? "yes" : "no"));
+			"\n   Compiled without debugging info: " + (notCompiledWithDebugInfo ? "yes" : "no"));
 		builder.append(
 			"\n   Compiled with LTCG: " + (compiledWithLinkTimeCodeGeneration ? "yes" : "no"));
 		builder.append(

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/CompileFlagsMsSymbol.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/CompileFlagsMsSymbol.java
@@ -32,8 +32,8 @@ public class CompileFlagsMsSymbol extends AbstractMsSymbol {
 	protected boolean pcodePresent;
 	protected int floatingPrecision;
 	protected int floatPackage;
-	protected int ambiantDataModel;
-	protected int ambiantCodeModel;
+	protected int ambientDataModel;
+	protected int ambientCodeModel;
 	protected boolean compiled32BitMode;
 	protected String compilerVersionString;
 
@@ -78,8 +78,8 @@ public class CompileFlagsMsSymbol extends AbstractMsSymbol {
 		builder.append(processor.toString());
 		builder.append("\n   Floating-point precision: " + floatingPrecision);
 		builder.append("\n   Floating-point package: " + floatPackage);
-		builder.append("\n   Ambiant data: " + ambiantDataModel);
-		builder.append("\n   Ambiant code: " + ambiantCodeModel);
+		builder.append("\n   Ambient data: " + ambientDataModel);
+		builder.append("\n   Ambient code: " + ambientCodeModel);
 		builder.append("\n   PCode present: " + (compiled32BitMode ? "yes" : "no"));
 		builder.append("\n   Version String:" + compilerVersionString);
 		builder.append("\n");
@@ -106,10 +106,10 @@ public class CompileFlagsMsSymbol extends AbstractMsSymbol {
 		flagsByte >>= 2;
 		floatPackage = (flagsByte & 0x03);
 		flagsByte >>= 2;
-		ambiantDataModel = (flagsByte & 0x07);
+		ambientDataModel = (flagsByte & 0x07);
 
 		flagsByte = flagsIn[2];
-		ambiantCodeModel = (flagsByte & 0x07);
+		ambientCodeModel = (flagsByte & 0x07);
 		flagsByte >>= 3;
 		compiled32BitMode = ((flagsByte & 0x0001) == 0x0001);
 

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/ReturnDescriptionMsSymbol.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/ReturnDescriptionMsSymbol.java
@@ -35,7 +35,7 @@ public class ReturnDescriptionMsSymbol extends AbstractMsSymbol {
 		UNKNOWN("unknown return", -1),
 		VOID("void return", 0x00),
 		RETURN_DATA_IN_REGISTERS("return data in registers", 0x01),
-		INDIRECT_CALLER_ALLOCATED_NEAR("indirected caller-allocated near", 0x02),
+		INDIRECT_CALLER_ALLOCATED_NEAR("indirect caller-allocated near", 0x02),
 		INDIRECT_CALLER_ALLOCATED_FAR("indirect caller-allocated far", 0x03),
 		INDIRECT_RETURNEE_ALLOCATED_NEAR("indirect returnee allocated near", 0x04),
 		INDIRECT_RETURNEE_ALLOCATED_FAR("indirect returnee allocated far", 0x05),

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/type/AbstractIndirectVirtualBaseClassMsType.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/type/AbstractIndirectVirtualBaseClassMsType.java
@@ -63,7 +63,7 @@ public abstract class AbstractIndirectVirtualBaseClassMsType extends AbstractMsT
 	}
 
 	/**
-	 * Returns the offset of the base base pointer within the class.
+	 * Returns the offset of the base pointer within the class.
 	 * @return the offset;
 	 */
 	public BigInteger getBasePointerOffset() {

--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/pdb/pdbapplicator/CompositeTypeApplier.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/pdb/pdbapplicator/CompositeTypeApplier.java
@@ -314,7 +314,7 @@ public class CompositeTypeApplier extends AbstractComplexTypeApplier {
 			for (Map.Entry<Integer, String> entry : componentComments.entrySet()) {
 				DataTypeComponent component = structure.getComponentAt(entry.getKey());
 				if (component == null) {
-					pdbLogAndInfoMessage(this, "Could not set comment for 'missing' componenent " +
+					pdbLogAndInfoMessage(this, "Could not set comment for 'missing' component " +
 						entry.getKey() + " for: " + structure.getName());
 					return;
 				}

--- a/Ghidra/Features/PDB/src/test/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/SymbolsTest.java
+++ b/Ghidra/Features/PDB/src/test/java/ghidra/app/util/bin/format/pdb2/pdbreader/symbol/SymbolsTest.java
@@ -281,7 +281,7 @@ public class SymbolsTest extends AbstractGenericTest {
 		String result = symbol.toString().trim();
 		assertEquals("COMPILE:\n" + "   Language: C\n" + "   Target Processor: 8080\n" +
 			"   Floating-point precision: 0\n" + "   Floating-point package: 0\n" +
-			"   Ambiant data: 0\n" + "   Ambiant code: 0\n" + "   PCode present: no\n" +
+			"   Ambient data: 0\n" + "   Ambient code: 0\n" + "   PCode present: no\n" +
 			"   Version String:CompilerVersionString", result);
 	}
 

--- a/Ghidra/Features/PDB/src/test/java/ghidra/app/util/bin/format/pdb2/pdbreader/type/TypesTest.java
+++ b/Ghidra/Features/PDB/src/test/java/ghidra/app/util/bin/format/pdb2/pdbreader/type/TypesTest.java
@@ -100,7 +100,7 @@ public class TypesTest extends AbstractGenericTest {
 			substringListMsType1 = dummyPdb700.addItemRecord(item);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}

--- a/Ghidra/Features/PDB/src/test/java/ghidra/app/util/pdb/pdbapplicator/CppCompositeTypeTest.java
+++ b/Ghidra/Features/PDB/src/test/java/ghidra/app/util/pdb/pdbapplicator/CppCompositeTypeTest.java
@@ -752,7 +752,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			D_struct.addMember("d1", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -781,7 +781,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			D_struct.addMember("d1", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -848,7 +848,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			F_struct.addMember("f1", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -883,7 +883,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			F_struct.addMember("f1", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -912,7 +912,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			G_struct.addMember("g1", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -934,7 +934,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			G_struct.addMember("g1", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -963,7 +963,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			G_struct.addMember("g1", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -992,7 +992,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			H_struct.addMember("h1", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1014,7 +1014,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			H_struct.addMember("h1", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1043,7 +1043,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			H_struct.addMember("h1", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1076,7 +1076,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			G1_struct.addMember("g11", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1104,7 +1104,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			G1_struct.addMember("g11", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1139,7 +1139,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			G1_struct.addMember("g11", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1172,7 +1172,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			H1_struct.addMember("h11", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1200,7 +1200,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			H1_struct.addMember("h11", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1235,7 +1235,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			H1_struct.addMember("h11", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1264,7 +1264,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG1_struct.addMember("gg11", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1286,7 +1286,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG1_struct.addMember("gg11", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1315,7 +1315,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG1_struct.addMember("gg11", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1344,7 +1344,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG2_struct.addMember("gg21", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1366,7 +1366,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG2_struct.addMember("gg21", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1395,7 +1395,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG2_struct.addMember("gg21", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1424,7 +1424,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG3_struct.addMember("gg31", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1446,7 +1446,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG3_struct.addMember("gg31", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1475,7 +1475,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG3_struct.addMember("gg31", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1504,7 +1504,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG4_struct.addMember("gg41", u4, false, 4);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1533,7 +1533,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			GG4_struct.addMember("gg41", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1570,7 +1570,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I_struct.addMember("i1", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1604,7 +1604,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I_struct.addMember("i1", u4, false, 16);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1645,7 +1645,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I_struct.addMember("i1", u4, false, 32);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1690,7 +1690,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I1_struct.addMember("i11", u4, false, 16);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1735,7 +1735,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I1_struct.addMember("i11", u4, false, 32);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1780,7 +1780,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I2_struct.addMember("i21", u4, false, 16);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1825,7 +1825,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I2_struct.addMember("i21", u4, false, 32);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1865,7 +1865,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I3_struct.addMember("i31", u4, false, 0);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1903,7 +1903,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I3_struct.addMember("i31", u4, false, 16);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1948,7 +1948,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I3_struct.addMember("i31", u4, false, 32);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -1988,7 +1988,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I4_struct.addMember("i41", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2028,7 +2028,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I4_struct.addMember("i41", u4, false, 16);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2068,7 +2068,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I5_struct.addMember("i51", u4, false, 8);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2108,7 +2108,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			I5_struct.addMember("i51", u4, false, 16);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2161,7 +2161,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J1_struct.addMember("j11", u4, false, 40);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2215,7 +2215,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J1_struct.addMember("j11", u4, false, 80);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2268,7 +2268,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J2_struct.addMember("j21", u4, false, 40);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2321,7 +2321,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J2_struct.addMember("j21", u4, false, 80);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2380,7 +2380,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J3_struct.addMember("j31", u4, false, 48);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2439,7 +2439,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J3_struct.addMember("j31", u4, false, 88);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2525,7 +2525,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J4_struct.addMember("j41", u4, false, 56);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2611,7 +2611,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J4_struct.addMember("j41", u4, false, 104);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2683,7 +2683,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J5_struct.addMember("j51", u4, false, 0); // TODO nned syntactic without index
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2769,7 +2769,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J5_struct.addMember("j51", u4, false, 56);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2855,7 +2855,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J5_struct.addMember("j51", u4, false, 104);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2906,7 +2906,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J6_struct.addMember("j61", u4, false, 12);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}
@@ -2957,7 +2957,7 @@ public class CppCompositeTypeTest extends AbstractGenericTest {
 			J6_struct.addMember("j61", u4, false, 16);
 		}
 		catch (Exception e) {
-			String msg = "Error in static initialization of testt: " + e;
+			String msg = "Error in static initialization of test: " + e;
 			Msg.error(null, msg);
 			throw new AssertException(msg);
 		}

--- a/Ghidra/Features/ProgramGraph/src/main/java/ghidra/graph/program/ProgramGraphPlugin.java
+++ b/Ghidra/Features/ProgramGraph/src/main/java/ghidra/graph/program/ProgramGraphPlugin.java
@@ -61,7 +61,7 @@ import ghidra.util.task.TaskLauncher;
 	shortDescription = "Program graph generator",
 	description = "This plugin provides actions for creating and managing program graphs"
 			+ " (block graphs and call graphs)."
-			+ "Once a graph is created, it uses the currenly selected graph output to display "
+			+ "Once a graph is created, it uses the currently selected graph output to display "
 			+ "or export the graph.  The plugin "
 			+ "also provides event handling to facilitate interaction between "
 			+ "the graph and the tool.",

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/db/AssociationDatabaseManager.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/db/AssociationDatabaseManager.java
@@ -160,7 +160,7 @@ public class AssociationDatabaseManager implements VTAssociationManager {
 			setAssociationAccepted(association);
 		}
 		catch (VTAssociationStatusException e) {
-			throw new AssertException("Attempted to add markup item on an non-accepted associaton");
+			throw new AssertException("Attempted to add markup item on an non-accepted association");
 		}
 
 		return createMarkupItemDB(markupItemStorage);

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/FunctionNameMarkupType.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/FunctionNameMarkupType.java
@@ -158,7 +158,7 @@ public class FunctionNameMarkupType extends FunctionEntryPointBasedAbstractMarku
 		}
 		catch (CircularDependencyException e) {
 			throw new VersionTrackingApplyException("Unable to restore function name: " +
-				destinationName + " due to circular dependancy on namespaces", e);
+				destinationName + " due to circular dependency on namespaces", e);
 		}
 	}
 
@@ -238,7 +238,7 @@ public class FunctionNameMarkupType extends FunctionEntryPointBasedAbstractMarku
 		}
 		catch (CircularDependencyException e) {
 			throw new VersionTrackingApplyException("Unable to apply function name: " + name +
-				" due to circular dependancy on namespaces", e);
+				" due to circular dependency on namespaces", e);
 		}
 		return true;
 	}

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/editors/TagEditorDialog.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/editors/TagEditorDialog.java
@@ -278,7 +278,7 @@ public class TagEditorDialog extends DialogComponentProvider {
 		private final Set<TagState> tags;
 
 		public CommitTagEditsTask(VTSession session, Set<TagState> tags) {
-			super("Commiting Tag Edits", true, true, true);
+			super("Committing Tag Edits", true, true, true);
 			this.tags = tags;
 		}
 

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/plugin/VTControllerImpl.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/plugin/VTControllerImpl.java
@@ -109,7 +109,7 @@ public class VTControllerImpl
 				e.getMessage());
 		}
 		catch (CancelledException e) {
-			Msg.error(this, "Got unexexped cancelled exception", e);
+			Msg.error(this, "Got unexpected cancelled exception", e);
 		}
 		catch (IOException e) {
 			Msg.showError(this, null, "Can't open " + domainFile.getName(), e.getMessage());

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/impliedmatches/ImpliedMatchAssociationHook.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/impliedmatches/ImpliedMatchAssociationHook.java
@@ -79,7 +79,7 @@ public class ImpliedMatchAssociationHook implements AssociationHook, VTControlle
 			processAssociationAccepted(impliedMatches);
 		}
 		catch (CancelledException e) {
-			Msg.info(this, "User cancelled finding implied matches when accepting an assocation");
+			Msg.info(this, "User cancelled finding implied matches when accepting an association");
 		}
 	}
 
@@ -127,7 +127,7 @@ public class ImpliedMatchAssociationHook implements AssociationHook, VTControlle
 			processAssociationCleared(impliedMatches);
 		}
 		catch (CancelledException e) {
-			Msg.info(this, "User cancelled finding implied matches when clearing an assocation");
+			Msg.info(this, "User cancelled finding implied matches when clearing an association");
 		}
 	}
 

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/relatedMatches/VTRelatedMatchTableModel.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/relatedMatches/VTRelatedMatchTableModel.java
@@ -36,7 +36,7 @@ import docking.widgets.table.TableColumnDescriptor;
 
 public class VTRelatedMatchTableModel extends AddressBasedTableModel<VTRelatedMatch> {
 
-	private static final String TITLE = "VTMatchMakupItem Table Model";
+	private static final String TITLE = "VTMatchMarkupItem Table Model";
 	private final VTController controller;
 
 	public VTRelatedMatchTableModel(VTController controller) {

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemDestinationAddressToAddressTableRowMapper.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemDestinationAddressToAddressTableRowMapper.java
@@ -64,7 +64,7 @@ public class VTMarkupItemDestinationAddressToAddressTableRowMapper extends
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's destination address)";
+			return super.getColumnName() + " (for a markup item's destination address)";
 		}
 
 		@Override
@@ -90,7 +90,7 @@ public class VTMarkupItemDestinationAddressToAddressTableRowMapper extends
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's destination address)";
+			return super.getColumnName() + " (for a markup item's destination address)";
 		}
 
 		@Override

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemDestinationAddressToProgramLocationTableRowMapper.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemDestinationAddressToProgramLocationTableRowMapper.java
@@ -70,7 +70,7 @@ public class VTMarkupItemDestinationAddressToProgramLocationTableRowMapper exten
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's destination address)";
+			return super.getColumnName() + " (for a markup item's destination address)";
 		}
 
 		@Override
@@ -96,7 +96,7 @@ public class VTMarkupItemDestinationAddressToProgramLocationTableRowMapper exten
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's destination address)";
+			return super.getColumnName() + " (for a markup item's destination address)";
 		}
 
 		@Override

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemSourceAddressToAddressTableRowMapper.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemSourceAddressToAddressTableRowMapper.java
@@ -62,7 +62,7 @@ public class VTMarkupItemSourceAddressToAddressTableRowMapper extends
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's Source address)";
+			return super.getColumnName() + " (for a markup item's Source address)";
 		}
 
 		@Override
@@ -87,7 +87,7 @@ public class VTMarkupItemSourceAddressToAddressTableRowMapper extends
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's Source address)";
+			return super.getColumnName() + " (for a markup item's Source address)";
 		}
 
 		@Override

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemSourceAddressToProgramLocationTableRowMapper.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMarkupItemSourceAddressToProgramLocationTableRowMapper.java
@@ -64,7 +64,7 @@ public class VTMarkupItemSourceAddressToProgramLocationTableRowMapper extends
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's Source address)";
+			return super.getColumnName() + " (for a markup item's Source address)";
 		}
 
 		@Override
@@ -89,7 +89,7 @@ public class VTMarkupItemSourceAddressToProgramLocationTableRowMapper extends
 
 		@Override
 		public String getColumnDescription() {
-			return super.getColumnName() + " (for a markup items's Source address)";
+			return super.getColumnName() + " (for a markup item's Source address)";
 		}
 
 		@Override

--- a/Ghidra/Features/VersionTracking/src/test.slow/java/ghidra/feature/vt/api/markupitem/FunctionNameMarkupItemTest.java
+++ b/Ghidra/Features/VersionTracking/src/test.slow/java/ghidra/feature/vt/api/markupitem/FunctionNameMarkupItemTest.java
@@ -307,7 +307,7 @@ public class FunctionNameMarkupItemTest extends AbstractVTMarkupItemTest {
 	@Test
 	public void testApplyExternalFunctionName_ReplaceAlways_WithNewName() throws Exception {
 		Function addedSourceFunction =
-			addExternalFunction(sourceProgram, "Modify Source Program", "apples", "origina-apples");
+			addExternalFunction(sourceProgram, "Modify Source Program", "apples", "original-apples");
 		Function addedDestinationFunction = addExternalFunction(destinationProgram,
 			"Modify Destination Program", "oranges", "original-oranges");
 

--- a/Ghidra/Features/VersionTracking/src/test/java/ghidra/feature/vt/db/UnappliedMarkupItemStorageDBTest.java
+++ b/Ghidra/Features/VersionTracking/src/test/java/ghidra/feature/vt/db/UnappliedMarkupItemStorageDBTest.java
@@ -129,7 +129,7 @@ public class UnappliedMarkupItemStorageDBTest extends VTBaseTestCase {
 
 		newStorage = newStorage.reset();
 		assertEquals(VTMarkupItemStatus.UNAPPLIED, newStorage.getStatus());
-		assertTrue("We should have impl storage object when reseting the status",
+		assertTrue("We should have impl storage object when resetting the status",
 			(newStorage instanceof MarkupItemStorageImpl));
 
 		//

--- a/Ghidra/Features/VersionTracking/src/test/java/ghidra/feature/vt/db/VTDomainObjectEventsTest.java
+++ b/Ghidra/Features/VersionTracking/src/test/java/ghidra/feature/vt/db/VTDomainObjectEventsTest.java
@@ -192,7 +192,7 @@ public class VTDomainObjectEventsTest extends VTBaseTestCase {
 	public void testMarkupDestinationAddressChangedEvent() throws Exception {
 		Msg.debug(this, "\tcalling getManualMatchSet()");
 		VTMatchSet manualMatchSet = db.getManualMatchSet();
-		Msg.debug(this, "\tcalling clrearEvents()");
+		Msg.debug(this, "\tcalling clearEvents()");
 		clearEvents();
 		Msg.debug(this, "\tcalling createRandomMatch()");
 		VTMatchInfo matchInfo = VTTestUtils.createRandomMatch(null);
@@ -312,7 +312,7 @@ public class VTDomainObjectEventsTest extends VTBaseTestCase {
 			return events.size() >= n;
 		});
 
-		assertEquals("Incorrect numbrer of domain events", n, events.size());
+		assertEquals("Incorrect number of domain events", n, events.size());
 	}
 
 	private void clearEvents() {

--- a/Ghidra/Features/VersionTracking/src/test/java/ghidra/feature/vt/db/VTMatchSetDBTest.java
+++ b/Ghidra/Features/VersionTracking/src/test/java/ghidra/feature/vt/db/VTMatchSetDBTest.java
@@ -129,7 +129,7 @@ public class VTMatchSetDBTest extends VTBaseTestCase {
 		// Set the match to rejected.
 		try {
 			matchFromDB.getAssociation().setRejected();
-			Assert.fail("Expeced exception when rejected accepted association");
+			Assert.fail("Expected exception when rejected accepted association");
 		}
 		catch (VTAssociationStatusException e) {
 			// expected exception here

--- a/Ghidra/Framework/DB/src/main/java/db/ChainedBuffer.java
+++ b/Ghidra/Framework/DB/src/main/java/db/ChainedBuffer.java
@@ -346,7 +346,7 @@ public class ChainedBuffer implements Buffer {
 		}
 		if (uninitializedDataSource != null) {
 			throw new UnsupportedOperationException(
-				"Buffer size may not be changed when using unintialized data source");
+				"Buffer size may not be changed when using uninitialized data source");
 		}
 		if (dataBufferIdTable == null) {
 			throw new AssertException("Invalid Buffer");
@@ -672,7 +672,7 @@ public class ChainedBuffer implements Buffer {
 		}
 		if (uninitializedDataSource != null) {
 			throw new UnsupportedOperationException(
-				"Buffer size may not be changed when using unintialized data source");
+				"Buffer size may not be changed when using uninitialized data source");
 		}
 		if (firstBufferId < 0) {
 			throw new AssertException("Invalid Buffer");

--- a/Ghidra/Framework/DB/src/main/java/db/buffers/ChangeMapFile.java
+++ b/Ghidra/Framework/DB/src/main/java/db/buffers/ChangeMapFile.java
@@ -126,7 +126,7 @@ public class ChangeMapFile {
 			success = true;
 		}
 		catch (NoSuchElementException e) {
-			throw new IOException("Required modification map paramater (" + e.getMessage() + ") not found: " + file);
+			throw new IOException("Required modification map parameter (" + e.getMessage() + ") not found: " + file);
 		}
 		finally {
 			if (!success) {
@@ -176,7 +176,7 @@ public class ChangeMapFile {
 			success = true;
 		}
 		catch (NoSuchElementException e) {
-			throw new IOException("Required modification map paramater (" + e.getMessage() + ") not found: " + file);
+			throw new IOException("Required modification map parameter (" + e.getMessage() + ") not found: " + file);
 		}
 		finally {
 			if (!success) {

--- a/Ghidra/Framework/DB/src/test/java/db/DBTestUtils.java
+++ b/Ghidra/Framework/DB/src/test/java/db/DBTestUtils.java
@@ -716,7 +716,7 @@ public class DBTestUtils {
 
 		byte[] bytes = field.getBinaryData();
 		if (bytes == null) {
-			Assert.fail("Bad test data: attempt to deccrement min value ");
+			Assert.fail("Bad test data: attempt to decrement min value ");
 		}
 
 		int len = bytes.length;

--- a/Ghidra/Framework/Docking/src/main/java/docking/DialogComponentProvider.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/DialogComponentProvider.java
@@ -400,7 +400,7 @@ public class DialogComponentProvider
 	protected void executeProgressTask(Task task, int delay) {
 		if (taskMonitorComponent == null) {
 			throw new AssertException("Cannot execute tasks in a " +
-				"DialogComponentProvider that has not been created to run taks.");
+				"DialogComponentProvider that has not been created to run takes.");
 		}
 
 		if (task.isModal()) {

--- a/Ghidra/Framework/Docking/src/main/java/docking/ErrLogDialog.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/ErrLogDialog.java
@@ -487,7 +487,7 @@ public class ErrLogDialog extends AbstractErrDialog {
 
 		@Override
 		public String getName() {
-			return "Unexpectd Errors";
+			return "Unexpected Errors";
 		}
 
 		@Override

--- a/Ghidra/Framework/Docking/src/main/java/docking/help/CustomTOCView.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/help/CustomTOCView.java
@@ -115,7 +115,7 @@ public class CustomTOCView extends TOCView {
 				return doCreateItem(tagName, atts, hs, locale);
 			}
 			catch (Exception e) {
-				Msg.error(this, "Unexected error creating a TOC item", e);
+				Msg.error(this, "Unexpected error creating a TOC item", e);
 				throw new RuntimeException("Unexpected error creating a TOC item", e);
 			}
 		}

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/FileDropDownSelectionDataModel.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/FileDropDownSelectionDataModel.java
@@ -153,7 +153,7 @@ public class FileDropDownSelectionDataModel implements DropDownTextFieldDataMode
 				File file = (File) o1;
 				return file.getName().compareToIgnoreCase(((String) o2));
 			}
-			throw new AssertException("FileCompartor used to compare files against a String key!");
+			throw new AssertException("FileComparator used to compare files against a String key!");
 		}
 	}
 

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filter/FilterOptionsEditorDialog.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filter/FilterOptionsEditorDialog.java
@@ -270,7 +270,7 @@ public class FilterOptionsEditorDialog extends DialogComponentProvider {
 
 			caseSensitiveCheckbox = new GCheckBox("Case Sensitive");
 			caseSensitiveCheckbox.setToolTipText(
-				"Toggles whether the case of the filter text matters in the match.  NOTE: does not apply to regular expressons.");
+				"Toggles whether the case of the filter text matters in the match.  NOTE: does not apply to regular expressions.");
 			if (initialFilterOptions.isCaseSensitive()) {
 				caseSensitiveCheckbox.setSelected(true);
 			}

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/constrainteditor/IntegerConstraintEditor.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/constrainteditor/IntegerConstraintEditor.java
@@ -137,7 +137,7 @@ public class IntegerConstraintEditor<T extends Number> extends AbstractColumnCon
 			return Long.MIN_VALUE;
 		}
 		throw new IllegalArgumentException(
-			"IntegerValueConstraintEditor does not suppport values of type " + class1);
+			"IntegerValueConstraintEditor does not support values of type " + class1);
 	}
 
 	private long getMaxValue() {
@@ -157,7 +157,7 @@ public class IntegerConstraintEditor<T extends Number> extends AbstractColumnCon
 			return Long.MAX_VALUE;
 		}
 		throw new IllegalArgumentException(
-			"IntegerValueConstraintEditor does not suppport values of type " + class1);
+			"IntegerValueConstraintEditor does not support values of type " + class1);
 	}
 
 }

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/constrainteditor/IntegerRangeConstraintEditor.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/constrainteditor/IntegerRangeConstraintEditor.java
@@ -222,7 +222,7 @@ public class IntegerRangeConstraintEditor<T extends Number>
 			return Long.MIN_VALUE;
 		}
 		throw new IllegalArgumentException(
-			"IntegerValueConstraintEditor does not suppport values of type " + class1);
+			"IntegerValueConstraintEditor does not support values of type " + class1);
 	}
 
 	private long getMaxAllowedValue() {
@@ -242,7 +242,7 @@ public class IntegerRangeConstraintEditor<T extends Number>
 			return Long.MAX_VALUE;
 		}
 		throw new IllegalArgumentException(
-			"IntegerValueConstraintEditor does not suppport values of type " + class1);
+			"IntegerValueConstraintEditor does not support values of type " + class1);
 	}
 
 	@Override

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/threaded/ThreadedTableModelUpdateMgr.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/threaded/ThreadedTableModelUpdateMgr.java
@@ -70,7 +70,7 @@ class ThreadedTableModelUpdateMgr<T> {
 		SystemUtilities.assertTrue(this.monitor.isCancelEnabled(),
 			"In order for this update manager to work correctly " +
 				"the given task monitor must be cancel enabled (e.g., you cannot use " +
-				"the TaskMonitorAdapter.DUMMY_MONITOR, as that is not cancelleable)");
+				"the TaskMonitorAdapter.DUMMY_MONITOR, as that is not cancellable)");
 
 		addRemoveUpdater = new SwingUpdateManager(DELAY, MAX_DELAY, () -> processAddRemoveItems());
 

--- a/Ghidra/Framework/Docking/src/test.slow/java/docking/widgets/filechooser/GhidraFileChooserTest.java
+++ b/Ghidra/Framework/Docking/src/test.slow/java/docking/widgets/filechooser/GhidraFileChooserTest.java
@@ -1361,7 +1361,7 @@ public class GhidraFileChooserTest extends AbstractDockingTest {
 
 		if (userDesktopDir == null) {
 			Msg.warn(this, "NOTE: unable to test 'Desktop' button in GhidraFileChooser " +
-				"in this enviornment because it does not have a detectable Desktop folder.");
+				"in this environment because it does not have a detectable Desktop folder.");
 			return;
 		}
 
@@ -1398,7 +1398,7 @@ public class GhidraFileChooserTest extends AbstractDockingTest {
 
 		try {
 			pressDesktop();
-			fail("Desktop btton should have been disabled");
+			fail("Desktop button should have been disabled");
 		}
 		catch (AssertionError e) {
 			// good

--- a/Ghidra/Framework/Docking/src/test.slow/java/docking/widgets/table/threaded/ThreadedTableTest.java
+++ b/Ghidra/Framework/Docking/src/test.slow/java/docking/widgets/table/threaded/ThreadedTableTest.java
@@ -899,7 +899,7 @@ public class ThreadedTableTest extends AbstractThreadedTableTest {
 				recorder.record("Swing - model load cancelled");
 			}
 			else {
-				recorder.record("Swing - model load finsished; size: " + model.getRowCount());
+				recorder.record("Swing - model load finished; size: " + model.getRowCount());
 			}
 		}
 

--- a/Ghidra/Framework/Docking/src/test/java/docking/widgets/fieldpanel/field/CompositeVerticalLayoutTextFieldTest.java
+++ b/Ghidra/Framework/Docking/src/test/java/docking/widgets/fieldpanel/field/CompositeVerticalLayoutTextFieldTest.java
@@ -551,8 +551,8 @@ public class CompositeVerticalLayoutTextFieldTest extends AbstractGenericTest {
 	@Test
 	public void testLayoutWrapping_MixedRows_TrailingWrappingRow() {
 
-		String row1 = "1: clipped row: This will be clipped horizonally";
-		String row2 = "2: clipped row: This will be clipped horizonally";
+		String row1 = "1: clipped row: This will be clipped horizontally";
+		String row2 = "2: clipped row: This will be clipped horizontally";
 		String row3 = "3: wrapped row: This field will wrap";
 		TextField field1 = clippedField(0, row1);
 		TextField field2 = clippedField(1, row2);

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/db/PackedDatabaseCache.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/db/PackedDatabaseCache.java
@@ -346,7 +346,7 @@ public class PackedDatabaseCache {
 				for (CachedDB entry : list) {
 					if (packedFilePath.equals(entry.packedDbFilePath)) {
 						if (!entry.dbDir.canExecute() || !entry.dbDir.canWrite()) {
-							throw new IOException("Permssion denied: " + entry.dbDir);
+							throw new IOException("Permission denied: " + entry.dbDir);
 						}
 						entry.lastAccessTime = now;
 						writeCacheList(list);

--- a/Ghidra/Framework/Generic/src/main/java/generic/constraint/DecisionNode.java
+++ b/Ghidra/Framework/Generic/src/main/java/generic/constraint/DecisionNode.java
@@ -54,7 +54,7 @@ public class DecisionNode<T> {
 			throws XmlParseException {
 		if (propertyMap.containsKey(propertyName)) {
 			throw new XmlParseException("Attempted to overwrite property value for " +
-				propertyName + " in contraint node: " + this);
+				propertyName + " in constraint node: " + this);
 		}
 		propertyMap.put(propertyName, new PropertyValue(value, source));
 	}

--- a/Ghidra/Framework/Generic/src/main/java/generic/stl/MapIteratorSTL.java
+++ b/Ghidra/Framework/Generic/src/main/java/generic/stl/MapIteratorSTL.java
@@ -81,14 +81,14 @@ public class MapIteratorSTL<K, V> implements IteratorSTL<Pair<K, V>> {
 
 	public boolean isBegin() {
 		if (erased) {
-			throw new RuntimeException("Iterater in invalid state");
+			throw new RuntimeException("Iterator in invalid state");
 		}
 		return node == tree.getFirst();
 	}
 
 	public boolean isEnd() {
 		if (erased) {
-			throw new RuntimeException("Iterater in invalid state");
+			throw new RuntimeException("Iterator in invalid state");
 		}
 		return node == null;
 	}

--- a/Ghidra/Framework/Generic/src/main/java/generic/stl/SetIterator.java
+++ b/Ghidra/Framework/Generic/src/main/java/generic/stl/SetIterator.java
@@ -83,14 +83,14 @@ public class SetIterator<T> implements IteratorSTL<T> {
 
 	public boolean isBegin() {
 		if (erased) {
-			throw new RuntimeException("Iterater in invalid state");
+			throw new RuntimeException("Iterator in invalid state");
 		}
 		return node == tree.getFirst();
 	}
 
 	public boolean isEnd() {
 		if (erased) {
-			throw new RuntimeException("Iterater in invalid state");
+			throw new RuntimeException("Iterator in invalid state");
 		}
 		return node == null;
 	}

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/net/http/HttpUtil.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/net/http/HttpUtil.java
@@ -82,7 +82,7 @@ public class HttpUtil {
 			c.disconnect();
 			String encodingStr = c.getHeaderField("Transfer-Encoding");
 			if (encodingStr != null) {
-				throw new IOException("Unsupport HTTP transfer encoding: " + encodingStr);
+				throw new IOException("Unsupported HTTP transfer encoding: " + encodingStr);
 			}
 			throw new IOException("Unsupported HTTP transfer (Content-Length not specified)");
 		}

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/MathUtilities.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/MathUtilities.java
@@ -30,7 +30,7 @@ public class MathUtilities {
 	 */
 	public static long unsignedDivide(long numerator, long denominator) {
 		if (denominator < 0) {
-			throw new IllegalArgumentException("denomintor too big");
+			throw new IllegalArgumentException("denominator too big");
 		}
 		if (numerator >= 0) {
 			return numerator / denominator;
@@ -56,7 +56,7 @@ public class MathUtilities {
 	 */
 	public static long unsignedModulo(long numerator, long denominator) {
 		if (denominator < 0) {
-			throw new IllegalArgumentException("denomintor too big");
+			throw new IllegalArgumentException("denominator too big");
 		}
 		if (numerator >= 0) {
 			return numerator % denominator;

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/NumericUtilitiesTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/NumericUtilitiesTest.java
@@ -316,7 +316,7 @@ public class NumericUtilitiesTest {
 
 	private void asssertBytesEquals(byte[] expected, byte[] actual) {
 
-		String errorMessage = "Byte arrays not equal - exptected: " + Arrays.toString(expected) +
+		String errorMessage = "Byte arrays not equal - expected: " + Arrays.toString(expected) +
 			"; actual: " + Arrays.toString(actual);
 
 		assertEquals(errorMessage, expected.length, actual.length);

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/BitTreeTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/BitTreeTest.java
@@ -65,7 +65,7 @@ public class BitTreeTest extends AbstractGenericTest {
         expect(bt, new int[]{});
 
 
-        System.out.println("Test puting all keys in set");
+        System.out.println("Test putting all keys in set");
         for(int i=0;i<1000;i++) {
             bt.put((short)i);
         }
@@ -98,7 +98,7 @@ public class BitTreeTest extends AbstractGenericTest {
             k = bt.getNext(k);
         }
         if (k != -1) {
-            Assert.fail("More values in bitTree than expeced");
+            Assert.fail("More values in bitTree than expected");
         }
     }
     public static void expectBackwards(BitTree bt, int[] values) {
@@ -110,7 +110,7 @@ public class BitTreeTest extends AbstractGenericTest {
             k = bt.getPrevious(k);
         }
         if (k != -1) {
-            Assert.fail("More values in bitTree than expeced");
+            Assert.fail("More values in bitTree than expected");
         }
     }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/IntObjectHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/IntObjectHashtableTest.java
@@ -110,7 +110,7 @@ public class IntObjectHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/LongIntHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/LongIntHashtableTest.java
@@ -115,7 +115,7 @@ public class LongIntHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/LongObjectHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/LongObjectHashtableTest.java
@@ -110,7 +110,7 @@ public class LongObjectHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ObjectIntHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ObjectIntHashtableTest.java
@@ -119,7 +119,7 @@ public class ObjectIntHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/RedBlackKeySetTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/RedBlackKeySetTest.java
@@ -86,26 +86,26 @@ public class RedBlackKeySetTest extends AbstractGenericTest {
 
     public static void expect(RedBlackKeySet bt, int[] values) {
         short k = bt.getFirst();
-        for(int i=0;i<values.length;i++) {
-            if (k != values[i]) {
-                Assert.fail("Expected "+values[i]+ " and got "+k);
+        for (int value : values) {
+            if (k != value) {
+                Assert.fail("Expected " + value + " and got " + k);
             }
             k = bt.getNext(k);
         }
         if (k != -1) {
-            Assert.fail("More values in RedBlackKeySet than expeced");
+            Assert.fail("More values in RedBlackKeySet than expected");
         }
     }
     public static void expectBackwards(RedBlackKeySet bt, int[] values) {
         short k = bt.getLast();
-        for(int i=0;i<values.length;i++) {
-            if (k != values[i]) {
-                Assert.fail("Expected "+values[i]+ " and got "+k);
+        for (int value : values) {
+            if (k != value) {
+                Assert.fail("Expected " + value + " and got " + k);
             }
             k = bt.getPrevious(k);
         }
         if (k != -1) {
-            Assert.fail("More values in RedBlackKeySet than expeced");
+            Assert.fail("More values in RedBlackKeySet than expected");
         }
     }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ShortLongHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ShortLongHashtableTest.java
@@ -115,7 +115,7 @@ public class ShortLongHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ShortObjectHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ShortObjectHashtableTest.java
@@ -110,7 +110,7 @@ public class ShortObjectHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ShortStringHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/ShortStringHashtableTest.java
@@ -110,7 +110,7 @@ public class ShortStringHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/StringIntHashtableTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/StringIntHashtableTest.java
@@ -115,7 +115,7 @@ public class StringIntHashtableTest extends AbstractGenericTest {
 
         for(int i=0;i<keys.length;i++) {
             if (!ht.contains(keys[i])) {
-                Assert.fail("hastable should contain key "+keys[i]+", but it doesn't");
+                Assert.fail("hashtable should contain key "+keys[i]+", but it doesn't");
             }
         }
 

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/StringKeyIndexerTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/StringKeyIndexerTest.java
@@ -154,7 +154,7 @@ public class StringKeyIndexerTest extends AbstractGenericTest {
         }
 
         if (keys.length != 100) {
-        	Assert.fail("Expeced keys to be length 100 and got "+keys.length);
+        	Assert.fail("Expected keys to be length 100 and got "+keys.length);
         }
         for(int i=0;i<100;i++) {
             if (!hashSet.contains(keys[i])) {
@@ -179,7 +179,7 @@ public class StringKeyIndexerTest extends AbstractGenericTest {
             hashSet.remove(key);
         }
         if (hashSet.size() != 0) {
-            Assert.fail("Expeced iterator to contain 100 Keys and got "+(100 - hashSet.size()));
+            Assert.fail("Expected iterator to contain 100 Keys and got "+(100 - hashSet.size()));
         }
 
 

--- a/Ghidra/Framework/Graph/src/main/java/ghidra/graph/viewer/GraphViewer.java
+++ b/Ghidra/Framework/Graph/src/main/java/ghidra/graph/viewer/GraphViewer.java
@@ -201,7 +201,7 @@ public class GraphViewer<V extends VisualVertex, E extends VisualEdge<V>>
 		PickedState<V> ps = super.getPickedVertexState();
 		if (!(ps instanceof GPickedState)) {
 			throw new IllegalArgumentException(
-				"GPickedState was not installed or was overrwritten");
+				"GPickedState was not installed or was overwritten");
 		}
 
 		return (GPickedState<V>) ps;

--- a/Ghidra/Framework/Graph/src/main/java/ghidra/service/graph/GraphDisplayOptions.java
+++ b/Ghidra/Framework/Graph/src/main/java/ghidra/service/graph/GraphDisplayOptions.java
@@ -812,7 +812,7 @@ public class GraphDisplayOptions implements OptionsChangeListener {
 			"If true, vertices are drawn using pre-rendered images versus compact shapes");
 
 		options.registerOption(LABEL_POSITION, OptionType.ENUM_TYPE, labelPosition, help,
-			"Relative postion of labels to vertex shape (Only applicable if \"Use Icons\" is true");
+			"Relative position of labels to vertex shape (Only applicable if \"Use Icons\" is true");
 
 		options.registerOption(FONT, OptionType.FONT_TYPE, font, help,
 			"Font to use for vertex labels");

--- a/Ghidra/Framework/Graph/src/main/java/ghidra/service/graph/VertexShape.java
+++ b/Ghidra/Framework/Graph/src/main/java/ghidra/service/graph/VertexShape.java
@@ -318,7 +318,7 @@ public abstract class VertexShape {
 	static class PentagonVertexShape extends EquilateralPolygonVertexShape {
 
 		private PentagonVertexShape(int size) {
-			super("Pentaon", 5, Math.PI + Math.PI / 10, size);
+			super("Pentagon", 5, Math.PI + Math.PI / 10, size);
 		}
 	}
 

--- a/Ghidra/Framework/Graph/src/test.slow/java/ghidra/graph/job/VisualGraphJobRunnerTest.java
+++ b/Ghidra/Framework/Graph/src/test.slow/java/ghidra/graph/job/VisualGraphJobRunnerTest.java
@@ -484,7 +484,7 @@ public class VisualGraphJobRunnerTest extends AbstractGenericTest {
 	private void assertFinishedAndNotShortcut(AbstractTestGraphJob... jobs) {
 
 		StringBuilder buffy =
-			new StringBuilder(jobs.length + " Jobs - should be finsihed and not shortcut\n");
+			new StringBuilder(jobs.length + " Jobs - should be finished and not shortcut\n");
 		for (AbstractTestGraphJob job : jobs) {
 
 			boolean isFinished = job.isFinished();
@@ -511,7 +511,7 @@ public class VisualGraphJobRunnerTest extends AbstractGenericTest {
 			buffy.append("\tdisposed? ").append(wasDisposed).append('\n');
 			buffy.append("\tnot started? ").append(didNotStart).append('\n');
 
-			assertTrue("Job should have been diposed/cancelled\n" + buffy,
+			assertTrue("Job should have been disposed/cancelled\n" + buffy,
 				wasDisposed || didNotStart);
 		}
 	}
@@ -673,7 +673,7 @@ public class VisualGraphJobRunnerTest extends AbstractGenericTest {
 			//
 			// Note: this code is NOT on the Swing thread, as it is a callback from a Thread
 			//
-			logger.trace("\t" + methodName + " calling listiner on Swing thread... (" + this + ")");
+			logger.trace("\t" + methodName + " calling listener on Swing thread... (" + this + ")");
 			runSwing(() -> jobListener.jobFinished(AbstractTestGraphJob.this));
 
 			logger.trace("\t" + methodName + " after listener call (" + this + ")");

--- a/Ghidra/Framework/Graph/src/test.slow/java/ghidra/graph/viewer/GraphComponentTest.java
+++ b/Ghidra/Framework/Graph/src/test.slow/java/ghidra/graph/viewer/GraphComponentTest.java
@@ -203,7 +203,7 @@ public class GraphComponentTest extends AbstractVisualGraphTest {
 		if (v.hasBeenEmphasised()) {
 
 			// below, once we are zoomed-out, then the emphasis should happen
-			Msg.debug(this, "No vertice should have been emphasized, since we are zoomed in " +
+			Msg.debug(this, "No vertex should have been emphasized, since we are zoomed in " +
 				" - twinkled vertex: " + v + "; all vertex states: ");
 			vertices.forEach(vertex -> {
 				Msg.debug(this, vertex + " - " + vertex.hasBeenEmphasised());

--- a/Ghidra/Framework/Help/src/main/java/help/validator/ReferenceTagProcessor.java
+++ b/Ghidra/Framework/Help/src/main/java/help/validator/ReferenceTagProcessor.java
@@ -112,7 +112,7 @@ public class ReferenceTagProcessor extends TagProcessor {
 			}
 			else {
 				errorCount++;
-				errors.append("Bad IMG Tag - unexpected attribtute (line " + lineNum + "): " +
+				errors.append("Bad IMG Tag - unexpected attribute (line " + lineNum + "): " +
 					htmlFile + EOL);
 			}
 		}

--- a/Ghidra/Framework/Help/src/main/java/help/validator/UnusedHelpImageFileFinder.java
+++ b/Ghidra/Framework/Help/src/main/java/help/validator/UnusedHelpImageFileFinder.java
@@ -44,13 +44,13 @@ public class UnusedHelpImageFileFinder {
 		List<HelpModuleLocation> helpCollections = collectHelp();
 
 		Collection<IMG> referencedIMGs = getReferencedIMGs(helpCollections);
-		debug("Found " + referencedIMGs.size() + " image referenes from help files");
+		debug("Found " + referencedIMGs.size() + " image references from help files");
 
 		Collection<Path> allImagesOnDisk = getAllImagesOnDisk(helpCollections);
 		debug("Found " + allImagesOnDisk.size() + " image files in help directories");
 
 		Collection<Path> unusedFiles = getUnusedFiles(referencedIMGs, allImagesOnDisk);
-		if (unusedFiles.size() == 0) {
+		if (unusedFiles.isEmpty()) {
 			System.out.println("No unused image files found!");
 			System.exit(0);
 		}
@@ -70,7 +70,7 @@ public class UnusedHelpImageFileFinder {
 		UnusedHelpImageFileFinder.debugEnabled = debugEnabled;
 
 		Collection<IMG> referencedIMGs = getReferencedIMGs(helpCollections);
-		debug("Found " + referencedIMGs.size() + " image referenes from help files");
+		debug("Found " + referencedIMGs.size() + " image references from help files");
 
 		Collection<Path> allImagesOnDisk = getAllImagesOnDisk(helpCollections);
 		debug("Found " + allImagesOnDisk.size() + " image files in help directories");

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/DomainFileProxy.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/DomainFileProxy.java
@@ -95,7 +95,7 @@ public class DomainFileProxy implements DomainFile {
 
 	@Override
 	public void setReadOnly(boolean state) {
-		throw new UnsupportedOperationException("setReadOnly() not suppported on DomainFileProxy");
+		throw new UnsupportedOperationException("setReadOnly() not supported on DomainFileProxy");
 	}
 
 	@Override

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/ProjectFileManager.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/ProjectFileManager.java
@@ -544,10 +544,10 @@ public class ProjectFileManager implements ProjectData {
 
 		newRepository.connect();
 		if (!newRepository.isConnected()) {
-			throw new IOException("new respository not connected");
+			throw new IOException("new repository not connected");
 		}
 		if (repository != null) {
-			throw new IllegalStateException("Only private project may be converted to shared");
+			throw new IllegalStateException("Only private projects may be converted to shared");
 		}
 
 		// 1) Convert versioned files (including checked-out files) to private files

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/FileActionManager.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/FileActionManager.java
@@ -362,7 +362,7 @@ class FileActionManager {
 				objs[lastIndex] = files.get(lastIndex).getDomainObject(this, false, false, null);
 			}
 			catch (Throwable t) {
-				Msg.error(this, "Failed to aqcuire domain object instance", t);
+				Msg.error(this, "Failed to acquire domain object instance", t);
 				locked = false;
 				break;
 			}

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
@@ -134,7 +134,7 @@ public class VersionControlCheckOutAction extends VersionControlAction {
 			if (n == 0) {
 				Msg.showError(this, tool.getToolFrame(), "Checkout Failed",
 					"The specified files do not contain any versioned files available for " +
-						"checkeout");
+						"checkout");
 				return false;
 			}
 

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/protocol/ghidra/GhidraURLWrappedContent.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/protocol/ghidra/GhidraURLWrappedContent.java
@@ -62,7 +62,7 @@ public class GhidraURLWrappedContent {
 
 	private void addConsumer(Object consumer) {
 		if (containsConsumer(consumer)) {
-			throw new RuntimeException("duplcate consumer");
+			throw new RuntimeException("duplicate consumer");
 		}
 		consumers.add(consumer);
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/Emulator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/emulator/Emulator.java
@@ -66,7 +66,7 @@ public class Emulator {
 
 		Language lang = cfg.getLanguage();
 		if (!(lang instanceof SleighLanguage)) {
-			throw new IllegalArgumentException("Invalid configuartion language [" +
+			throw new IllegalArgumentException("Invalid configuration language [" +
 				lang.getLanguageID() + "]: only Sleigh languages are supported by emulator");
 		}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/PcodeEmitObjects.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/PcodeEmitObjects.java
@@ -72,13 +72,12 @@ public class PcodeEmitObjects extends PcodeEmit {
 		if (labelref == null) {
 			return;
 		}
-		for (int i = 0; i < labelref.size(); ++i) {
-			int opindex = labelref.get(i);
+		for (int opindex : labelref) {
 			PcodeOp op = oplist.get(opindex);
 			Varnode vn = op.getInput(0);
 			int labelid = (int) vn.getOffset();
 			if ((labelid >= labeldef.size()) || (labeldef.get(labelid) == null)) {
-				throw new SleighException("Reference to non-existant sleigh label");
+				throw new SleighException("Reference to non-existent sleigh label");
 			}
 			long res = (long) labeldef.get(labelid) - (long) opindex;
 			if (vn.getSize() < 8) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/PcodeEmitPacked.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/PcodeEmitPacked.java
@@ -80,10 +80,9 @@ public class PcodeEmitPacked extends PcodeEmit {
 		if (labelref == null) {
 			return;
 		}
-		for (int i = 0; i < labelref.size(); ++i) {
-			LabelRef ref = labelref.get(i);
+		for (LabelRef ref : labelref) {
 			if ((ref.labelIndex >= labeldef.size()) || (labeldef.get(ref.labelIndex) == null)) {
-				throw new SleighException("Reference to non-existant sleigh label");
+				throw new SleighException("Reference to non-existent sleigh label");
 			}
 			long res = (long) labeldef.get(ref.labelIndex) - (long) ref.opIndex;
 			if (ref.labelSize < 8) {
@@ -92,7 +91,7 @@ public class PcodeEmitPacked extends PcodeEmit {
 				res &= mask;
 			}
 			// We need to skip over op_tag, op_code, void_tag, addrsz_tag, and spc bytes
-			insertOffset(ref.streampos + 5, res);		// Insert the final offset into the stream
+			insertOffset(ref.streampos + 5, res);        // Insert the final offset into the stream
 		}
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SleighDebugLogger.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SleighDebugLogger.java
@@ -85,7 +85,7 @@ public class SleighDebugLogger {
 
 		if (!(language instanceof SleighLanguage)) {
 			throw new IllegalArgumentException(
-				"unsupport language provider: " + language.getClass().getSimpleName());
+				"unsupported language provider: " + language.getClass().getSimpleName());
 		}
 
 		ContextCache contextCache = new ContextCache();

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SpecExtensionPanel.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SpecExtensionPanel.java
@@ -272,7 +272,7 @@ public class SpecExtensionPanel extends JPanel {
 			}
 			catch (LockException ex) {
 				Msg.showError(this, null, "Missing Exclusive Access",
-					"Do not have exclusive acces");
+					"Do not have exclusive access");
 			}
 			catch (XmlParseException | SAXException ex) {
 				Msg.showError(this, null, "Failed Committing Extension Changes", ex.getMessage());

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoCodeUnit.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoCodeUnit.java
@@ -139,7 +139,7 @@ abstract class PseudoCodeUnit implements CodeUnit {
 	public void invalidate() {
 		if (program == null) {
 			throw new UnsupportedOperationException(
-				"Pseduo code unit has null program - refresh not supported");
+				"Pseudo code unit has null program - refresh not supported");
 		}
 		isValid = false;
 	}
@@ -675,7 +675,7 @@ abstract class PseudoCodeUnit implements CodeUnit {
 		if (offset < 0 || offset >= bytes.length) {
 			if (program == null) {
 				throw new MemoryAccessException(
-					"Pseduo code unit has null program - memory request out of range");
+					"Pseudo code unit has null program - memory request out of range");
 			}
 			Memory memory = program.getMemory();
 			try {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoInstruction.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoInstruction.java
@@ -342,7 +342,7 @@ public class PseudoInstruction extends PseudoCodeUnit implements Instruction, In
 
 	@Override
 	public Address getFallFrom() {
-		throw new UnsupportedOperationException("Not supported by pseduo instruction");
+		throw new UnsupportedOperationException("Not supported by pseudo instruction");
 //		// check if the instruction before this is in a delay slot
 //		// If it is then back up until hit an instruction that claims
 //		// to be a delay slot instruction that is not in a delay slot

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/memstate/MemoryState.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/memstate/MemoryState.java
@@ -368,7 +368,7 @@ public class MemoryState {
 	public void setInitialized(boolean initialized, AddressSpace spc, long off, int size) {
 		MemoryBank mspace = getMemoryBank(spc);
 		if (mspace == null)
-			throw new LowlevelError("Setting intialization status of unmapped memory space: " +
+			throw new LowlevelError("Setting initialization status of unmapped memory space: " +
 				spc.getName());
 		mspace.setInitialized(off, size, initialized);
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
@@ -746,7 +746,7 @@ public class SleighCompile extends SleighBase {
 	}
 
 	public void setUnnecessaryPcodeWarning(boolean val) {
-		entry("setUnecessaryPcodeWarning", val);
+		entry("setUnnecessaryPcodeWarning", val);
 		warnunnecessarypcode = val;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompileLauncher.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompileLauncher.java
@@ -275,7 +275,7 @@ public class SleighCompileLauncher implements GhidraLaunchable {
 				"Options file not found: " + optionsFile.getAbsolutePath());
 			if (SystemUtilities.isInDevelopmentMode()) {
 				Msg.error(SleighCompile.class,
-					"Eclipse language module must be selected and 'gradle prepdev' prevously run");
+					"Eclipse language module must be selected and 'gradle prepdev' previously run");
 			}
 			return null;
 		}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ProgramUserDataDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ProgramUserDataDB.java
@@ -568,7 +568,7 @@ class ProgramUserDataDB extends DomainObjectAdapterDB implements ProgramUserData
 			throw new AssertException("Unexpected Error", e);
 		}
 		catch (VersionException e) {
-			throw new IOException("Incompatable property data for '" +
+			throw new IOException("Incompatible property data for '" +
 				rec.getString(PROPERTY_NAME_COL) + "': " + e.getMessage());
 		}
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
@@ -1939,7 +1939,7 @@ public class CodeManager implements ErrorHandler, ManagerDB {
 		if (!program.getMemory().contains(startAddr, endAddr)) {
 			long length = endAddr.subtract(startAddr) + 1;
 			throw new CodeUnitInsertionException(
-				"Insufficent memory at address " + startAddr + " (length: " + length + " bytes)");
+				"Insufficient memory at address " + startAddr + " (length: " + length + " bytes)");
 		}
 
 		RecordIterator recIt = instAdapter.getRecords(startAddr, true);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeUnitDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeUnitDB.java
@@ -559,7 +559,7 @@ abstract class CodeUnitDB extends DatabaseObject implements CodeUnit, ProcessorC
 				}
 				catch (DuplicateNameException e) {
 					throw new AssertException(
-						"Assert problem in CodeUnitImpl.setProperty(Stirng,Object)");
+						"Assert problem in CodeUnitImpl.setProperty(String,Object)");
 				}
 			}
 			pm.add(address, value);
@@ -604,7 +604,7 @@ abstract class CodeUnitDB extends DatabaseObject implements CodeUnit, ProcessorC
 					pm = upm.createVoidPropertyMap(name);
 				}
 				catch (DuplicateNameException e) {
-					throw new AssertException("Assert problem in CodeUnitImpl.setProperty(Stirng)");
+					throw new AssertException("Assert problem in CodeUnitImpl.setProperty(String)");
 				}
 			}
 			pm.add(address);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/CategoryDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/CategoryDB.java
@@ -177,7 +177,7 @@ class CategoryDB extends DatabaseObject implements Category {
 			catch (IOException e) {
 				mgr.dbError(e);
 			}
-			parent.catagoryRenamed(this, oldName);
+			parent.categoryRenamed(this, oldName);
 			mgr.categoryRenamed(oldPath, this);
 		}
 		finally {
@@ -608,7 +608,7 @@ class CategoryDB extends DatabaseObject implements Category {
 		parent = newParent;
 	}
 
-	private void catagoryRenamed(CategoryDB childCategory, String oldName) {
+	private void categoryRenamed(CategoryDB childCategory, String oldName) {
 		subcategoryMap.remove(oldName);
 		subcategoryMap.put(childCategory.getName(), childCategory);
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/CategoryDBAdapter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/CategoryDBAdapter.java
@@ -50,7 +50,7 @@ abstract class CategoryDBAdapter {
 
 	/**
 	 * Returns a list of categoryIDs that have the given parent ID.
-	 * @param categoryID the key into the catagory table
+	 * @param categoryID the key into the category table
 	 * @return an array of categoryIDs that have the specified parent.  Field array 
 	 * returned with LongField key values.
 	 * @throws IOException if IO error occurs
@@ -60,7 +60,7 @@ abstract class CategoryDBAdapter {
 	/**
 	 * Creates a new category with the given name and parent ID.
 	 * @param name the name of the new category.
-	 * @param parentID the parent key into the catagory table
+	 * @param parentID the parent key into the category table
 	 * @return a new record for the new category.
 	 * @throws IOException if IO error occurs
 	 */

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
@@ -1257,7 +1257,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 			// Don't support replacement with Factory or Dynamic datatype
 			if (replacementDt instanceof Dynamic || replacementDt instanceof FactoryDataType) {
 				throw new IllegalArgumentException(
-					"Datatype replacment with dynamic or factory type not permitted.");
+					"Datatype replacement with dynamic or factory type not permitted.");
 			}
 			if (getID(existingDt) < 0) {
 				throw new IllegalArgumentException(
@@ -1305,7 +1305,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 				}
 				catch (Exception e) {
 					// not sure what to do here
-					Msg.error(this, "Unable to set the CatagoryPath to " + path +
+					Msg.error(this, "Unable to set the CategoryPath to " + path +
 						"on " + replacementDt + " while replacing the original datatype", e);
 				}
 			}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryBlockDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryBlockDB.java
@@ -695,7 +695,7 @@ public class MemoryBlockDB implements MemoryBlock {
 		}
 		subBlocks.clear();
 		DBRecord subRecord = adapter.createSubBlockRecord(id, 0, length,
-			MemoryMapDBAdapter.SUB_TYPE_UNITIALIZED, 0, 0);
+			MemoryMapDBAdapter.SUB_TYPE_UNINITIALIZED, 0, 0);
 		subBlocks.add(new UninitializedSubMemoryBlock(adapter, subRecord));
 
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDB.java
@@ -1058,24 +1058,24 @@ public class MemoryMapDB implements Memory, ManagerDB, LiveMemoryListener {
 	}
 
 	@Override
-	public MemoryBlock convertToInitialized(MemoryBlock unitializedBlock, byte initialValue)
+	public MemoryBlock convertToInitialized(MemoryBlock uninitializedBlock, byte initialValue)
 			throws MemoryBlockException, NotFoundException, LockException {
 		lock.acquire();
 		try {
-			checkBlock(unitializedBlock);
+			checkBlock(uninitializedBlock);
 			program.checkExclusiveAccess();
-			if (unitializedBlock.isInitialized()) {
+			if (uninitializedBlock.isInitialized()) {
 				throw new IllegalArgumentException(
 					"Only an Uninitialized Block may be converted to an Initialized Block");
 			}
-			if (unitializedBlock.getType() != MemoryBlockType.DEFAULT) {
+			if (uninitializedBlock.getType() != MemoryBlockType.DEFAULT) {
 				throw new IllegalArgumentException("Block is of a type that cannot be initialized");
 			}
-			long size = unitializedBlock.getSize();
+			long size = uninitializedBlock.getSize();
 			if (size > MAX_BLOCK_SIZE) {
 				throw new MemoryBlockException("Block too large to initialize");
 			}
-			MemoryBlockDB memBlock = (MemoryBlockDB) unitializedBlock;
+			MemoryBlockDB memBlock = (MemoryBlockDB) uninitializedBlock;
 			try {
 				memBlock.initializeBlock(initialValue);
 				allInitializedAddrSet.addRange(memBlock.getStart(), memBlock.getEnd());

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapter.java
@@ -74,7 +74,7 @@ abstract class MemoryMapDBAdapter {
 	public static final byte SUB_TYPE_BIT_MAPPED = MemoryMapDBAdapterV3.V3_SUB_TYPE_BIT_MAPPED;
 	public static final byte SUB_TYPE_BYTE_MAPPED = MemoryMapDBAdapterV3.V3_SUB_TYPE_BYTE_MAPPED;
 	public static final byte SUB_TYPE_BUFFER = MemoryMapDBAdapterV3.V3_SUB_TYPE_BUFFER;
-	public static final byte SUB_TYPE_UNITIALIZED = MemoryMapDBAdapterV3.V3_SUB_TYPE_UNITIALIZED;
+	public static final byte SUB_TYPE_UNINITIALIZED = MemoryMapDBAdapterV3.V3_SUB_TYPE_UNINITIALIZED;
 	public static final byte SUB_TYPE_FILE_BYTES = MemoryMapDBAdapterV3.V3_SUB_TYPE_FILE_BYTES;
 
 	static MemoryMapDBAdapter getAdapter(DBHandle handle, int openMode, MemoryMapDB memMap,

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapterV0.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapterV0.java
@@ -159,7 +159,7 @@ class MemoryMapDBAdapterV0 extends MemoryMapDBAdapter {
 				record.setLongValue(SUB_LONG_DATA2_COL, bufID);
 				return new BufferSubMemoryBlock(this, record);
 			case MemoryMapDBAdapterV2.UNINITIALIZED:
-				record.setByteValue(SUB_TYPE_COL, SUB_TYPE_UNITIALIZED);
+				record.setByteValue(SUB_TYPE_COL, SUB_TYPE_UNINITIALIZED);
 				return new UninitializedSubMemoryBlock(this, record);
 			default:
 				throw new IOException("Unknown memory block type: " + type);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapterV2.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapterV2.java
@@ -135,7 +135,7 @@ class MemoryMapDBAdapterV2 extends MemoryMapDBAdapter {
 				record.setIntValue(SUB_INT_DATA1_COL, bufID);
 				return new BufferSubMemoryBlock(this, record);
 			case MemoryMapDBAdapterV2.UNINITIALIZED:
-				record.setByteValue(SUB_TYPE_COL, SUB_TYPE_UNITIALIZED);
+				record.setByteValue(SUB_TYPE_COL, SUB_TYPE_UNINITIALIZED);
 				return new UninitializedSubMemoryBlock(this, record);
 			default:
 				throw new IOException("Unknown memory block type: " + type);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapterV3.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDBAdapterV3.java
@@ -54,7 +54,7 @@ public class MemoryMapDBAdapterV3 extends MemoryMapDBAdapter {
 	public static final byte V3_SUB_TYPE_BIT_MAPPED = 0;
 	public static final byte V3_SUB_TYPE_BYTE_MAPPED = 1;
 	public static final byte V3_SUB_TYPE_BUFFER = 2;
-	public static final byte V3_SUB_TYPE_UNITIALIZED = 3;
+	public static final byte V3_SUB_TYPE_UNINITIALIZED = 3;
 	public static final byte V3_SUB_TYPE_FILE_BYTES = 4;
 
 	static Schema V3_BLOCK_SCHEMA = new Schema(V3_VERSION, "Key",
@@ -200,7 +200,7 @@ public class MemoryMapDBAdapterV3 extends MemoryMapDBAdapter {
 		if (initializeBytes) {
 			return createInitializedBlock(name, startAddr, null, length, permissions);
 		}
-		return createUnitializedBlock(name, startAddr, length, permissions);
+		return createUninitializedBlock(name, startAddr, length, permissions);
 	}
 
 	@Override
@@ -224,7 +224,7 @@ public class MemoryMapDBAdapterV3 extends MemoryMapDBAdapter {
 		return newBlock;
 	}
 
-	MemoryBlockDB createUnitializedBlock(String name, Address startAddress, long length,
+	MemoryBlockDB createUninitializedBlock(String name, Address startAddress, long length,
 			int permissions) throws IOException, AddressOverflowException {
 		updateAddressMapForAllAddresses(startAddress, length);
 
@@ -232,7 +232,7 @@ public class MemoryMapDBAdapterV3 extends MemoryMapDBAdapter {
 		DBRecord blockRecord = createMemoryBlockRecord(name, startAddress, length, permissions);
 		long key = blockRecord.getKey();
 
-		DBRecord subRecord = createSubBlockRecord(key, 0, length, V3_SUB_TYPE_UNITIALIZED, 0, 0);
+		DBRecord subRecord = createSubBlockRecord(key, 0, length, V3_SUB_TYPE_UNINITIALIZED, 0, 0);
 		subBlocks.add(new UninitializedSubMemoryBlock(this, subRecord));
 
 		memBlockTable.putRecord(blockRecord);
@@ -412,7 +412,7 @@ public class MemoryMapDBAdapterV3 extends MemoryMapDBAdapter {
 				return new ByteMappedSubMemoryBlock(this, record);
 			case V3_SUB_TYPE_BUFFER:
 				return new BufferSubMemoryBlock(this, record);
-			case V3_SUB_TYPE_UNITIALIZED:
+			case V3_SUB_TYPE_UNINITIALIZED:
 				return new UninitializedSubMemoryBlock(this, record);
 			case V3_SUB_TYPE_FILE_BYTES:
 				return new FileBytesSubMemoryBlock(this, record);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/UninitializedSubMemoryBlock.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/UninitializedSubMemoryBlock.java
@@ -79,7 +79,7 @@ class UninitializedSubMemoryBlock extends SubMemoryBlock {
 		adapter.updateSubBlockRecord(record);
 
 		DBRecord newSubRecord = adapter.createSubBlockRecord(-1, 0, newLength,
-			MemoryMapDBAdapter.SUB_TYPE_UNITIALIZED, 0, 0);
+			MemoryMapDBAdapter.SUB_TYPE_UNINITIALIZED, 0, 0);
 
 		return new UninitializedSubMemoryBlock(adapter, newSubRecord);
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DialogResourceDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DialogResourceDataType.java
@@ -35,7 +35,7 @@ public class DialogResourceDataType extends DynamicDataType {
 		itemTypeMap.put(0x0081, "Edit");
 		itemTypeMap.put(0x0082, "Static");
 		itemTypeMap.put(0x0083, "List Box");
-		itemTypeMap.put(0x0084, "Scoll Bar");
+		itemTypeMap.put(0x0084, "Scroll Bar");
 		itemTypeMap.put(0x0085, "Combo Box");
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/InstructionBlock.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/InstructionBlock.java
@@ -139,7 +139,7 @@ public class InstructionBlock implements Iterable<Instruction> {
 		}
 		else if (!maxAddress.isSuccessor(instructionMinAddr)) {
 			throw new IllegalArgumentException("Newly added instruction at address " +
-				instructionMinAddr + " is not the immediate succesor to address " + maxAddress);
+				instructionMinAddr + " is not the immediate successor to address " + maxAddress);
 		}
 		instructionMap.put(instructionMinAddr, instruction);
 		if (!instruction.isInDelaySlot()) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/mem/Memory.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/mem/Memory.java
@@ -380,14 +380,14 @@ public interface Memory extends AddressSetView {
 	/**
 	 * Convert an existing uninitialized block with an
 	 * initialized block.
-	 * @param unitializedBlock unitialized block to convert
+	 * @param uninitializedBlock uninitialized block to convert
 	 * @param initialValue initial value for the bytes
 	 * @throws LockException if exclusive lock not in place (see haveLock())
 	 * @throws MemoryBlockException if there is no block in memory
 	 * at the same address as block or if the block lengths are not
 	 * the same.
 	 */
-	public MemoryBlock convertToInitialized(MemoryBlock unitializedBlock, byte initialValue)
+	public MemoryBlock convertToInitialized(MemoryBlock uninitializedBlock, byte initialValue)
 			throws LockException, MemoryBlockException, NotFoundException;
 
 	public MemoryBlock convertToUninitialized(MemoryBlock itializedBlock)

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/LanguageTranslatorFactory.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/LanguageTranslatorFactory.java
@@ -167,7 +167,7 @@ public class LanguageTranslatorFactory {
 			}
 			catch (Exception e) {
 				Msg.error(this,
-					"Failed to instatiate language translator: " + translatorClass.getName(), e);
+					"Failed to instantiate language translator: " + translatorClass.getName(), e);
 				++badFileCount;
 			}
 		}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/OldLanguageFactory.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/OldLanguageFactory.java
@@ -214,7 +214,7 @@ public class OldLanguageFactory {
 		LanguageService languageService = DefaultLanguageService.getLanguageService();
 		if (lang instanceof OldLanguage) {
 			throw new LanguageNotFoundException(
-				"Can't create an Old Langauge file from an OldLanguage");
+				"Can't create an Old Language file from an OldLanguage");
 		}
 		LanguageDescription languageDescription =
 			languageService.getLanguageDescription(lang.getLanguageID());

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/SimpleLanguageTranslator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/SimpleLanguageTranslator.java
@@ -331,7 +331,7 @@ class SimpleLanguageTranslator extends LanguageTranslatorAdapter {
 			}
 			else if ("post_upgrade_handler".equals(elementName)) {
 				if (postUpgradeInstructionHandlerClass != null) {
-					throw new SAXException("Only a single post_upgrade_analzer may be specified");
+					throw new SAXException("Only a single post_upgrade_analyzer may be specified");
 				}
 				postUpgradeInstructionHandlerClass = parsePostUpgradeHandlerEntry(element);
 			}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/VariableLocation.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/VariableLocation.java
@@ -29,13 +29,13 @@ public class VariableLocation extends FunctionLocation {
 
 	private boolean isParameter;
 
-	private int ordinalOrfirstUseOffset;
+	private int ordinalOrFirstUseOffset;
 	private Address variableAddress; // will be NO_ADDRESS for return and auto-parameters
 
 	@Override
 	public String toString() {
 		return super.toString() + ", isParameter = " + isParameter +
-			", ordinalOrfirstUseOffset = " + ordinalOrfirstUseOffset + ", Variable Address = " +
+			", ordinalOrFirstUseOffset = " + ordinalOrFirstUseOffset + ", Variable Address = " +
 			variableAddress;
 	}
 
@@ -62,10 +62,10 @@ public class VariableLocation extends FunctionLocation {
 		variableAddress = getVariableAddress(var);
 		if (var instanceof Parameter) {
 			isParameter = true;
-			ordinalOrfirstUseOffset = ((Parameter) var).getOrdinal();
+			ordinalOrFirstUseOffset = ((Parameter) var).getOrdinal();
 		}
 		else {
-			ordinalOrfirstUseOffset = var.getFirstUseOffset();
+			ordinalOrFirstUseOffset = var.getFirstUseOffset();
 		}
 	}
 
@@ -91,13 +91,13 @@ public class VariableLocation extends FunctionLocation {
 			return null;
 		}
 		if (isParameter) { // return or parameter
-			return function.getParameter(ordinalOrfirstUseOffset);
+			return function.getParameter(ordinalOrFirstUseOffset);
 		}
 		if (variableAddress == null || !variableAddress.isVariableAddress()) {
 			return null;
 		}
 		for (Variable var : function.getLocalVariables()) {
-			if (var.getFirstUseOffset() == ordinalOrfirstUseOffset &&
+			if (var.getFirstUseOffset() == ordinalOrFirstUseOffset &&
 				var.getSymbol().getAddress().equals(variableAddress)) {
 				return var;
 			}
@@ -132,17 +132,17 @@ public class VariableLocation extends FunctionLocation {
 			return false;
 		}
 		if (var instanceof Parameter) {
-			return isParameter && (ordinalOrfirstUseOffset == ((Parameter) var).getOrdinal());
+			return isParameter && (ordinalOrFirstUseOffset == ((Parameter) var).getOrdinal());
 		}
-		return (ordinalOrfirstUseOffset == var.getFirstUseOffset() && variableAddress.equals(getVariableAddress(var)));
+		return (ordinalOrFirstUseOffset == var.getFirstUseOffset() && variableAddress.equals(getVariableAddress(var)));
 	}
 
 	public boolean isParameter() {
-		return isParameter && ordinalOrfirstUseOffset != Parameter.RETURN_ORIDINAL;
+		return isParameter && ordinalOrFirstUseOffset != Parameter.RETURN_ORIDINAL;
 	}
 
 	public boolean isReturn() {
-		return isParameter && ordinalOrfirstUseOffset == Parameter.RETURN_ORIDINAL;
+		return isParameter && ordinalOrFirstUseOffset == Parameter.RETURN_ORIDINAL;
 	}
 
 	@Override
@@ -150,7 +150,7 @@ public class VariableLocation extends FunctionLocation {
 		if (super.equals(object)) {
 			VariableLocation loc = (VariableLocation) object;
 			if (isParameter != loc.isParameter ||
-				ordinalOrfirstUseOffset != loc.ordinalOrfirstUseOffset) {
+				ordinalOrFirstUseOffset != loc.ordinalOrFirstUseOffset) {
 				return false;
 			}
 			return isParameter || variableAddress.equals(loc.variableAddress);
@@ -169,7 +169,7 @@ public class VariableLocation extends FunctionLocation {
 					if (!otherLoc.isParameter) {
 						return -1;
 					}
-					int retVal = ordinalOrfirstUseOffset - otherLoc.ordinalOrfirstUseOffset;
+					int retVal = ordinalOrFirstUseOffset - otherLoc.ordinalOrFirstUseOffset;
 					if (retVal != 0) {
 						return retVal;
 					}
@@ -203,7 +203,7 @@ public class VariableLocation extends FunctionLocation {
 	public void restoreState(Program p, SaveState obj) {
 		super.restoreState(p, obj);
 		isParameter = obj.getBoolean("_IS_PARAMETER", false);
-		ordinalOrfirstUseOffset = obj.getInt("_ORDINAL_FIRST_USE_OFFSET", 0);
+		ordinalOrFirstUseOffset = obj.getInt("_ORDINAL_FIRST_USE_OFFSET", 0);
 		variableAddress = Address.NO_ADDRESS; // corresponds to return parameter
 		if (obj.hasValue("_VARIABLE_OFFSET")) {
 			long offset = obj.getLong("_VARIABLE_OFFSET", -1L);
@@ -217,7 +217,7 @@ public class VariableLocation extends FunctionLocation {
 	public void saveState(SaveState obj) {
 		super.saveState(obj);
 		obj.putBoolean("_IS_PARAMETER", isParameter);
-		obj.putInt("_ORDINAL_FIRST_USE_OFFSET", ordinalOrfirstUseOffset);
+		obj.putInt("_ORDINAL_FIRST_USE_OFFSET", ordinalOrFirstUseOffset);
 		if (variableAddress.isVariableAddress()) {
 			obj.putLong("_VARIABLE_OFFSET", variableAddress.getOffset());
 		}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/sleigh/grammar/ParsingEnvironment.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/sleigh/grammar/ParsingEnvironment.java
@@ -152,7 +152,7 @@ public class ParsingEnvironment {
 		else if (e instanceof MismatchedTokenException) {
 			MismatchedTokenException mte = (MismatchedTokenException) e;
 			if (mte.token == null) {
-				msg = "expecting '" + ((char) mte.expecting) + "', unexpected characer: '" +
+				msg = "expecting '" + ((char) mte.expecting) + "', unexpected character: '" +
 					((char) mte.c) + "'";
 			}
 			else {

--- a/Ghidra/Framework/SoftwareModeling/src/test.slow/java/ghidra/program/model/data/FileDataTypeManagerTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test.slow/java/ghidra/program/model/data/FileDataTypeManagerTest.java
@@ -83,7 +83,7 @@ public class FileDataTypeManagerTest extends AbstractGenericTest {
 				}
 
 				Assert.fail(
-					"Did not get exptected data types of byte, Typdef and Typedef.  Instead found:\n" +
+					"Did not get expected data types of byte, Typdef and Typedef.  Instead found:\n" +
 						buffy.toString());
 			}
 

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcode/memstate/UniqueMemoryBankTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcode/memstate/UniqueMemoryBankTest.java
@@ -73,7 +73,7 @@ public class UniqueMemoryBankTest extends AbstractGenericTest {
 	}
 
 	@Test(expected = LowlevelError.class)
-	public void testGetUnitializedByte() {
+	public void testGetUninitializedByte() {
 		WordInfo info = new WordInfo();
 		info.setByte((byte) 0, 0);
 		info.setByte((byte) 1, 1);
@@ -217,13 +217,13 @@ public class UniqueMemoryBankTest extends AbstractGenericTest {
 	}
 
 	@Test(expected = LowlevelError.class)
-	public void testUnitializedReadStop() {
+	public void testUninitializedReadStop() {
 		byte[] dest = new byte[16];
 		uniqueBank.getChunk(0x1000, 0x10, dest, false);
 	}
 
 	@Test
-	public void testUnitializedReadContinue() {
+	public void testUninitializedReadContinue() {
 		byte[] dest = new byte[16];
 		int bytesRead = uniqueBank.getChunk(0x1000, 0x10, dest, true);
 		assertEquals(0, bytesRead);

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/database/mem/MemBlockDBTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/database/mem/MemBlockDBTest.java
@@ -125,7 +125,7 @@ public class MemBlockDBTest extends AbstractGenericTest {
 		assertEquals(addr(9), info.getMaxAddress());
 		try {
 			block.getByte(addr(0));
-			fail("expected exception trying to read bytes on unitialized block");
+			fail("expected exception trying to read bytes on uninitialized block");
 		}
 		catch (MemoryAccessException e) {
 			// expected
@@ -133,7 +133,7 @@ public class MemBlockDBTest extends AbstractGenericTest {
 	}
 
 	@Test
-	public void testCreateUnitializedOverlayBlock() throws Exception {
+	public void testCreateUninitializedOverlayBlock() throws Exception {
 		MemoryBlock block = mem.createUninitializedBlock("test", addr(0), 10, true);
 
 		assertEquals(10, block.getSize());
@@ -150,7 +150,7 @@ public class MemBlockDBTest extends AbstractGenericTest {
 		assertEquals(10, info.getLength());
 		try {
 			block.getByte(block.getStart());
-			fail("expected exception trying to read bytes on unitialized block");
+			fail("expected exception trying to read bytes on uninitialized block");
 		}
 		catch (MemoryAccessException e) {
 			// expected
@@ -208,7 +208,7 @@ public class MemBlockDBTest extends AbstractGenericTest {
 		}
 		try {
 			mem.getByte(block.getStart().add(10));
-			fail("expected exception trying to read bytes on mapped unitialized block");
+			fail("expected exception trying to read bytes on mapped uninitialized block");
 		}
 		catch (MemoryAccessException e) {
 			// expected 
@@ -245,7 +245,7 @@ public class MemBlockDBTest extends AbstractGenericTest {
 		}
 		try {
 			mem.getByte(block.getStart().add(8));
-			fail("expected exception trying to read bytes on mapped unitialized block");
+			fail("expected exception trying to read bytes on mapped uninitialized block");
 		}
 		catch (MemoryAccessException e) {
 			// expected 
@@ -535,7 +535,7 @@ public class MemBlockDBTest extends AbstractGenericTest {
 	}
 
 	@Test
-	public void testSplitAndJoinUnitializedBlock() throws Exception {
+	public void testSplitAndJoinUninitializedBlock() throws Exception {
 		MemoryBlock block = mem.createUninitializedBlock("test", addr(0), 40, false);
 		mem.split(block, addr(10));
 		MemoryBlock[] blocks = mem.getBlocks();
@@ -979,7 +979,7 @@ public class MemBlockDBTest extends AbstractGenericTest {
 	}
 
 	@Test
-	public void testAddressSourceInfoForUnitialized() throws Exception {
+	public void testAddressSourceInfoForUninitialized() throws Exception {
 		mem.createUninitializedBlock("test", addr(0), 10, false);
 
 		AddressSourceInfo info = mem.getAddressSourceInfo(addr(0));

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/framework/ApplicationProperties.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/framework/ApplicationProperties.java
@@ -117,7 +117,7 @@ public class ApplicationProperties extends Properties {
 
 		String workingDir = System.getProperty("user.dir");
 		if (workingDir == null) {
-			throw new FileNotFoundException("Cannot determing the current working directory");
+			throw new FileNotFoundException("Cannot determine the current working directory");
 		}
 
 		File dir = new File(workingDir);

--- a/Ghidra/Framework/Utility/src/main/java/utilities/util/FileUtilities.java
+++ b/Ghidra/Framework/Utility/src/main/java/utilities/util/FileUtilities.java
@@ -959,7 +959,7 @@ public final class FileUtilities {
 				return FileSystems.newFileSystem(jarURI, env);
 			}
 			catch (IOException e1) {
-				Msg.debug(FileUtilities.class, "Unexepecedly could not create jar filesystem");
+				Msg.debug(FileUtilities.class, "Unexpectedly could not create jar filesystem");
 				return null;
 			}
 		}

--- a/Ghidra/Processors/68000/src/main/java/ghidra/app/plugin/core/analysis/Motorola68KAnalyzer.java
+++ b/Ghidra/Processors/68000/src/main/java/ghidra/app/plugin/core/analysis/Motorola68KAnalyzer.java
@@ -60,7 +60,7 @@ public class Motorola68KAnalyzer extends ConstantPropagationAnalyzer {
 
 	@Override
 	public AddressSetView flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
 		// follow all flows building up context
@@ -170,7 +170,7 @@ public class Motorola68KAnalyzer extends ConstantPropagationAnalyzer {
 
 	int tableSizeMax;
 
-	private void recoverSwitches(final Program program, SymbolicPropogator symEval,
+	private void recoverSwitches(final Program program, SymbolicPropagator symEval,
 			AddressSet destSet, TaskMonitor monitor) throws CancelledException {
 
 		final ArrayList<CreateDataCmd> dataCmdList = new ArrayList<CreateDataCmd>();
@@ -336,7 +336,7 @@ public class Motorola68KAnalyzer extends ConstantPropagationAnalyzer {
 		SwitchEvaluator switchEvaluator = new SwitchEvaluator();
 
 		// clear past constants.  This example doesn't seem to depend on them
-		symEval = new SymbolicPropogator(program);
+		symEval = new SymbolicPropagator(program);
 		// now flow with the simple block of this branch....
 
 		// for each unknown branch destination,

--- a/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/plugin/core/analysis/AARCH64PltThunkAnalyzer.java
+++ b/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/plugin/core/analysis/AARCH64PltThunkAnalyzer.java
@@ -174,7 +174,7 @@ public class AARCH64PltThunkAnalyzer extends AbstractAnalyzer {
 	private void analyzePltThunk(Program program, Address entryAddr, int thunkSize, TaskMonitor monitor) 
 			throws CancelledException {
 		
-		SymbolicPropogator symEval = new SymbolicPropogator(program);
+		SymbolicPropagator symEval = new SymbolicPropagator(program);
 		symEval.setParamRefCheck(false);
 		symEval.setReturnRefCheck(false);
 		symEval.setStoredRefCheck(false);

--- a/Ghidra/Processors/ARM/src/main/java/ghidra/app/plugin/core/analysis/ArmAnalyzer.java
+++ b/Ghidra/Processors/ARM/src/main/java/ghidra/app/plugin/core/analysis/ArmAnalyzer.java
@@ -76,7 +76,7 @@ public class ArmAnalyzer extends ConstantPropagationAnalyzer {
 
 	@Override
 	public AddressSet flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 		// follow all flows building up context
 		// use context to fill out addresses on certain instructions
@@ -223,7 +223,7 @@ public class ArmAnalyzer extends ConstantPropagationAnalyzer {
 	}
 
 	private void recoverSwitches(final Program program, AddressSet destSet,
-			SymbolicPropogator symEval, TaskMonitor monitor) throws CancelledException {
+			SymbolicPropagator symEval, TaskMonitor monitor) throws CancelledException {
 
 		// now handle symbolic execution assuming values!
 		class SwitchEvaluator implements ContextEvaluator {
@@ -492,10 +492,10 @@ public class ArmAnalyzer extends ConstantPropagationAnalyzer {
 
 			Instruction targetInstr = program.getListing().getInstructionAt(loc);
 
-			SymbolicPropogator targetEval = symEval;
+			SymbolicPropagator targetEval = symEval;
 			// if this is a tbX instruction, don't assume any old values
 			if (targetInstr != null && targetInstr.getMnemonicString().startsWith("tb")) {
-				targetEval = new SymbolicPropogator(program);
+				targetEval = new SymbolicPropagator(program);
 			}
 
 			Address zeroAddr = targetInstr.getMinAddress().getNewAddress(0);

--- a/Ghidra/Processors/HCS12/src/main/java/ghidra/app/plugin/core/analysis/HCS12ConstantAnalyzer.java
+++ b/Ghidra/Processors/HCS12/src/main/java/ghidra/app/plugin/core/analysis/HCS12ConstantAnalyzer.java
@@ -24,7 +24,7 @@ import ghidra.program.model.pcode.PcodeOp;
 import ghidra.program.model.symbol.RefType;
 import ghidra.program.model.symbol.SourceType;
 import ghidra.program.util.ContextEvaluator;
-import ghidra.program.util.SymbolicPropogator;
+import ghidra.program.util.SymbolicPropagator;
 import ghidra.program.util.VarnodeContext;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
@@ -105,7 +105,7 @@ public class HCS12ConstantAnalyzer extends ConstantPropagationAnalyzer {
 
 	@Override
 	public AddressSetView flowConstants(final Program program, Address flowStart, AddressSetView flowSet,
-			final SymbolicPropogator symEval, final TaskMonitor monitor) throws CancelledException {
+			final SymbolicPropagator symEval, final TaskMonitor monitor) throws CancelledException {
 
 		// follow all flows building up context
 		// use context to fill out addresses on certain instructions 

--- a/Ghidra/Processors/JVM/src/main/java/ghidra/javaclass/format/constantpool/ConstantPoolFactory.java
+++ b/Ghidra/Processors/JVM/src/main/java/ghidra/javaclass/format/constantpool/ConstantPoolFactory.java
@@ -81,7 +81,7 @@ public class ConstantPoolFactory {
 
 			default:
 				throw new IllegalArgumentException(
-					"Unsupport Constant Pool Entry Type: " + reader.peekNextByte());
+					"Unsupported Constant Pool Entry Type: " + reader.peekNextByte());
 		}
 	}
 

--- a/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsAddressAnalyzer.java
+++ b/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsAddressAnalyzer.java
@@ -216,7 +216,7 @@ public class MipsAddressAnalyzer extends ConstantPropagationAnalyzer {
 
 	@Override
 	public AddressSetView flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
 		// get the function body

--- a/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsPreAnalyzer.java
+++ b/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsPreAnalyzer.java
@@ -33,7 +33,7 @@ import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
 
 public class MipsPreAnalyzer extends AbstractAnalyzer {
-	private static final String NAME = "MIPS UnAlligned Instruction Fix";
+	private static final String NAME = "MIPS Unaligned Instruction Fix";
 	private static final String DESCRIPTION =
 		"Analyze MIPS Instructions for unaligned load pairs ldl/ldr sdl/sdr lwl/lwr swl/swr.";
 

--- a/Ghidra/Processors/PA-RISC/data/languages/pa-risc.sinc
+++ b/Ghidra/Processors/PA-RISC/data/languages/pa-risc.sinc
@@ -1408,7 +1408,7 @@ lse21: off				is im21less0 & bit0 & im21_1_12 & im21_12_14 & im21_14_16 & im21_1
 # Note for the im11 11-bit immediate, the sign is in bit 0, and the rest of the value is in bit 1 to 10.
 # Negative numbers are stored 2s complement, with bit0 set to 1.
 #
-# Need to set temp32 to lse11 since the value of lse11 does not propogate so well to uplevel tables, maybe a compiler bug
+# Need to set temp32 to lse11 since the value of lse11 does not propagate so well to uplevel tables, maybe a compiler bug
 #
 #lse11: immed				is im11 & bit0
 lse11: immed				is im11less0 & bit0

--- a/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic16Analyzer.java
+++ b/Ghidra/Processors/PIC/src/main/java/ghidra/app/plugin/core/analysis/Pic16Analyzer.java
@@ -74,7 +74,7 @@ public class Pic16Analyzer extends ConstantPropagationAnalyzer {
 	}
 	
 	@Override
-	public AddressSet flowConstants(final Program program, Address flowStart, AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+	public AddressSet flowConstants(final Program program, Address flowStart, AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 		
 		// follow all flows building up context

--- a/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/plugin/core/analysis/PPC64CallStubAnalyzer.java
+++ b/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/plugin/core/analysis/PPC64CallStubAnalyzer.java
@@ -247,7 +247,7 @@ public class PPC64CallStubAnalyzer extends AbstractAnalyzer {
 	private void analyzeCallStub(Program program, Function stubFunction, int stubLength,
 			TaskMonitor monitor) throws CancelledException {
 		
-		SymbolicPropogator symEval = new SymbolicPropogator(program);
+		SymbolicPropagator symEval = new SymbolicPropagator(program);
 		symEval.setParamRefCheck(false);
 		symEval.setReturnRefCheck(false);
 		symEval.setStoredRefCheck(false);

--- a/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/plugin/core/analysis/PowerPCAddressAnalyzer.java
+++ b/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/plugin/core/analysis/PowerPCAddressAnalyzer.java
@@ -137,7 +137,7 @@ public class PowerPCAddressAnalyzer extends ConstantPropagationAnalyzer {
 
 	@Override
 	public AddressSet flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
 		RegisterValue initR2Value = lookupR2(program, flowStart);
@@ -376,7 +376,7 @@ public class PowerPCAddressAnalyzer extends ConstantPropagationAnalyzer {
 		return false;
 	}
 
-	private void recoverSwitches(final Program program, SymbolicPropogator symEval,
+	private void recoverSwitches(final Program program, SymbolicPropagator symEval,
 			AddressSet destinationSet, TaskMonitor monitor) throws CancelledException {
 
 		final ArrayList<Address> targetList = new ArrayList<>();

--- a/Ghidra/Processors/RISCV/src/main/java/ghidra/app/plugin/core/analysis/RISCVAddressAnalyzer.java
+++ b/Ghidra/Processors/RISCV/src/main/java/ghidra/app/plugin/core/analysis/RISCVAddressAnalyzer.java
@@ -23,7 +23,7 @@ import ghidra.program.model.lang.*;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.symbol.Symbol;
 import ghidra.program.model.symbol.SymbolUtilities;
-import ghidra.program.util.SymbolicPropogator;
+import ghidra.program.util.SymbolicPropagator;
 import ghidra.program.util.VarnodeContext;
 import ghidra.util.Msg;
 import ghidra.util.exception.AssertException;
@@ -75,7 +75,7 @@ public class RISCVAddressAnalyzer extends ConstantPropagationAnalyzer {
 
 	@Override
 	public AddressSetView flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
 		// get the function body

--- a/Ghidra/Processors/Sparc/src/main/java/ghidra/app/plugin/core/analysis/SparcAnalyzer.java
+++ b/Ghidra/Processors/Sparc/src/main/java/ghidra/app/plugin/core/analysis/SparcAnalyzer.java
@@ -48,7 +48,7 @@ public class SparcAnalyzer extends ConstantPropagationAnalyzer {
 	}
 
 	@Override
-	public AddressSetView flowConstants(final Program program, Address flowStart, AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+	public AddressSetView flowConstants(final Program program, Address flowStart, AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 		
 		// get the function body

--- a/Ghidra/Processors/SuperH4/src/main/java/ghidra/app/plugin/core/analysis/SH4AddressAnalyzer.java
+++ b/Ghidra/Processors/SuperH4/src/main/java/ghidra/app/plugin/core/analysis/SH4AddressAnalyzer.java
@@ -71,7 +71,7 @@ public class SH4AddressAnalyzer extends ConstantPropagationAnalyzer {
 
 	@Override
 	public AddressSetView flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
 		// follow all flows building up context

--- a/Ghidra/Processors/SuperH4/src/main/java/ghidra/app/plugin/core/analysis/SH4EarlyAddressAnalyzer.java
+++ b/Ghidra/Processors/SuperH4/src/main/java/ghidra/app/plugin/core/analysis/SH4EarlyAddressAnalyzer.java
@@ -40,7 +40,7 @@ public class SH4EarlyAddressAnalyzer extends SH4AddressAnalyzer {
 
 	@Override
 	public AddressSetView flowConstants(final Program program, Address flowStart,
-			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
 		// follow all flows building up context

--- a/Ghidra/Processors/x86/src/main/java/ghidra/app/plugin/core/analysis/X86Analyzer.java
+++ b/Ghidra/Processors/x86/src/main/java/ghidra/app/plugin/core/analysis/X86Analyzer.java
@@ -43,7 +43,7 @@ public class X86Analyzer extends ConstantPropagationAnalyzer {
 	}
 
 	@Override
-	public AddressSetView flowConstants(final Program program, Address flowStart, AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+	public AddressSetView flowConstants(final Program program, Address flowStart, AddressSetView flowSet, final SymbolicPropagator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 		
 		// follow all flows building up context

--- a/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/CParserPluginScreenShots.java
+++ b/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/CParserPluginScreenShots.java
@@ -45,7 +45,7 @@ public class CParserPluginScreenShots extends GhidraScreenShotGenerator {
 			"C Parser: Encountered errors during parse.\n" +
 				"        in C:\\tmp\\samp.h near line 12\n " +
 				"       near token: \"This function or variable may be unsafe. Consider using \" \n" +
-				"        Last Valid Dataype: PCUWSTR");
+				"        Last Valid Datatype: PCUWSTR");
 		captureDialog();
 		closeAllWindowsAndFrames();
 	}

--- a/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/DataTypeManagerPluginScreenShots.java
+++ b/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/DataTypeManagerPluginScreenShots.java
@@ -239,7 +239,7 @@ public class DataTypeManagerPluginScreenShots extends GhidraScreenShotGenerator 
 
 		DataTypeManager dtm = program.getDataTypeManager();
 
-		StandAloneDataTypeManager sourceDTM = new StandAloneDataTypeManager("MyArhcive");
+		StandAloneDataTypeManager sourceDTM = new StandAloneDataTypeManager("MyArchive");
 		StructureDataType sdt1 = new StructureDataType("MyDataType1", 0);
 		sdt1.add(new PointerDataType(new StringDataType()), "name", null);
 		sdt1.add(new IntegerDataType(), "age", null);
@@ -318,7 +318,7 @@ public class DataTypeManagerPluginScreenShots extends GhidraScreenShotGenerator 
 			Set<DataTypeSyncInfo> set) {
 		DataTypeManager dtm = program.getDataTypeManager();
 
-		StandAloneDataTypeManager sourceDTM = new StandAloneDataTypeManager("MyArhcive");
+		StandAloneDataTypeManager sourceDTM = new StandAloneDataTypeManager("MyArchive");
 		StructureDataType sdt1 = new StructureDataType("MyDataType1", 0);
 		sdt1.add(new PointerDataType(new StringDataType()), "name", null);
 		sdt1.add(new IntegerDataType(), "age", null);

--- a/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/FunctionGraphPluginScreenShots.java
+++ b/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/FunctionGraphPluginScreenShots.java
@@ -77,7 +77,7 @@ public class FunctionGraphPluginScreenShots extends AbstractFunctionGraphTest {
 			screen.setUp();
 		}
 		catch (Exception e) {
-			failWithException("Unepected exception in setup", e);
+			failWithException("Unexpected exception in setup", e);
 		}
 
 		super.setUp();

--- a/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/IntroScreenShots.java
+++ b/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/IntroScreenShots.java
@@ -79,7 +79,7 @@ public class IntroScreenShots extends GhidraScreenShotGenerator {
 	@Test
 	public void testSimple_err_dialog() {
 
-		OkDialog.showError("Some Resonable Error",
+		OkDialog.showError("Some Reasonable Error",
 			"Your operation did not complete because... (i.e File Not Found)");
 		captureDialog();
 	}

--- a/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/RepositoryCustomScreenShots.java
+++ b/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/RepositoryCustomScreenShots.java
@@ -277,7 +277,7 @@ public class RepositoryCustomScreenShots extends GhidraScreenShotGenerator {
 		progressPanel.add(progress);
 		ImageIcon infoIcon = ResourceManager.loadImage("images/information.png");
 		progressPanel.add(
-			new JLabel("Finding conflicting code unit chagnes...", infoIcon, SwingConstants.LEFT));
+			new JLabel("Finding conflicting code unit changes...", infoIcon, SwingConstants.LEFT));
 		progressPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 100, 0));
 
 		mainPanel.add(progressPanel);

--- a/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/framework/client/GhidraServerSerialFilterFailureTest.java
+++ b/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/framework/client/GhidraServerSerialFilterFailureTest.java
@@ -120,7 +120,7 @@ public class GhidraServerSerialFilterFailureTest extends AbstractGhidraHeadlessI
 			Throwable cause = e.getCause();
 			assertTrue("expected remote unmarshall exception", cause instanceof UnmarshalException);
 			cause = cause.getCause();
-			assertTrue("expected remote invalid class exceptionn",
+			assertTrue("expected remote invalid class exception",
 				cause instanceof InvalidClassException);
 		}
 		

--- a/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/framework/main/SharedProjectUtil.java
+++ b/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/framework/main/SharedProjectUtil.java
@@ -129,7 +129,7 @@ public class SharedProjectUtil {
 		if (!finishButton.isEnabled()) {
 			String statusMessage = projPanel.getStatusMessage();
 			System.err.println(
-				"Finish button is unexectedly disabled!!\n\t" + "Status message: " + statusMessage);
+				"Finish button is unexpectedly disabled!!\n\t" + "Status message: " + statusMessage);
 			return false;
 		}
 

--- a/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/framework/main/ToolConnectionTest.java
+++ b/Ghidra/Test/IntegrationTest/src/test.slow/java/ghidra/framework/main/ToolConnectionTest.java
@@ -95,7 +95,7 @@ public class ToolConnectionTest extends AbstractGhidraHeadedIntegrationTest {
 		runSwing(() -> pm.openProgram(p.getDomainFile()));
 
 		waitForCondition(() -> pm2.getCurrentProgram() != null,
-			"Tool 2 did not open a proagram when one was opened in tool1");
+			"Tool 2 did not open a program when one was opened in tool1");
 
 		assertEquals(p, pm2.getCurrentProgram());
 

--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ChooseGhidraModuleProjectWizardPage.java
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/src/main/java/ghidradev/ghidraprojectcreator/wizards/pages/ChooseGhidraModuleProjectWizardPage.java
@@ -52,7 +52,7 @@ public class ChooseGhidraModuleProjectWizardPage extends WizardPage {
 		container.setLayout(new GridLayout(2, false));
 
 		Label projectNameLabel = new Label(container, SWT.NULL);
-		projectNameLabel.setText("Ghida module project:");
+		projectNameLabel.setText("Ghidra module project:");
 		projectCombo = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
 		GridData gd = new GridData(GridData.FILL_HORIZONTAL);
 		projectCombo.setLayoutData(gd);

--- a/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/JavaConfig.java
+++ b/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/JavaConfig.java
@@ -307,7 +307,7 @@ public class JavaConfig {
 		}
 		catch (NumberFormatException e) {
 			throw new ParseException(
-				"Failed to parse application's minimum supported Java major verison", 0);
+				"Failed to parse application's minimum supported Java major version", 0);
 		}
 
 		// Optional properties
@@ -318,7 +318,7 @@ public class JavaConfig {
 			}
 			catch (NumberFormatException e) {
 				throw new ParseException(
-					"Failed to parse application's maximum supported Java major verison", 0);
+					"Failed to parse application's maximum supported Java major version", 0);
 			}
 		}
 		else {


### PR DESCRIPTION
A somewhat big PR, probably should split into multiple pieces, but since they all deal with typos, I don't know how to split this up in a way that makes sense without having a separate PR for every change.

Nevertheless, this deals with primarily typos in user-facing strings; strings the user will read while using the program.

I don't expect this to be merged as-is, but if it were to be, there would be no issue since this contains all the changes I wanted to make.