### PR TITLE
Corrected ARM bfi pcode

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -1344,12 +1344,13 @@ macro th_set_carry_for_asr(op1,shift_count) {
 	Rd0811 = Rd0811 & clearMask;
 }
 
-:bfi^ItCond	Rd0811,Rn0003,thLsbImm,thBitWidth 		is TMode=1 & ItCond & op4=0xf36 & Rn0003; thc1515=0 & Rd0811 & thc0505=0 & thLsbImm & thMsbImm & thBitWidth
+:bfi^ItCond	Rd0811,Rn0003,thLsbImm,thBitWidth 		is TMode=1 & ItCond & op4=0xf36 & Rn0003; thc1515=0 & Rd0811 & thc0505=0 & thLsbImm & thBitWidth
 {
     build ItCond;
-	clearMask:4 = (-1 << (thMsbImm + 1)) | (-1 >> (32 - thLsbImm));
-	bits:4 = (Rn0003 << thLsbImm) & ~clearMask;
-	Rd0811 = (Rd0811 & clearMask) | bits;
+    vmask:4 = (1 << thBitWidth) - 1;
+    clear:4 = ~(vmask << thLsbImm);
+    bits:4 = (Rn0003 & vmask) << thLsbImm;
+    Rd0811 = (Rd0811 & clear) | bits;
 }
 
 @endif # VERSION_6T2 || VERSION_7

--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -2166,14 +2166,14 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
 	Rd = Rd & clearMask;
 }
 
-:bfi^COND Rd,Rm,lsbImm,bitWidth	is $(AMODE) &  COND & c2127=0x3e & msbImm & Rd & Rm & lsbImm & bitWidth & c0406=1	{
+:bfi^COND Rd,Rm,lsbImm,bitWidth	is $(AMODE) &  COND & c2127=0x3e & Rd & Rm & lsbImm & bitWidth & c0406=1	{
 	build COND;
 	build lsbImm;
-	build msbImm;
 	build bitWidth;
-	clearMask:4 = (-1 << (msbImm + 1)) | (-1 >> (32 - lsbImm));
-	bits:4 = (Rm << lsbImm) & ~clearMask;
-	Rd = (Rd & clearMask) | bits;
+	vmask:4 = (1 << bitWidth) - 1;
+	clear:4 = ~(vmask << lsbImm);
+	bits:4 = (Rm & vmask) << lsbImm;
+	Rd = (Rd & clear) | bits;
 }
 
 @endif # VERSION_6T2


### PR DESCRIPTION
It should be functionally equivalent to `Rd[lsbImm:bitWidth] = Rm[0:bitWidth`. According to the documentation [here](https://www.keil.com/support/man/docs/armasm/armasm_dom1361289864536.htm) `bitWidth` cannot be 0. I'm not sure if this is already accounted for elsewhere or not.

Edit: It seems the 0 width case is covered somewhere as I couldn't patch an instruction and set it to 0.