### PR TITLE
Added Check Before Environment Variable Overwrite

### DIFF
--- a/Ghidra/RuntimeScripts/Linux/support/analyzeHeadless
+++ b/Ghidra/RuntimeScripts/Linux/support/analyzeHeadless
@@ -6,7 +6,9 @@
 
 # Maximum heap memory may be changed if default is inadequate. This will generally be up to 1/4 of 
 # the physical memory available to the OS. Uncomment MAXMEM setting if non-default value is needed.
-MAXMEM=2G
+if [ -z $MAXMEM ]; then
+  MAXMEM=2G
+fi
 
 # Launch mode can be changed to one of the following: fg, debug, debug-suspend
 LAUNCH_MODE=fg


### PR DESCRIPTION
Instead of always overwriting this env var, it could be checked for a value first, removing the need to always edit this file.
Just throwing it here to potentially solve a common annoyance.