### PR TITLE
Fix the layout of DialogComponentProvider

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/DialogComponentProvider.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/DialogComponentProvider.java
@@ -144,7 +144,7 @@ public class DialogComponentProvider
 		};
 		mainPanel = new JPanel(new BorderLayout());
 		mainPanel.setBorder(BorderFactory.createEtchedBorder());
-		rootPanel.add(mainPanel, BorderLayout.CENTER);
+		rootPanel.add(mainPanel, BorderLayout.NORTH);
 
 		taskScheduler = new TaskScheduler(this);
 


### PR DESCRIPTION
The current implementation positions the main panel in the `CENTER` of a `BorderLayout`, which does not respect the preferred size of the contents. This commit moves the main panel to the `NORTH` area.

Data Type Chooser Dialog before the fix:

![image](https://user-images.githubusercontent.com/1223476/188339700-6bc5de6c-debb-4b80-81e3-7bde1455f89d.png)

After the fix:

![image](https://user-images.githubusercontent.com/1223476/188339665-684ad356-f5a2-45c4-974e-3fa14712762e.png)
