### PR TITLE
Fixing PE driver COFF symbol offsets

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/DebugDataDirectory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/DebugDataDirectory.java
@@ -57,7 +57,8 @@ public class DebugDataDirectory extends DataDirectory {
 			return false;
 		}
 		
-		parser = new DebugDirectoryParser(reader, ptr, size, ntHeader);
+		parser = new DebugDirectoryParser(reader, ptr, size,
+			ntHeader.getOptionalHeader().getSizeOfImage());
     	return true;
     }
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SeparateDebugHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SeparateDebugHeader.java
@@ -131,7 +131,7 @@ public class SeparateDebugHeader implements OffsetValidator {
 
 		ptr += exportedNamesSize;
 
-		parser = new DebugDirectoryParser(reader, ptr, debugDirectorySize, this);
+		parser = new DebugDirectoryParser(reader, ptr, debugDirectorySize, sizeOfImage);
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/debug/DebugCOFFSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/debug/DebugCOFFSymbol.java
@@ -299,4 +299,9 @@ public class DebugCOFFSymbol implements StructConverter {
     	return structure;
     }
 
+	@Override
+	public String toString() {
+		return String.format("%s section=%d value=0x%x type=0x%x class=0x%x aux=%d", name,
+			sectionNumber, value, type, storageClass, numberOfAuxSymbols);
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/DbgLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/DbgLoader.java
@@ -94,7 +94,8 @@ public class DbgLoader extends AbstractPeDebugLoader {
 				sectionToAddress.put(sectionHeader,
 					imageBase.add(sectionHeader.getVirtualAddress()));
 			}
-			processDebug(debug.getParser(), fileHeader, sectionToAddress, prog, monitor);
+			processDebug(debug.getParser(), parentPE.getNTHeader(), sectionToAddress, prog,
+				monitor);
 		}
 		finally {
 			if (provider2 != null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
@@ -140,10 +140,10 @@ public class PeLoader extends AbstractPeDebugLoader {
 			processImports(optionalHeader, program, monitor, log);
 			processDelayImports(optionalHeader, program, monitor, log);
 			processRelocations(optionalHeader, program, monitor, log);
-			processDebug(optionalHeader, fileHeader, sectionToAddress, program, monitor);
+			processDebug(optionalHeader, ntHeader, sectionToAddress, program, monitor);
 			processProperties(optionalHeader, program, monitor);
 			processComments(program.getListing(), monitor);
-			processSymbols(fileHeader, sectionToAddress, program, monitor, log);
+			processSymbols(ntHeader, sectionToAddress, program, monitor, log);
 			processImageRuntimeFunctionEntries(fileHeader, program, monitor, log);
 
 			processEntryPoints(ntHeader, program, monitor);
@@ -286,12 +286,13 @@ public class PeLoader extends AbstractPeDebugLoader {
 		}
 	}
 
-	private void processSymbols(FileHeader fileHeader, Map<SectionHeader, Address> sectionToAddress,
+	private void processSymbols(NTHeader ntHeader, Map<SectionHeader, Address> sectionToAddress,
 			Program program, TaskMonitor monitor, MessageLog log) {
+		FileHeader fileHeader = ntHeader.getFileHeader();
 		List<DebugCOFFSymbol> symbols = fileHeader.getSymbols();
 		int errorCount = 0;
 		for (DebugCOFFSymbol symbol : symbols) {
-			if (!processDebugCoffSymbol(symbol, fileHeader, sectionToAddress, program, monitor)) {
+			if (!processDebugCoffSymbol(symbol, ntHeader, sectionToAddress, program, monitor)) {
 				++errorCount;
 			}
 		}
@@ -923,7 +924,7 @@ public class PeLoader extends AbstractPeDebugLoader {
 		return null;
 	}
 
-	private void processDebug(OptionalHeader optionalHeader, FileHeader fileHeader,
+	private void processDebug(OptionalHeader optionalHeader, NTHeader ntHeader,
 			Map<SectionHeader, Address> sectionToAddress, Program program, TaskMonitor monitor) {
 		if (monitor.isCancelled()) {
 			return;
@@ -946,7 +947,7 @@ public class PeLoader extends AbstractPeDebugLoader {
 			return;
 		}
 
-		processDebug(parser, fileHeader, sectionToAddress, program, monitor);
+		processDebug(parser, ntHeader, sectionToAddress, program, monitor);
 	}
 
 	@Override


### PR DESCRIPTION
Some PE driver COFF symbols are offset from image base rather than section start. Also, symbol table offset validation is now based on file offsets rather than RVA.