### PR TITLE
decompiler: fix Merge::compareHighByBlock

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/merge.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/merge.hh
@@ -157,7 +157,7 @@ inline bool Merge::compareHighByBlock(const HighVariable *a,const HighVariable *
       PcodeOp *def1 = v1->getDef();
       PcodeOp *def2 = v2->getDef();
       if ( def1 == (PcodeOp *) 0 ) {
-	return true;
+	return def2 != (PcodeOp *) 0;
       }
       else if ( def2 == (PcodeOp *) 0 ) {
 	return false;


### PR DESCRIPTION
This fixes a decompiler crash on code I can't share, but I promise I wasn't randomly looking for inconsequential mathematical errors!

The current `compareHighByBlock` will determine that `a < b` when high variables `a` and `b` have equal `wholecover` and for `v1=a->getInstance(0)` and `v2=b->getInstance(0)`, `v1->getAddr() == v2->getAddr()` and `v1->getDef()==v2->getDef() == nullptr`.    In particular, for such `a` and `b`, we also get that `b < a` and `compareHighByBlock` doesn't satisfy the C++ requirement for [compare](https://en.cppreference.com/w/cpp/named_req/Compare).  Why treating it like one in `std::sort` causes a crash I don't know, honestly, but fixing this makes my crash go away.  🤷🏻‍♂️ 


