### PR TITLE
Update to yajsw-stable-13.03

### DIFF
--- a/DevGuide.md
+++ b/DevGuide.md
@@ -55,8 +55,8 @@ You may not need all of these, depending on which portions you are building or d
     - https://github.com/pxb1988/dex2jar/releases
 * AXMLPrinter2
     - https://code.google.com/archive/p/android4me/downloads
-* Yet Another Java Service Wrapper. We use version 13.01 - Only to build Ghidra package.
-    - https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-beta-13.01/
+* Yet Another Java Service Wrapper. We use version 13.03 - Only to build Ghidra package.
+    - https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.03/
 * Eclipse PDE - Environment for developing the GhidraDev plugin.
     - https://www.eclipse.org/pde/
 * Eclipse CDT. We build against version 8.6.0 - Build dependency for the GhidraDev plugin.
@@ -122,7 +122,7 @@ directory populated with the following files:
  * flatRepo/dex-writer-2.0.jar
  * GhidraDev/cdt-8.6.0.zip
  * GhidraDev/PyDev 6.3.1.zip
- * GhidraServer/yajsw-beta-13.01.zip
+ * GhidraServer/yajsw-stable-13.03.zip
  * fidb/*.fidb
 
 If you see these, congrats! Skip to [building](#building-ghidra) or [developing](#developing-ghidra). If not, continue with manual download 
@@ -163,14 +163,14 @@ curl -OL https://storage.googleapis.com/google-code-archive-downloads/v2/code.go
 
 #### Get Dependencies for GhidraServer
 
-Building the GhidraServer requires "Yet another Java service wrapper" (yajsw) version 13.01.
-Download `yajsw-beta-13.01.zip` from their project on www.sourceforge.net, and place it in:
+Building the GhidraServer requires "Yet another Java service wrapper" (yajsw) version 13.03.
+Download `yajsw-stable-13.03.zip` from their project on www.sourceforge.net, and place it in:
 `~/git/ghidra/dependencies/GhidraServer/`:
 
 ```bash
 cd ~/Downloads   # Or wherever
-curl -OL https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-beta-13.01/yajsw-beta-13.01.zip
-cp ~/Downloads/yajsw-beta-13.01.zip ~/git/ghidra/dependencies/GhidraServer/
+curl -OL https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.03/yajsw-stable-13.03.zip
+cp ~/Downloads/yajsw-stable-13.03.zip ~/git/ghidra/dependencies/GhidraServer/
 ```
 
 #### Get Dependencies for GhidraDev

--- a/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
+++ b/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
@@ -238,7 +238,7 @@
     <li><I>Importer:Mach-O</I>. The Mach-O loader now outputs a warning when it encounters encrypted sections. (GP-1406, Issue #1935)</li>
     <li><I>Importer:Mach-O</I>. Added support for the new iOS 15 and macOS Monterey dyld_shared_cache format. (GP-1524, Issue #3345, #3666)</li>
     <li><I>Importer:PE</I>. Added support for long section names (e.g., "/1234" indicates offset into string table where actual section name is found) in PE binaries. (GP-1177, Issue #1267)</li>
-    <li><I>Multi-User</I>. Upgraded YAJSW to 13.01-beta.  Ghidra Server can now run with JDK 17. (GP-1266, Issue #3406)</li>
+    <li><I>Multi-User</I>. Upgraded YAJSW to 13.03.  Ghidra Server can now run with JDK 17. (GP-1266, Issue #3406)</li>
     <li><I>PDB</I>. Improved processing time on huge PDBs, especially when many labels are seen at the same address, such as with Identical COMDAT Folding. This change also allows some additional valid labels to be applied at these addresses. (GP-1298)</li>
     <li><I>Processors</I>. Added pcodetests for ARM version 5, which does not support thumb mode. (GP-1078)</li>
     <li><I>Processors</I>. Added 65C02 opcodes to the 6502 processor. (GP-1112, Issue #1261, #3170)</li>

--- a/Ghidra/Features/GhidraServer/build.gradle
+++ b/Ghidra/Features/GhidraServer/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'eclipse'
 
 eclipse.project.name = 'Features GhidraServer'
 
-def yajswRelease = "yajsw-beta-13.01"
+def yajswRelease = "yajsw-stable-13.03"
 
 configurations {
 	runGhidraServer
@@ -42,20 +42,15 @@ CopySpec yajswCopySpec = copySpec {
 	// First check if the file is in the dependencies repo.  If not, check in the bin repo.
 	def yajswZipTree = depsFile.exists() ? zipTree(depsFile) : zipTree(binRepoFile)
 	
-	// In yajsw-beta-13.01.zip there is not a top level directory like there was in previous
-	// versions, so we need the "into".  This is a bug which will be fixed in a future version,
-	// of yajsw, so for the next upgrade we'll likely need to get rid of the into and preface each 
-	// include with a ${yajswRelease} like we used to do.
 	from(yajswZipTree) {
-		include "lib/core/**"
-		include "lib/extended/**"
-		include "templates/**"
-		include "*.jar"
-		include "doc/**"
-		include "LICENSE.txt"
-		include "yajsw.policy.txt"
+		include "${yajswRelease}/lib/core/**"
+		include "${yajswRelease}/lib/extended/**"
+		include "${yajswRelease}/templates/**"
+		include "${yajswRelease}/*.jar"
+		include "${yajswRelease}/doc/**"
+		include "${yajswRelease}/LICENSE.txt"
+		include "${yajswRelease}/yajsw.policy.txt"
 	}
-	into "${yajswRelease}"
 }
 // Unpack YAJSW archive into build/data for development use
 task yajswDevUnpack(type:Copy) {

--- a/gradle/support/fetchDependencies.gradle
+++ b/gradle/support/fetchDependencies.gradle
@@ -74,9 +74,9 @@ ext.deps = [
 		destination: FLAT_REPO_DIR
 	],
 	[
-		name: "yajsw-beta-13.01.zip",
-		url: "https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-beta-13.01/yajsw-beta-13.01.zip",
-		sha256: "430fb7901bd0fd52a5b90bd0cbd89e9d334077eb72a9b26896f465de1e593a99",
+		name: "yajsw-stable-13.03.zip",
+		url: "https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-13.03/yajsw-stable-13.03.zip",
+		sha256: "5449d361b990e972a6a53aa421af1e71301574cc822871a57dd14330a15e3f35",
 		destination: file("${DEPS_DIR}/GhidraServer")
 	],
 	[


### PR DESCRIPTION
We should be using stable versions. In addition, this version also updated their log4j dependency on their end, so we should use that anyway