### PR TITLE
DebugDirectory type is in range 0-20

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/debug/DebugDirectory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/debug/DebugDirectory.java
@@ -85,7 +85,7 @@ public class DebugDirectory implements StructConverter, ByteArrayConverter {
 		addressOfRawData = reader.readNextInt();
 		pointerToRawData = reader.readNextInt();
 
-		if (type < 0 || type > 16 || sizeOfData < 0) {
+		if (type < 0 || type > 20 || sizeOfData < 0) {
 			Msg.error(this, "Invalid DebugDirectory");
 				sizeOfData = 0;
 				reader.setPointerIndex(oldIndex);


### PR DESCRIPTION
Valid values of `_IMAGE_DEBUG_DIRECTORY::Type` are between 0 and 20. Currently, `IMAGE_DEBUG_TYPE_EX_DLLCHARACTERISTICS (20)` is used when importing DLL files that have [/CETCOMPAT](https://docs.microsoft.com/en-us/cpp/build/reference/cetcompat?view=msvc-160) flag enabled.

I think almost all Windows 11 system DLLs have this flag enabled. This is the one I used for testing: https://msdl.microsoft.com/download/symbols/kernelbase.dll/8D5BD3DA379000/kernelbase.dll

References: 
https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#debug-type
https://github.com/dotnet/runtime/issues/51839