### PR TITLE
Any value assigned to "EXCLUDE FROM GHIDRA JAR" will always exclude from build

### DIFF
--- a/Ghidra/Framework/Utility/src/main/java/utility/module/ModuleManifestFile.java
+++ b/Ghidra/Framework/Utility/src/main/java/utility/module/ModuleManifestFile.java
@@ -96,15 +96,8 @@ public class ModuleManifestFile {
 		}
 		else if (trimmedLine.startsWith(EXCLUDE_FROM_GHIDRA_JAR)) {
 			String[] tokens = trimmedLine.split(":");
-
-            if (tokens.length == 2) {
-                if (tokens[1].toLowerCase().trim().compareTo("false") == 0)
-                    excludeFromGhidraJar = false;
-                else
-                    excludeFromGhidraJar = true;
-            }
-            else
-                excludeFromGhidraJar = true; // Default to not be included in build
+			String value = tokens.length == 2 ? tokens[1].trim() : "";
+			excludeFromGhidraJar = Boolean.valueOf(value);
 		}
 		else if (trimmedLine.startsWith(MODULE_FILE_LICENSE)) {
 			processModuleFileLicense(trimmedLine);

--- a/Ghidra/Framework/Utility/src/main/java/utility/module/ModuleManifestFile.java
+++ b/Ghidra/Framework/Utility/src/main/java/utility/module/ModuleManifestFile.java
@@ -95,7 +95,16 @@ public class ModuleManifestFile {
 			// ignore for now
 		}
 		else if (trimmedLine.startsWith(EXCLUDE_FROM_GHIDRA_JAR)) {
-			excludeFromGhidraJar = true;
+			String[] tokens = trimmedLine.split(":");
+
+            if (tokens.length == 2) {
+                if (tokens[1].toLowerCase().trim().compareTo("false") == 0)
+                    excludeFromGhidraJar = false;
+                else
+                    excludeFromGhidraJar = true;
+            }
+            else
+                excludeFromGhidraJar = true; // Default to not be included in build
 		}
 		else if (trimmedLine.startsWith(MODULE_FILE_LICENSE)) {
 			processModuleFileLicense(trimmedLine);


### PR DESCRIPTION
The value associated with "EXCLUDE FROM GHIDRA JAR" module configuration has no effect when building the JAR file, unless the entire line is deleted, for example, "EXCLUDE FROM GHIDRA JAR: false" will have no effect and the module will still be excluded since the current code checks only if the line starts with "EXCLUDE FROM GHIDRA JAR" but does not examine the assigned value. I updated the code to enable the effect of the true/false values.