### PR TITLE
Disable pattern lookups for log4j

### DIFF
--- a/Ghidra/Debug/Framework-Debugging/src/main/resources/log4j-appender-console.xml
+++ b/Ghidra/Debug/Framework-Debugging/src/main/resources/log4j-appender-console.xml
@@ -4,6 +4,6 @@
 <Console 	
 	name="console" 
 	target="SYSTEM_OUT">
-	<PatternLayout pattern="%-5p %m (%c{1}) %ex %n"/>  
+	<PatternLayout pattern="%-5p %m{nolookups} (%c{1}) %ex %n"/>
 </Console>
 

--- a/Ghidra/Debug/Framework-Debugging/src/main/resources/log4j-appender-logpanel.xml
+++ b/Ghidra/Debug/Framework-Debugging/src/main/resources/log4j-appender-logpanel.xml
@@ -2,6 +2,6 @@
 	
 <!-- Log4j appender that writes messages to the {@link LogPanelAppender}. -->
 <LogPanelAppender name="logPanel">
-	<PatternLayout pattern="%-5p %m %ex"/>  
+	<PatternLayout pattern="%-5p %m{nolookups} %ex"/>
 </LogPanelAppender>
 

--- a/Ghidra/Framework/Generic/src/main/resources/log4j-appender-console-with-links.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/log4j-appender-console-with-links.xml
@@ -11,6 +11,6 @@
 <Console 	
 	name="console" 
 	target="SYSTEM_OUT">
-	<PatternLayout pattern="%-5p %m %ex %hl %n"/>  
+	<PatternLayout pattern="%-5p %m{nolookups} %ex %hl %n"/>
 </Console>
 

--- a/Ghidra/Framework/Generic/src/main/resources/log4j-appender-console.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/log4j-appender-console.xml
@@ -4,6 +4,6 @@
 <Console 	
 	name="console" 
 	target="SYSTEM_OUT">
-	<PatternLayout pattern="%-5p %m (%c{1}) %ex %n"/>  
+	<PatternLayout pattern="%-5p %m{nolookups} (%c{1}) %ex %n"/>
 </Console>
 

--- a/Ghidra/Framework/Generic/src/main/resources/log4j-appender-logpanel.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/log4j-appender-logpanel.xml
@@ -2,6 +2,6 @@
 	
 <!-- Log4j appender that writes messages to the {@link LogPanelAppender}. -->
 <LogPanelAppender name="logPanel">
-	<PatternLayout pattern="%-5p %m %ex"/>  
+	<PatternLayout pattern="%-5p %m{nolookups} %ex"/>
 </LogPanelAppender>
 

--- a/Ghidra/Framework/Generic/src/main/resources/log4j-appender-rolling-file-scripts.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/log4j-appender-rolling-file-scripts.xml
@@ -14,7 +14,7 @@
 	fileName="${sys:scriptLogFilename}"
 	filePattern="${sys:scriptLogFilename}-%d{yyyy-MM-dd}-%i.log">   
 	
-	<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %m %ex %n"/>	 
+	<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %m{nolookups} %ex %n"/>
 	
 	<!--
 		Only allow messages from scripts (see the note above).  

--- a/Ghidra/Framework/Generic/src/main/resources/log4j-appender-rolling-file.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/log4j-appender-rolling-file.xml
@@ -5,7 +5,7 @@
 	name="detail" 
 	fileName="${sys:logFilename}"
 	filePattern="${sys:logFilename}-%d{yyyy-MM-dd}-%i.log">   
-	<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p (%c{1}) %m %ex %n"/> 
+	<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p (%c{1}) %m{nolookups} %ex %n"/>
 	<Policies>
 		<SizeBasedTriggeringPolicy size="50000 KB"/>
 	</Policies>  

--- a/Ghidra/Framework/Generic/src/main/resources/log4j-appender-test-console-with-links.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/log4j-appender-test-console-with-links.xml
@@ -11,6 +11,6 @@
 <Console 	
 	name="console" 
 	target="SYSTEM_OUT"> 
-	<PatternLayout pattern="%d{HH:mm:ss} %-5p %m %ex %hl %n"/> 
+	<PatternLayout pattern="%d{HH:mm:ss} %-5p %m{nolookups} %ex %hl %n"/>
 </Console>
 

--- a/Ghidra/Framework/SoftwareModeling/src/test.slow/java/log4j.xml
+++ b/Ghidra/Framework/SoftwareModeling/src/test.slow/java/log4j.xml
@@ -5,7 +5,7 @@
 
   <appender name="console" class="org.apache.log4j.ConsoleAppender">
     <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="%-5p %c{1}: %m%n"/>
+      <param name="ConversionPattern" value="%-5p %c{1}: %m{nolookups}%n"/>
     </layout>
   </appender>
 

--- a/Ghidra/Framework/SoftwareModeling/src/test/resources/log4j.xml
+++ b/Ghidra/Framework/SoftwareModeling/src/test/resources/log4j.xml
@@ -5,7 +5,7 @@
 
   <appender name="console" class="org.apache.log4j.ConsoleAppender">
     <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="%-5p %c{1}: %m%n"/>
+      <param name="ConversionPattern" value="%-5p %c{1}: %m{nolookups}%n"/>
     </layout>
   </appender>
 

--- a/Ghidra/RuntimeScripts/Common/support/debug.log4j.xml
+++ b/Ghidra/RuntimeScripts/Common/support/debug.log4j.xml
@@ -17,13 +17,13 @@
   	<Console 	
 		name="console" 
 		target="SYSTEM_OUT">
-		<PatternLayout pattern="%-5p %m %hl %n"/>  
+		<PatternLayout pattern="%-5p %m{nolookups} %hl %n"/>
 	</Console>
 	<RollingFile 
 		name="detail" 
 		fileName="${sys:logFilename}"
 		filePattern="${sys:logFilename}-%d{yyyy-MM-dd}-%i.log">   
-		<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c	%m %ex %n"/>
+		<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c	%m{nolookups} %ex %n"/>
 		<Policies>
 			<SizeBasedTriggeringPolicy size="50000 KB"/>
 		</Policies>  
@@ -36,7 +36,7 @@
 		fileName="${sys:scriptLogFilename}"
 		filePattern="${sys:scriptLogFilename}-%d{yyyy-MM-dd}-%i.log">
 		   
-		<PatternLayout pattern="%d{ISO8601} %-5p %m%n"/> 
+		<PatternLayout pattern="%d{ISO8601} %-5p %m{nolookups}%n"/>
 				
 		<!--
 			Only allow messages from scripts.  We prepend each script message with its name and 
@@ -51,7 +51,7 @@
 	</RollingFile>
 	
 	<LogPanelAppender name="logPanel">
-		<PatternLayout pattern="%-5p %m %ex"/>  
+		<PatternLayout pattern="%-5p %m{nolookups} %ex"/>
 	</LogPanelAppender>
   </Appenders>
   


### PR DESCRIPTION
While this PR does not fix the RCE outlined in https://github.com/NationalSecurityAgency/ghidra/issues/3736, it disables pattern lookups for logging with log4j, making the vulnerability inaccessible (outside of actually changing the log4j config itself).

Additionally, when the next log4j release (2.15.0) becomes available, the dependency should be updated to that, since that release heavily restricts the possible LDAP connections. The changes in this PR are however still relevant, as pattern lookups should still be disabled for messages containing unknown text from outside the software.