### PR TITLE
Add missing x86 push/mov post pattern

### DIFF
--- a/Ghidra/Processors/x86/data/patterns/x86win_patterns.xml
+++ b/Ghidra/Processors/x86/data/patterns/x86win_patterns.xml
@@ -10,6 +10,7 @@
     </prepatterns>
     <postpatterns>
       <data>0x558bec</data>  <!-- PUSH EBP : MOV EBP,ESP -->
+      <data>0x5589e5</data>  <!-- PUSH EBP : MOV EBP,ESP -->
       <data>0x83ec 0.....00 </data> <!-- SUBESP#small -->
       <data>0x6aff68........64a100000000 </data> <!-- PUSH-1 PUSHFUNC MOVEAXFS[0] -->
       <data>0x568bf1 </data> <!-- PUSHESI MOVESIECX -->


### PR DESCRIPTION
Ran into issue with functions/instructions not being created because they started with `PUSH EBP ; MOV EBP,ESP` instructions encoded as `55 89 e5`.

The PR adds the missing pattern.