### PR TITLE
Initialize success as false, not true

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/data/DataSettingsDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/data/DataSettingsDialog.java
@@ -454,7 +454,7 @@ public class DataSettingsDialog extends DialogComponentProvider {
 
 	private void applySettings() {
 		int txId = program.startTransaction(name);
-		boolean success = true;
+		boolean success = false;
 		try {
 			if (selection != null) {
 				applyCommonSettings();


### PR DESCRIPTION
applySettings is bugged in that it always calls program.endTransaction(txId, success); assuming the application of settings was a success, even though the success is supposed to be applied at the end of the tried block.

This fixes that mistake.