### PR TITLE
Update OperandType.java to fix whitespace

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/OperandType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/OperandType.java
@@ -467,9 +467,9 @@ public final class OperandType {
 			append(buf, "COP ");
 		}
 
-        if (isDynamic(operandType)) {
-            append(buf, "DYN ");
-        }
+		if (isDynamic(operandType)) {
+			append(buf, "DYN ");
+		}
 
 		return buf.toString();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/OperandType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/OperandType.java
@@ -341,7 +341,7 @@ public final class OperandType {
 		return (operandType & COP) != 0;
 	}
 	
-    /**
+	/**
 	 * check the DYNAMIC flag.
 	 * @param operandType the bit field to examine.
 	 *


### PR DESCRIPTION
I noticed there is a whitespace mismatch in this file `Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/OperandType.java` introduced by #4356.

Thanks!