### PR TITLE
Fix broken sanity check

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AutoTableDisassemblerPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AutoTableDisassemblerPlugin.java
@@ -433,7 +433,7 @@ public class AutoTableDisassemblerPlugin extends ProgramPlugin implements Domain
 	// address table in the selected rows
 	private int getIndexOfShortestAddressTable(int[] selectedRows) {
 
-		if (selectedRows.length < 0) {
+		if (selectedRows.length == 0) {
 			throw new AssertionError(
 				"There must be rows selected in " + "order to process multiple rows.");
 		}


### PR DESCRIPTION
If there were 0 rows selected, the assertion error would not be thrown, even though a size of 0 means nothing was selected. It is impossible for the length to be below 0. This could cause disasterous results.