### PR TITLE
Use length == 0 to compare arrays, not ==

### DIFF
--- a/GPL/DMG/src/dmg/java/mobiledevices/dmg/ghidra/GRandomAccessFile.java
+++ b/GPL/DMG/src/dmg/java/mobiledevices/dmg/ghidra/GRandomAccessFile.java
@@ -287,7 +287,7 @@ public class GRandomAccessFile {
 
 	private void swapInLast() throws IOException {
 		checkOpen();
-		if (buffer == EMPTY) {
+		if (buffer.length == 0) {
 			return;
 		}
 		// swap em and return

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/GhidraRandomAccessFile.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/GhidraRandomAccessFile.java
@@ -306,7 +306,7 @@ public class GhidraRandomAccessFile implements AutoCloseable {
 
 	private void swapInLast() throws IOException {
 		checkOpen();
-		if (buffer == EMPTY) {
+		if (buffer.length == 0) {
 			return;
 		}
 		// swap em and return


### PR DESCRIPTION
The way it was before could lead to bugs