### PR TITLE
Fix segment table generation and rel16 offsets for DOS MZ executables

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
@@ -263,10 +263,6 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 				int off = Conv.shortToInt(reader.readNextShort());
 				int seg = Conv.shortToInt(reader.readNextShort());
 
-				// compute the new segment referenced at the location
-				SegmentedAddress segStartAddr = space.getAddress(seg + csStart, 0);
-				segMap.put(segStartAddr, segStartAddr);
-
 				int location = (seg << 4) + off;
 				int locOffset = location + dataStart;
 

--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -786,7 +786,8 @@ Mem: segWide^addr32 is $(LONGMODE_OFF) & addrsize=1 & segWide; addr32       		{ 
 Mem: segWide^addr32 is $(LONGMODE_OFF) & addrsize=1 & segWide & highseg=1; addr32 	{ tmp:$(SIZE) = segWide + zext(addr32); export tmp; }
 
 rel8: reloc is simm8        [ reloc=inst_next+simm8; ] { export *[ram]:$(SIZE) reloc; }
-rel16: reloc is simm16      [ reloc=((inst_next >> 16) << 16) | ((inst_next + simm16) & 0xFFFF); ] { export *[ram]:$(SIZE) reloc; }
+rel16: reloc is protectedMode=0 & simm16      [ reloc=inst_next+simm16; ] { export *[ram]:$(SIZE) reloc; }
+rel16: reloc is protectedMode=1 & simm16      [ reloc=((inst_next >> 16) << 16) | ((inst_next + simm16) & 0xFFFF); ] { export *[ram]:$(SIZE) reloc; }
 rel32: reloc is simm32      [ reloc=inst_next+simm32; ] { export *[ram]:$(SIZE) reloc; }
 
 


### PR DESCRIPTION
Two small fixes for DOS MZ executables:

- MZ files don't have a formal list of segment bounds, you instead work it out from addresses in the relocation table. There were two lines which added segments based on the address of the relocation table entry itself; for pretty much every multisegment DOS EXE I tried this would create additional segment boundaries that didn't match with other tools. Removing these two lines fixes the segment list.
- Originally, rel16 offset arguments to instructions would be rigged to remain in the same segment. This holds true for protected mode, but in real mode it's possible to jump segment boundaries. This was fixed by adding a conditional in the .sinc file for real mode to use a normal offset calculation. Tested and confirmed to be working with real mode MZ and protected mode NE executables.

Should fix #981 .