### PR TITLE
Fix null pointer crash in fspec.cc

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
@@ -900,6 +900,8 @@ void ParamListStandard::forceExclusionGroup(ParamActive *active)
   int4 inactiveCount = 0;
   for(int4 i=0;i<numTrials;++i) {
     ParamTrial &curtrial(active->getTrial(i));
+    if (curtrial.getEntry() == (const ParamEntry *) 0)
+      continue;
     int4 grp = curtrial.getEntry()->getGroup();
     if (grp != curGroup) {
       if (inactiveCount > 1)


### PR DESCRIPTION
Before being able to investigate issue #4334, I came across this crash that is caused by an uncaught null pointer in the function `ParamListStandard::forceExclusionGroup`. Simply skipping a trial if the entry is a null pointer seems to fix this issue.

To reproduce the bug, follow the steps outlined in issue #4334.

Tagging @caheckman since the following commit seems to be the origin of the bug: https://github.com/NationalSecurityAgency/ghidra/commit/b7955f2a799ef767f92f40011e4b9654efc5326b#diff-05f19b5959d562c8d400a30618ce956562925c22788f415fffae34bfb70c7cffR903