### PR TITLE
Fix disassembly of ARM vsub instruction

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -4560,7 +4560,7 @@ define pcodeop VectorSubAndNarrow;
 
 @if defined(VFPv2) || defined(VFPv3)
 
-:vsub^COND^".f32" Sd,Sm		is COND & ( ($(AMODE) & ARMcond=1 & c2327=0x1c & c2021=3 & c0811=10 & c0606=1 & c0404=0) |
+:vsub^COND^".f32" Sd,Sn,Sm		is COND & ( ($(AMODE) & ARMcond=1 & c2327=0x1c & c2021=3 & c0811=10 & c0606=1 & c0404=0) |
                                         ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=3 & thv_c0811=10 & thv_c0606=1 & thv_c0404=0) ) & Sm & Sn & Sd
 {
 	build COND;
@@ -4570,7 +4570,7 @@ define pcodeop VectorSubAndNarrow;
 	Sd = Sn f- Sm;
 }
 
-:vsub^COND^".f64" Dd,Dm		is COND & ( ($(AMODE) & ARMcond=1 & c2327=0x1c & c2021=3 & c0811=11 & c0606=1 & c0404=0 ) |
+:vsub^COND^".f64" Dd,Dn,Dm		is COND & ( ($(AMODE) & ARMcond=1 & c2327=0x1c & c2021=3 & c0811=11 & c0606=1 & c0404=0 ) |
                                         ($(TMODE_E) & thv_c2327=0x1c & thv_c2021=3 & thv_c0811=11 & thv_c0606=1 & thv_c0404=0) ) & Dm & Dn & Dd
 {
 	build COND;


### PR DESCRIPTION
Add missing second operand (`Sn` or `Dn` depending on the variant of the instruction) to disassembly of `vsub` instruction.

Fixes #3943.