### PR TITLE
MIPS:  jump target can be negative in pattern

### DIFF
--- a/Ghidra/Processors/MIPS/data/patterns/MIPS_BE_patterns.xml
+++ b/Ghidra/Processors/MIPS/data/patterns/MIPS_BE_patterns.xml
@@ -5,9 +5,9 @@
       <data>0x03e00008 0x........ 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x03e00008 0x........ 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x03e00008 0x........ 0x00000000 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
-      <data>0x08...... 0x27 0xbd 0....... ......00</data> <!-- J xyz : _ADDIU   This is probably a shared return-->
+      <data>000010.. 0x...... 0x27 0xbd 0....... ......00</data> <!-- J xyz : _ADDIU   This is probably a shared return-->
       <data>0x1000.... 0x27 0xbd 0....... ......00</data> <!-- B xyz : _ADDIU   This is probably a shared return-->
-      <data>0x03 0x20 00000...  ..001000 0x27 0xbd 0x0. 0x.. </data>  <!-- JR t9   : _ADDIU --> 
+      <data>0x03 0x20 00000...  ..001000 0x27 0xbd 0x0. 0x.. </data>  <!-- JR t9   : _ADDIU -->
     </prepatterns>
     <postpatterns>
       <data>00100111 10111101 1....... ......00</data>             <!-- ADDIU SP,SP,-xxxx -->
@@ -24,7 +24,9 @@
       <data>0x03e00008 0x........ 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x03e00008 0x........ 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x03e00008 0x........ 0x00000000 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
-      <data>0x08...... 0x27 0xbd 0....... ......00</data> <!-- J xyz : _ADDIU   This is probably a shared return-->
+      <data>000010.. 0x...... 0x27 0xbd 0....... ......00</data> <!-- J xyz : _ADDIU   This is probably a shared return-->
+      <data>0x1000.... 0x27 0xbd 0....... ......00</data> <!-- B xyz : _ADDIU   This is probably a shared return-->
+      <data>0x03 0x20 00000...  ..001000 0x27 0xbd 0x0. 0x.. </data>  <!-- JR t9   : _ADDIU -->
     </prepatterns>
     <postpatterns>
       <data>0x3c06.... </data>                                     <!-- lui a2,xxx -->

--- a/Ghidra/Processors/MIPS/data/patterns/MIPS_LE_patterns.xml
+++ b/Ghidra/Processors/MIPS/data/patterns/MIPS_LE_patterns.xml
@@ -5,9 +5,9 @@
       <data>0x0800e003 0x........ 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x0800e003 0x........ 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x0800e003 0x........ 0x00000000 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
-      <data>0x......08 ......00 0....... 0xbd 0x27 </data> <!-- J xyz : _ADDIU   This is probably a shared return-->
+      <data>0x...... 000010.. ......00 0....... 0xbd 0x27 </data> <!-- J xyz : _ADDIU   This is probably a shared return-->
       <data>0x....0010 ......00 0....... 0xbd 0x27</data> <!-- B xyz : _ADDIU   This is probably a shared return-->
-      <data>..001000 00000... 0x20 0x03  0x0. 0x.. 0xbd 0x27 </data>  <!-- JR t9   : _ADDIU --> 
+      <data>..001000 00000... 0x20 0x03  0x0. 0x.. 0xbd 0x27 </data>  <!-- JR t9   : _ADDIU -->
     </prepatterns>
     <postpatterns>
       <data>......00  1....... 10111101 00100111</data>             <!-- ADDIU SP,SP,-xxxx -->
@@ -24,7 +24,9 @@
       <data>0x0800e003 0x........ 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x0800e003 0x........ 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
       <data>0x0800e003 0x........ 0x00000000 0x00000000 0x00000000 </data> <!-- RETN :  delayslot filler -->
-      <data>0x......08 ......00 0....... 0xbd 0x27 </data> <!-- J xyz : _ADDIU   This is probably a shared return-->
+      <data>0x...... 000010.. ......00 0....... 0xbd 0x27 </data> <!-- J xyz : _ADDIU   This is probably a shared return-->
+      <data>0x....0010 ......00 0....... 0xbd 0x27</data> <!-- B xyz : _ADDIU   This is probably a shared return-->
+      <data>..001000 00000... 0x20 0x03  0x0. 0x.. 0xbd 0x27 </data>  <!-- JR t9   : _ADDIU -->
     </prepatterns>
     <postpatterns>
       <data>0x....063c </data>                                     <!-- lui a2,xxx -->


### PR DESCRIPTION
The jump target had the most significant bit set to zero in the pattern, but this can be a negative jump. 

Fixes #3677 