### PR TITLE
Fix function merge to check if thunkedFunction2 is null

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/merge/listing/FunctionMerger.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/merge/listing/FunctionMerger.java
@@ -1867,7 +1867,7 @@ class FunctionMerger extends AbstractFunctionMerger implements ListingMerger {
 			}
 			return isEquivalent(thunkedFunction1, thunkedFunction2);
 		}
-		else if (thunkedFunction1 != null) {
+		else if (thunkedFunction2 != null) {
 			return false;
 		}
 


### PR DESCRIPTION
This can otherwise cause the program to act as if thunkedFunction2 is never null whenever thunkedFunction1 is, which is wrong.