### PR TITLE
Port pcodetest builder to Python 3.

### DIFF
--- a/Ghidra/Extensions/SleighDevTools/pcodetest/build
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/build
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys
@@ -13,7 +13,7 @@ from pcodetest import *
 # set default properties first, then update values from the command
 # line before they are instantiated.
 
-execfile('defaults.py')
+exec(compile(open('defaults.py', "rb").read(), 'defaults.py', 'exec'))
 
 parser = argparse.ArgumentParser(description='''Build pcodetests.
 One and only one of the following options must be given:
@@ -63,21 +63,24 @@ PCodeTest.defaults.variants = args.variants
 PCodeTest.defaults.verbose = args.verbose
 PCodeTest.defaults.force = args.force
 PCodeTest.defaults.no_publish = args.no_publish
+PCodeTest.defaults.toolchain_root = args.toolchain_root
+PCodeTest.defaults.build_root = args.build_root
+PCodeTest.defaults.gcc_version = args.gcc_version
 
 # load the known pcodetests
 
-execfile('pcode_defs.py')
+exec(compile(open('pcode_defs.py', "rb").read(), 'pcode_defs.py', 'exec'))
 
 cwd = os.getcwd()
 
 if args.pcodetest_list:
     PCodeTest.print_all()
 elif args.pcodetest_all:
-    for n,pct in sorted(PCodeTest.list.iteritems(), key=lambda x: x[0].lower()):
+    for n,pct in sorted(PCodeTest.list.items(), key=lambda x: x[0].lower()):
         if pct.config.build_all:
             try: PCodeTestBuild.factory(pct).main()
             except Exception as e:
-                print 'unhandled exception while building %s' % n
+                print('unhandled exception while building %s' % n)
                 traceback.print_exc(file=sys.stdout)
                 os.chdir(cwd)
 elif args.pcodetest:
@@ -85,7 +88,7 @@ elif args.pcodetest:
         PCodeTest = PCodeTest.list[args.pcodetest]
         PCodeTestBuild.factory(PCodeTest).main()
     else:
-        print 'the pcode test %s is not in the list' % args.pcodetest
+        print('the pcode test %s is not in the list' % args.pcodetest)
 else:
     parser.print_help()
 

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/build.py
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/build.py
@@ -21,7 +21,7 @@ import pwd
 import grp
 import re
 
-class BuildUtil(object):
+class BuildUtil:
 
     def __init__(self):
         self.log = False
@@ -30,7 +30,7 @@ class BuildUtil(object):
         self.num_warnings = 0
 
     def run(self, cmd, stdout=False, stderr=False, verbose=True):
-        if isinstance(cmd, basestring):
+        if isinstance(cmd, str):
             if stdout and stderr:
                 cmd += ' 1>%s 2>%s' % (stdout, stderr)
             elif stdout and not stderr:
@@ -40,19 +40,19 @@ class BuildUtil(object):
             if verbose: self.log_info(cmd)
             os.system(cmd)
         else:
-            str = ' '.join(cmd);
+            string = ' '.join(cmd)
             if stdout:
-                f = file(stdout, 'w+')
-                str += ' 1>%s 2>&1' % (stdout)
+                f = open(stdout, 'w+')
+                string += ' 1>%s 2>&1' % (stdout)
             else:
                 f = subprocess.PIPE
-            if verbose: self.log_info(str)
+            if verbose: self.log_info(string)
             try:
                 sp = subprocess.Popen(cmd, stdout=f, stderr=subprocess.PIPE)
             except OSError as e:
-                self.log_err("Command: " + str)
-                self.log_err(e.message)
-                return 0,e.message#raise
+                self.log_err("Command: " + string)
+                self.log_err(e.strerror)
+                return 0, e.strerror
             if stdout: f.close()
             out, err = sp.communicate()
             # print 'run returned %d bytes stdout and %d bytes stderr' % (len(out) if out else 0, len(err) if err else 0)
@@ -112,19 +112,18 @@ class BuildUtil(object):
         try:
             if not os.path.isdir(dname):
                 self.makedirs(dname)
-            else:
-                self.copy(fname, dname, verbose=True)
+            self.copy(fname, dname, verbose=True)
         except IOError as e:
             self.log_err('Error occurred exporting %s to %s' % (fname, dname))
             self.log_err("Unexpected error: %s" % str(e))
 
-    def rmtree(self, dir, verbose=True):
-        if verbose: self.log_info('rm -r %s' % dir)
-        shutil.rmtree(dir)
+    def rmtree(self, directory, verbose=True):
+        if verbose: self.log_info('rm -r %s' % directory)
+        shutil.rmtree(directory)
 
-    def makedirs(self, dir, verbose=True):
-        if verbose: self.log_info('mkdir -p %s' % dir)
-        try: os.makedirs(dir)
+    def makedirs(self, directory, verbose=True):
+        if verbose: self.log_info('mkdir -p %s' % directory)
+        try: os.makedirs(directory)
         except: pass
 
     # copy a file/directory to a directory
@@ -138,9 +137,9 @@ class BuildUtil(object):
                 shutil.rmtree(dname)
             shutil.copytree(fname, dname)
 
-    def chdir(self, dir, verbose=True):
-        if verbose: self.log_info('cd %s' % dir)
-        os.chdir(dir)
+    def chdir(self, directory, verbose=True):
+        if verbose: self.log_info('cd %s' % directory)
+        os.chdir(directory)
 
     def remove(self, fname, verbose=True):
         if verbose: self.log_info('rm -f %s' % fname)
@@ -189,9 +188,9 @@ class BuildUtil(object):
     def log_close(self):
         if self.log:
             if self.num_errors > 0:
-                print '# ERROR: There were errors, see %s' % self.name
+                print('# ERROR: There were errors, see %s' % self.name)
             elif self.num_warnings > 0:
-                print '# WARNING: There were warnings, see %s' % self.name
+                print('# WARNING: There were warnings, see %s' % self.name)
             self.log.close()
         self.log = False
         self.name = False
@@ -199,7 +198,7 @@ class BuildUtil(object):
         self.num_warnings = 0
 
     def log_pr(self, prefix, what):
-        if isinstance(what, basestring):
+        if isinstance(what, str):
             log_string = prefix + what
         else:
             log_string = prefix + repr(what)
@@ -208,7 +207,7 @@ class BuildUtil(object):
             self.log.write(log_string + '\n')
             self.log.flush()
         else:
-            print log_string
+            print(log_string)
             sys.stdout.flush()
 
     def log_err(self, what):
@@ -278,7 +277,7 @@ class BuildUtil(object):
 
         f.close()
 
-class Config(object):
+class Config:
 
     def __init__(self, *obj):
         for o in obj:
@@ -286,23 +285,23 @@ class Config(object):
             else: self.__dict__.update(o.__dict__)
 
     def format(self, val):
-        if isinstance(val, basestring) and '%' in val:
+        if isinstance(val, str) and '%' in val:
             return val % self.__dict__
         elif isinstance(val, dict):
-            return dict(map(lambda (k,v): (k,self.format(v)), val.iteritems()))
+            return {k: self.format(v) for k, v in val.items()}
         else: return val
 
     def __getattr__(self, attr):
         return ''
 
     def expand(self):
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             self.__dict__[k] = self.format(v)
 
     def dump(self):
         ret = ''
-        for k,v in sorted(self.__dict__.iteritems()):
-            if isinstance(v, basestring): vv = "'" + v + "'"
+        for k,v in sorted(self.__dict__.items()):
+            if isinstance(v, str): vv = "'" + v + "'"
             else: vv = str(v)
             ret += ' '.ljust(10) + k.ljust(20) + vv + '\n'
         return ret

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/pcodetest.py
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/pcodetest.py
@@ -53,11 +53,9 @@ class PCodeTest(BuildUtil):
 
     @classmethod
     def print_all(cls):
-        pct = sorted(cls.list.iteritems(), key=lambda x: x[0].lower())
-        
-        for t,pcodetest in sorted(cls.list.iteritems(), key=lambda x: x[0].lower()):
-            print str(pcodetest)
-            if pcodetest.config.verbose: print pcodetest.config.dump()
+        for t,pcodetest in sorted(cls.list.items(), key=lambda x: x[0].lower()):
+            print(str(pcodetest))
+            if pcodetest.config.verbose: print(pcodetest.config.dump())
 
     def __str__(self):
         cb = 'build-all:%-5s' % ('yes' if self.config.build_all else 'no')
@@ -81,7 +79,7 @@ class PCodeTestBuild(BuildUtil):
         elif pcode_test.config.toolchain_type == 'sdcc':
             return PCodeBuildSDCC(pcode_test)
         else:
-            raise Exception(self.config.format('Toolchain type %(toolchain_type)s not known'))
+            raise Exception(pcode_test.config.format('Toolchain type %(toolchain_type)s not known'))
 
     def which(self, what):
         return self.config.format('%(toolchain_dir)s/%(' + what + ')s')
@@ -122,7 +120,7 @@ class PCodeTestBuild(BuildUtil):
         if not self.config.has_longlong: available_files = [x for x in available_files if not fnmatch.fnmatch(x, '*LONGLONG*')]
             
         # compile for each optimization
-        for opt_name,opt_cflag in sorted(self.config.variants.iteritems()):
+        for opt_name,opt_cflag in sorted(self.config.variants.items()):
 
             kind = 'PCodeTest'
 


### PR DESCRIPTION
As requested in https://github.com/NationalSecurityAgency/ghidra/pull/4239#issuecomment-1145006780 - here is the pcodetest builder ported to Python 3.

I've tested this with Python 3.x as far back as Python 3.7, which is the earliest maintained version at the time of writing.

This also includes the changes in #4239, along with a couple more (namely honor the `--toolchain-root`,  `--build-root`, and `--gcc-version` parameters).