### PR TITLE
3906: fix NPE when removing specification extensions

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/SpecExtension.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/SpecExtension.java
@@ -669,7 +669,7 @@ public class SpecExtension {
 	private void clearPrototypeEvaluationModel(EvaluationModelType modelType, String modelName) {
 		CompilerSpec compilerSpec = program.getCompilerSpec();
 		PrototypeModel evalModel = compilerSpec.getPrototypeEvaluationModel(modelType);
-		if (!evalModel.getName().equals(modelName)) {
+		if (evalModel == null || !evalModel.getName().equals(modelName)) {
 			return;
 		}
 		String newName = compilerSpec.getDefaultCallingConvention().getName();


### PR DESCRIPTION
Attempting to remove a specification extension of a calling convention (prototype) from a program with an invalid `Decompiler->Prototype Evaluation` setting resulted in a NullPointerException due to a missing null check. This change adds a null check to allow the removal to complete successfully.

See #3906 for the full context of the issue.