### PR TITLE
Fix Comments -> Set... in the decompiler not defaulting to editing existing comments

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.cc
@@ -258,11 +258,13 @@ void EmitXml::tagField(const char *ptr,syntax_highlight hl,const Datatype *ct,in
 /// \param hl indicates how the comment should be highlighted
 /// \param spc is the address space of the address where the comment is attached
 /// \param off is the offset of the address where the comment is attached
+/// \param type is the type of the comment
 void EmitXml::tagComment(const char *ptr,syntax_highlight hl,
-			   const AddrSpace *spc,uintb off) {
+			   const AddrSpace *spc,uintb off, const char* type) {
   *s << "<comment " << highlight[(int4)hl];
   a_v(*s,"space",spc->getName());
   a_v_u(*s,"off",off);
+  a_v(*s,"type",type);
   *s << '>';
   xml_escape(*s,ptr);
   *s << "</comment>";
@@ -422,7 +424,7 @@ void TokenSplit::print(EmitXml *emit) const
     emit->tagField(tok.c_str(),hl,ptr_second.ct,(int4)off);
     break;
   case comm_t:	// tagComment
-    emit->tagComment(tok.c_str(),hl,ptr_second.spc,off);
+    emit->tagComment(tok.c_str(),hl,ptr_second.spc,off,ptr_second.type);
     break;
   case label_t:	// tagLabel
     emit->tagLabel(tok.c_str(),hl,ptr_second.spc,off);
@@ -1064,11 +1066,11 @@ void EmitPrettyPrint::tagField(const char *ptr,syntax_highlight hl,const Datatyp
 }
 
 void EmitPrettyPrint::tagComment(const char *ptr,syntax_highlight hl,
-				   const AddrSpace *spc,uintb off)
+				   const AddrSpace *spc,uintb off, const char* type)
 {
   checkstring();
   TokenSplit &tok( tokqueue.push() );
-  tok.tagComment(ptr,hl,spc,off);
+  tok.tagComment(ptr,hl,spc,off,type);
   scan();
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
@@ -122,7 +122,7 @@ public:
   virtual void tagFuncName(const char *ptr,syntax_highlight hl,const Funcdata *fd,const PcodeOp *op);
   virtual void tagType(const char *ptr,syntax_highlight hl,const Datatype *ct);
   virtual void tagField(const char *ptr,syntax_highlight hl,const Datatype *ct,int4 off);
-  virtual void tagComment(const char *ptr,syntax_highlight hl,const AddrSpace *spc,uintb off);
+  virtual void tagComment(const char *ptr,syntax_highlight hl,const AddrSpace *spc,uintb off,const char *type);
   virtual void tagLabel(const char *ptr,syntax_highlight hl,const AddrSpace *spc,uintb off);
   virtual void print(const char *str,syntax_highlight hl=no_color);
   virtual int4 openParen(char o,int4 id=0);		///< Emit an open parenthesis
@@ -273,7 +273,7 @@ public:
   virtual void tagField(const char *ptr,syntax_highlight hl,const Datatype *ct,int4 off) {
     *s << ptr; }
   virtual void tagComment(const char *ptr,syntax_highlight hl,
-			   const AddrSpace *spc,uintb off) {
+			   const AddrSpace *spc,uintb off, const char* type) {
     *s << ptr; }
   virtual void tagLabel(const char *ptr,syntax_highlight hl,
 			 const AddrSpace *spc,uintb off) {
@@ -354,13 +354,14 @@ private:
   EmitXml::syntax_highlight hl;	///< Highlighting for token
   // Additional markup elements for token
   const PcodeOp *op;		///< Pcode-op associated with \b this token
-  union {
+  struct {
     const Varnode *vn;		///< Associated Varnode
     const FlowBlock *bl;	///< Associated Control-flow
     const Funcdata *fd;		///< Associated Function
     const Datatype *ct;		///< Associated Data-type
     const AddrSpace *spc;	///< Associated Address
     const Symbol *symbol;	///< Associated Symbol being displayed
+    const char *type;		///< Associated comment type
   } ptr_second;			///< Additional markup associated with the token
   uintb off;			///< Offset associated either with address or field markup
   int4 indentbump;		///< Amount to indent if a line breaks
@@ -514,9 +515,10 @@ public:
   /// \param h indicates how the comment should be highlighted
   /// \param s is the address space of the address where the comment is attached
   /// \param o is the offset of the address where the comment is attached
+  /// \param type is the type of the comment
   void tagComment(const char *ptr,EmitXml::syntax_highlight h,
-		   const AddrSpace *s,uintb o) {
-    tok = ptr; size = tok.size(); ptr_second.spc=s; off=o;
+		   const AddrSpace *s,uintb o, const char* type) {
+    tok = ptr; size = tok.size(); ptr_second.spc=s; off=o; ptr_second.type=type;
     tagtype=comm_t; delimtype=tokenstring; hl=h; }
 
   /// \brief Create a code label identifier token
@@ -775,7 +777,7 @@ public:
   virtual void tagType(const char *ptr,syntax_highlight hl,const Datatype *ct);
   virtual void tagField(const char *ptr,syntax_highlight hl,const Datatype *ct,int4 off);
   virtual void tagComment(const char *ptr,syntax_highlight hl,
-			  const AddrSpace *spc,uintb off);
+			  const AddrSpace *spc,uintb off, const char* type);
   virtual void tagLabel(const char *ptr,syntax_highlight hl,
 			const AddrSpace *spc,uintb off);
   virtual void print(const char *str,syntax_highlight hl=no_color);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
@@ -590,6 +590,7 @@ void PrintLanguage::emitLineComment(int4 indent,const Comment *comm)
 {
   const string &text( comm->getText() );
   const AddrSpace *spc = comm->getAddr().getSpace();
+  const string type = Comment::decodeCommentType(comm->getType());
   uintb off = comm->getAddr().getOffset();
   if (indent <0)
     indent = line_commentindent; // User specified default indent
@@ -598,7 +599,7 @@ void PrintLanguage::emitLineComment(int4 indent,const Comment *comm)
   // The comment delimeters should not be printed as
   // comment tags, so that they won't get filled
   emit->tagComment(commentstart.c_str(),EmitXml::comment_color,
-		    spc,off);
+		    spc,off, type.c_str());
   int4 pos = 0;
   while(pos < text.size()) {
     char tok = text[pos++];
@@ -626,12 +627,12 @@ void PrintLanguage::emitLineComment(int4 indent,const Comment *comm)
       }
       string sub = text.substr(pos-count,count);
       emit->tagComment(sub.c_str(),EmitXml::comment_color,
-			spc,off);
+			spc,off,type.c_str());
     }
   }
   if (commentend.size() != 0)
     emit->tagComment(commentend.c_str(),EmitXml::comment_color,
-		      spc,off);
+		      spc,off,type.c_str());
   emit->stopComment(id);
   comm->setEmitted(true);
 }

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangCommentToken.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangCommentToken.java
@@ -18,12 +18,14 @@ package ghidra.app.decompiler;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.pcode.PcodeFactory;
+import ghidra.program.util.CommentType;
 import ghidra.util.xml.SpecXmlUtils;
 import ghidra.xml.XmlElement;
 
 public class ClangCommentToken extends ClangToken {
 
 	private Address srcaddr;	// source address of the comment
+	private int commenttype;
 
 	public static ClangCommentToken derive(ClangCommentToken source, String text) {
 
@@ -34,6 +36,7 @@ public class ClangCommentToken extends ClangToken {
 		newToken.setSyntaxType(source.getSyntaxType());
 		newToken.setHighlight(source.getHighlight());
 		newToken.srcaddr = source.srcaddr;
+		newToken.commenttype = source.commenttype;
 		return newToken;
 	}
 
@@ -57,6 +60,10 @@ public class ClangCommentToken extends ClangToken {
 		return srcaddr;
 	}
 
+	public int getCommentType() {
+		return commenttype;
+	}
+
 	@Override
 	public void restoreFromXML(XmlElement el, XmlElement end, PcodeFactory pfactory) {
 		super.restoreFromXML(el, end, pfactory);
@@ -64,6 +71,7 @@ public class ClangCommentToken extends ClangToken {
 		AddressSpace spc = pfactory.getAddressFactory().getAddressSpace(name);
 		long offset = SpecXmlUtils.decodeLong(el.getAttribute(ClangXML.OFFSET));
 		srcaddr = spc.getAddress(offset);
+		commenttype = CommentType.encodeCommentType(el.getAttribute(ClangXML.TYPE));
 	}
 
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/CommentType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/CommentType.java
@@ -73,4 +73,19 @@ public class CommentType {
 		return true;
 	}
 
+	public static int encodeCommentType(String name) {
+		switch (name) {
+		case "user1":
+			return CodeUnit.EOL_COMMENT;
+		case "user2":
+			return CodeUnit.PRE_COMMENT;
+		case "user3":
+			return CodeUnit.POST_COMMENT;
+		case "header":
+			return CodeUnit.PLATE_COMMENT;
+		default:
+			// Hit for "warning" and "warningheader"
+			return CodeUnit.NO_COMMENT;
+		}
+	}
 }


### PR DESCRIPTION
Fixes #3921.

There are a few things about this implementation I don't like (needing to change prettyprint.hh's `ptr_second` from a `union` to a `struct` since I need both `spc` and `type`, and needing to special-case `DecompilerLocation` in `DecompilerCommentsActionFactory` instead of in `CommentType`), but I don't see an easy way to solve them.  I also find the `user1`/`user2`/`user3` names a bit odd, but [that's what's used internally](https://github.com/NationalSecurityAgency/ghidra/blob/3eb03b1608b24aaae1cd1d5c86a5df36270ac54d/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java#L753-L776).  Still, this implementation does work.