### PR TITLE
Use ComSpec in Manual Viewer

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/util/ManualViewerCommandWrappedOption.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/ManualViewerCommandWrappedOption.java
@@ -118,7 +118,7 @@ public class ManualViewerCommandWrappedOption implements CustomOption {
 		ManualViewerCommandWrappedOption option = new ManualViewerCommandWrappedOption();
 
 		if (Platform.CURRENT_PLATFORM.getOperatingSystem() == OperatingSystem.WINDOWS) {
-			option.setCommandString("cmd.exe");
+			option.setCommandString(System.getenv("ComSpec"));
 			String[] args = new String[] { "/c", "start" };
 			option.setCommandArguments(args);
 			option.setUrlReplacementString(DEFAULT_URL_REPLACEMENT_STRING);


### PR DESCRIPTION
This PR fixes cmd.exe binary planting vulnerability in Manual Viewer. 

Originally posted by @0x6d696368 in https://github.com/NationalSecurityAgency/ghidra/issues/107#issuecomment-545572515