### PR TITLE
add macro to loadimage_bfd.hh, easier to build.

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/loadimage_bfd.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/loadimage_bfd.hh
@@ -20,7 +20,25 @@
 #define __LOADIMAGE_BFD__
 
 #include "loadimage.hh"
-#include <bfd.h>
+#ifndef PACKAGE
+  #define PACKAGE
+  #ifndef PACKAGE_VERSION
+    #define PACKAGE_VERSION
+    #include <bfd.h>
+    #undef PACKAGE_VERSION
+  #else
+    #include <bfd.h>
+  #endif
+  #undef PACKAGE
+#else
+  #ifndef PACKAGE_VERSION
+    #define PACKAGE_VERSION
+    #include <bfd.h>
+    #undef PACKAGE_VERSION
+  #else
+    #include <bfd.h>
+  #endif
+#endif
 
 struct ImportRecord {
   string dllname;


### PR DESCRIPTION
Prevents potential bfd compile issue: "error: config.h must be included before this header"