### PR TITLE
Fix possible null exception SourceCodeLookupPlugin

### DIFF
--- a/Ghidra/Features/SourceCodeLookup/src/main/java/ghidra/app/plugin/core/scl/SourceCodeLookupPlugin.java
+++ b/Ghidra/Features/SourceCodeLookup/src/main/java/ghidra/app/plugin/core/scl/SourceCodeLookupPlugin.java
@@ -140,12 +140,11 @@ public class SourceCodeLookupPlugin extends ProgramPlugin {
 				Msg.debug(this, reply);
 				tool.setStatusInfo(reply);
 
-				if (symbolText.startsWith("_")) {
-					symbolText = symbolText.substring(1);
-				}
-				else {
+				if (!symbolText.startsWith("_")) {
 					break;
 				}
+				
+				symbolText = symbolText.substring(1);
 			}
 			catch (IOException e) {
 				// shouldn't happen


### PR DESCRIPTION
One should check the clientSocket before the bufferedReader, or else a null exception will happen when one attempts to call getInputStream()