### PR TITLE
Escape html angle brackets in description for "Enter accepts comment" option in settings

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/comments/CommentsPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/comments/CommentsPlugin.java
@@ -86,7 +86,7 @@ public class CommentsPlugin extends Plugin implements OptionsChangeListener {
 		HelpLocation helpLocation = new HelpLocation(getName(), "Comments_Option");
 		options.setOptionsHelpLocation(helpLocation);
 		options.registerOption(OPTION_NAME, dialog.getEnterMode(), helpLocation,
-			"Toggle for whether pressing the <Enter> key causes the comment to be entered," +
+			"Toggle for whether pressing the &lt;Enter&gt; key causes the comment to be entered," +
 				" versus adding a new line character in the comment.");
 
 		setOptions(options);


### PR DESCRIPTION
If not for this suspiciously wide space character, I wouldn't even notice something's missing
Before: 
![image](https://user-images.githubusercontent.com/8329446/188099497-05f6af99-5d11-4675-943c-921fb1e85b27.png)
After:
![image](https://user-images.githubusercontent.com/8329446/188099530-e710d0af-842c-4c88-ad9f-21944acff74b.png)
