### PR TITLE
Decompiler docs: Specify DocBook XSL Stylesheets V1.78.1 instead of "current"

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/doc/commonprofile.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/commonprofile.xsl
@@ -2,5 +2,5 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl"/>
+  <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/profiling/profile.xsl"/>
 </xsl:stylesheet>

--- a/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/html/chunk.xsl"/>
 
 <xsl:param name="generate.toc">
   article/appendix  nop

--- a/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/html/chunk.xsl"/>
 
 <xsl:include href="decompileplugin_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_pdf.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_pdf.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/fo/docbook.xsl"/>
 
 <xsl:include href="decompileplugin_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/main_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/main_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/html/docbook.xsl"/>
 
 <xsl:param name="generate.toc">
   article/appendix  nop

--- a/Ghidra/Features/Decompiler/src/main/doc/pcoderef_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/pcoderef_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/html/chunk.xsl"/>
 
 <xsl:include href="pcoderef_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/pcoderef_pdf.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/pcoderef_pdf.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/fo/docbook.xsl"/>
 
 <xsl:template match="table" mode="label.markup"/>
 

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/html/chunk.xsl"/>
 
 <xsl:include href="sleigh_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh_pdf.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh_pdf.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.78.1/fo/docbook.xsl"/>
 
 <xsl:include href="sleigh_common.xsl" />
 

--- a/GhidraDocs/languages/html/pcoderef.html
+++ b/GhidraDocs/languages/html/pcoderef.html
@@ -25,7 +25,7 @@
 <div class="titlepage">
 <div>
 <div><h1 class="title">
-<a name="idm140035470386944"></a>P-Code Reference Manual</h1></div>
+<a name="idm1"></a>P-Code Reference Manual</h1></div>
 <div><p class="releaseinfo">Last updated September 5, 2019</p></div>
 </div>
 <hr>
@@ -215,7 +215,7 @@ The core concepts of p-code are:
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140035470234080"></a>Address Space</h3></div></div></div>
+<a name="idm200"></a>Address Space</h3></div></div></div>
 <p>
 The <span class="bold"><strong>address space</strong></span> for p-code is a generalization
 of RAM. It is defined simply as an indexed sequence of bytes that can
@@ -256,7 +256,7 @@ any of the other p-code operations.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140035470224608"></a>Varnode</h3></div></div></div>
+<a name="idm214"></a>Varnode</h3></div></div></div>
 <p>
 A <span class="bold"><strong>varnode</strong></span> is a generalization of
 either a register or a memory location. It is represented by the formal triple:
@@ -303,7 +303,7 @@ on them by the p-code operations that use them.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140035470216864"></a>P-code Operation</h3></div></div></div>
+<a name="idm229"></a>P-code Operation</h3></div></div></div>
 <p>
 A <span class="bold"><strong>p-code operation</strong></span> is the analog of a
 machine instruction. All p-code operations have the same basic format

--- a/GhidraDocs/languages/html/sleigh.html
+++ b/GhidraDocs/languages/html/sleigh.html
@@ -25,7 +25,7 @@
 <div class="titlepage">
 <div>
 <div><h1 class="title">
-<a name="idm140526921073488"></a>SLEIGH</h1></div>
+<a name="idm1"></a>SLEIGH</h1></div>
 <div><h3 class="subtitle"><i>A Language for Rapid Processor Specification</i></h3></div>
 <div><p class="releaseinfo">Last updated October 28, 2020</p></div>
 <div><p class="pubdate">Originally published December 16, 2005</p></div>
@@ -35,51 +35,51 @@
 <div class="toc">
 <p><b>Table of Contents</b></p>
 <dl class="toc">
-<dt><span class="sect1"><a href="sleigh.html#idm140526921048752">1. Introduction to P-Code</a></span></dt>
+<dt><span class="sect1"><a href="sleigh.html#idm22">1. Introduction to P-Code</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh.html#idm140526921040400">1.1. Address Spaces</a></span></dt>
+<dt><span class="sect2"><a href="sleigh.html#idm41">1.1. Address Spaces</a></span></dt>
 <dt><span class="sect2"><a href="sleigh.html#sleigh_varnodes">1.2. Varnodes</a></span></dt>
-<dt><span class="sect2"><a href="sleigh.html#idm140526921024752">1.3. Operations</a></span></dt>
+<dt><span class="sect2"><a href="sleigh.html#idm75">1.3. Operations</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_layout.html">2. Basic Specification Layout</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920986416">2.1. Comments</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920983776">2.2. Identifiers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920982144">2.3. Strings</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920980384">2.4. Integers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_layout.html#idm140526920976000">2.5. White Space</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm144">2.1. Comments</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm149">2.2. Identifiers</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm152">2.3. Strings</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm155">2.4. Integers</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_layout.html#idm163">2.5. White Space</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_preprocessing.html">3. Preprocessing</a></span></dt>
 <dd><dl>
 <dt><span class="sect2"><a href="sleigh_preprocessing.html#sleigh_including_files">3.1. Including Files</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm140526920968368">3.2. Preprocessor Macros</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm140526920961536">3.3. Conditional Compilation</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm176">3.2. Preprocessor Macros</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_preprocessing.html#idm187">3.3. Conditional Compilation</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_definitions.html">4. Basic Definitions</a></span></dt>
 <dd><dl>
 <dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_endianess_definition">4.1. Endianess Definition</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526921098128">4.2. Alignment Definition</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526921095104">4.3. Space Definitions</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm250">4.2. Alignment Definition</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm256">4.3. Space Definitions</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_naming_registers">4.4. Naming Registers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526920875744">4.5. Bit Range Registers</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_definitions.html#idm140526920863712">4.6. User-Defined Operations</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm319">4.5. Bit Range Registers</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#idm340">4.6. User-Defined Operations</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_symbols.html">5. Introduction to Symbols</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_symbols.html#idm140526920845152">5.1. Notes on Namespaces</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_symbols.html#idm376">5.1. Notes on Namespaces</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_symbols.html#sleigh_predefined_symbols">5.2. Predefined Symbols</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_tokens.html">6. Tokens and Fields</a></span></dt>
 <dd><dl>
 <dt><span class="sect2"><a href="sleigh_tokens.html#sleigh_defining_tokens">6.1. Defining Tokens and Fields</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_tokens.html#idm140526920800080">6.2. Fields as Family Symbols</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_tokens.html#idm140526920794256">6.3. Attaching Alternate Meanings to Fields</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_tokens.html#idm468">6.2. Fields as Family Symbols</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_tokens.html#idm476">6.3. Attaching Alternate Meanings to Fields</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_tokens.html#sleigh_context_variables">6.4. Context Variables</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_constructors.html">7. Constructors</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920750848">7.1. The Five Sections of a Constructor</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920746272">7.2. The Table Header</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm552">7.1. The Five Sections of a Constructor</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm562">7.2. The Table Header</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_display_section">7.3. The Display Section</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_bit_pattern">7.4. The Bit Pattern Section</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_disassembly_actions">7.5. Disassembly Actions Section</a></span></dt>
@@ -87,12 +87,12 @@
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_semantic_section">7.7. The Semantic Section</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_tables">7.8. Tables</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_constructors.html#sleigh_macros">7.9. P-code Macros</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920290640">7.10. Build Directives</a></span></dt>
-<dt><span class="sect2"><a href="sleigh_constructors.html#idm140526920281024">7.11. Delay Slot Directives</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm1345">7.10. Build Directives</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_constructors.html#idm1358">7.11. Delay Slot Directives</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_context.html">8. Using Context</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_context.html#idm140526920261472">8.1. Basic Use of Context Variables</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_context.html#idm1389">8.1. Basic Use of Context Variables</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_context.html#sleigh_local_change">8.2. Local Context Change</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_context.html#sleigh_global_change">8.3. Global Context Change</a></span></dt>
 </dl></dd>
@@ -101,7 +101,7 @@
 </div>
 <div class="simplesect">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="idm140526921055904"></a>History</h2></div></div></div>
+<a name="idm7"></a>History</h2></div></div></div>
 <p>
   This document describes the syntax for the SLEIGH processor
   specification language, which was developed for the GHIDRA
@@ -129,7 +129,7 @@
 </div>
 <div class="simplesect">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="idm140526921052720"></a>Overview</h2></div></div></div>
+<a name="idm12"></a>Overview</h2></div></div></div>
 <p>
 SLEIGH is a language for describing the instruction sets of general
 purpose microprocessors, in order to facilitate the reverse
@@ -162,7 +162,7 @@ Italics are used when defining terms and for named entities. Bold is used for SL
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="idm140526921048752"></a>1. Introduction to P-Code</h2></div></div></div>
+<a name="idm22"></a>1. Introduction to P-Code</h2></div></div></div>
 <p>
 Although p-code is a distinct language from SLEIGH, because a major
 purpose of SLEIGH is to specify the translation from machine code to
@@ -221,7 +221,7 @@ respectively.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921040400"></a>1.1. Address Spaces</h3></div></div></div>
+<a name="idm41"></a>1.1. Address Spaces</h3></div></div></div>
 <p>
 An <span class="emphasis"><em>address</em></span> space for p-code is a generalization of
 the indexed memory (RAM) that a typical processor has access to, and
@@ -322,7 +322,7 @@ must be provided and enforced by the specification designer.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921024752"></a>1.3. Operations</h3></div></div></div>
+<a name="idm75"></a>1.3. Operations</h3></div></div></div>
 <p>
 P-code is intended to emulate a target processor by substituting a
 sequence of p-code operations for each machine instruction. Thus every

--- a/GhidraDocs/languages/html/sleigh_constructors.html
+++ b/GhidraDocs/languages/html/sleigh_constructors.html
@@ -60,7 +60,7 @@ multiple constructors into a single table are addressed in <a class="xref" href=
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920750848"></a>7.1. The Five Sections of a Constructor</h3></div></div></div>
+<a name="idm552"></a>7.1. The Five Sections of a Constructor</h3></div></div></div>
 <p>
 A single complex statement in the specification file describes a
 constructor. This statement is always made up of five distinct
@@ -92,7 +92,7 @@ in turn.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920746272"></a>7.2. The Table Header</h3></div></div></div>
+<a name="idm562"></a>7.2. The Table Header</h3></div></div></div>
 <p>
 Every constructor must be part of a table, which is the element with
 an actual family symbol identifier associated with it. So each
@@ -230,7 +230,7 @@ no such requirement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920716688"></a>7.3.2. The '^' character</h4></div></div></div>
+<a name="idm615"></a>7.3.2. The '^' character</h4></div></div></div>
 <p>
 The &#8216;^&#8217; character in the display section is used to separate
 identifiers from other characters where there shouldn&#8217;t be white space
@@ -278,7 +278,7 @@ to <span class="emphasis"><em>match</em></span> the constructor being defined.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920705248"></a>7.4.1. Constraints</h4></div></div></div>
+<a name="idm635"></a>7.4.1. Constraints</h4></div></div></div>
 <p>
 The patterns required for processor specifications can almost always
 be described as a mask and value pair. Given a specific instruction
@@ -337,7 +337,7 @@ requires two or more mask/value style checks to correctly implement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920691312"></a>7.4.3. Defining Operands and Invoking Subtables</h4></div></div></div>
+<a name="idm660"></a>7.4.3. Defining Operands and Invoking Subtables</h4></div></div></div>
 <p>
 The principle way of defining a constructor operand, left undefined
 from the display section, is done in the bit pattern section. If an
@@ -396,7 +396,7 @@ statement of the grouping of old symbols into the new constructor.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920679904"></a>7.4.4. Variable Length Instructions</h4></div></div></div>
+<a name="idm678"></a>7.4.4. Variable Length Instructions</h4></div></div></div>
 <p>
 There are some additional complexities to designing a specification
 for a processor with variable length instructions. Some initial
@@ -419,7 +419,7 @@ designer control over how tokens fit together.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920676432"></a>7.4.4.1. The ';' Operator</h5></div></div></div>
+<a name="idm681"></a>7.4.4.1. The ';' Operator</h5></div></div></div>
 <p>
 The most important operator for patterns defining variable length
 instructions is the concatenation operator &#8216;;&#8217;. When building a
@@ -481,7 +481,7 @@ operator, so parentheses may be necessary to get the intended meaning.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920661120"></a>7.4.4.2. The '...' Operator</h5></div></div></div>
+<a name="idm708"></a>7.4.4.2. The '...' Operator</h5></div></div></div>
 <p>
 The ellipsis operator &#8216;...&#8217; is used to satisfy the token matching
 requirements of the &#8216;&amp;&#8217; and &#8216;|&#8217; operators (described in the previous
@@ -557,7 +557,7 @@ don&#8217;t quite match the assembly.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920640560"></a>7.4.6. Empty Patterns</h4></div></div></div>
+<a name="idm746"></a>7.4.6. Empty Patterns</h4></div></div></div>
 <p>
 Occasionally there is a need for an empty pattern when building
 tables. An empty pattern matches everything. There is a predefined
@@ -567,7 +567,7 @@ to indicate an empty pattern.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920638720"></a>7.4.7. Advanced Constraints</h4></div></div></div>
+<a name="idm750"></a>7.4.7. Advanced Constraints</h4></div></div></div>
 <p>
 A constraint does not have to be of the form &#8220;field = constant&#8221;,
 although this is almost always what is needed. In certain situations,
@@ -939,7 +939,7 @@ varnode is <span class="emphasis"><em>r1</em></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920530304"></a>7.7.1. Expressions</h4></div></div></div>
+<a name="idm919"></a>7.7.1. Expressions</h4></div></div></div>
 <p>
 Expressions are built out of symbols and the binary and unary
 operators listed in <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table 5. Semantic Expression Operators and Syntax">Table 5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
@@ -954,7 +954,7 @@ within expressions to affect this order.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920527872"></a>7.7.1.1. Arithmetic, Logical and Boolean Operators</h5></div></div></div>
+<a name="idm924"></a>7.7.1.1. Arithmetic, Logical and Boolean Operators</h5></div></div></div>
 <p>
 For the most part these operators should be familiar to software
 developers. The only real differences arise from the fact that
@@ -1017,7 +1017,7 @@ set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920515552"></a>7.7.1.3. Extension</h5></div></div></div>
+<a name="idm944"></a>7.7.1.3. Extension</h5></div></div></div>
 <p>
 Most processors have instructions that extend small values into big
 values, and many instructions do these minor data manipulations
@@ -1039,7 +1039,7 @@ the <span class="bold"><strong>sext</strong></span> operator.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920508832"></a>7.7.1.4. Truncation</h5></div></div></div>
+<a name="idm957"></a>7.7.1.4. Truncation</h5></div></div></div>
 <p>
 There are two forms of syntax indicating a truncation of the input
 varnode. In one the varnode is followed by a colon &#8216;:&#8217; and an integer
@@ -1169,7 +1169,7 @@ the offset portion of the address, and to copy the desired value, the
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920484032"></a>7.7.1.7. Managed Code Operations</h5></div></div></div>
+<a name="idm1005"></a>7.7.1.7. Managed Code Operations</h5></div></div></div>
 <p>
 SLEIGH provides basic support for instructions where encoding and context
 don't provide a complete description of the semantics. This is the case
@@ -1231,7 +1231,7 @@ define pcodeop arctan;
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920471120"></a>7.7.2. Statements</h4></div></div></div>
+<a name="idm1027"></a>7.7.2. Statements</h4></div></div></div>
 <p>
 We describe the types of semantic statements that are allowed in SLEIGH.
 </p>
@@ -1305,7 +1305,7 @@ and may be enforced in future compiler versions.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920458176"></a>7.7.2.2. Storage Statements</h5></div></div></div>
+<a name="idm1049"></a>7.7.2.2. Storage Statements</h5></div></div></div>
 <p>
 SLEIGH supports fairly standard <span class="emphasis"><em>storage statement</em></span>
 syntax to complement the load operator. The left-hand side of an
@@ -1336,7 +1336,7 @@ attribute is set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920452240"></a>7.7.2.3. Exports</h5></div></div></div>
+<a name="idm1059"></a>7.7.2.3. Exports</h5></div></div></div>
 <p>
 The semantic section doesn&#8217;t just specify how to generate p-code for a
 constructor. Except for those constructors in the root table, this
@@ -1388,7 +1388,7 @@ varnode being modified to be exported as an integer constant.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920441008"></a>7.7.2.4. Dynamic References</h5></div></div></div>
+<a name="idm1078"></a>7.7.2.4. Dynamic References</h5></div></div></div>
 <p>
 The only other operator allowed as part of
 an <span class="bold"><strong>export</strong></span> statement, is the &#8216;*&#8217;
@@ -1447,7 +1447,7 @@ levels.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920427360"></a>7.7.2.5. Branching Statements</h5></div></div></div>
+<a name="idm1102"></a>7.7.2.5. Branching Statements</h5></div></div></div>
 <p>
 This section discusses statements that generate p-code branching
 operations. These are listed in <a class="xref" href="sleigh_ref.html#branchref.htmltable" title="Table 7. Branching Statements">Table 7, &#8220;Branching Statements&#8221;</a>, in the Appendix.
@@ -1802,7 +1802,7 @@ each followed by a variation which corrects the error.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920360336"></a>7.7.4. Unimplemented Semantics</h4></div></div></div>
+<a name="idm1222"></a>7.7.4. Unimplemented Semantics</h4></div></div></div>
 <p>
 The semantic section must be present for every constructor in the
 specification. But the designer can leave the semantics explicitly
@@ -1962,7 +1962,7 @@ should generally be avoided.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920333184"></a>7.8.2. Specific Symbol Trees</h4></div></div></div>
+<a name="idm1272"></a>7.8.2. Specific Symbol Trees</h4></div></div></div>
 <p>
 When the SLEIGH parser analyzes an instruction, it starts with the
 root symbol <span class="emphasis"><em>instruction</em></span>, and decides which of the
@@ -2045,7 +2045,7 @@ and p-code for these encodings by walking the trees.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920314640"></a>7.8.2.1. Disassembly Trees</h5></div></div></div>
+<a name="idm1308"></a>7.8.2.1. Disassembly Trees</h5></div></div></div>
 <p>
 If the nodes of each tree are replaced with the display information of
 the corresponding specific symbol, we see how the disassembly
@@ -2068,7 +2068,7 @@ statements corresponding to the original instruction encodings.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="idm140526920308256"></a>7.8.2.2. P-code Trees</h5></div></div></div>
+<a name="idm1319"></a>7.8.2.2. P-code Trees</h5></div></div></div>
 <p>
 A similar procedure produces the resulting p-code translation of the
 instruction. If each node in the specific symbol tree is replaced with
@@ -2147,7 +2147,7 @@ directive however should not be used in a macro.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920290640"></a>7.10. Build Directives</h3></div></div></div>
+<a name="idm1345"></a>7.10. Build Directives</h3></div></div></div>
 <p>
 Because the nodes of a specific symbol tree are traversed in a
 depth-first order, the p-code for a child node in general comes before
@@ -2202,7 +2202,7 @@ normal action of the instruction.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920281024"></a>7.11. Delay Slot Directives</h3></div></div></div>
+<a name="idm1358"></a>7.11. Delay Slot Directives</h3></div></div></div>
 <p>
 For processors with a pipe-lined architecture, multiple instructions
 are typically executing simultaneously. This can lead to processor

--- a/GhidraDocs/languages/html/sleigh_context.html
+++ b/GhidraDocs/languages/html/sleigh_context.html
@@ -85,7 +85,7 @@ whose encodings are otherwise the same.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920261472"></a>8.1. Basic Use of Context Variables</h3></div></div></div>
+<a name="idm1389"></a>8.1. Basic Use of Context Variables</h3></div></div></div>
 <p>
 Suppose a processor supports the use of two different sets of
 registers in its main addressing mode, based on the setting of a

--- a/GhidraDocs/languages/html/sleigh_definitions.html
+++ b/GhidraDocs/languages/html/sleigh_definitions.html
@@ -56,7 +56,7 @@ otherwise the specification language hides endianess issues.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921098128"></a>4.2. Alignment Definition</h3></div></div></div>
+<a name="idm250"></a>4.2. Alignment Definition</h3></div></div></div>
 <p>
 An alignment definition looks like
 </p>
@@ -73,7 +73,7 @@ instruction as an error.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526921095104"></a>4.3. Space Definitions</h3></div></div></div>
+<a name="idm256"></a>4.3. Space Definitions</h3></div></div></div>
 <p>
 The definition of an address space looks like
 </p>
@@ -228,7 +228,7 @@ define register offset=0 size=1
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920875744"></a>4.5. Bit Range Registers</h3></div></div></div>
+<a name="idm319"></a>4.5. Bit Range Registers</h3></div></div></div>
 <p>
 Many processors define registers that either consist of a single bit
 or otherwise don't use an integral number of bytes. A recurring
@@ -299,7 +299,7 @@ used as an alternate syntax for defining overlapping registers.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920863712"></a>4.6. User-Defined Operations</h3></div></div></div>
+<a name="idm340"></a>4.6. User-Defined Operations</h3></div></div></div>
 <p>
 The specification designer can define new p-code operations using
 a <span class="bold"><strong>define pcodeop</strong></span> statement.  This

--- a/GhidraDocs/languages/html/sleigh_layout.html
+++ b/GhidraDocs/languages/html/sleigh_layout.html
@@ -36,7 +36,7 @@ by the compiler.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920986416"></a>2.1. Comments</h3></div></div></div>
+<a name="idm144"></a>2.1. Comments</h3></div></div></div>
 <p>
 Comments start with the &#8216;#&#8217; character and continue to the end of the
 line. Comments can appear anywhere except the <span class="emphasis"><em>display section</em></span> of a
@@ -46,7 +46,7 @@ interpreted as something that should be printed in disassembly.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920983776"></a>2.2. Identifiers</h3></div></div></div>
+<a name="idm149"></a>2.2. Identifiers</h3></div></div></div>
 <p>
 Identifiers are made up of letters a-z, capitals A-Z, digits 0-9 and
 the characters &#8216;.&#8217; and &#8216;_&#8217;. An identifier can use these characters in
@@ -55,7 +55,7 @@ any order and for any length, but it must not start with a digit.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920982144"></a>2.3. Strings</h3></div></div></div>
+<a name="idm152"></a>2.3. Strings</h3></div></div></div>
 <p>
 String literals can be used, when specifying names and when specifying
 how disassembly should be printed, so that special characters are
@@ -66,7 +66,7 @@ meaning.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920980384"></a>2.4. Integers</h3></div></div></div>
+<a name="idm155"></a>2.4. Integers</h3></div></div></div>
 <p>
 Integers are specified either in a decimal format or in a standard
 <span class="emphasis"><em>C-style</em></span> hexadecimal format by prepending the
@@ -92,7 +92,7 @@ integers internally with 64 bits of precision.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920976000"></a>2.5. White Space</h3></div></div></div>
+<a name="idm163"></a>2.5. White Space</h3></div></div></div>
 <p>
 White space characters include space, tab, line-feed, vertical
 line-feed, and carriage-return (&#8216; &#8216;, &#8216;\t&#8217;, &#8216;\r&#8217;, &#8216;\v&#8217;,

--- a/GhidraDocs/languages/html/sleigh_preprocessing.html
+++ b/GhidraDocs/languages/html/sleigh_preprocessing.html
@@ -54,7 +54,7 @@ own <span class="bold"><strong>@include</strong></span> directives.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920968368"></a>3.2. Preprocessor Macros</h3></div></div></div>
+<a name="idm176"></a>3.2. Preprocessor Macros</h3></div></div></div>
 <p>
 SLEIGH allows simple (unparameterized) macro definitions and
 expansions. A macro definition occurs on one line and starts with
@@ -85,7 +85,7 @@ definition of a macro from that point on in the file.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920961536"></a>3.3. Conditional Compilation</h3></div></div></div>
+<a name="idm187"></a>3.3. Conditional Compilation</h3></div></div></div>
 <p>
 SLEIGH supports several directives that allow conditional inclusion of
 parts of a specification, based on the existence of a macro, or its
@@ -103,7 +103,7 @@ and <span class="bold"><strong>@endif</strong></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920955392"></a>3.3.1. @ifdef and @ifndef</h4></div></div></div>
+<a name="idm197"></a>3.3.1. @ifdef and @ifndef</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@ifdef</strong></span> directive is followed by a
 macro identifier and evaluates to true if the macro is defined.
@@ -129,7 +129,7 @@ or <span class="bold"><strong>@elif</strong></span> directive (See below).
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920949120"></a>3.3.2. @if</h4></div></div></div>
+<a name="idm208"></a>3.3.2. @if</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@if</strong></span> directive is followed by a
 boolean expression with macros as the variables and strings as the
@@ -158,7 +158,7 @@ is defined.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920942032"></a>3.3.3. @else and @elif</h4></div></div></div>
+<a name="idm220"></a>3.3.3. @else and @elif</h4></div></div></div>
 <p>
 An <span class="bold"><strong>@else</strong></span> directive splits the lines
 bounded by an <span class="bold"><strong>@if</strong></span> directive and

--- a/GhidraDocs/languages/html/sleigh_symbols.html
+++ b/GhidraDocs/languages/html/sleigh_symbols.html
@@ -105,7 +105,7 @@ the predefined identifier <span class="emphasis"><em>instruction</em></span>.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920845152"></a>5.1. Notes on Namespaces</h3></div></div></div>
+<a name="idm376"></a>5.1. Notes on Namespaces</h3></div></div></div>
 <p>
 Almost all identifiers live in the same global "scope". The global scope includes
 </p>

--- a/GhidraDocs/languages/html/sleigh_tokens.html
+++ b/GhidraDocs/languages/html/sleigh_tokens.html
@@ -88,7 +88,7 @@ different names.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920800080"></a>6.2. Fields as Family Symbols</h3></div></div></div>
+<a name="idm468"></a>6.2. Fields as Family Symbols</h3></div></div></div>
 <p>
 Fields are the most basic form of family symbol; they define a natural
 map from instruction bits to a specific symbol as follows. We take the
@@ -113,7 +113,7 @@ the <span class="bold"><strong>dec</strong></span> attribute is not supported]
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idm140526920794256"></a>6.3. Attaching Alternate Meanings to Fields</h3></div></div></div>
+<a name="idm476"></a>6.3. Attaching Alternate Meanings to Fields</h3></div></div></div>
 <p>
 The default interpretation of a field is probably the most natural but
 of course processors interpret fields within an instruction in a wide
@@ -124,7 +124,7 @@ interpretations must be built up out of tables.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920792112"></a>6.3.1. Attaching Registers</h4></div></div></div>
+<a name="idm480"></a>6.3.1. Attaching Registers</h4></div></div></div>
 <p>
 Probably <span class="emphasis"><em>the</em></span> most common processor interpretation
 of a field is as an encoding of a particular register. In SLEIGH this
@@ -163,7 +163,7 @@ of the instruction.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920783840"></a>6.3.2. Attaching Other Integers</h4></div></div></div>
+<a name="idm495"></a>6.3.2. Attaching Other Integers</h4></div></div></div>
 <p>
 Sometimes a processor interprets a field as an integer but not the
 integer given by the default interpretation. A different integer
@@ -185,7 +185,7 @@ unspecified positions in the list using a &#8216;_&#8217;]
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="idm140526920778208"></a>6.3.3. Attaching Names</h4></div></div></div>
+<a name="idm505"></a>6.3.3. Attaching Names</h4></div></div></div>
 <p>
 It is possible to just modify the display characteristics of a field
 without changing the semantic meaning. The need for this is rare, but


### PR DESCRIPTION
This makes building the docs via `gradle cleanBuildDecompilerDocumentationHtml` and `gradle buildDecompilerDocumentationHtml` much more consistent. I still got some slight differences (which I have included in this PR) but they are a lot less significant than what happens when "current" is used.

```
$ xsltproc --version
Using libxml 20910, libxslt 10134 and libexslt 820
xsltproc was compiled against libxml 20910, libxslt 10134 and libexslt 820
libxslt 10134 was compiled against libxml 20910
libexslt 820 was compiled against libxml 20910
```

This is intended to help with #2810, where I needed to make actual doc changes and don't want the noise from this showing up in that PR. (For now I've included the same commit there, though).