### PR TITLE
make isMySignature time constant

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/net/ApplicationKeyManagerUtils.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/net/ApplicationKeyManagerUtils.java
@@ -162,7 +162,7 @@ public class ApplicationKeyManagerUtils {
 	public static boolean isMySignature(Principal[] authorities, byte[] token, byte[] signature)
 			throws NoSuchAlgorithmException, SignatureException, CertificateException {
 		SignedToken signedToken = getSignedToken(authorities, token);
-		return Arrays.equals(signature, signedToken.signature);
+		return MessageDigest.equals(signature, signedToken.signature);
 	}
 
 	/**


### PR DESCRIPTION
Security-related functions should use constant-time comparisons to avoid timing channel attacks.