### PR TITLE
Fixed typos in Pointer DataType description commments

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer24DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer24DataType.java
@@ -19,7 +19,7 @@ package ghidra.program.model.data;
 import ghidra.util.classfinder.ClassTranslator;
 
 /**
- * Pointer16 is really a factory for generating 2-byte pointers.
+ * Pointer24 is really a factory for generating 3-byte pointers.
  */
 public class Pointer24DataType extends PointerDataType {
 	static {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer32DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer32DataType.java
@@ -19,7 +19,7 @@ package ghidra.program.model.data;
 import ghidra.util.classfinder.ClassTranslator;
 
 /**
- * Pointer16 is really a factory for generating 2-byte pointers.
+ * Pointer32 is really a factory for generating 4-byte pointers.
  */
 public class Pointer32DataType extends PointerDataType {
 	static {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer40DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer40DataType.java
@@ -19,7 +19,7 @@ package ghidra.program.model.data;
 import ghidra.util.classfinder.ClassTranslator;
 
 /**
- * Pointer16 is really a factory for generating 5-byte pointers.
+ * Pointer40 is really a factory for generating 5-byte pointers.
  */
 public class Pointer40DataType extends PointerDataType {
 	static {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer48DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer48DataType.java
@@ -19,7 +19,7 @@ package ghidra.program.model.data;
 import ghidra.util.classfinder.ClassTranslator;
 
 /**
- * Pointer16 is really a factory for generating 6-byte pointers.
+ * Pointer48 is really a factory for generating 6-byte pointers.
  */
 public class Pointer48DataType extends PointerDataType {
 	static {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer56DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer56DataType.java
@@ -19,7 +19,7 @@ package ghidra.program.model.data;
 import ghidra.util.classfinder.ClassTranslator;
 
 /**
- * Pointer16 is really a factory for generating 7-byte pointers.
+ * Pointer56 is really a factory for generating 7-byte pointers.
  */
 public class Pointer56DataType extends PointerDataType {
 	static {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer64DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer64DataType.java
@@ -19,7 +19,7 @@ package ghidra.program.model.data;
 import ghidra.util.classfinder.ClassTranslator;
 
 /**
- * Pointer16 is really a factory for generating 2-byte pointers.
+ * Pointer64 is really a factory for generating 8-byte pointers.
  */
 public class Pointer64DataType extends PointerDataType {
 	static {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer8DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Pointer8DataType.java
@@ -19,7 +19,7 @@ package ghidra.program.model.data;
 import ghidra.util.classfinder.ClassTranslator;
 
 /**
- * Pointer16 is really a factory for generating 2-byte pointers.
+ * Pointer8 is really a factory for generating 1-byte pointers.
  */
 public class Pointer8DataType extends PointerDataType {
 	static {


### PR DESCRIPTION
Small fix for typos in description comments of Pointer[X]DataType classes