### PR TITLE
ARM: Fix detection of vraddhn instruction

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -1784,7 +1784,7 @@ extImm: "#"^thv_c0811	is TMode=1 & thv_c0811	{ tmp:1 = thv_c0811; export tmp; }
 }
 
 
-:vraddhn.i^esize2021x2 Dd,Qn,Qm    is (($(AMODE) & cond=15 & c2527=1 & c2323=0 & c2021<3  & c0811=4 & Q6=0 & c0404=0) |
+:vraddhn.i^esize2021x2 Dd,Qn,Qm    is (($(AMODE) & cond=15 & c2527=1 & c2323=1 & c2021<3  & c0811=4 & Q6=0 & c0404=0) |
 	                                   ($(TMODE_F) & thv_c2327=0x1f & thv_c2021<3  & thv_c0811=4 & thv_Q6=0 & thv_c0404=0) ) & Qm & esize2021x2 & Qn & Dd
 {
 	Dd = VectorRoundAddAndNarrow(Qn,Qm,esize2021x2);


### PR DESCRIPTION
In the first line of `vraddhn` instruction's constructor: https://github.com/NationalSecurityAgency/ghidra/blob/b170ea5c4359353a5cd120ba051ca724fdc791df/Ghidra/Processors/ARM/data/languages/ARMneon.sinc#L1787 there is a constraint `c2323=0` that means that value of 23-rd bit of the instruction is expected to be 0.

However, according to encoding of the instruction from [ARM reference manual](https://developer.arm.com/documentation/ddi0406/cd/?lang=en), value of 23-rd bit of the instruction has to be 1: ![image](https://user-images.githubusercontent.com/61097734/153125862-c47b99c7-471e-4b23-8cad-ae616ef57b35.png)
Suggested change fixes this mistake by replacing 0 with 1 in `c2323=0` constraint.