### PR TITLE
Upgrading protobuf so ghidra complies natively on M1 macs

### DIFF
--- a/Ghidra/Debug/Debugger-gadp/Module.manifest
+++ b/Ghidra/Debug/Debugger-gadp/Module.manifest
@@ -1,1 +1,1 @@
-MODULE FILE LICENSE: lib/protobuf-java-3.17.3.jar BSD-3-GOOGLE
+MODULE FILE LICENSE: lib/protobuf-java-3.21.2.jar BSD-3-GOOGLE

--- a/Ghidra/Debug/Debugger-gadp/build.gradle
+++ b/Ghidra/Debug/Debugger-gadp/build.gradle
@@ -33,33 +33,33 @@ configurations {
 def platform = getCurrentPlatformName()
 
 dependencies {
-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
+	allProtocArtifacts 'com.google.protobuf:protoc:3.21.2:windows-x86_64@exe'
+	allProtocArtifacts 'com.google.protobuf:protoc:3.21.2:linux-x86_64@exe'
+	allProtocArtifacts 'com.google.protobuf:protoc:3.21.2:linux-aarch_64@exe'
+	allProtocArtifacts 'com.google.protobuf:protoc:3.21.2:osx-x86_64@exe'
+	allProtocArtifacts 'com.google.protobuf:protoc:3.21.2:osx-aarch_64@exe'
 
 	if (isCurrentWindows()) {
-		protocArtifact 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
+		protocArtifact 'com.google.protobuf:protoc:3.21.2:windows-x86_64@exe'
 	}
 	if (isCurrentLinux()) {
 		if (platform.endsWith("x86_64")) {
-			protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
+			protocArtifact 'com.google.protobuf:protoc:3.21.2:linux-x86_64@exe'
 		}
 		else {
-			protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
+			protocArtifact 'com.google.protobuf:protoc:3.21.2:linux-aarch_64@exe'
 		}
 	}
 	if (isCurrentMac()) {
 		if (platform.endsWith("x86_64")) {
-			protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
+			protocArtifact 'com.google.protobuf:protoc:3.21.2:osx-x86_64@exe'
 		}
 		else {
-			protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
+			protocArtifact 'com.google.protobuf:protoc:3.21.2:osx-aarch_64@exe'
 		}
 	}
 
-	api 'com.google.protobuf:protobuf-java:3.17.3'
+	api 'com.google.protobuf:protobuf-java:3.21.2'
 	api project(':Framework-AsyncComm')
 	api project(':Framework-Debugging')
 	api project(':ProposedUtils')
@@ -70,7 +70,7 @@ dependencies {
 
 /*protobuf {
 	protoc {
-		artifact = 'com.google.protobuf:protoc:3.17.3'
+		artifact = 'com.google.protobuf:protoc:3.21.2'
 	}
 }*/
 


### PR DESCRIPTION
Ghidra does not compile on M1 macs due to the protobuf library not having the appropriate executable -- it appears that they included the wrong binary.  Bumping up the version to 3.21.2 fixes this issue.

With this patch, ghidra compiles without the need for rosetta2.  The compiled version seems to run natively without the need for rosetta2.
