### PR TITLE
add noreturn functions in Windows WDK

### DIFF
--- a/Ghidra/Features/Base/data/PEFunctionsThatDoNotReturn
+++ b/Ghidra/Features/Base/data/PEFunctionsThatDoNotReturn
@@ -6,9 +6,14 @@ crtExitProcess
 ExitProcess
 ExitThread
 exit
+ExRaiseAccessViolation
+ExRaiseDatatypeMisalignment
+ExRaiseStatus
 FreeLibraryAndExitThread
 invalid_parameter_noinfo_noreturn
 invoke_watson
+KeBugCheck
+KeBugCheckEx
 longjmp
 quick_exit
 RpcRaiseException


### PR DESCRIPTION
Add five more noreturn functions: `KeBugCheck`, `ExRaiseDatatypeMisalignment`, `ExRaiseAccessViolation`, `KeBugCheckEx`, `ExRaiseStatus`. These functions are found by running these commands in WSL:
```
cd '/mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.22000.0/km'
grep -r -A 4 'NORETURN'
```
The output is:
```
ntddk.h:DECLSPEC_NORETURN
ntddk.h-VOID
ntddk.h-NTAPI
ntddk.h-KeBugCheck (
ntddk.h-    _In_ ULONG BugCheckCode
--
ntddk.h:DECLSPEC_NORETURN
ntddk.h-VOID
ntddk.h-ExRaiseDatatypeMisalignment (
ntddk.h-    VOID
ntddk.h-    );
--
ntddk.h:DECLSPEC_NORETURN
ntddk.h-VOID
ntddk.h-ExRaiseAccessViolation (
ntddk.h-    VOID
ntddk.h-    );
--
wdm.h:DECLSPEC_NORETURN
wdm.h-VOID
wdm.h-__fastfail(
wdm.h-    _In_ unsigned int Code
wdm.h-    );
--
wdm.h:DECLSPEC_NORETURN
wdm.h-FORCEINLINE
wdm.h-VOID
wdm.h-RtlFailFast(
wdm.h-    _In_ ULONG Code
--
wdm.h:DECLSPEC_NORETURN
wdm.h-VOID
wdm.h-NTAPI
wdm.h-KeBugCheckEx(
wdm.h-    _In_ ULONG BugCheckCode,
--
wdm.h:DECLSPEC_NORETURN
wdm.h-VOID
wdm.h-NTAPI
wdm.h-ExRaiseStatus (
wdm.h-    _In_ NTSTATUS Status
```
`RtlFailFast` is an inline function, and `__fastfail` is an intrinsic, so they are not added.