### PR TITLE
Fix typo causing "hasRangeMatch" to always be true

### DIFF
--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/ApplyFunctions.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/ApplyFunctions.java
@@ -112,7 +112,7 @@ class ApplyFunctions {
 			return null;
 		}
 		AddressSet thunkBody = new AddressSet(thunkFunction.getBody());
-		boolean hasRangeMatch = true;
+		boolean hasRangeMatch = false;
 		AddressRangeIterator ari = thunkBody.getAddressRanges(true);
 		while (ari.hasNext()) {
 			if (monitor.isCancelled()) {


### PR DESCRIPTION
It should be set to false initially until a match is found. Because of this error, checkInsideThunkFunction will always think there is a range match, which could cause disastrous results.