### PR TITLE
.bss sections don't need valid file offsets

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
@@ -3090,7 +3090,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 			if (type != ElfSectionHeaderConstants.SHT_NULL &&
 				(includeOtherBlocks || elfSectionToLoad.isAlloc())) {
 				long fileOffset = elfSectionToLoad.getOffset();
-				if (fileOffset < 0 || fileOffset >= fileBytes.getSize()) {
+				if (type != ElfSectionHeaderConstants.SHT_NOBITS && (fileOffset < 0 || fileOffset >= fileBytes.getSize())) {
 					log("Skipping section [" + elfSectionToLoad.getNameAsString() +
 						"] with invalid file offset");
 					continue;


### PR DESCRIPTION
The ELF loader incorrectly skips NOBITS sections that have invalid file offsets, like .bss; however, the file offset is ignored for NOBITS sections.

This is essentially applying #2136 to the file offset as well.