### PR TITLE
Migrate Guava Predicate and Iterator usage to Java's API Predicate and Iterator usage

### DIFF
--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramViewBookmarkManager.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramViewBookmarkManager.java
@@ -18,12 +18,13 @@ package ghidra.trace.database.program;
 import java.awt.Color;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.swing.ImageIcon;
 
 import org.apache.commons.collections4.IteratorUtils;
 
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Range;
 
 import generic.NestedIterator;
@@ -294,7 +295,9 @@ public class DBTraceProgramViewBookmarkManager implements TraceProgramViewBookma
 	@SuppressWarnings("unchecked")
 	protected static <T, U extends T> Iterator<T> filteredIterator(Iterator<U> it,
 			Predicate<? super U> predicate) {
-		return (Iterator<T>) Iterators.filter(it, e -> predicate.test(e));
+		Iterable<U> iterable = () -> it;
+		Stream<U> filterStream = StreamSupport.stream(iterable.spliterator(), false);
+		return (Iterator<T>) filterStream.filter(e -> predicate.test(e)).iterator();
 	}
 
 	@Override

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/util/WrappingFunctionIterator.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/util/WrappingFunctionIterator.java
@@ -16,9 +16,9 @@
 package ghidra.trace.util;
 
 import java.util.Iterator;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterators;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.FunctionIterator;
@@ -32,7 +32,9 @@ public class WrappingFunctionIterator implements FunctionIterator {
 
 	public <T extends Function> WrappingFunctionIterator(Iterator<T> it,
 			Predicate<? super T> filter) {
-		this.it = Iterators.filter(it, filter);
+		Iterable<T> iterable = () -> it;
+		Stream<T> filterStream = StreamSupport.stream(iterable.spliterator(), false);
+		this.it = filterStream.filter(filter).iterator();
 	}
 
 	@Override

--- a/Ghidra/Debug/ProposedUtils/src/test/java/ghidra/util/database/spatial/RStarTreeMapTest.java
+++ b/Ghidra/Debug/ProposedUtils/src/test/java/ghidra/util/database/spatial/RStarTreeMapTest.java
@@ -29,6 +29,8 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -36,8 +38,6 @@ import javax.swing.JPanel;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.*;
-
-import com.google.common.collect.Iterators;
 
 import db.DBHandle;
 import db.DBRecord;
@@ -723,56 +723,66 @@ public class RStarTreeMapTest {
 
 	@Test
 	public void testQueryIntersecting() {
+		Iterable<IntRect> it = ()-> allRects(range);
+		Stream<IntRect> filterStream = StreamSupport.stream(it.spliterator(), false);
+
 		List<IntRect> expected = new ArrayList<>();
-		Iterators.filter(allRects(range), queryRect::intersects).forEachRemaining(expected::add);
+		filterStream.filter(queryRect::intersects).iterator().forEachRemaining(expected::add);
 
 		IntRectQuery query = IntRectQuery.intersecting(queryRect);
 		List<IntRect> actual = new ArrayList<>();
-		Iterators.filter(allRects(range), query::testData).forEachRemaining(actual::add);
+		filterStream.filter(query::testData).iterator().forEachRemaining(actual::add);
 
 		assertEquals(expected, actual);
 	}
 
 	@Test
 	public void testQueryEnclosing() {
+		Iterable<IntRect> it = ()-> allRects(range);
+		Stream<IntRect> filterStream = StreamSupport.stream(it.spliterator(), false);
+
 		List<IntRect> expected = new ArrayList<>();
-		Iterators.filter(allRects(range), queryRect::enclosedBy).forEachRemaining(expected::add);
+		filterStream.filter(queryRect::enclosedBy).iterator().forEachRemaining(expected::add);
 
 		IntRectQuery query = IntRectQuery.enclosing(queryRect);
 		List<IntRect> actual = new ArrayList<>();
-		Iterators.filter(allRects(range), query::testData).forEachRemaining(actual::add);
+		filterStream.filter(query::testData).iterator().forEachRemaining(actual::add);
 
 		assertEquals(expected, actual);
 	}
 
 	@Test
 	public void testQueryEnclosed() {
+		Iterable<IntRect> it = ()-> allRects(range);
+		Stream<IntRect> filterStream = StreamSupport.stream(it.spliterator(), false);
+
 		List<IntRect> expected = new ArrayList<>();
-		Iterators.filter(allRects(range), queryRect::encloses).forEachRemaining(expected::add);
+		filterStream.filter(queryRect::encloses).iterator().forEachRemaining(expected::add);
 
 		IntRectQuery query = IntRectQuery.enclosed(queryRect);
 		List<IntRect> actual = new ArrayList<>();
-		Iterators.filter(allRects(range), query::testData).forEachRemaining(actual::add);
+		filterStream.filter(query::testData).iterator().forEachRemaining(actual::add);
 
 		assertEquals(expected, actual);
 	}
 
 	@Test
 	public void testQueryIntersectionAndIntersection() {
+		Iterable<IntRect> it = ()-> allRects(range);
+		Stream<IntRect> filterStream = StreamSupport.stream(it.spliterator(), false);
+
 		IntRect queryRect1 = rect(1, 1, 12, 13);
 		IntRect queryRect2 = rect(4, 4, 12, 13);
+
 		List<IntRect> expected = new ArrayList<>();
-		Iterators.filter(allRects(range),
-			r -> queryRect1.intersects(r) && queryRect2.intersects(r))
-				.forEachRemaining(
-					expected::add);
+		filterStream.filter(r -> queryRect1.intersects(r) && queryRect2.intersects(r)).iterator().forEachRemaining(expected::add);
 
 		System.out.println(expected);
 
 		IntRectQuery query =
 			IntRectQuery.intersecting(queryRect1).and(IntRectQuery.intersecting(queryRect2));
 		List<IntRect> actual = new ArrayList<>();
-		Iterators.filter(allRects(range), query::testData).forEachRemaining(actual::add);
+		filterStream.filter(query::testData).iterator().forEachRemaining(actual::add);
 
 		assertEquals(expected, actual);
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/BitFieldEditorPanel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/BitFieldEditorPanel.java
@@ -17,12 +17,11 @@ package ghidra.app.plugin.core.compositeeditor;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.function.Predicate;
 
 import javax.swing.*;
 import javax.swing.event.CellEditorListener;
 import javax.swing.event.ChangeEvent;
-
-import com.google.common.base.Predicate;
 
 import docking.ActionContext;
 import docking.widgets.DropDownSelectionTextField;
@@ -70,8 +69,6 @@ public class BitFieldEditorPanel extends JPanel {
 	private JSpinnerWithMouseWheel bitSizeInput;
 
 	private GDLabel statusTextField;
-
-	private BitSelectionHandler bitSelectionHandler;
 
 
 	private boolean updating = false;
@@ -447,7 +444,7 @@ public class BitFieldEditorPanel extends JPanel {
 		placementComponent.setFont(UIManager.getFont("TextField.font"));
 		placementComponent.addMouseWheelListener(e -> bitSizeInput.mouseWheelMoved(e));
 
-		bitSelectionHandler = new BitSelectionHandler();
+		BitSelectionHandler bitSelectionHandler = new BitSelectionHandler();
 		placementComponent.addMouseListener(bitSelectionHandler);
 		placementComponent.addMouseMotionListener(bitSelectionHandler);
 
@@ -486,7 +483,7 @@ public class BitFieldEditorPanel extends JPanel {
 		}
 		if (isValid) {
 			DataType dt = dtChoiceEditor.getCellEditorValueAsDataType();
-			if (!dataTypeValidator.apply(baseDataType)) {
+			if (!dataTypeValidator.test(baseDataType)) {
 				setStatus("Valid bitfield base datatype entry required");
 				isValid = false;
 			}
@@ -496,7 +493,7 @@ public class BitFieldEditorPanel extends JPanel {
 			}
 		}
 		else {
-			dataTypeValidator.apply(null); // affects button enablement
+			dataTypeValidator.test(null); // affects button enablement
 		}
 		return isValid;
 	}
@@ -569,7 +566,7 @@ public class BitFieldEditorPanel extends JPanel {
 		updating = true;
 		try {
 			baseDataType = initialBaseDataType;
-			dataTypeValidator.apply(baseDataType);
+			dataTypeValidator.test(baseDataType);
 			dtChoiceEditor.setCellEditorValue(initialBaseDataType);
 			fieldNameTextField.setText(initialFieldName);
 			fieldCommentTextField.setText(initialComment);

--- a/Ghidra/Features/FunctionGraphDecompilerExtension/src/main/java/ghidra/app/plugin/core/functiongraph/graph/layout/DNLEdgeLabelRenderer.java
+++ b/Ghidra/Features/FunctionGraphDecompilerExtension/src/main/java/ghidra/app/plugin/core/functiongraph/graph/layout/DNLEdgeLabelRenderer.java
@@ -19,8 +19,7 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.util.List;
-
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.graph.Graph;
@@ -67,9 +66,9 @@ class DNLEdgeLabelRenderer<V extends FGVertex, E extends FGEdge>
 		V startv = endpoints.getFirst();
 		V endv = endpoints.getSecond();
 
-		Predicate<Context<Graph<V, E>, V>> includeVertex = rc.getVertexIncludePredicate();
-		if (!includeVertex.apply(Context.getInstance(jungGraph, startv)) ||
-			!includeVertex.apply(Context.getInstance(jungGraph, endv))) {
+		Predicate<Context<Graph<V, E>, V>> includeVertex = rc.getVertexIncludePredicate()::apply;
+		if (!includeVertex.test(Context.getInstance(jungGraph, startv)) ||
+			!includeVertex.test(Context.getInstance(jungGraph, endv))) {
 			return;
 		}
 

--- a/Ghidra/Framework/Docking/src/main/java/ghidra/docking/settings/SettingsImpl.java
+++ b/Ghidra/Framework/Docking/src/main/java/ghidra/docking/settings/SettingsImpl.java
@@ -17,12 +17,11 @@ package ghidra.docking.settings;
 
 import java.io.Serializable;
 import java.util.*;
+import java.util.function.Predicate;
 
 import javax.help.UnsupportedOperationException;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-
-import com.google.common.base.Predicate;
 
 import ghidra.util.Msg;
 
@@ -107,7 +106,7 @@ public class SettingsImpl implements Settings, Serializable {
 			return false;
 		}
 		if (allowedSettingPredicate != null &&
-			!allowedSettingPredicate.apply(settingsDefinition.getStorageKey())) {
+			!allowedSettingPredicate.test(settingsDefinition.getStorageKey())) {
 			return false;
 		}
 		return true;
@@ -124,7 +123,7 @@ public class SettingsImpl implements Settings, Serializable {
 			return false;
 		}
 		if (name != null && allowedSettingPredicate != null &&
-			!allowedSettingPredicate.apply(name)) {
+			!allowedSettingPredicate.test(name)) {
 			Msg.warn(this, "Ignored disallowed setting '" + name + "'");
 			return false;
 		}

--- a/Ghidra/Framework/Graph/src/main/java/ghidra/graph/job/FilterVerticesJob.java
+++ b/Ghidra/Framework/Graph/src/main/java/ghidra/graph/job/FilterVerticesJob.java
@@ -21,9 +21,8 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.Iterators;
-import com.google.common.collect.UnmodifiableIterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import ghidra.graph.graphs.FilteringVisualGraph;
 import ghidra.graph.viewer.*;
@@ -119,9 +118,9 @@ public class FilterVerticesJob<V extends VisualVertex, E extends VisualEdge<V>>
 	}
 
 	private Set<V> findCurrentVerticesFailingTheFilter(Set<V> validVertices) {
-
-		UnmodifiableIterator<V> nonMatchingIterator =
-			Iterators.filter(filterGraph.getUnfilteredVertices(), v -> !validVertices.contains(v));
+		Iterable<V> isFilter = () -> filterGraph.getUnfilteredVertices();
+		Stream<V> filterStream = StreamSupport.stream(isFilter.spliterator(), false);
+		Iterator<V> nonMatchingIterator = filterStream.filter(v -> !validVertices.contains(v)).iterator();
 		Set<V> nonMatching = asSet(nonMatchingIterator);
 		return nonMatching;
 	}

--- a/Ghidra/Framework/Graph/src/main/java/ghidra/graph/viewer/edge/VisualEdgeRenderer.java
+++ b/Ghidra/Framework/Graph/src/main/java/ghidra/graph/viewer/edge/VisualEdgeRenderer.java
@@ -18,11 +18,11 @@ package ghidra.graph.viewer.edge;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
+import java.util.function.Predicate;
 
 import javax.swing.JComponent;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.graph.Graph;
@@ -324,8 +324,8 @@ public abstract class VisualEdgeRenderer<V extends VisualVertex, E extends Visua
 		//
 		// Arrow Head
 		//
-		Predicate<Context<Graph<V, E>, E>> predicate = rc.getEdgeArrowPredicate();
-		boolean drawArrow = predicate.apply(context);
+		Predicate<Context<Graph<V, E>, E>> predicate = rc.getEdgeArrowPredicate()::apply;
+		boolean drawArrow = predicate.test(context);
 		if (!drawArrow) {
 			g.setPaint(oldPaint);
 			return;
@@ -480,7 +480,7 @@ public abstract class VisualEdgeRenderer<V extends VisualVertex, E extends Visua
 	 */
 	public Shape getFullShape(RenderContext<V, E> rc, Layout<V, E> layout, V vertex) {
 		Function<? super V, Shape> vertexShaper = rc.getVertexShapeTransformer();
-		Shape shape = null;
+		Shape shape;
 		if (vertexShaper instanceof VisualGraphVertexShapeTransformer) {
 			@SuppressWarnings("unchecked")
 			VisualGraphVertexShapeTransformer<V> vgShaper =

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeSettingsDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeSettingsDB.java
@@ -15,7 +15,7 @@
  */
 package ghidra.program.database.data;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 
 import ghidra.docking.settings.*;
 import ghidra.program.model.data.*;
@@ -82,11 +82,8 @@ class DataTypeSettingsDB implements Settings {
 		if (locked) {
 			return false;
 		}
-		if (allowedSettingPredicate != null &&
-			!allowedSettingPredicate.apply(settingsDefinition.getStorageKey())) {
-			return false;
-		}
-		return true;
+		return allowedSettingPredicate == null ||
+				allowedSettingPredicate.test(settingsDefinition.getStorageKey());
 	}
 
 	@Override
@@ -113,7 +110,7 @@ class DataTypeSettingsDB implements Settings {
 			return false;
 		}
 		if (name != null && allowedSettingPredicate != null &&
-			!allowedSettingPredicate.apply(name)) {
+			!allowedSettingPredicate.test(name)) {
 			Msg.warn(this, "Ignored disallowed setting '" + name + "'");
 			return false;
 		}
@@ -207,7 +204,7 @@ class DataTypeSettingsDB implements Settings {
 	@Override
 	public void setValue(String name, Object value) {
 		if (value instanceof Long) {
-			setLong(name, ((Long) value).longValue());
+			setLong(name, (Long) value);
 		}
 		else if (value instanceof String) {
 			setString(name, (String) value);


### PR DESCRIPTION
There is no need to rely on Google's implementation of predicates since Java has them.

Sadly, for now, we cannot do the same with Function because the JUNG library depends on Google's version.