### PR TITLE
Update CodeBlockReferenceIterator to be Iterable

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockReferenceIterator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockReferenceIterator.java
@@ -16,24 +16,64 @@
  */
 package ghidra.program.model.block;
 
+import java.util.Iterator;
+
 import ghidra.util.exception.CancelledException;
+import ghidra.util.task.TaskMonitor;
+import util.CollectionUtils;
 
 /**
  * An iterator interface over CodeBlockReferences.
+ *
+ * <P>Note: this iterator is also {@link Iterable}.  The {@link #hasNext()} and {@link #next()}
+ * methods of this interface throw a {@link CancelledException} if the monitor is cancelled.  The
+ * iterator returned from {@link #iterator()} does <b>not</b> throw a cancelled exception.  If
+ * you need to know the cancelled state of this iterator, then you must check the cancelled state
+ * of the monitor passed into this iterator via the {@link CodeBlockModel}.  See
+ * {@link TaskMonitor#isCancelled()}.
+ *
  * @see ghidra.program.model.block.CodeBlockReference
+ * @see CollectionUtils#asIterable
  */
-public interface CodeBlockReferenceIterator {
+public interface CodeBlockReferenceIterator extends Iterable<CodeBlockReference> {
 
     /**
      * Return true if next() will return a CodeBlockReference.
+     * @return true if next() will return a CodeBlockReference.
      * @throws CancelledException thrown if the operation is cancelled.
      */
-	public boolean hasNext() throws CancelledException;
+    public boolean hasNext() throws CancelledException;
 
     /**
      * Return the next CodeBlockReference.
+     * @return the next CodeBlockReference.
      * @throws CancelledException thrown if the operation is cancelled.
      */
     public CodeBlockReference next() throws CancelledException;
+
+    @Override
+    default Iterator<CodeBlockReference> iterator() {
+        return new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                try {
+                    return CodeBlockReferenceIterator.this.hasNext();
+                }
+                catch (CancelledException e) {
+                    return false;
+                }
+            }
+
+            @Override
+            public CodeBlock next() {
+                try {
+                    return CodeBlockReferenceIterator.this.next();
+                }
+                catch (CancelledException e) {
+                    return null;
+                }
+            }
+        };
+    }
 }
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockReferenceIterator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/block/CodeBlockReferenceIterator.java
@@ -37,43 +37,43 @@ import util.CollectionUtils;
  */
 public interface CodeBlockReferenceIterator extends Iterable<CodeBlockReference> {
 
-    /**
-     * Return true if next() will return a CodeBlockReference.
-     * @return true if next() will return a CodeBlockReference.
-     * @throws CancelledException thrown if the operation is cancelled.
-     */
-    public boolean hasNext() throws CancelledException;
+	/**
+	 * Return true if next() will return a CodeBlockReference.
+	 * @return true if next() will return a CodeBlockReference.
+	 * @throws CancelledException thrown if the operation is cancelled.
+	 */
+	public boolean hasNext() throws CancelledException;
 
-    /**
-     * Return the next CodeBlockReference.
-     * @return the next CodeBlockReference.
-     * @throws CancelledException thrown if the operation is cancelled.
-     */
-    public CodeBlockReference next() throws CancelledException;
+	/**
+	 * Return the next CodeBlockReference.
+	 * @return the next CodeBlockReference.
+	 * @throws CancelledException thrown if the operation is cancelled.
+	 */
+	public CodeBlockReference next() throws CancelledException;
 
-    @Override
-    default Iterator<CodeBlockReference> iterator() {
-        return new Iterator<>() {
-            @Override
-            public boolean hasNext() {
-                try {
-                    return CodeBlockReferenceIterator.this.hasNext();
-                }
-                catch (CancelledException e) {
-                    return false;
-                }
-            }
+	@Override
+	default Iterator<CodeBlockReference> iterator() {
+		return new Iterator<>() {
+			@Override
+			public boolean hasNext() {
+				try {
+					return CodeBlockReferenceIterator.this.hasNext();
+				}
+				catch (CancelledException e) {
+					return false;
+				}
+			}
 
-            @Override
-            public CodeBlock next() {
-                try {
-                    return CodeBlockReferenceIterator.this.next();
-                }
-                catch (CancelledException e) {
-                    return null;
-                }
-            }
-        };
-    }
+			@Override
+			public CodeBlockReference next() {
+				try {
+					return CodeBlockReferenceIterator.this.next();
+				}
+				catch (CancelledException e) {
+					return null;
+				}
+			}
+		};
+	}
 }
 


### PR DESCRIPTION
The `CodeBlockReferenceIterator` class defines an iterator-like interface but does not implement `Iterable`.

This is pretty much just a duplicate of a similar update that was made to `CodeBlockIterator` in commit 88225a5 addressing #3478.