### PR TITLE
Use short circuit operators when possible

### DIFF
--- a/GPL/DMG/src/dmg/java/mobiledevices/dmg/reader/DmgFileReader.java
+++ b/GPL/DMG/src/dmg/java/mobiledevices/dmg/reader/DmgFileReader.java
@@ -287,7 +287,7 @@ public class DmgFileReader implements Closeable {
 	 * If the entry is actually a directory, then -1 is returned.
 	 */
 	public long getLength( FSEntry entry ) {
-		if ( entry != null & entry.isFile() ) {
+		if (entry != null && entry.isFile()) {
 			FSFork mainFork = entry.asFile().getMainFork();
 			if ( mainFork.getLength() > 0 ) {
 				return mainFork.getLength();

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/pcode/exec/trace/TraceBytesPcodeExecutorState.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/pcode/exec/trace/TraceBytesPcodeExecutorState.java
@@ -97,7 +97,7 @@ public class TraceBytesPcodeExecutorState
 	}
 
 	public void setThread(TraceThread thread) {
-		if (thread != null & thread.getTrace() != trace) {
+		if (thread != null && thread.getTrace() != trace) {
 			throw new IllegalArgumentException("Thread, if given, must be part of the same trace");
 		}
 		this.thread = thread;

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/pcode/exec/trace/TraceMemoryStatePcodeExecutorStatePiece.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/pcode/exec/trace/TraceMemoryStatePcodeExecutorStatePiece.java
@@ -67,7 +67,7 @@ public class TraceMemoryStatePcodeExecutorStatePiece extends
 	}
 
 	public void setThread(TraceThread thread) {
-		if (thread != null & thread.getTrace() != trace) {
+		if (thread != null && thread.getTrace() != trace) {
 			throw new IllegalArgumentException("Thread, if given, must be part of the same trace");
 		}
 		this.thread = thread;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/disassemble/DisassembleCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/disassemble/DisassembleCommand.java
@@ -309,7 +309,7 @@ public class DisassembleCommand extends BackgroundCommand {
 			doDisassemblySeeds(disassembler, seedSet, mgr);
 		}
 
-		return disassemblyPerformed || (!nonExecutableStart & !unalignedStart);
+		return disassemblyPerformed || (!nonExecutableStart && !unalignedStart);
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/nav/LocationMemento.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/nav/LocationMemento.java
@@ -126,13 +126,10 @@ public class LocationMemento {
 		if (loc1.getClass() == loc2.getClass()) {
 			return true;
 		}
-		// at this point we know they have the some addresses, but different location types (fields)
+		// at this point we know they have the same addresses, but different location types (fields)
 		// also consider generic program locations to be equal to addressField locations
-		boolean isAddr1 =
-			loc1 instanceof AddressFieldLocation || loc1.getClass() == ProgramLocation.class;
-		boolean isAddr2 =
-			loc2 instanceof AddressFieldLocation || loc2.getClass() == ProgramLocation.class;
-		return isAddr1 & isAddr2;
+		return (loc1 instanceof AddressFieldLocation || loc1.getClass() == ProgramLocation.class) &&
+			(loc2 instanceof AddressFieldLocation || loc2.getClass() == ProgramLocation.class);
 	}
 
 	public void saveState(SaveState saveState) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AnalysisBackgroundCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AnalysisBackgroundCommand.java
@@ -71,7 +71,7 @@ public class AnalysisBackgroundCommand extends MergeableBackgroundCommand {
 			+ "managers of the two commands are the same instance and this is not the case.");
 
 		// once we encounter a markAsAnalyzed value that is true, then leave it on
-		markAsAnalyzed = markAsAnalyzed | abc.markAsAnalyzed;
+		markAsAnalyzed = markAsAnalyzed || abc.markAsAnalyzed;
 		return this;
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/DndTableCellRenderer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/DndTableCellRenderer.java
@@ -185,7 +185,7 @@ public class DndTableCellRenderer implements TableCellRenderer {
 				if (column == 0 && !inserting) {
 					border.addBorders(DndBorder.LEFT);
 				}
-				if (column == myTable.getColumnCount() - 1 & !inserting) {
+				if (column == myTable.getColumnCount() - 1 && !inserting) {
 					border.addBorders(DndBorder.RIGHT);
 				}
 				c.setBorder(border);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTableAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/disassembler/AddressTableAnalyzer.java
@@ -257,7 +257,7 @@ public class AddressTableAnalyzer extends AbstractAnalyzer {
 
 	private AddressSetView removeNonSearchableMemory(Program program, AddressSetView addrSet) {
 		// get rid of any non-initialized blocks
-		ignoreBookmarks = ignoreBookmarks | addrSet.hasSameAddresses(program.getMemory());
+		ignoreBookmarks = ignoreBookmarks || addrSet.hasSameAddresses(program.getMemory());
 
 		addrSet = addrSet.intersect(program.getMemory().getLoadedAndInitializedAddressSet());
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/GhidraSourceBundle.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/GhidraSourceBundle.java
@@ -624,7 +624,7 @@ public class GhidraSourceBundle extends GhidraBundle {
 			if (bundle != null) {
 				bundleHost.deactivateSynchronously(bundle);
 			}
-			return anythingChanged | wipeBinDir();
+			return anythingChanged || wipeBinDir();
 		}
 		catch (IOException | GhidraBundleException e) {
 			Msg.showError(this, null, "Source bundle clean error",

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/overview/OverviewColorComponent.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/overview/OverviewColorComponent.java
@@ -223,7 +223,7 @@ public class OverviewColorComponent extends JPanel implements OverviewProvider {
 		int pixelStart = getPixelIndex(start);
 		int pixelEnd = getPixelIndex(end);
 		for (int i = pixelStart; i <= pixelEnd; i++) {
-			if (i >= 0 & i < colors.length) {
+			if (i >= 0 && i < colors.length) {
 				colors[i] = null;
 			}
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/SearchOptions.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/SearchOptions.java
@@ -112,7 +112,7 @@ public class SearchOptions implements Cloneable {
 	 * Return true if instruction mnemonics should be searched.
 	 */
 	public boolean searchBothInstructionMnemonicAndOperands() {
-		return instructionMnemonics & instructionOperands;
+		return instructionMnemonics && instructionOperands;
 	}
 
 	public boolean searchInstructionMnemonics() {
@@ -135,7 +135,7 @@ public class SearchOptions implements Cloneable {
 	 * Return true if data mnemonics should be searched.
 	 */
 	public boolean searchBothDataMnemonicsAndOperands() {
-		return dataMnemonics & dataOperands;
+		return dataMnemonics && dataOperands;
 	}
 
 	public boolean searchDataMnemonics() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/util/SymbolicPropogator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/util/SymbolicPropogator.java
@@ -1300,7 +1300,7 @@ public class SymbolicPropogator {
 						val2 = vContext.getValue(in[1], true, evaluator);
 						long subbyte = 8 * vContext.getConstant(val2, evaluator);
 
-						if (vContext.isSymbol(val1) & subbyte == 0 &&
+						if (vContext.isSymbol(val1) && subbyte == 0 &&
 							out.getSize() == instruction.getAddress().getPointerSize()) {
 							// assume the subpiece is just downcasting to be used as a pointer, just ignore, since this is already an offset, and shouldn't matter.
 							result = val1;

--- a/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/PCodeTestAbstractControlBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/PCodeTestAbstractControlBlock.java
@@ -491,8 +491,7 @@ public abstract class PCodeTestAbstractControlBlock {
 				return false;
 			}
 			FunctionInfo other = (FunctionInfo) obj;
-			return functionName.equals(other.functionName) &
-				functionAddr.equals(other.functionAddr);
+			return functionName.equals(other.functionName) && functionAddr.equals(other.functionAddr);
 		}
 
 		@Override

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/yaffs2/YAFFS2FileSystem.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/yaffs2/YAFFS2FileSystem.java
@@ -130,7 +130,7 @@ public class YAFFS2FileSystem extends GFileSystemBase {
 		GFile parentFile = (parentObjectId == 1) ? root : map.get(parentObjectId);
 
 		// skip the first header (always a meaningless, "root" header)
-		if ((objectId == 1) & (parentObjectId == 1)) {
+		if ((objectId == 1) && (parentObjectId == 1)) {
 			return;
 		}
 

--- a/Ghidra/Features/FunctionGraph/src/main/java/ghidra/graph/viewer/FGViewUpdater.java
+++ b/Ghidra/Features/FunctionGraph/src/main/java/ghidra/graph/viewer/FGViewUpdater.java
@@ -447,8 +447,8 @@ public class FGViewUpdater extends VisualGraphViewUpdater<FGVertex, FGEdge> {
 			GroupedFunctionGraphVertex groupVertex, Point2D groupVertexLocation,
 			boolean relayoutOverride, boolean animate, boolean isRegroup) {
 
-		boolean doAnimate = animate & isAnimationEnabled(); // never animate when the user has disabled it
-		if (groupVertex.getVertices().size() == 0) {
+		boolean doAnimate = animate && isAnimationEnabled(); // never animate when the user has disabled it
+		if (groupVertex.getVertices().isEmpty()) {
 			return false;
 		}
 

--- a/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/cmd/data/rtti/CreateRtti1BackgroundCmd.java
+++ b/Ghidra/Features/MicrosoftCodeAnalyzer/src/main/java/ghidra/app/cmd/data/rtti/CreateRtti1BackgroundCmd.java
@@ -71,7 +71,7 @@ public class CreateRtti1BackgroundCmd extends AbstractCreateDataBackgroundCmd<Rt
 	@Override
 	protected boolean createAssociatedData() throws CancelledException {
 
-		return createRtti0() | createRtti3();
+		return createRtti0() || createRtti3();
 	}
 
 	private boolean createRtti0() throws CancelledException {

--- a/Ghidra/Features/MicrosoftDmang/src/main/java/mdemangler/functiontype/MDFunctionType.java
+++ b/Ghidra/Features/MicrosoftDmang/src/main/java/mdemangler/functiontype/MDFunctionType.java
@@ -159,7 +159,7 @@ public class MDFunctionType extends MDType {
 			dmang.insertString(builder, "(");
 			dmang.appendString(builder, ")");
 		}
-		if (hasArgs & argsList != null) {
+		if (hasArgs && argsList != null) {
 			dmang.appendString(builder, "(");
 			argsList.insert(builder);
 			dmang.appendString(builder, ")");

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/actions/AutoVersionTrackingTask.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/actions/AutoVersionTrackingTask.java
@@ -222,7 +222,7 @@ public class AutoVersionTrackingTask extends Task {
 			options.setDouble(scoreOption, minCombinedReferenceCorrelatorScore);
 
 			monitor.setPrefix(String.format(prefix, "Data Reference", ++count));
-			hasApplyErrors = hasApplyErrors | correlateAndPossiblyApply(factory, options, monitor);
+			hasApplyErrors |= correlateAndPossiblyApply(factory, options, monitor);
 			monitor.doIncrementProgress();
 
 			// Get the number of data and function matches again if this correlator ran
@@ -240,7 +240,7 @@ public class AutoVersionTrackingTask extends Task {
 			factory = new FunctionReferenceProgramCorrelatorFactory();
 
 			monitor.setPrefix(String.format(prefix, "Function Reference", ++count));
-			hasApplyErrors = hasApplyErrors | correlateAndPossiblyApply(factory, options, monitor);
+			hasApplyErrors |= correlateAndPossiblyApply(factory, options, monitor);
 			monitor.doIncrementProgress();
 
 			// Get the number of data and function matches again if this correlator ran
@@ -257,7 +257,7 @@ public class AutoVersionTrackingTask extends Task {
 			options.setDouble(scoreOption, minCombinedReferenceCorrelatorScore);
 
 			monitor.setPrefix(String.format(prefix, "Function and Data", ++count));
-			hasApplyErrors = hasApplyErrors | correlateAndPossiblyApply(factory, options, monitor);
+			hasApplyErrors |= correlateAndPossiblyApply(factory, options, monitor);
 			monitor.doIncrementProgress();
 		}
 

--- a/Ghidra/Framework/DB/src/main/java/db/buffers/BufferMgr.java
+++ b/Ghidra/Framework/DB/src/main/java/db/buffers/BufferMgr.java
@@ -1784,7 +1784,7 @@ public class BufferMgr {
 					// Monitor not supported for remote saves
 					monitor.setCancelEnabled(false);
 					outFile = ((ManagedBufferFile) sourceFile).getSaveFile();
-					monitor.setCancelEnabled(oldCancelState & !monitor.isCancelled());
+					monitor.setCancelEnabled(oldCancelState && !monitor.isCancelled());
 				}
 				if (outFile == null) {
 					throw new IOException("Save not allowed");
@@ -1816,7 +1816,7 @@ public class BufferMgr {
 				}
 				finally {
 					((ManagedBufferFile) sourceFile).saveCompleted(success);
-					monitor.setCancelEnabled(oldCancelState & !monitor.isCancelled());
+					monitor.setCancelEnabled(oldCancelState && !monitor.isCancelled());
 				}
 
 				setSourceFile(outFile);

--- a/Ghidra/Framework/Docking/src/main/java/docking/options/editor/GhidraColorChooser.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/options/editor/GhidraColorChooser.java
@@ -129,7 +129,7 @@ public class GhidraColorChooser extends JColorChooser {
 
 		List<Color> mruColorList = recentColorCache.getMRUColorList();
 		AbstractColorChooserPanel[] chooserPanels = getChooserPanels();
-		if (chooserPanels != null & chooserPanels.length > 1) {
+		if (chooserPanels != null && chooserPanels.length > 1) {
 			AbstractColorChooserPanel panel = chooserPanels[0];
 			if (panel instanceof SettableColorSwatchChooserPanel) {
 				// we've already added our panel--reuse

--- a/Ghidra/Framework/Project/src/main/java/ghidra/util/exception/VersionException.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/util/exception/VersionException.java
@@ -120,7 +120,7 @@ public class VersionException extends UsrException {
 		if (ve != null) {
 			if (this.versionIndicator != ve.versionIndicator)
 				versionIndicator = UNKNOWN_VERSION;
-			upgradeable = upgradeable & ve.upgradeable;
+			upgradeable = upgradeable && ve.upgradeable;
 			if (detailMessage == null) {
 				detailMessage = ve.detailMessage;
 			}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/parse/AssemblyParseMachine.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/parse/AssemblyParseMachine.java
@@ -164,10 +164,10 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 		if (result != 0) {
 			return result;
 		}
-		if (this.accepted & !that.accepted) {
+		if (this.accepted && !that.accepted) {
 			return 1;
 		}
-		if (!this.accepted & that.accepted) {
+		if (!this.accepted && that.accepted) {
 			return -1;
 		}
 		result = (this.error - that.error);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/core/analysis/ReferenceAddressPair.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/core/analysis/ReferenceAddressPair.java
@@ -54,6 +54,6 @@ public class ReferenceAddressPair {
 			return false;
 		}
 		ReferenceAddressPair otherPair = (ReferenceAddressPair) obj;
-		return source.equals(otherPair.source) & destination.equals(otherPair.destination);
+		return source.equals(otherPair.source) && destination.equals(otherPair.destination);
 	}
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoDisassembler.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/PseudoDisassembler.java
@@ -730,7 +730,7 @@ public class PseudoDisassembler {
 							// if jump target is the same as the fallthru
 							// Instructions with delay slots are allowed.
 							if (fallThru != null &&
-								address.equals(fallThru) & !instr.getPrototype().hasDelaySlots()) {
+                                    address.equals(fallThru) && !instr.getPrototype().hasDelaySlots()) {
 								return false;
 							}
 							// if this code jumps to an existing function, allow it
@@ -835,16 +835,13 @@ public class PseudoDisassembler {
 			if (program != null) {
 				func = program.getFunctionManager().getFunctionAt(flows[0]);
 			}
-		}
-		else {
-			if (flowType.isComputed() & !flowType.isConditional()) {
-				for (int opIndex = 0; opIndex < instr.getNumOperands(); opIndex++) {
-					RefType operandRefType = instr.getOperandRefType(opIndex);
-					if (operandRefType.isIndirect()) {
-						Address addr = instr.getAddress(opIndex);
-						if (addr != null) {
-							func = program.getFunctionManager().getReferencedFunction(addr);
-						}
+		} else if (flowType.isComputed() && !flowType.isConditional()) {
+			for (int opIndex = 0; opIndex < instr.getNumOperands(); opIndex++) {
+				RefType operandRefType = instr.getOperandRefType(opIndex);
+				if (operandRefType.isIndirect()) {
+					Address addr = instr.getAddress(opIndex);
+					if (addr != null) {
+						func = program.getFunctionManager().getReferencedFunction(addr);
 					}
 				}
 			}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/FloatFormat.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/floatformat/FloatFormat.java
@@ -751,7 +751,7 @@ public strictfp class FloatFormat {
 	public BigInteger opNotEqual(BigInteger a, BigInteger b) { // a != b
 		BigFloat fa = getHostFloat(a);
 		BigFloat fb = getHostFloat(b);
-		if (fa.isNaN() | fb.isNaN()) {
+		if (fa.isNaN() || fb.isNaN()) {
 			return BigInteger.ONE;
 		}
 		BigInteger res = SystemUtilities.isEqual(fa, fb) ? BigInteger.ZERO : BigInteger.ONE;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/FunctionPrototype.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/FunctionPrototype.java
@@ -158,7 +158,7 @@ public class FunctionPrototype {
 			(f.getSignatureSource() != SourceType.DEFAULT) && f.getParameterCount() == 0;
 		dotdotdot = f.hasVarArgs();
 		isinline = f.isInline();
-		noreturn = f.hasNoReturn() | isNoReturnInjection(f, injectname);
+		noreturn = f.hasNoReturn() || isNoReturnInjection(f, injectname);
 		custom = f.hasCustomVariableStorage();
 
 		// This assumes that the Purge is the value popped from the excluding normal

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/OldLanguage.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/OldLanguage.java
@@ -327,8 +327,8 @@ class OldLanguage implements Language {
 			throw new SAXException(
 				"Missing required " + element.getName() + " '" + name + "' attribute");
 		}
-		boolean val = valStr.equalsIgnoreCase("yes") | valStr.equalsIgnoreCase("true");
-		if (!val && !valStr.equalsIgnoreCase("no") & !valStr.equalsIgnoreCase("false")) {
+		boolean val = "yes".equalsIgnoreCase(valStr) || "true".equalsIgnoreCase(valStr);
+		if (!val && !"no".equalsIgnoreCase(valStr) && !"false".equalsIgnoreCase(valStr)) {
 			throw new SAXException(
 				"invalid boolean attribute value " + name + "=\"" + valStr + "\"");
 		}

--- a/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsAddressAnalyzer.java
+++ b/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsAddressAnalyzer.java
@@ -385,7 +385,7 @@ public class MipsAddressAnalyzer extends ConstantPropagationAnalyzer {
 					return false;
 				}
 
-				if ((refType.isJump() || refType.isCall()) & refType.isComputed()) {
+				if ((refType.isJump() || refType.isCall()) && refType.isComputed()) {
 					//if (refType.isJump() || refType.isCall()) {
 					addr = MipsExtDisassembly(program, instr, context, address, monitor);
 					//addr = flowISA(program, instr, context, address);

--- a/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsPreAnalyzer.java
+++ b/Ghidra/Processors/MIPS/src/main/java/ghidra/app/plugin/core/analysis/MipsPreAnalyzer.java
@@ -451,7 +451,7 @@ public class MipsPreAnalyzer extends AbstractAnalyzer {
 		}
 
 		// Check base and destination registers
-		if (base1.equals(base2) && (destReg1.equals(destReg2) | destReg2.equals(alternateReg))) {
+		if (base1.equals(base2) && (destReg1.equals(destReg2) || destReg2.equals(alternateReg))) {
 			// Match found
 			return curr_inst;
 		}


### PR DESCRIPTION
There are places were a bitwise operator is accidentally used instead of a logical one. In most of these cases, the effect is benign, just costing a tiny bit of performance. However, in cases like (trace != null) & trace... this can cause crashes where it isn't necessary, especially when the first condition is meant to prevent the second condition from happening if a variable/object was null.

This PR fixes those mistakes.