### PR TITLE
Sleigh x86 improvements

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -733,7 +733,7 @@ addr64: [Base64 + Index64*ss]			is mod=0 & r_m=4; Index64 & Base64 & ss         
 addr64: [Base64]						is mod=0 & r_m=4; rexXprefix=0 & index64=4 & Base64    { export Base64; }
 addr64: [simm32_64 + Index64*ss]		is mod=0 & r_m=4; Index64 & base64=5 & ss; simm32_64   { local tmp=simm32_64+Index64*ss; export tmp; }
 addr64: [Index64*ss]					is mod=0 & r_m=4; Index64 & base64=5 & ss; imm32=0 { local tmp=Index64*ss; export tmp; }
-addr64: [imm32_64]						is mod=0 & r_m=4; rexXprefix=0 & index64=4 & base64=5; imm32_64      { export *[const]:8 imm32_64; }
+addr64: [simm32_64]						is mod=0 & r_m=4; rexXprefix=0 & index64=4 & base64=5; simm32_64      { export *[const]:8 simm32_64; }
 addr64: [Base64 + simm8_64]				is mod=1 & r_m=4; rexXprefix=0 & index64=4 & Base64; simm8_64     { local tmp=simm8_64+Base64; export tmp; }
 addr64: [Base64 + Index64*ss + simm8_64] is mod=1 & r_m=4; Index64 & Base64 & ss; simm8_64 { local tmp=simm8_64+Base64+Index64*ss; export tmp; }
 addr64: [Base64 + Index64*ss]			is mod=1 & r_m=4; Index64 & Base64 & ss; simm8=0   { local tmp=Base64+Index64*ss; export tmp; }

--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -3201,8 +3201,8 @@ define pcodeop swap_bytes;
 :NEG rm64      is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf7; rm64 & reg_opcode=3 ... { negflags(rm64); rm64 = -rm64; resultflags(rm64); }
 @endif
 
-:NOP            is vexMode=0 & opsize=0 & byte=0x90                        { }
-:NOP            is vexMode=0 & opsize=1 & byte=0x90                        { }
+:NOP            is vexMode=0 & opsize=0 & byte=0x90 & rexprefix=0   { }
+:NOP            is vexMode=0 & opsize=1 & byte=0x90 & rexprefix=0   { }
 :NOP rm16       is vexMode=0 & mandover & opsize=0 & byte=0x0f; high5=3; rm16  ...    { }
 :NOP rm32       is vexMode=0 & mandover & opsize=1 & byte=0x0f; high5=3; rm32  ...    { }
 :NOP^"/reserved" rm16 is vexMode=0 & mandover & opsize=0 & byte=0x0f; byte=0x18; rm16 & reg_opcode_hb=1 ...    { }


### PR DESCRIPTION
This PR contains 2 bug fixes ~and 1 improvement~ to the `x86` sleigh specification. Since the changes are very easy to review I have packed everything in a single PR. Each change has its own commit.

- fix the constructor for `addr64` that uses 32-bit immediate: it was parsing the immediate as unsigned instead of signed (`imm32` instead of `simm32`)
- fix mistakes in the constructors for the `NOP` instruction which were causing `XCHG R8D, EAX` and `XCHG R8W, AX` to be erroneously decoded as `NOP`
- ~add support for lifting the `SHUFPD` instruction~

The issues were found while using [Maat](https://github.com/trailofbits/maat) which uses sleigh to lift and emulate instructions. I didn't find related issues on the Ghidra repo so I'm opening this PR standalone.
 