### PR TITLE
Remove Big Endian address size check

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighFunctionDBUtil.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighFunctionDBUtil.java
@@ -635,18 +635,6 @@ public class HighFunctionDBUtil {
 			return null;
 		}
 		Address addr = storage.getFirstVarnode().getAddress();
-		if (storage.size() != dt.getLength() && program.getMemory().isBigEndian()) {
-			// maintain address of lsb
-			long delta = storage.size() - dt.getLength();
-			try {
-				addr = addr.addNoWrap(delta);
-			}
-			catch (AddressOverflowException e) {
-				throw new InvalidInputException(
-					"Unable to resize global storage for " + dt.getName() + " at " + addr);
-			}
-		}
-
 		Listing listing = program.getListing();
 		Data d = listing.getDataAt(addr);
 		if (d != null && d.getDataType().isEquivalent(dt)) {


### PR DESCRIPTION
Removes a check specific to big endian that incorrectly checks backwards from an address.  The pointer here is the start of data and not the end, regardless of endianess.  The current code moves the address to be checked backwards and it would be checking against invalid data and will often fail as something could already be there.

fixes #2809 