### PR TITLE
Demangle all gcc compiled files including PE files

### DIFF
--- a/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemangler.java
+++ b/Ghidra/Features/GnuDemangler/src/main/java/ghidra/app/util/demangler/gnu/GnuDemangler.java
@@ -56,6 +56,11 @@ public class GnuDemangler implements Demangler {
 		if (!specId.toLowerCase().contains("windows")) {
 			return true;
 		}
+
+		String compiler = program.getCompiler();
+		if (compiler.startsWith("gcc:")) {
+			return true;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Currently gcc compiled Windows PE files are not demangled by the GNU demangler. This issue will be fixed after both #4514 and this PR are merged.

Before:
![before gnu demangler](https://user-images.githubusercontent.com/16713498/183768593-7a9b61ab-df92-4208-bbf1-d455567e2bbf.png)

After:
![after gnu](https://user-images.githubusercontent.com/16713498/183768618-4f40b086-bc9a-4685-9f63-64277261c00b.png)
