### PR TITLE
Fix display error in which checkout progress displayed starts from 0 instead of 1

### DIFF
--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/VersionControlCheckOutAction.java
@@ -134,7 +134,7 @@ public class VersionControlCheckOutAction extends VersionControlAction {
 			if (n == 0) {
 				Msg.showError(this, tool.getToolFrame(), "Checkout Failed",
 					"The specified files do not contain any versioned files available for " +
-						"checkeout");
+						"checkout");
 				return false;
 			}
 
@@ -193,7 +193,7 @@ public class VersionControlCheckOutAction extends VersionControlAction {
 				};
 
 				List<DomainFile> failedCheckouts = new ArrayList<>();
-				int progress = 0;
+				int progress = 1;
 				for (DomainFile df : versionedFiles) {
 
 					monitor.checkCanceled();


### PR DESCRIPTION
Since we are displaying the number of the file in relation to the number of files to be checked out, the progress number should start at 1, instead of 0, because otherwise it gives the impression one more file than there actually are are set to be checked out.