### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
+++ b/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
@@ -11,7 +11,7 @@
 <blockquote><p><u>Improvements</u></p>
 <ul>
     <li><I>Analysis</I>. Fixed headless analysis exception related to running UI code from the GNU Demangler analyzer. (GP-1613, Issue #3765)</li>
-    <li><I>Basic Infrastructure</I>. Upgrade logging dependency to use <i>log4j</i> 2.17.0 (GP-1621)</li>
+    <li><I>Basic Infrastructure</I>. Upgrade logging dependency to use <i>log4j</i> 2.17.1 (GP-1621)</li>
     <li><I>Debugger:Memory</I>. Added <B>New Memory Bytes View</B> to Window->Debugger menu. (GP-1465)</li>
     <li><I>Debugger:Memory</I>. Fixed issue with Debugger Memory view scrolling. (GP-1591)</li>
     <li><I>GUI</I>. Removed restriction that prevented renaming tree nodes while the tree is filtered. (GP-1507)</li>

--- a/Ghidra/Configurations/Public_Release/src/global/docs/WhatsNew.html
+++ b/Ghidra/Configurations/Public_Release/src/global/docs/WhatsNew.html
@@ -46,7 +46,7 @@
     <H1><span style="color:#FF0000">Log4j Vulnerability Mitigation</span></H1>
     <p><span style="color:#FF0000">Please read!</span> There have been several
     published CVE security vulnerabilities noted for log4j which Ghidra uses for logging.  The known issues
-    have been resolved in log4j 2.17.0.  We strongly encourage
+    have been resolved in log4j 2.17.1.  We strongly encourage
     anyone using previous versions of Ghidra or a build from source, to remediate this issue by either upgrading
     to the latest Ghidra 10.1.1 version, or patching your current version.</P>
     
@@ -56,8 +56,8 @@
 	<BLOCKQUOTE>
 	<UL>
     <li>Delete any log4j jar files in <b>Ghidra/Framework/Generic/lib</b>.</li>
-    <li>Replace those jar files with the newer log4j 2.17.0 version: <b>log4j-api-2.17.0.jar</b> and <b>log4j-core-2.17.0.jar</b>.</li>
-    <li>Update the log4j version to refer to 2.17.0 in <b>&ltinstall_dir&gt/Ghidra/Features/GhidraServer/data/classpath.frag</b>.</li></UL>
+    <li>Replace those jar files with the newer log4j 2.17.1 version: <b>log4j-api-2.17.1.jar</b> and <b>log4j-core-2.17.1.jar</b>.</li>
+    <li>Update the log4j version to refer to 2.17.1 in <b>&ltinstall_dir&gt/Ghidra/Features/GhidraServer/data/classpath.frag</b>.</li></UL>
     </BLOCKQUOTE>
     </p>
     
@@ -65,8 +65,8 @@
 	You can find these in the latest Ghidra 10.1.1 release, or from:
 	<BLOCKQUOTE>
 	<UL>
-    <li>https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.0/log4j-api-2.17.0.jar</li>
-    <li>https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.0/log4j-core-2.17.0.jar</li>
+    <li>https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar</li>
+    <li>https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar</li>
     </UL></BLOCKQUOTE>
     </p>
     


### PR DESCRIPTION
2.17.0 has a vulnerability (CVE-2021-44832), that is resolved in 2.17.1, so let's use 2.17.1 instead.