### PR TITLE
Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ If applicable, please attach any files that caused problems or log files generat
  - OS: [e.g. macOS 10.14.2]
  - Java Version: [e.g. 11.0]
  - Ghidra Version: [e.g. 9.1.2]
- - Ghidra Origin: [e.g. official ghidra-sre.org distro, third party distro, locally built] 
+ - Ghidra Origin: [e.g. official GitHub distro, third party distro, locally built] 
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ If applicable, please attach any files that caused problems or log files generat
 **Environment (please complete the following information):**
  - OS: [e.g. macOS 10.14.2]
  - Java Version: [e.g. 11.0]
- - Ghidra Version: [e.g. 9.1.2]
+ - Ghidra Version: [e.g. 10.1.4]
  - Ghidra Origin: [e.g. official GitHub distro, third party distro, locally built] 
 
 **Additional context**


### PR DESCRIPTION
Since Ghidra is now released on GitHub, change "official ghidra-sre.org distro" to "official GitHub distro."