### PR TITLE
Make it possible to import symbols into arbitrary memory regions

### DIFF
--- a/Ghidra/Features/Python/ghidra_scripts/ImportSymbolsScript.py
+++ b/Ghidra/Features/Python/ghidra_scripts/ImportSymbolsScript.py
@@ -13,7 +13,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ##
-# Imports a file with lines in the form "symbolName 0xADDRESS function_or_label" where "f" indicates a function and "l" a label
+# Imports a text file containing symbol definitions, with a maximum of one symbol defined per line. Each symbol definition is in the form of "symbol_name address function_or_label", where "symbol_name" is the name of the symbol, "address" is the address of the symbol in one of the forms listed below, and "function_or_label" is either "f" or "l", with "f" indicating that a function is to be created and "l" indicating that a label is to be created.
+# Address formats are the same as those that can be used with the "Go to address" function. For example:
+# - 1234abcd
+# - 0x1234abcd
+# - ADDRESS_SPACE:1234abcd
+# - ADDRESS_SPACE:0x1234abcd
+# - MEMORY_REGION:1234abcd
+# - MEMORY_REGION:0x1234abcd
+# Omitting the address space or memory region specifier from the address will result in the function or label being created in the default address space.
 # @author unkown; edited by matedealer <git@matedealer.de>
 # @category Data
 #
@@ -29,7 +37,7 @@ for line in file(f.absolutePath):  # note, cannot use open(), since that is in G
     pieces = line.split()
 
     name = pieces[0]
-    address = toAddr(long(pieces[1], 16))
+    address = toAddr(pieces[1])
 
     try:
         function_or_label = pieces[2]


### PR DESCRIPTION
Before this change, ImportSymbolsScript.py was limited to importing symbols into the default memory region. With this change, arbitrary memory regions can be specified along with the address, making it possible for symbols to be imported into non-default memory regions. This functionality is backwards-compatible with existing symbol list files.

For example, if you have CODE and DATA memory regions/address spaces and CODE is the default address space, you can specify the address as `0x1234` or `CODE:0x1234` to put the label in CODE space and `DATA:0x1234` to put it in DATA space. This functionality saves me a lot of time when reverse engineering binaries for microcontrollers like the 8051, since in a single file I can define all the MMIO addresses in EXTMEM space and special function registers in SFR space for a particular chip, and then import those labels into Ghidra whenever I'm working on a binary for that chip.