### PR TITLE
Fix #3726 for Ghidra on OSTree

### DIFF
--- a/Ghidra/Framework/Utility/src/main/java/generic/jar/ResourceFile.java
+++ b/Ghidra/Framework/Utility/src/main/java/generic/jar/ResourceFile.java
@@ -31,6 +31,7 @@ public class ResourceFile implements Comparable<ResourceFile> {
 	private static final String JAR_FILE_PREFIX = "jar:file:";
 	private Resource resource;
 	private static Map<String, JarResource> jarRootsMap = new HashMap<String, JarResource>();
+	private long lastModifiedTime;
 
 	/**
 	 * Construct a ResourceFile that represents a normal file in the file system.
@@ -182,7 +183,14 @@ public class ResourceFile implements Comparable<ResourceFile> {
 	 * @return the time that this file was last modified.
 	 */
 	public long lastModified() {
-		return resource.lastModified();
+		long modTime = resource.lastModified();
+		if (modTime == 0) {
+			if (lastModifiedTime == 0) {
+				lastModifiedTime = System.currentTimeMillis();
+			}
+			modTime = lastModifiedTime;
+		}
+		return modTime;
 	}
 
 	/**


### PR DESCRIPTION
Simple fix that check if the last modified date of a file is valid. And generate a psedo one in case of an invalid one.

This prevent from the packed database not bening ever updated if the last modified date is invalid. This is the case on systems such as OSTree that don't store last modified date of files.

This should solve #3726.