### PR TITLE
Specify JavaSE-17 for GhidraDevPlugin

### DIFF
--- a/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/META-INF/MANIFEST.MF
+++ b/GhidraBuild/EclipsePlugins/GhidraDev/GhidraDevPlugin/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Require-Bundle: org.eclipse.ant.core;bundle-version="3.5.800",
  org.python.pydev.ast;bundle-version="6.3.1";resolution:=optional,
  org.eclipse.cdt.core;bundle-version="5.9.1";resolution:=optional,
  org.eclipse.cdt.ui;bundle-version="5.9.0";resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Ghidra
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,


### PR DESCRIPTION
When following the directions for building the GhidraDevPlugin, I encountered an error about incompatibility when building with JDK 17. Making this change fixed it.