### PR TITLE
Fix "Name cannot end with a delimiter: Program Information. in Options"

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/BinaryReader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/BinaryReader.java
@@ -393,9 +393,9 @@ public class BinaryReader {
 	 * @exception IOException if an I/O error occurs
 	 */
 	public String readNextUnicodeString() throws IOException {
-		String s = readUnicodeString(currentIndex);
+		String s = readUnicodeStringUntrimmed(currentIndex);
 		currentIndex += ((s.length() + 1) * 2);
-		return s;
+		return s.trim();
 	}
 
 	/**
@@ -588,6 +588,23 @@ public class BinaryReader {
 	 * @exception IOException if an I/O error occurs
 	 */
 	public String readUnicodeString(long index) throws IOException {
+		return readUnicodeStringUntrimmed(index).trim();
+	}
+
+	/**
+	 * Reads a null-terminated UTF-16 Unicode string starting
+	 * at <code>index</code> using the pre-specified
+	 * {@link #setLittleEndian(boolean) endianness}.
+	 * <p>
+	 * The end of the string is denoted by a two-byte (ie. short) <code>null</code> character.
+	 * <p>
+	 * Leading and trailing spaces will NOT be trimmed before the string is returned.
+	 * <p>
+	 * @param index the index where the UTF-16 Unicode string begins
+	 * @return the un-trimmed UTF-16 Unicode string
+	 * @exception IOException if an I/O error occurs
+	 */
+	public String readUnicodeStringUntrimmed(long index) throws IOException {
 		StringBuilder buffer = new StringBuilder();
 		while (index < length()) {
 			int ch = readUnsignedShort(index);
@@ -597,7 +614,7 @@ public class BinaryReader {
 			buffer.append((char) ch);
 			index += 2;
 		}
-		return buffer.toString().trim();
+		return buffer.toString();
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/BinaryReader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/BinaryReader.java
@@ -345,9 +345,9 @@ public class BinaryReader {
 	 * @exception IOException if an I/O error occurs
 	 */
 	public String readNextAsciiString() throws IOException {
-		String s = readAsciiString(currentIndex);
+		String s = readAsciiStringUntrimmed(currentIndex);
 		currentIndex += (s.length() + 1);
-		return s;
+		return s.trim();
 	}
 
 	/**
@@ -477,6 +477,21 @@ public class BinaryReader {
 	 * @exception IOException if an I/O error occurs
 	 */
 	public String readAsciiString(long index) throws IOException {
+		return readAsciiStringUntrimmed(index).trim();
+	}
+
+	/**
+	 * Reads an Ascii string starting at <code>index</code>, ending
+	 * at the next character outside the range [32..126] or when
+	 * reaching the end of the underlying ByteProvider.
+	 * <p>
+	 * Leading and trailing spaces will NOT be trimmed before the string is returned.
+	 *
+	 * @param index the index where the Ascii string begins
+	 * @return the un-trimmed Ascii string
+	 * @exception IOException if an I/O error occurs
+	 */
+	public String readAsciiStringUntrimmed(long index) throws IOException {
 		StringBuilder buffer = new StringBuilder();
 		long len = provider.length();
 		while (true) {
@@ -492,7 +507,7 @@ public class BinaryReader {
 				break;
 			}
 		}
-		return buffer.toString().trim();
+		return buffer.toString();
 	}
 
 	/**
@@ -832,9 +847,9 @@ public class BinaryReader {
 		}
 		String[] arr = new String[nElements];
 		for (int i = 0; i < nElements; ++i) {
-			String tmp = readAsciiString(index);
-			arr[i] = tmp;
-			index += (tmp == null ? 1 : tmp.length());
+			String tmp = readAsciiStringUntrimmed(index);
+			arr[i] = tmp.trim();
+			index += tmp.length();
 		}
 		return arr;
 	}


### PR DESCRIPTION
add readUnicodeStringUntrimmed function

On importing a PE file, I get these exceptions in the console window:
```
2022-07-18 12:15:42 ERROR (ResourceDataDirectory) Invalid resource data: Name cannot end with a delimiter: Program Information. in Options  java.lang.IllegalArgumentException: Name cannot end with a delimiter: Program Information. in Options
	at ghidra.framework.options.AbstractOptions.validateOptionName(AbstractOptions.java:721)
	at ghidra.framework.options.AbstractOptions.getOption(AbstractOptions.java:215)
	at ghidra.framework.options.AbstractOptions.putObject(AbstractOptions.java:295)
	at ghidra.framework.options.AbstractOptions.setString(AbstractOptions.java:529)
	at ghidra.framework.options.SubOptions.setString(SubOptions.java:227)
	at ghidra.app.util.bin.format.pe.ResourceDataDirectory.processVersionInfo(ResourceDataDirectory.java:418)
	at ghidra.app.util.bin.format.pe.ResourceDataDirectory.markup(ResourceDataDirectory.java:358)
	at ghidra.app.util.opinion.PeLoader.load(PeLoader.java:133)
	at ghidra.app.util.opinion.AbstractLibrarySupportLoader.doLoad(AbstractLibrarySupportLoader.java:356)
	at ghidra.app.util.opinion.AbstractLibrarySupportLoader.loadProgram(AbstractLibrarySupportLoader.java:84)
	at ghidra.app.util.opinion.AbstractProgramLoader.load(AbstractProgramLoader.java:116)
	at ghidra.plugin.importer.ImporterUtilities.importSingleFile(ImporterUtilities.java:368)
	at ghidra.plugin.importer.ImporterDialog.lambda$okCallback$7(ImporterDialog.java:351)
	at ghidra.util.task.TaskBuilder$TaskBuilderTask.run(TaskBuilder.java:306)
	at ghidra.util.task.Task.monitoredRun(Task.java:134)
	at ghidra.util.task.TaskRunner.lambda$startTaskThread$0(TaskRunner.java:106)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

I tracked this down to readNextUnicodeString in BinaryReader.java:
```
public String readNextUnicodeString() throws IOException {
	String s = readUnicodeString(currentIndex);
	currentIndex += ((s.length() + 1) * 2);
	return s;
}
```

The problem is that the String returned by readUnicodeString is trimmed and its length is being used to compute indices.

The assumption being that length() characters were read, but that is incorrect if the String had whitespace at the beginning or end.

This pull requests adds a readUnicodeStringUntrimmed function that is appropriate for using length() to compute indices.

It would also be possible to make a different PR that has a function return a combination of {trimmed string, original length}.

Let me know if anything should be changed in this PR.


I looked in the issues and pull requests and could not see anything related to this.

Let me know if I should also create an issue for this.