### PR TITLE
Disabling wildcard path expansion on foreground tasks

### DIFF
--- a/Ghidra/RuntimeScripts/Linux/support/launch.sh
+++ b/Ghidra/RuntimeScripts/Linux/support/launch.sh
@@ -193,7 +193,7 @@ if [ "${BACKGROUND}" = true ]; then
 	fi
 	exit 0
 else
-	eval "\"${JAVA_CMD}\" ${VMARG_LIST} -showversion -cp \"${CPATH}\" ghidra.Ghidra ${CLASSNAME} ${ARGS[@]}"
+	eval "(set -o noglob; \"${JAVA_CMD}\" ${VMARG_LIST} -showversion -cp \"${CPATH}\" ghidra.Ghidra ${CLASSNAME} ${ARGS[@]})"
 	exit $?
 fi
 


### PR DESCRIPTION
Fixes #3409, which shows how using `'*'` on the headless command still expands the wildcard despite the single quotes.

Any cross-platform/portability junkies see any issues with this?  Works for me on macOS and Ubuntu.