### PR TITLE
Debugger trace: add check for mappingService is null

### DIFF
--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/listing/DebuggerListingProvider.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/listing/DebuggerListingProvider.java
@@ -825,6 +825,9 @@ public class DebuggerListingProvider extends CodeViewerProvider {
 		if (loc == null) { // Redundant?
 			return;
 		}
+		if (mappingService == null) {
+			return;
+		}
 		ProgramLocation mapped = mappingService.getStaticLocationFromDynamic(loc);
 		if (mapped != null) {
 			// No need to import what is already mapped and open


### PR DESCRIPTION
This PR is a potential fix to the issue I filed in #4022. It simply adds a check for `mappingService` to see if it is null. If so, it returns like other cases in that function.

FIXES: #4022 