### PR TITLE
Allow compilerspecs to specify their return storage pointer register

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/data/languages/compiler_spec.rxg
+++ b/Ghidra/Framework/SoftwareModeling/data/languages/compiler_spec.rxg
@@ -384,6 +384,7 @@
 
       <element name="output">
         <optional> <attribute name="killedbycall"/> </optional>
+        <optional> <attribute name="returnstorageid"/> </optional>
         <zeroOrMore>
           <element name="pentry">
             <ref name="pentry_type"/>

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/ParamList.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/ParamList.java
@@ -44,7 +44,7 @@ public interface ParamList {
 	public void assignMap(Program prog, DataType[] proto, ArrayList<VariableStorage> res,
 			boolean addAutoParams);
 
-	public void saveXml(StringBuilder buffer, boolean isInput);
+	public void saveXml(StringBuilder buffer);
 
 	public void restoreXml(XmlPullParser parser, CompilerSpec cspec) throws XmlParseException;
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/PrototypeModel.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/PrototypeModel.java
@@ -384,9 +384,9 @@ public class PrototypeModel {
 			SpecXmlUtils.encodeStringAttribute(buffer, "strategy", "register");
 		}
 		buffer.append(">\n");
-		inputParams.saveXml(buffer, true);
+		inputParams.saveXml(buffer);
 		buffer.append('\n');
-		outputParams.saveXml(buffer, false);
+		outputParams.saveXml(buffer);
 		buffer.append('\n');
 		if (hasUponEntry || hasUponReturn) {
 			InjectPayload payload =

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64.cspec
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64.cspec
@@ -120,12 +120,15 @@
           <addr offset="0" space="stack"/>
         </pentry>
       </input>
-      <output>
+      <output returnstorageid="2">
         <pentry minsize="1" maxsize="8" metatype="float">
           <register name="d0"/>
         </pentry>
         <pentry minsize="1" maxsize="8" extension="zero">
           <register name="x0"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="zero">
+          <register name="x8"/>
         </pentry>
       </output>
       <unaffected>


### PR DESCRIPTION
Fixes #951

I've been running into this issue a lot while reversing an AARCH64 project. I believe I've come up with an appropriate fix. Unfortunately, I've been running into trouble building Ghidra (even on a clean branch) so I have not been able to test this yet myself. Until I'm able to test locally, I'm opening this as a draft so that I can receive feedback on the change. Thanks in advance!

Brief summary of changes:
 - ParamLists are now identified as input/output by their name in a compilerspec rather than their size
 - output ParamLists now store the index of their return storage pointer ParamEntry, which is optionally specified in the .cspec file (defaults to 1 to maintain existing behavior)
 - AARCH64's .cspec has been updated to reflect the x8 register being its return storage pointer rather than the x0 register