### PR TITLE
Increment count at end of loop

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileDebug.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileDebug.java
@@ -318,6 +318,7 @@ public class DecompileDebug {
 				if (count % 20 == 19) {
 					buf.append("\n  ");
 				}
+				count++;
 			}
 			buf.append("00\n</bytes>\n");
 			buf.append("</string>\n");


### PR DESCRIPTION
The count variable isn't updated, which means there is never a line break after 20 iterations. This PR fixes this, as it was forgotten for some reason.