### PR TITLE
SuperH: Fix trapa Regression

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -1985,7 +1985,8 @@ define pcodeop Sleep_Standby;
     r15 = r15 - 4;
     *r15 = pc + 2;
 
-    call [vbr + (imm_00_07 * 4)];
+    pc = *(vbr + (imm_00_07 * 4));
+    call [pc];
 }
 
 @if defined(FPU)


### PR DESCRIPTION
Fix regression in trapa instruction involving PC deref. Closes https://github.com/NationalSecurityAgency/ghidra/issues/4396. Fixes https://github.com/NationalSecurityAgency/ghidra/pull/3600. 