### PR TITLE
Enable One Shot analyzers when Listing not focused

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisPlugin.java
@@ -337,25 +337,26 @@ public class AutoAnalysisPlugin extends Plugin implements AutoAnalysisManagerLis
 
 		@Override
 		public void actionPerformed(ActionContext context) {
-			if (!(context instanceof ListingActionContext)) {
+			if (!(context instanceof ProgramActionContext)) {
 				return;
 			}
-			ListingActionContext programContext = (ListingActionContext) context;
+			ProgramActionContext programContext = (ProgramActionContext) context;
+			Program program = programContext.getProgram();
+
 			AddressSetView set;
-			if (programContext.hasSelection()) {
-				set = programContext.getSelection();
+			if (context instanceof ListingActionContext &&
+				((ListingActionContext)context).hasSelection()) {
+					set = ((ListingActionContext)context).getSelection();
 			}
 			else {
-				Memory memory = programContext.getProgram().getMemory();
+				Memory memory = program.getMemory();
 				AddressSet external = new AddressSet(AddressSpace.EXTERNAL_SPACE.getMinAddress(),
 					AddressSpace.EXTERNAL_SPACE.getMaxAddress());
 				set = memory.union(external);
 			}
 
-			AutoAnalysisManager analysisMgr =
-				AutoAnalysisManager.getAnalysisManager(programContext.getProgram());
+			AutoAnalysisManager analysisMgr = AutoAnalysisManager.getAnalysisManager(program);
 
-			Program program = programContext.getProgram();
 			Options options = program.getOptions(Program.ANALYSIS_PROPERTIES);
 			options = options.getOptions(analyzer.getName());
 			analyzer.optionsChanged(options, program);
@@ -369,10 +370,10 @@ public class AutoAnalysisPlugin extends Plugin implements AutoAnalysisManagerLis
 
 		@Override
 		public boolean isEnabledForContext(ActionContext context) {
-			if (!(context instanceof ListingActionContext)) {
+			if (!(context instanceof ProgramActionContext)) {
 				return false;
 			}
-			ListingActionContext programContext = (ListingActionContext) context;
+			ProgramActionContext programContext = (ProgramActionContext) context;
 			Program p = programContext.getProgram();
 			if (p != canAnalyzeProgram) {
 				canAnalyzeProgram = p;


### PR DESCRIPTION
Currently if the Listing panel is not focused, One Shot analyzers are disabled. I wonder if this restriction is necessary.

This part is one place that relies on Listing context, which checks if there's selection in Listing:
https://github.com/NationalSecurityAgency/ghidra/blob/6a2cd8055086905c76bf4ac3fe0700d2db28652f/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisPlugin.java#L339-L347

This PR relaxes this restriction. There's one drawback: if another panel is focused, it's treated as if there's no selection in Listing, even if there is. Users may mistakenly believe only the selected addresses in Listing are analyzed. Is there a way to get selection in Listing even if the context is different?