### PR TITLE
Corrected `e_shnum` parsing from first section header.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -188,6 +188,10 @@ public class ElfHeader implements StructConverter, Writeable {
 
 			e_shstrndx = reader.readNextShort();
 
+			if (e_shnum == 0) {
+				e_shnum = readExtendedSectionHeaderCount(); // use extended stored section header count
+			}
+
 			if (e_shnum >= Short.toUnsignedInt(ElfSectionHeaderConstants.SHN_LORESERVE)) {
 				e_shnum = readExtendedSectionHeaderCount(); // use extended stored section header count
 			}
@@ -2032,3 +2036,4 @@ public class ElfHeader implements StructConverter, Writeable {
 	}
 
 }
+


### PR DESCRIPTION
Hello!
I found an issue with a very large ELF in “the wild” that contained many sections, it did not load correctly since the `e_shnum` was not properly being parsed from section_header0.sh_size, as the conditional for doing so appears to be incorrectly implemented:


```
if (e_shnum >= Short.toUnsignedInt(ElfSectionHeaderConstants.SHN_LORESERVE)) {
        e_shnum = readExtendedSectionHeaderCount(); // use extended stored section header count
}
```

Per the [ELF (5) man page](https://www.man7.org/linux/man-pages/man5/elf.5.html), when the number of section headers within an ELF file is greater than `SHN_LORESERVE` then the `e_shnum` value will be *zero*, not that `e_shnum` itself will be greater than `SHN_LORESERVE`. Full excerpt is below. It’s a quick fix, I left the current conditional in there in case other toolchains do in fact make the same interpretation a I don’t think it should hurt, though you may wish to consider removing the old one or combining the conditionals if you think this is best.

```
       e_shnum
              This member holds the number of entries in the section
              header table.  Thus the product of e_shentsize and e_shnum
              gives the section header table's size in bytes.  If a file
              has no section header table, e_shnum holds the value of
              zero.

              If the number of entries in the section header table is
              larger than or equal to SHN_LORESERVE (0xff00), e_shnum
              holds the value zero and the real number of entries in the
              section header table is held in the sh_size member of the
              initial entry in section header table.  Otherwise, the
              sh_size member of the initial entry in the section header
              table holds the value zero.
  ```

Applying this fix did allow the binary to load correctly :+1: .

Unfortunately the _original_ binary cannot be shared for testing, though I've attached a contrived hello world example that's been modified "by hand" in case that is helpful. ( I just swapped the e_shnum and sec[0].size values).

[hellow_world_patched.zip](https://github.com/NationalSecurityAgency/ghidra/files/9124009/hellow_world_patched.zip)

