### PR TITLE
Add support for the `fsrra`, `fsca` and `movua.l` instructions for the SuperH4 processor

### DIFF
--- a/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
+++ b/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
@@ -348,6 +348,7 @@ define token instr(16)
 	FRN_0 = ( 8,11) # float register id
         FRN_1 = ( 8,10) # float register id
         FRN_2 = ( 8,10) # float register id
+        DRN_0 = ( 8,10) # double register id
 	DRN_1 = ( 9,11) # double register id
 	XDN_1 = ( 9,11) # double register id
 	XDRN  = ( 8,11) # float register id
@@ -373,15 +374,20 @@ attach variables [ FRN_0 FRM_0] [
 ];
 
 attach variables [ FRN_1 ] [
-  fr0 fr1  fr2  fr3  fr4  fr5  fr6  fr7
+  fr0 fr2  fr4  fr6  fr8  fr10  fr12  fr14
 ];
 
 attach variables [ FRN_2 ] [
-  fr1  fr2  fr3  fr4  fr5  fr6  fr7  fr8
+  fr1  fr3  fr5  fr7  fr9  fr11  fr13  fr15
 ];
 
 # attach double registers
 attach variables [ DRN_1 DRM_1 ] [
+  dr0 dr2 dr4 dr6 dr8 dr10 dr12 dr14
+];
+
+# attach double registers
+attach variables [ DRN_0 ] [
   dr0 dr2 dr4 dr6 dr8 dr10 dr12 dr14
 ];
 
@@ -1513,8 +1519,8 @@ define pcodeop cos;
 # pattern 1111nnn011111101
 # text	  fsca FPUL,<F_REG_N>
 # arch    # arch_sh2a_or_sh3e_up
-:fsca FPUL,FRN_1 is
-	OP_0=0xF & FPUL & FRN_1 & FRN_2  & OP_4=0xFD {
+:fsca FPUL,DRN_0 is
+	OP_0=0xF & FPUL & DRN_0 & FRN_1 & FRN_2  & OP_4=0xFD {
 	if (( $(FPSCR_PR) != 0 )) goto inst_next;       
 	
 	angle:4 = int2float(0 :4);    			# float

--- a/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
+++ b/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
@@ -346,6 +346,8 @@ define token instr(16)
 	N_1   = ( 9,11) # register id
 	N_2   = (10,11) # register id
 	FRN_0 = ( 8,11) # float register id
+        FRN_1 = ( 8,10) # float register id
+        FRN_2 = ( 8,10) # float register id
 	DRN_1 = ( 9,11) # double register id
 	XDN_1 = ( 9,11) # double register id
 	XDRN  = ( 8,11) # float register id
@@ -368,6 +370,14 @@ attach variables [ N_0 M_0 ] [
 # attach float registers 
 attach variables [ FRN_0 FRM_0] [
   fr0  fr1  fr2  fr3  fr4  fr5  fr6  fr7  fr8  fr9  fr10  fr11  fr12  fr13  fr14  fr15
+];
+
+attach variables [ FRN_1 ] [
+  fr0 fr1  fr2  fr3  fr4  fr5  fr6  fr7
+];
+
+attach variables [ FRN_2 ] [
+  fr1  fr2  fr3  fr4  fr5  fr6  fr7  fr8
 ];
 
 # attach double registers
@@ -1490,17 +1500,11 @@ N_0txx: r0",@"^N_0  is r0 & N_0 { tmp:4 = N_0; export tmp; }
 # pattern 1111nnnn01111101			
 # text	  fsrra <F_REG_N>
 # arch    # arch_sh2a_or_sh3e_up
-:fsrra FRN_0t	is
-	OP_0=0xF & FRN_0t & DRN_1t & OP_4=0x7D {
-	if (!( $(FPSCR_PR) == 0 )) goto <doublePrecision>;
-	FRN_0t = int2float(1 :4) f/ sqrt( FRN_0t );
-	goto <skip>;
-	<doublePrecision>
-	DRN_1t = int2float(1 :4) f/ sqrt( DRN_1t );
-	<skip>
+:fsrra FRN_0	is
+	OP_0=0xF & FRN_0 & OP_4=0x7D {
+	FRN_0 = int2float(1 :4) f/ sqrt( FRN_0 );
 }
 
-#define pcodeop fsca;
 define pcodeop sin;
 define pcodeop cos;
 
@@ -1508,10 +1512,9 @@ define pcodeop cos;
 # pattern 1111nnn011111101
 # text	  fsca FPUL,<F_REG_N>
 # arch    # arch_sh2a_or_sh3e_up
-:fsca FPUL,FRN_0t is
-	OP_0=0xF & FPUL & FRN_0t & OP_4=0xFD {
-	#fsca(FPUL, FRN_0t);
-	if (( $(FPSCR_PR) != 0 )) goto <skip>;
+:fsca FPUL,FRN_1 is
+	OP_0=0xF & FPUL & FRN_1 & FRN_2  & OP_4=0xFD {
+	if (( $(FPSCR_PR) == 0 )) goto inst_next;
 	
 	angle:4 = int2float(0 :4);    			# float
 	offset:4 = 0x00010000;				# long
@@ -1527,13 +1530,8 @@ define pcodeop cos;
 	local _sin:4 = sin(angle);			# call fake sin & cos
 	local _cos:4 = cos(angle);
 	
-	FRN_0t = _sin;					# _sin goes to FR[n]
-	*:4 ( FRN_0t + 4 ) = _cos;			# _cos goes to FR[n+1]
-							# what is this nasty hack?
-	*[register]:4 (&:4 FRN_0t + 4) = _cos;
-	
-	# PC = PC + 2;
-	<skip>
+	FRN_1 = _sin;					# _sin goes to FR[n]
+	FRN_2 = _cos;           			# _cos goes to FR[n+1]
 }
 
 # Transfer from System Register
@@ -2324,32 +2322,23 @@ define pcodeop mac_wOp;
 }
 
 
-# Load non-boundary alignment data (32-bit)
+# Move Unaligned Long
 # pattern 0100mmmm10101001
 # text    movua.l @<REG_M>,R0
 # arch    
 :movua.l M_0t_at,r0               is OP_0=0x4 & M_0t_at & r0 & OP_4=0xA9  {
-	r0 = (*:4 ( M_0t_at ));
-	
-	if (M_0t_at != 0) goto <increment>;
-	goto <skip>;
-	<increment>
-	M_0t_at = M_0t_at + 4;
-	<skip>
+	r0 = (*:4 ( M_0t_at ));                 
 }
 
-# Load non-boundary alignment data (32-bit)
+# Move Unaligned Long Pointer
 # pattern 0100mmmm11101001
 # text    movua.l @<REG_M>+,R0
 # arch    
 :movua.l M_0t_at,r0               is OP_0=0x4 & M_0t_at & r0 & OP_4=0xE9 {
 	r0 = (*:4 ( M_0t_at ));
 	
-	if (M_0t_at != 0) goto <increment>;
-	goto <skip>;
-	<increment>
+	if (M_0t_at == 0) goto inst_next;
 	M_0t_at = M_0t_at + 4;
-	<skip>
 }
 
 # Double-Precision Multiplication

--- a/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
+++ b/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
@@ -1525,7 +1525,7 @@ define pcodeop cos;
 	
 	pi:4 = 0x40490fdb;				# 3.1415927.. as 32-bit float
 	pi2:4 = int2float(2 :4) f* pi;			# multiply pi by 2 (2pi)
-        angle = (pi2 f* angle) f/ offset;  		# convert to radian
+        angle = (pi2 f* angle) f/ int2float(65536 :4);  # convert to radian
     
 	local _sin:4 = sin(angle);			# call fake sin & cos
 	local _cos:4 = cos(angle);

--- a/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
+++ b/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
@@ -1486,6 +1486,56 @@ N_0txx: r0",@"^N_0  is r0 & N_0 { tmp:4 = N_0; export tmp; }
 	<skip>
 }
 
+# Floating Point Square Reciprocal Approximate
+# pattern 1111nnnn01111101			
+# text	  fsrra <F_REG_N>
+# arch    # arch_sh2a_or_sh3e_up
+:fsrra FRN_0t	is
+	OP_0=0xF & FRN_0t & DRN_1t & OP_4=0x7D {
+	if (!( $(FPSCR_PR) == 0 )) goto <doublePrecision>;
+	FRN_0t = int2float(1 :4) f/ sqrt( FRN_0t );
+	goto <skip>;
+	<doublePrecision>
+	DRN_1t = int2float(1 :4) f/ sqrt( DRN_1t );
+	<skip>
+}
+
+#define pcodeop fsca;
+define pcodeop sin;
+define pcodeop cos;
+
+# Floating Point Sine And Cosine Approximate
+# pattern 1111nnn011111101
+# text	  fsca FPUL,<F_REG_N>
+# arch    # arch_sh2a_or_sh3e_up
+:fsca FPUL,FRN_0t is
+	OP_0=0xF & FPUL & FRN_0t & OP_4=0xFD {
+	#fsca(FPUL, FRN_0t);
+	if (( $(FPSCR_PR) != 0 )) goto <skip>;
+	
+	angle:4 = int2float(0 :4);    			# float
+	offset:4 = 0x00010000;				# long
+        fraction:4 = 0x0000FFFF;			# long
+	
+	fraction = fraction & FPUL;			# extract sub-rotation
+	angle 	 = int2float(fraction);			# convert to float
+	
+	pi:4 = 0x40490fdb;				# 3.1415927.. as 32-bit float
+	pi2:4 = int2float(2 :4) f* pi;			# multiply pi by 2 (2pi)
+        angle = (pi2 f* angle) / offset;  		# convert to radian
+    
+	local _sin:4 = sin(angle);			# call fake sin & cos
+	local _cos:4 = cos(angle);
+	
+	FRN_0t = _sin;					# _sin goes to FR[n]
+	*:4 ( FRN_0t + 4 ) = _cos;			# _cos goes to FR[n+1]
+							# what is this nasty hack?
+	*[register]:4 (&:4 FRN_0t + 4) = _cos;
+	
+	# PC = PC + 2;
+	<skip>
+}
+
 # Transfer from System Register
 # pattern 1111nnnn00001101
 # text    fsts FPUL,<F_REG_N>
@@ -2273,6 +2323,34 @@ define pcodeop mac_wOp;
 	N_0t = zext($(T_FLAG));
 }
 
+
+# Load non-boundary alignment data (32-bit)
+# pattern 0100mmmm10101001
+# text    movua.l @<REG_M>,R0
+# arch    
+:movua.l M_0t_at,r0               is OP_0=0x4 & M_0t_at & r0 & OP_4=0xA9  {
+	r0 = (*:4 ( M_0t_at ));
+	
+	if (M_0t_at != 0) goto <increment>;
+	goto <skip>;
+	<increment>
+	M_0t_at = M_0t_at + 4;
+	<skip>
+}
+
+# Load non-boundary alignment data (32-bit)
+# pattern 0100mmmm11101001
+# text    movua.l @<REG_M>+,R0
+# arch    
+:movua.l M_0t_at,r0               is OP_0=0x4 & M_0t_at & r0 & OP_4=0xE9 {
+	r0 = (*:4 ( M_0t_at ));
+	
+	if (M_0t_at != 0) goto <increment>;
+	goto <skip>;
+	<increment>
+	M_0t_at = M_0t_at + 4;
+	<skip>
+}
 
 # Double-Precision Multiplication
 # pattern 0000nnnnmmmm0111

--- a/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
+++ b/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
@@ -1514,7 +1514,7 @@ define pcodeop cos;
 # arch    # arch_sh2a_or_sh3e_up
 :fsca FPUL,FRN_1 is
 	OP_0=0xF & FPUL & FRN_1 & FRN_2  & OP_4=0xFD {
-	if (( $(FPSCR_PR) == 0 )) goto inst_next;
+	if (( $(FPSCR_PR) == 0 )) goto inst_next;       
 	
 	angle:4 = int2float(0 :4);    			# float
 	offset:4 = 0x00010000;				# long
@@ -1525,7 +1525,7 @@ define pcodeop cos;
 	
 	pi:4 = 0x40490fdb;				# 3.1415927.. as 32-bit float
 	pi2:4 = int2float(2 :4) f* pi;			# multiply pi by 2 (2pi)
-        angle = (pi2 f* angle) / offset;  		# convert to radian
+        angle = (pi2 f* angle) f/ offset;  		# convert to radian
     
 	local _sin:4 = sin(angle);			# call fake sin & cos
 	local _cos:4 = cos(angle);

--- a/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
+++ b/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
@@ -1523,15 +1523,14 @@ define pcodeop cos;
 	fraction = fraction & FPUL;			# extract sub-rotation
 	angle 	 = int2float(fraction);			# convert to float
 	
-	pi:4 = 0x40490fdb;				# 3.1415927.. as 32-bit float
-	pi2:4 = int2float(2 :4) f* pi;			# multiply pi by 2 (2pi)
-        angle = (pi2 f* angle) f/ int2float(65536 :4);  # convert to radian
+	pi:4 = 0x40c90fdb;				# 6.2831855.. as 32-bit float
+        angle = (pi f* angle) f/ int2float(65536 :4);   # convert to radian
     
 	local _sin:4 = sin(angle);			# call fake sin & cos
 	local _cos:4 = cos(angle);
 	
-	FRN_1 = _sin;					# _sin goes to FR[n]
-	FRN_2 = _cos;           			# _cos goes to FR[n+1]
+	FRN_1 = float2float(_sin);			# _sin goes to FR[n]
+	FRN_2 = float2float(_cos);           		# _cos goes to FR[n+1]
 }
 
 # Transfer from System Register

--- a/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
+++ b/Ghidra/Processors/SuperH4/data/languages/SuperH4.sinc
@@ -1502,6 +1502,7 @@ N_0txx: r0",@"^N_0  is r0 & N_0 { tmp:4 = N_0; export tmp; }
 # arch    # arch_sh2a_or_sh3e_up
 :fsrra FRN_0	is
 	OP_0=0xF & FRN_0 & OP_4=0x7D {
+	if (( $(FPSCR_PR) != 0 )) goto inst_next;       
 	FRN_0 = int2float(1 :4) f/ sqrt( FRN_0 );
 }
 
@@ -1514,10 +1515,9 @@ define pcodeop cos;
 # arch    # arch_sh2a_or_sh3e_up
 :fsca FPUL,FRN_1 is
 	OP_0=0xF & FPUL & FRN_1 & FRN_2  & OP_4=0xFD {
-	if (( $(FPSCR_PR) == 0 )) goto inst_next;       
+	if (( $(FPSCR_PR) != 0 )) goto inst_next;       
 	
 	angle:4 = int2float(0 :4);    			# float
-	offset:4 = 0x00010000;				# long
         fraction:4 = 0x0000FFFF;			# long
 	
 	fraction = fraction & FPUL;			# extract sub-rotation


### PR DESCRIPTION
These instructions are present on most variants of the SuperH4 processor. Last week I made changes which implemented the aforementioned instructions into the processor definition within Ghidra. The changes included are as described.