### PR TITLE
Decompiler docs: Specify DocBook XSL Stylesheets V1.79.1 instead of "current"

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/doc/commonprofile.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/commonprofile.xsl
@@ -2,5 +2,5 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/profiling/profile.xsl"/>
+  <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/profiling/profile.xsl"/>
 </xsl:stylesheet>

--- a/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/html/chunk.xsl"/>
 
 <xsl:param name="generate.toc">
   article/appendix  nop

--- a/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/html/chunk.xsl"/>
 
 <xsl:include href="decompileplugin_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_pdf.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_pdf.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/fo/docbook.xsl"/>
 
 <xsl:include href="decompileplugin_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/main_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/main_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/html/docbook.xsl"/>
 
 <xsl:param name="generate.toc">
   article/appendix  nop

--- a/Ghidra/Features/Decompiler/src/main/doc/pcoderef_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/pcoderef_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/html/chunk.xsl"/>
 
 <xsl:include href="pcoderef_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/pcoderef_pdf.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/pcoderef_pdf.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/fo/docbook.xsl"/>
 
 <xsl:template match="table" mode="label.markup"/>
 

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh_html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/html/chunk.xsl"/>
 
 <xsl:include href="sleigh_common.xsl" />
 

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh_pdf.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh_pdf.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/fo/docbook.xsl"/>
 
 <xsl:include href="sleigh_common.xsl" />
 


### PR DESCRIPTION
Replaces #4436. d33cd8a92e069ece58d356cc53c472912691e8e9 already regenerated the docs, so there is a lot less noise from this change, fortunately (but "current" will produce noise again later on should a new version of DocBook XSL Stylesheets be released).