### PR TITLE
SQUOTE bug fix in the shell

### DIFF
--- a/Ghidra/Debug/Framework-Debugging/src/main/java/ghidra/dbg/util/ShellUtils.java
+++ b/Ghidra/Debug/Framework-Debugging/src/main/java/ghidra/dbg/util/ShellUtils.java
@@ -80,6 +80,7 @@ public class ShellUtils {
 						default:
 							curArg.append(c);
 					}
+					break;
 				case SQUOTE_ESCAPE:
 					curArg.append(c);
 					state = State.SQUOTE;


### PR DESCRIPTION
without this break statement, curArg would be overwritten as the statement falls through