### PR TITLE
Fix JavaDoc convention issue in OSFileNotFoundException.java

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/OSFileNotFoundException.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/OSFileNotFoundException.java
@@ -69,7 +69,8 @@ public class OSFileNotFoundException extends FileNotFoundException {
 		this(Platform.CURRENT_PLATFORM, null, fileName);
 	}
 
-	/** Gets the {@link Platform} associated with this exception
+	/**
+	 * Gets the {@link Platform} associated with this exception
 	 * 
 	 * @return The {@link Platform} associated with this exception
 	 */


### PR DESCRIPTION
As described in #4076 there was a small mistake with the placing of the first line of documentation in the javadoc for the ```getPlatform()``` function. This PR fixes that.