### PR TITLE
Remove unused stray String

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
@@ -663,9 +663,6 @@ public class GhidraJarBuilder implements GhidraLaunchable {
 		}
 
 		public void writeExtensionPointClassFile() throws IOException {
-			String s = "abc";
-			s.getBytes();
-
 			ZipEntry entry = new ZipEntry(ROOT_GHIDRA + "EXTENSION_POINT_CLASSES");
 
 			try {


### PR DESCRIPTION
Considering this is not a test method, there is no reason why String s = "abc" should be here, considering it is not even used.

This was likely added by mistake.