### PR TITLE
Refixed relative ObjC methods referenced in #3611.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Class.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Class.java
@@ -52,7 +52,7 @@ public class ObjectiveC2_Class implements StructConverter {
 		AddressSpace space = _state.program.getAddressFactory().getDefaultAddressSpace();
 		Address addr = space.getAddress(_index);
 		Symbol symbol = _state.program.getSymbolTable().getPrimarySymbol(addr);
-		if (symbol.getParentNamespace().getName().equals(SectionNames.SECT_GOT)) {
+		if (symbol != null && symbol.getParentNamespace().getName().equals(SectionNames.SECT_GOT)) {
 			return;
 		}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Method.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Method.java
@@ -37,9 +37,13 @@ public class ObjectiveC2_Method extends ObjectiveC_Method {
 
 		if (isSmallList) {
 			int nameOffset = (int)ObjectiveC1_Utilities.readNextIndex(reader, true);
-			int namePtr = reader.readInt(_index + nameOffset);
-			long imagebase = state.program.getImageBase().getOffset(); // When we support dyld_shared_cache, this base will likely have to change
-			name = reader.readAsciiString(imagebase + namePtr);
+			long namePtr;
+			if (state.is32bit)
+				namePtr = reader.readInt(_index + nameOffset);
+			else
+				namePtr = reader.readLong(_index + nameOffset);
+
+			name = reader.readAsciiString(namePtr);
 
 			int typesOffset = (int)ObjectiveC1_Utilities.readNextIndex(reader, true);
 			types = reader.readAsciiString(_index + 4 + typesOffset);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Method.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Method.java
@@ -38,10 +38,12 @@ public class ObjectiveC2_Method extends ObjectiveC_Method {
 		if (isSmallList) {
 			int nameOffset = (int)ObjectiveC1_Utilities.readNextIndex(reader, true);
 			long namePtr;
-			if (state.is32bit)
+			if (state.is32bit) {
 				namePtr = reader.readInt(_index + nameOffset);
-			else
+			}
+			else {
 				namePtr = reader.readLong(_index + nameOffset);
+			}
 
 			name = reader.readAsciiString(namePtr);
 


### PR DESCRIPTION
Referenced in #3611, the name field in a method_t_small is an offset to a pointer to a C string. And while 85d1a3c works fine for most macho files, it doesn't work when there are gaps between segments (like binaries from DyldExtractor).

I found that when the name pointer is read, it only reads 4 bytes, when it should be pointer sized. After changing it, the method name could be found without referencing the image base.

Also, in [ObjectiveC2_Class.java](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/objc2/ObjectiveC2_Class.java), when it tries to detect if the class is in the __got section, it breaks when there is no associated symbol. I fixed this with a null check.