### PR TITLE
Assume developmentMode if -DbinaryPath is present

### DIFF
--- a/Ghidra/Framework/Utility/src/main/java/ghidra/util/SystemUtilities.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/util/SystemUtilities.java
@@ -82,6 +82,11 @@ public class SystemUtilities {
 	private static boolean checkForDevelopmentMode() {
 		Class<?> myClass = SystemUtilities.class;
 		ClassLoader loader = myClass.getClassLoader();
+		if (System.getProperty("binaryPath") != null) {
+			// Someone went out of their way to specify this argument, so they probably intend to run in developmentMode
+			// because this property will only be used in developmentMode
+			return true;
+		}
 		if (loader == null) {
 			// Can happen when called from the Eclipse GhidraDev plugin 
 			return false;


### PR DESCRIPTION
`-DbinaryPath=...` controls the `utility.module.ModuleUtilities#BINARY_PATH` variable which is only used in
`utility.module.ModuleUtilities#getModuleBinDirectories`, which is only called as part of `ghidra.GhidraLauncher#addModuleBinPaths`, which is only called if `SystemUtilities.checkForDevelopmentMode()` returns true.

This is a fairly obscure property/command line argument that isn't documented and only useful for specifying different paths for module class files when running a dev setup with no IDE or an IDE other than Eclipse.
Thus it can IMO be safely assumed that if it is present then the user really wants to run under developmentMode, and doesn't want to rely  on other checks for this to work.

Before commit a503ded1 by @ryanmkurtz `SystemUtilities.checkForDevelopmentMode()` returned true if the ClassLoader of the SystemUtilities class was null, but this changed for reasons that I don't know because I am not familiar with the internal design of the Eclipse Plugin.

The goal of all this is make it possible to:
1. setup a dev environment according to the official instructions (but without opening eclipse),
2. Run  `gradle classes` to build the classes
3. Run a bare invocation of `java -Djava.system.class.loader=ghidra.GhidraClassLoader -Xshare:off -DbinaryPath=build/classes/java/main:build/resources/main/:bin/default/:src/main/resources/ -Xbootclasspath/a:./Ghidra/Framework/Utility
/build/classes/java/main/ -cp ./Ghidra/Framework/Utility/ ghidra.Ghidra ghidra.GhidraRun`

Which then starts a Ghidra development setup, without having to rely on more than gradle, which  makes developing Ghidra possible without Eclipse. This of course has other limitations, and often requires more tinkering with other IDEs so I in no way expect this to be _officially_ supported, but I think the proposed change is minimal and should never interfere with the official setup, as far as I know.

