### PR TITLE
Fix NullPointerException which occurs when getAddressValue returns null

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/TLSDataDirectory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/TLSDataDirectory.java
@@ -79,7 +79,7 @@ public class TLSDataDirectory extends DataDirectory {
 					Address nextCallbackAddr = PointerDataType.getAddressValue(
 						new DumbMemBufferImpl(program.getMemory(), nextCallbackPtrAddr),
 						pointerDataType.getLength(), space);
-					if (nextCallbackAddr.getOffset() == 0) {
+					if (nextCallbackAddr == null || nextCallbackAddr.getOffset() == 0) {
 						break;
 					}
 					PeUtils.createData(program, nextCallbackPtrAddr, pointerDataType, log);


### PR DESCRIPTION
# Goal
Avoid unexpected NullPointerException.

# Detailed description
There are some cases where [getAddressValue](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_10.1.2_build/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/PointerDataType.java#L348) returns null, which leads to an unhandled NullPointerException in [TLSDataDirectory](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_10.1.2_build/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/TLSDataDirectory.java#L94).
This PR fixes the issue by adding a null check.
