### PR TITLE
Bug fix for creating symbol

### DIFF
--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/pdb/pdbapplicator/LabelSymbolApplier.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/pdb/pdbapplicator/LabelSymbolApplier.java
@@ -69,7 +69,7 @@ public class LabelSymbolApplier extends MsSymbolApplier {
 				name = NamespaceUtils.getNamespaceQualifiedName(f, name, true);
 			}
 		}
-		applicator.createSymbol(symbolAddress, symbol.getName(), false);
+		applicator.createSymbol(symbolAddress, name, false);
 	}
 
 	@Override


### PR DESCRIPTION
None of the modifications to name actually have any effect because the result of symbol.getName() is used, instead of name.

This PR fixes that.