### PR TITLE
PeLoader: Pointer to symbol table check.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
@@ -431,6 +431,9 @@ public class FileHeader implements StructConverter {
 		long oldIndex = reader.getPointerIndex();
 
 		int tmpIndex = getPointerToSymbolTable();
+		if (tmpIndex == 0) {
+			return;
+		}
 		if (!ntHeader.checkRVA(tmpIndex)) {
 			Msg.error(this, "Invalid file index " + Integer.toHexString(tmpIndex));
 			return;


### PR DESCRIPTION
Fixes #3830.

Number of symbols is > 0, but pointer to symbol table == 0.  