### PR TITLE
Initialize hasBeenRestored

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/importer/LibrarySearchPathManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/importer/LibrarySearchPathManager.java
@@ -28,7 +28,7 @@ public class LibrarySearchPathManager {
 
 	private static List<String> pathList = createPathList();
 
-	private static boolean hasBeenRestored;
+	private static boolean hasBeenRestored = false;
 
 	private static List<String> createPathList() {
 		pathList = new ArrayList<>();
@@ -103,6 +103,7 @@ public class LibrarySearchPathManager {
 		}
 
 		setLibraryPaths(paths);
+		hasBeenRestored = true;
 	}
 
 	/**


### PR DESCRIPTION
This variable is not used at all nor is it initialized, which can cause problems and for the restoration to happen multiple times. This PR fixes that.