### PR TITLE
Skip IntelliJ files when creating extension dists.

### DIFF
--- a/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
+++ b/Ghidra/RuntimeScripts/Common/support/buildExtension.gradle
@@ -137,6 +137,8 @@ task buildExtension (type: Zip) {
 		exclude '.classpath'
 		exclude '.project'
 		exclude '.settings/**'
+		exclude '.idea/**'
+		exclude '*.iml'
 		exclude 'developer_scripts'
 		exclude '.antProperties.xml'
 		exclude 'gradlew'


### PR DESCRIPTION
The `buildExtension` grade task right now is meant to skip Eclipse project files.  Since [IntelliJ-Ghidra](https://github.com/garyttierney/intellij-ghidra) has existed for quite some time, extensions developed from IntelliJ have their project files included in the dist package when built with `buildExtension`, something that is not desirable.

I am unaware of any NetBeans plugin for developing Ghidra extensions, so I only added IntelliJ project files to the exclusion list.