### PR TITLE
Avoid getHostname()

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/ErrLogDialog.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/ErrLogDialog.java
@@ -119,8 +119,7 @@ public class ErrLogDialog extends AbstractErrDialog {
 
 		String hostname = getHostnameString();
 		if (hostname != null) {
-			sb.append("Workstation: ");
-			sb.append(getHostname());
+			sb.append(hostname);
 			sb.append(EOL);
 		}
 		return sb.toString();


### PR DESCRIPTION
Use hostname returned by getHostnameString() in error info.