### PR TITLE
Improve sleigh error reporting

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/address.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/address.hh
@@ -479,7 +479,7 @@ inline bool Range::contains(const Address &addr) const {
 
 /// \param size is the desired size in bytes
 /// \return a value appropriate for masking off the first \e size bytes
-inline uintb calc_mask(int4 size) { return uintbmasks[(size<8)? size : 8]; }
+inline uintb calc_mask(uint4 size) { return uintbmasks[(size<8)? size : 8]; }
 
 /// Perform a CPUI_INT_RIGHT on the given val
 /// \param val is the value to shift
@@ -518,7 +518,7 @@ inline uintb minimalmask(uintb val)
 }
 
 extern bool signbit_negative(uintb val,int4 size);	///< Return true if the sign-bit is set
-extern uintb calc_mask(int4 size);			///< Calculate a mask for a given byte size
+extern uintb calc_mask(uint4 size);			///< Calculate a mask for a given byte size
 extern uintb uintb_negate(uintb in,int4 size);		///< Negate the \e sized value
 extern uintb sign_extend(uintb in,int4 sizein,int4 sizeout);	///< Sign-extend a value between two byte sizes
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
@@ -1945,8 +1945,10 @@ void SleighCompile::buildPatterns(void)
     errors += 1;
   }
   for(int4 i=0;i<tables.size();++i) {
-    if (tables[i]->isError())
+    if (tables[i]->isError()) {
+      reportError(getLocation(tables[i]), "Problem in table '"+tables[i]->getName() + "':" + msg.str());
       errors += 1;
+    }
     if (tables[i]->getPattern() == (TokenPattern *)0) {
       reportWarning(getLocation(tables[i]), "Unreferenced table '"+tables[i]->getName() + "'");
     }
@@ -2192,7 +2194,11 @@ const Location *SleighCompile::getLocation(Constructor *ctor) const
 const Location *SleighCompile::getLocation(SleighSymbol *sym) const
 
 {
-  return &symbolLocationMap.at(sym);
+  try {
+    return &symbolLocationMap.at(sym);
+  } catch (const std::exception &e) {
+    return NULL;
+  }
 }
 
 /// The current filename and line number are placed into a Location object
@@ -2241,7 +2247,7 @@ void SleighCompile::reportError(const Location* loc, const string &msg)
 void SleighCompile::reportError(const string &msg)
 
 {
-  cerr << "ERROR   " << msg << endl;
+  cerr << filename.back() << ":" << lineno.back() << " - ERROR " << msg << endl;
   errors += 1;
   if (errors > 1000000) {
     cerr << "Too many errors: Aborting" << endl;
@@ -2670,7 +2676,10 @@ void SleighCompile::attachValues(vector<SleighSymbol *> *symlist,vector<intb> *n
     if (sym == (ValueSymbol *)0) continue;
     PatternValue *patval = sym->getPatternValue();
     if (patval->maxValue() + 1 != numlist->size()) {
-      reportError(getCurrentLocation(), "Attach value '" + sym->getName() + "' is wrong size for list");
+      ostringstream msg;
+      msg << "Attach value '" + sym->getName();
+      msg << "' (range 0.." << patval->maxValue() << ") is wrong size for list (of " << numlist->size() << " entries";
+      reportError(getCurrentLocation(), msg.str());
     }
     symtab.replaceSymbol(sym, new ValueMapSymbol(sym->getName(),patval,*numlist));
   }
@@ -2695,7 +2704,10 @@ void SleighCompile::attachNames(vector<SleighSymbol *> *symlist,vector<string> *
     if (sym == (ValueSymbol *)0) continue;
     PatternValue *patval = sym->getPatternValue();
     if (patval->maxValue() + 1 != names->size()) {
-      reportError(getCurrentLocation(), "Attach name '" + sym->getName() + "' is wrong size for list");
+      ostringstream msg;
+      msg << "Attach name '" + sym->getName();
+      msg << "' (range 0.." << patval->maxValue() << ") is wrong size for list (of " << names->size() << " entries)";
+      reportError(getCurrentLocation(), msg.str());
     }
     symtab.replaceSymbol(sym,new NameSymbol(sym->getName(),patval,*names));
   }
@@ -2720,7 +2732,10 @@ void SleighCompile::attachVarnodes(vector<SleighSymbol *> *symlist,vector<Sleigh
     if (sym == (ValueSymbol *)0) continue;
     PatternValue *patval = sym->getPatternValue();
     if (patval->maxValue() + 1 != varlist->size()) {
-      reportError(getCurrentLocation(), "Attach varnode '" + sym->getName() + "' is wrong size for list");
+      ostringstream msg;
+      msg << "Attach varnode '" + sym->getName();
+      msg << "' (range 0.." << patval->maxValue() << ") is wrong size for list (of " << varlist->size() << " entries)";
+      reportError(getCurrentLocation(), msg.str());
     }
     int4 sz = 0;      
     for(int4 j=0;j<varlist->size();++j) {


### PR DESCRIPTION
This improves error reporting from the `sleigh` language parser.

- making the `calc_mask()` `size` parameter unsigned prevents sleigh from just crashing with
```
terminate called after throwing an instance of 'std::out_of_range'
  what():  map::at
Aborted (core dumped)
```

- the other commit adds location information to sleigh error messages, improving the above error to
```
vax.slaspec:379 - ERROR Error: Pattern size cannot vary (missing '...'?): for table "instruction" constructor starting at line 373

No output produced
```
