### PR TITLE
Replace error-prone '==' with 'equals()'

### DIFF
--- a/Ghidra/Features/VersionTracking/src/test.slow/java/ghidra/feature/vt/gui/provider/VTFunctionReferenceCorrelator_ELF_Test.java
+++ b/Ghidra/Features/VersionTracking/src/test.slow/java/ghidra/feature/vt/gui/provider/VTFunctionReferenceCorrelator_ELF_Test.java
@@ -105,7 +105,7 @@ public class VTFunctionReferenceCorrelator_ELF_Test extends AbstractVTCorrelator
 		List<VTMatchSet> exactMatchSets = session.getMatchSets();
 		for (VTMatchSet ms : exactMatchSets) {
 			String corrName = ms.getProgramCorrelatorInfo().getName();
-			if (corrName == exactSymbolNameCorrelator) {
+			if (corrName.equals(exactSymbolNameCorrelator)) {
 				ApplyMatchTask task =
 					new ApplyMatchTask(controller, (List<VTMatch>) ms.getMatches());
 				runTask(task);


### PR DESCRIPTION
This pull request fix error-prone usage of string comparison.
As a beginner, I've been trying to find a way to contribute to Ghidra. After reading the source code I found this one. I know run-time issues are more welcomed but I hope this fix makes sense.
If I'm wrong please let me know.