### PR TITLE
Fix: No disassemly for the last instructions

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/address/AbstractAddressSpace.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/address/AbstractAddressSpace.java
@@ -383,7 +383,7 @@ abstract class AbstractAddressSpace implements AddressSpace {
 				"Address Overflow in add: " + addr + " + 0x" + Long.toHexString(displacement));
 		}
 		long addrOff = addr.getOffset();
-		long maxOff = maxAddress.getOffset();
+		long maxOff = maxAddress.getOffset() + 1;
 		long result = addrOff + displacement;
 		if (maxOff < 0) { // 64 bit unsigned
 			if (addrOff < 0 && result >= 0) {


### PR DESCRIPTION
Fix for the bug related to impossibility to disassemble two last instructions (includes one delay slot).
https://github.com/NationalSecurityAgency/ghidra/issues/3840

Doesn't fix other overlays bugs.