### PR TITLE
Correct wrong GCC/VS compiler detection

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
@@ -1170,14 +1170,7 @@ public class PeLoader extends AbstractPeDebugLoader {
 //					return compilerType;
 //				}
 
-				// Now look for offset to code (0x1000 for gcc) and PointerToSymbols
-				// (0 for VS, non-zero for gcc)
-				int addrCode = br.readInt(dh.e_lfanew() + 40);
-				if (addrCode != 0x1000) {
-					compilerType = CompilerEnum.VisualStudio;
-					return compilerType;
-				}
-
+				// Now look for PointerToSymbols (0 for VS, non-zero for gcc)
 				int ptrSymTable = br.readInt(dh.e_lfanew() + 12);
 				if (ptrSymTable != 0) {
 					compilerType = CompilerEnum.GCC;


### PR DESCRIPTION
The GCC's offset to code may not necessarily be 0x1000. This bug causes some GCC compiled binaries mistakenly identified as visual studio binaries.

For example, this hello world exe ([helloworld.zip](https://github.com/NationalSecurityAgency/ghidra/files/9276100/helloworld.zip)) is compiled by gcc 12.1.0

```
C:\Windows\System32>gcc.exe --version
gcc.exe (Rev3, Built by MSYS2 project) 12.1.0
```
Its entry code is at 0x14d0:
![address](https://user-images.githubusercontent.com/16713498/183273568-1d1b09c7-92f2-4345-aa6b-b9576b7dfdb0.png)

Before:
<img alt="before" src="https://user-images.githubusercontent.com/16713498/183273932-a3ed0a9b-3ba7-4eb9-ab29-fb30665a9840.png">


After:
<img alt="after" src="https://user-images.githubusercontent.com/16713498/183273891-2b71da9c-d05c-4138-a75f-712b7b9a76f9.png">
