### PR TITLE
Fix incorrect positioning of Function Call Graph when minimized

### DIFF
--- a/Ghidra/Features/GraphFunctionCalls/src/main/java/functioncalls/plugin/FcgProvider.java
+++ b/Ghidra/Features/GraphFunctionCalls/src/main/java/functioncalls/plugin/FcgProvider.java
@@ -172,6 +172,13 @@ public class FcgProvider
 		if (!graphData.hasResults()) {
 			return;
 		}
+		
+		// The graph component won't contain valid perspective information if it's not 'initialized'
+		// (i.e. rendered or displayed to the user). It may happen if the graph has been kept minimized 
+		// in the separate tab. Related method: `GraphComponent::viewerInitialized`
+		if (view.getGraphComponent().isUninitialized()) {
+			return;
+		}
 
 		GraphPerspectiveInfo<FcgVertex, FcgEdge> info = view.generateGraphPerspective();
 		graphData.setGraphPerspective(info);


### PR DESCRIPTION
Hello. I found a bug in the Function Call Graph plugin. It’s demonstrated in the gif below.

[ghidra_function_graph_bug.webm](https://user-images.githubusercontent.com/8329446/187489886-8b88ef59-226f-40a8-b7d7-b6acd38cf910.webm)

Basically, it goes like this. I open the graph view for my function in the separate tab and everything’s perfectly fine for a moment, then I return back to the decompiler and slowly jump back and forth couple of times, eventually I come back to see my beautiful graph again, but what I see is that the view somehow has been teleported away to the top left corner of the window. Needless to say, it is a bit annoying.
	
So, now why it happens (that’s probably unnecessary, but whatever).  The positioning and zooming information is stored and preserved between function transitions in the GraphPerspectiveInfo class. Every time the user jumps to a function and opens its graph the positioning information is loaded from the cache (or initialized anew if there is no cached data yet). This info tells the graph view how to draw it. When the user jumps from that function, the perspective information from the view is updated and cached back in the GraphPerspectiveInfo object for later use.

Now, here comes one problem. What if the user will open a function without viewing its graph? (by keeping it minimized in the separate tab, for example) In that case the loading step will be skipped and the perspective info won’t be loaded into the view. But, nonetheless, when the user will try to jump to some function next time, the information of the last perspective will be as usual “saved” into the GraphPerspectiveInfo. That will effectively overwrite correct information that could be there and reset graph's position and zoom parameters to default ones (as can bee seen in the video).

Anyways. I believe I have solved the problem. Now, if the graph is marked as “uninitialized” (i.e. it hasn’t been shown to the user), the perspective info in the cache won’t be updated with that false data.