### PR TITLE
Fixed toCamel so that only _ are converted to uppercase letters

### DIFF
--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/PdbKind.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb/PdbKind.java
@@ -52,6 +52,7 @@ public enum PdbKind {
 			}
 			if (makeUpper) {
 				c = Character.toUpperCase(c);
+				makeUpper = false;
 			}
 			buf.append(c);
 		}


### PR DESCRIPTION
makeUpper being set to perpetually true meant that the entire name was in uppercase letters. This commit fixes that.