### PR TITLE
x86-64-gcc: Support passing structs in regs, per SysV.

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86-64-gcc.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-64-gcc.cspec
@@ -61,17 +61,32 @@
         <pentry minsize="1" maxsize="8">
           <register name="RSI"/>
         </pentry>
+        <pentry minsize="9" maxsize="16">
+          <addr space="join" piece1="RSI" piece2="RDI"/>
+        </pentry>
         <pentry minsize="1" maxsize="8">
           <register name="RDX"/>
+        </pentry>
+        <pentry minsize="9" maxsize="16">
+          <addr space="join" piece1="RDX" piece2="RSI"/>
         </pentry>
         <pentry minsize="1" maxsize="8">
           <register name="RCX"/>
         </pentry>
+        <pentry minsize="9" maxsize="16">
+          <addr space="join" piece1="RCX" piece2="RDX"/>
+        </pentry>
         <pentry minsize="1" maxsize="8">
           <register name="R8"/>
         </pentry>
+        <pentry minsize="9" maxsize="16">
+          <addr space="join" piece1="R8" piece2="RCX"/>
+        </pentry>
         <pentry minsize="1" maxsize="8">
           <register name="R9"/>
+        </pentry>
+        <pentry minsize="9" maxsize="16">
+          <addr space="join" piece1="R9" piece2="R8"/>
         </pentry>
         <pentry minsize="1" maxsize="500" align="8">
           <addr offset="8" space="stack"/>


### PR DESCRIPTION
The AMD64 SysV ABI allows most structures up to two QWORDs in size to be passed
in a pair of registers instead of on the stack. This patch handles the case(s)
where the fields are all INTEGER (int or pointer) types.

Limitation: In the event that a struct has floating-point members, those members are
allocated to the XMM registers if possible. A struct may contain both integral
types as well as floating-point types, meaning that a 16-byte struct may
feasibly be split into one GPR and one SSE register. `metatype=float` does not
examine structure fields, however, so structs with floating-point fields are not
correctly allocated by this patch.

This is related to the issue in #4052.