### PR TITLE
Don't skip the first pcodetest artifact if target directory does not exist.

### DIFF
--- a/Ghidra/Extensions/SleighDevTools/pcodetest/build.py
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/build.py
@@ -112,8 +112,7 @@ class BuildUtil(object):
         try:
             if not os.path.isdir(dname):
                 self.makedirs(dname)
-            else:
-                self.copy(fname, dname, verbose=True)
+            self.copy(fname, dname, verbose=True)
         except IOError as e:
             self.log_err('Error occurred exporting %s to %s' % (fname, dname))
             self.log_err("Unexpected error: %s" % str(e))


### PR DESCRIPTION
As per the title, the pcodetest artifacts' build script would not copy the first binary if the target directory did not exist on the first run.

Incidentally, this script still depends on Python 2.x, which has been EOL'd 18 months ago.  I've had to port the build scripts to Python 3.7 - should I submit a PR with that as well?