### PR TITLE
Fix NPE in selectFieldNumber in ForceUnionAction.java

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ForceUnionAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ForceUnionAction.java
@@ -190,21 +190,6 @@ public class ForceUnionAction extends AbstractDecompilerAction {
 	}
 
 	/**
-	 * Find the index of a given string, within an array of strings
-	 * @param list is the array of strings
-	 * @param value is the given string to find
-	 * @return the index of the given string within the array, or -1 if it isn't present
-	 */
-	private static int findStringIndex(ArrayList<String> list, String value) {
-		for (int i = 0; i < list.size(); ++i) {
-			if (list.get(i).equals(value)) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	/**
 	 * Let the user choose the particular field to force on the selected Varnode. The names
 	 * of the fields in the associated union are presented, possibly along with the special
 	 * string "no field". The choices are filtered so that they match the size of the Varnode
@@ -224,7 +209,7 @@ public class ForceUnionAction extends AbstractDecompilerAction {
 			OkDialog.show("No Field Choices", "Only one field fits the selected variable");
 			return false;
 		}
-		int currentChoice = findStringIndex(allFields, defaultFieldName);
+		int currentChoice = allFields.indexOf(defaultFieldName);
 		if (currentChoice < 0) {
 			defaultFieldName = null;
 		}
@@ -234,7 +219,7 @@ public class ForceUnionAction extends AbstractDecompilerAction {
 		if (userChoice == null) {
 			return false;		// User cancelled when making the choice
 		}
-		fieldNumber = findStringIndex(allFields, userChoice);
+		fieldNumber = allFields.indexOf(userChoice);
 		if (fieldNumber < 0 || fieldNumber == currentChoice) {
 			return false;	// User chose original value or something not in list, treat as cancel
 		}


### PR DESCRIPTION
If the `allFields` ArrayList contains element null, `findStringIndex()` will throw a NPE. Use `allFields.indexOf()` will not have this issue.

Fixes #4207