### PR TITLE
Fix pcodeparse.y after only the generated pcodeparse.cc was changed

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/pcodeparse.y
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/pcodeparse.y
@@ -635,10 +635,10 @@ void PcodeLexer::initialize(istream *t)
   }
 }
 
-uintb PcodeSnippet::allocateTemp(void)
+uint4 PcodeSnippet::allocateTemp(void)
 
 { // Allocate a variable in the unique space and return the offset
-  uintb res = tempbase;
+  uint4 res = tempbase;
   tempbase += 16;
   return res;
 }


### PR DESCRIPTION
311a22c038eab8181b61042ccbfceb7897f428a5 has changed the purely generated pcodeparse.cc instead of updating pcodeparse.y and re-generating the source. This meant that the .y file was out of sync with the .h file and re-generating would lead to compiler errors because of the uintb/uint4 mismatch, e.g. https://github.com/rizinorg/rz-ghidra/runs/5521624060?check_suite_focus=true#step:5:655

I locally also built the very old bison 3.0.4 and re-generated the `pcodeparse.cc` using it to make sure they are in sync again. Apart from the license header comment, the diff was empty then.

(As my entirely personal opinion, I think 4b1beb742f0110ea7653a5010e143bd70b37aefe was a very bad idea, exactly because of such issues, as also discussed in #3842. It only adds more potentially untested and broken control flow to the build system.)