### PR TITLE
BUGFIX: AddDependent puts the entire entry set instead of the dependents

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/DataTypeDependencyOrderer.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/DataTypeDependencyOrderer.java
@@ -361,13 +361,8 @@ public class DataTypeDependencyOrderer {
 		if (entry == null) {
 			return;
 		}
-		Set<Entry> dependents = whoDependsOnMe.get(entry);
-		if (dependents == null) {
-			dependents = new HashSet<>();
-			whoDependsOnMe.put(entry, dependents);
-		}
-		Set<Entry> support = new HashSet<>();
-		whoIDependOn.put(entry, support);
+        Set<Entry> dependents = whoDependsOnMe.computeIfAbsent(entry, k -> new HashSet<>());
+		whoIDependOn.put(entry, dependents);
 	}
 
 	private void removeMyDependentsEdgesToMe(Entry entry) {


### PR DESCRIPTION
Currently, a new empty set is added to entry when this function was called, instead of the dependents set.

This PR fixes that to do the intended behavior.