### PR TITLE
Minor typos/grammar in totd/tips.txt

### DIFF
--- a/Ghidra/Features/Base/src/main/resources/ghidra/app/plugin/core/totd/tips.txt
+++ b/Ghidra/Features/Base/src/main/resources/ghidra/app/plugin/core/totd/tips.txt
@@ -24,7 +24,7 @@ The largest diamond that was ever found was 3106.75 carats.
 
 You can edit program bytes using the byte viewer provided those bytes are not disassembled.
 
-You can add URL's to your comments to link to other documents. Hit F1 while making a comment to learn how.
+You can add URLs to your comments to link to other documents. Hit F1 while making a comment to learn how.
 You can embed links to other program locations in your comments.
 
 A cubic yard of air weighs about 2 pounds.
@@ -33,7 +33,7 @@ You can create structures, unions, and enums using the Ghidra data type manager.
 Use enums (not equates) to get constant names to appear in the decompiler. Enums are also listed in the Equates menu if you want to make one an equate in the Listing.   
 To edit a row in the datatype (eg structure) editor, double-click on the "DataType" column.
 Ghidra can extract datatype and function signatures from C header files using the CParser.
-You can drag datatypes from the datatype manager and drop it into the browser to apply at address.
+You can drag datatypes from the datatype manager and drop them into the browser to apply at address.
 You can apply multiple copies of a data type by making a selection and then dragging that data type from the Data Type Manager onto the selection.
 
 You can find view information about your current program by selecting "Help -> About {program name}...".


### PR DESCRIPTION
_URL's_ to _URLs_ -- no apostrophe is usually convention unless it's hard to read; had a quick look and the repo seems to use "URLs" as standard.

_it_ to _them_ when talking about datatypes, plural.