### PR TITLE
Add include guards to decompiler C++ headers

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/bfd_arch.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/bfd_arch.hh
@@ -17,6 +17,9 @@
 /// \file bfd_arch.hh
 /// \brief Specific implementation of Architecture using GNU BFD libraries
 
+#ifndef __BFD_ARCH__
+#define __BFD_ARCH__
+
 #include "sleigh_arch.hh"
 #include "loadimage_bfd.hh"
 
@@ -47,3 +50,5 @@ public:
   BfdArchitecture(const string &fname,const string &targ,ostream *estream);	///< Constructor
   virtual ~BfdArchitecture(void) {}
 };
+
+#endif

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/graph.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/graph.hh
@@ -14,8 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifndef __GRAPH__
+#define __GRAPH__
+
 #include "funcdata.hh"
 
 extern void dump_dataflow_graph(Funcdata &data,ostream &s);
 extern void dump_controlflow_graph(const string &name,const BlockGraph &graph,ostream &s);
 extern void dump_dom_graph(const string &name,const BlockGraph &graph,ostream &s);
+
+#endif

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ifaceterm.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ifaceterm.hh
@@ -16,6 +16,9 @@
 /// \file ifaceterm.hh
 /// \brief Add some terminal capabilities to the command-line interface (IfaceStatus)
 
+#ifndef __IFACE_TERM__
+#define __IFACE_TERM__
+
 #include "interface.hh"
 
 #ifdef __TERMINAL__
@@ -48,3 +51,5 @@ public:
   virtual void popScript(void);
   virtual bool isStreamFinished(void) const;
 };
+
+#endif

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/raw_arch.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/raw_arch.hh
@@ -15,6 +15,10 @@
  */
 /// \file raw_arch.hh
 /// \brief Bare bones capability for treating a file as a raw executable image
+
+#ifndef __RAW_ARCH__
+#define __RAW_ARCH__
+
 #include "sleigh_arch.hh"
 #include "loadimage.hh"
 
@@ -46,3 +50,4 @@ public:
   virtual ~RawBinaryArchitecture(void) {}
 };
 
+#endif

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.hh
@@ -16,6 +16,9 @@
 /// \file slgh_compile.hh
 /// \brief High-level control of the sleigh compilation process
 
+#ifndef __SLGH_COMPILE__
+#define __SLGH_COMPILE__
+
 #include "sleighbase.hh"
 #include "pcodecompile.hh"
 #include "filemanage.hh"
@@ -446,3 +449,5 @@ public:
 
 extern SleighCompile *slgh;		///< A global reference to the SLEIGH compiler accessible to the parse functions
 extern int yydebug;			///< Debug state for the SLEIGH parse functions
+
+#endif

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/xml_arch.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/xml_arch.hh
@@ -15,6 +15,10 @@
  */
 /// \file xml_arch.hh
 /// \brief Extension to read executables based on an XML format
+
+#ifndef __XML_ARCH__
+#define __XML_ARCH__
+
 #include "sleigh_arch.hh"
 #include "loadimage_xml.hh"
 
@@ -45,3 +49,5 @@ public:
   XmlArchitecture(const string &fname,const string &targ,ostream *estream);	///< Constructor
   virtual ~XmlArchitecture(void) {}
 };
+
+#endif


### PR DESCRIPTION
This prevents double-inclusion errors.

I followed the naming convention that other files used for the definition name (the name of the file without the `.hh` suffix).