### PR TITLE
Upgrade to com.google.protobuf:protobuf-java

### DIFF
--- a/Ghidra/Debug/Debugger-gadp/build.gradle
+++ b/Ghidra/Debug/Debugger-gadp/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 		}
 	}
 
-	api 'com.google.protobuf:protobuf-java:3.17.3'
+	api 'com.google.protobuf:protobuf-java:3.18.2'
 	api project(':Framework-AsyncComm')
 	api project(':Framework-Debugging')
 	api project(':ProposedUtils')


### PR DESCRIPTION
Affected versions of this package are vulnerable to Denial of Service (DoS). An issue in protobuf-java allowed the interleaving of com.google.protobuf.UnknownFieldSet fields in such a way that would be processed out of order. A small malicious payload can occupy the parser for several minutes by creating large numbers of short-lived objects that cause frequent, repeated pauses.

Signed-off-by: Bhaskar Ram <bhaskar@parrotsec.in>