### PR TITLE
Correct PE rich header write method

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/RichHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/RichHeader.java
@@ -111,7 +111,7 @@ public class RichHeader implements StructConverter, Writeable {
 	public void write(RandomAccessFile raf, DataConverter dc) throws IOException {
 
 		if (table != null) {
-			raf.write(dc.getBytes(IMAGE_DANS_SIGNATURE));
+			raf.write(dc.getBytes(IMAGE_DANS_SIGNATURE ^ table.getMask()));
 
 			raf.write(dc.getBytes(table.getMask())); // 0 ^ mask
 			raf.write(dc.getBytes(table.getMask())); // 0 ^ mask


### PR DESCRIPTION
IMAGE_DANS_SIGNATURE should be XOR'ed with the mask.