### PR TITLE
Debugger Trace: add checks that addresses are in the same region

### DIFF
--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/modules/DefaultRegionMapProposal.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/service/modules/DefaultRegionMapProposal.java
@@ -94,6 +94,16 @@ public class DefaultRegionMapProposal
 		}
 
 		protected int computeOffsetScore() {
+			AddressSpace space1 = fromRange.getMinAddress().getAddressSpace();
+			AddressSpace space2 = fromBase.getAddressSpace();
+			if (!space1.equals(space2)) {
+				return 0;
+			}
+			AddressSpace space3 = toRange.getMinAddress().getAddressSpace();
+			AddressSpace space4 = toBase.getAddressSpace();
+			if (!space3.equals(space4)) {
+				return 0;
+			}
 			long fOff = fromRange.getMinAddress().subtract(fromBase);
 			long tOff = toRange.getMinAddress().subtract(toBase);
 			if (fOff == tOff) {


### PR DESCRIPTION
This is a potential fix to the issue I filed: #4024.

From the stack trace I was able to see that it was possible that `RegionMatcher` is given addresses from two different regions on various cases. Here I added checks to ensure that the addresses compared are in the same address space. If they are not the offset score returns 0.

FIXES: #4024