### PR TITLE
Fix UBSAN errors in decompiler

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
@@ -646,9 +646,9 @@ void zero_extend(intb &val,int4 bit)
 
 {
   intb mask = 0;
-  mask = (~mask)<<bit;
-  mask <<= 1;
-  val &= (~mask);
+  for (int4 i = 0; i <= bit; ++i)
+    mask |= (1ULL << i);
+  val &= mask;
 }
 
 /// Swap the least significant \b size bytes in \b val

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/pcodecompile.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/pcodecompile.cc
@@ -623,7 +623,17 @@ vector<OpTpl *> *PcodeCompile::assignBitRange(VarnodeTpl *vn,uint4 bitoffset,uin
   bool shiftneeded = (bitoffset != 0);
   bool zextneeded = true;
   uintb mask = (uintb)2;
-  mask = ~(((mask<<(numbits-1))-1) << bitoffset);
+  int4 masknumbits = sizeof(mask) * 8;
+  if (numbits - 1 < masknumbits)
+    mask <<= (numbits - 1);
+  else
+    mask = 0;
+  --mask;
+  if (bitoffset < masknumbits)
+    mask <<= bitoffset;
+  else
+    mask = 0;
+  mask = ~(mask);
 
   if (vn->getSize().getType()==ConstTpl::real) {
     // If we know the size of the bitranged varnode, we can
@@ -728,8 +738,12 @@ ExprTree *PcodeCompile::createBitRange(SpecificSymbol *sym,uint4 bitoffset,uint4
   }
 
   uintb mask = (uintb)2;
-  mask = ((mask<<(numbits-1))-1);
-  
+  if (numbits - 1 < sizeof(mask) * 8)
+    mask <<= (numbits - 1);
+  else
+    mask = 0;
+  --mask;
+
   if (truncneeded && ((bitoffset % 8)==0)) {
     truncshift = bitoffset/8;
     bitoffset = 0;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
@@ -20,6 +20,7 @@ ConstTpl::ConstTpl(const_type tp)
 
 {				// Constructor for relative jump constants and uniques
   type = tp;
+  select = v_space;
 }
 
 ConstTpl::ConstTpl(const_type tp,uintb val)
@@ -54,6 +55,7 @@ ConstTpl::ConstTpl(AddrSpace *sid)
 {
   type = spaceid;
   value.spaceid = sid;
+  select = v_space;
 }
 
 bool ConstTpl::isConstSpace(void) const

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.hh
@@ -46,7 +46,7 @@ private:
   static void printHandleSelector(ostream &s,v_field val);
   static v_field readHandleSelector(const string &name);
 public:
-  ConstTpl(void) { type = real; value_real = 0; }
+  ConstTpl(void) { type = real; value_real = 0; select = v_space; }
   ConstTpl(const ConstTpl &op2) {
     type=op2.type; value=op2.value; value_real=op2.value_real; select=op2.select; }
   ConstTpl(const_type tp,uintb val);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
@@ -2150,8 +2150,8 @@ string SleighCompile::checkSymbols(SymbolScope *scope)
   ostringstream msg;
   SymbolTree::const_iterator iter;
   for(iter=scope->begin();iter!=scope->end();++iter) {
+    if ((*iter)->getType() != SleighSymbol::label_symbol) continue;
     LabelSymbol *sym = (LabelSymbol *)*iter;
-    if (sym->getType() != SleighSymbol::label_symbol) continue;
     if (sym->getRefCount() == 0)
       msg << "   Label <" << sym->getName() << "> was placed but not used" << endl;
     else if (!sym->isPlaced())


### PR DESCRIPTION
When compiling a `x86.slaspec` to a `.sla` file, I noticed that UBSAN reports a few errors.