### PR TITLE
No 10 hour builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 # Increase maximum Gradle heap size (default is 1G)
 org.gradle.jvmargs=-Xmx2G
+org.gradle.parallel=true


### PR DESCRIPTION
Now takes about 10 minutes.

According to the [gradle user guide](https://docs.gradle.org/current/userguide/gradle_daemon.html#:~:text=If%20the%20requested%20build%20environment%20does%20not%20specify%20a%20maximum,than%20enough%20for%20most%20builds.) 512 MB should be enough heap space for most builds. It may or may not be worth looking into whether or not 2GB is necessary.