### PR TITLE
Search Memory window: Allow pasting prefixed hex numbers in the forms 0xABC and ABCh

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchDialog.java
@@ -710,6 +710,9 @@ class MemSearchDialog extends DialogComponentProvider {
 		public void insertString(int offs, String str, AttributeSet a) throws BadLocationException {
 			clearStatusText();
 
+			// allow pasting numbers in the forms like 0xABC or ABCh 
+			str = removeNumberBasePrefixAndSuffix(str);
+			
 			String currentText = getText(0, getLength());
 			String beforeOffset = currentText.substring(0, offs);
 			String afterOffset = currentText.substring(offs, currentText.length());
@@ -787,6 +790,34 @@ class MemSearchDialog extends DialogComponentProvider {
 				}
 			}
 			return null;
+		}
+		
+		private String removeNumberBasePrefixAndSuffix(String str) {
+			if (!(currentFormat instanceof HexSearchFormat || currentFormat instanceof BinarySearchFormat)) {
+				return str;
+			}
+			
+			String numMaybe = str.strip();
+			String lowercase = numMaybe.toLowerCase();
+			if (currentFormat instanceof HexSearchFormat) {
+				if (lowercase.startsWith("0x")) {
+					numMaybe = numMaybe.substring(2);
+				} else if (lowercase.startsWith("$")) {
+					numMaybe = numMaybe.substring(1);
+				} else if (lowercase.endsWith("h")) {
+					numMaybe = numMaybe.substring(0, numMaybe.length() - 1);
+				}
+			} else {
+				if (lowercase.startsWith("0b")) {
+					numMaybe = numMaybe.substring(2);
+				}
+			}
+			
+			// check if the resultant number looks valid for insertion (i.e. not empty)
+			if (!numMaybe.isEmpty()) {
+				return numMaybe;
+			}
+			return str;
 		}
 	}
 

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MemSearchBinaryTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MemSearchBinaryTest.java
@@ -107,6 +107,17 @@ public class MemSearchBinaryTest extends AbstractMemSearchTest {
 		myTypeText("01110000 01110000");
 		assertEquals("01110000 01110000", valueField.getText());
 	}
+	
+	@Test
+	public void testBinaryPasteNumberWithPrefix() {
+		// paste a number with a binary prefix;
+		// the prefix should be removed before the insertion
+		setValueText("0b00101010");
+		assertEquals("00101010", valueField.getText());
+		
+		setValueText("0B1010 10");
+		assertEquals("1010 10", valueField.getText());
+	}
 
 	@Test
 	public void testBinarySearch() throws Exception {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MemSearchHexTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MemSearchHexTest.java
@@ -187,6 +187,27 @@ public class MemSearchHexTest extends AbstractMemSearchTest {
 
 		assertEquals("01 23 45 67 89", valueField.getText());
 	}
+	
+	@Test
+	public void testHexPasteNumberWithPrefixAndSuffix() {
+		// paste a number with a hex prefix;
+		// the prefix should be removed before the insertion
+		setValueText("0xabcdef");
+		assertEquals("abcdef", valueField.getText());
+		
+		setValueText("$68000"); 
+		assertEquals("68000", valueField.getText());
+		
+		// same for 'h' the suffix
+		setValueText("ABCDEFh");
+		assertEquals("ABCDEF", valueField.getText());
+		
+		// should also somehow work with leading and trailing white spaces
+		setValueText("  0X321  ");
+		assertEquals("321", valueField.getText().strip());
+		setValueText("  123H ");
+		assertEquals("123", valueField.getText().strip());
+	}
 
 	@Test
 	public void testHexSearch() throws Exception {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MnemonicSearchPluginTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MnemonicSearchPluginTest.java
@@ -109,8 +109,8 @@ public class MnemonicSearchPluginTest extends AbstractGhidraHeadedIntegrationTes
 		JTextField valueField = (JTextField) comboBox.getEditor().getEditorComponent();
 
 		assertEquals(
-			"01010101 10001011 11101100 10000001 11101100 ........ ........ ........ ........ ",
-			valueField.getText());
+			"01010101 10001011 11101100 10000001 11101100 ........ ........ ........ ........",
+			valueField.getText().strip());
 
 	}
 
@@ -131,8 +131,8 @@ public class MnemonicSearchPluginTest extends AbstractGhidraHeadedIntegrationTes
 		JTextField valueField = (JTextField) comboBox.getEditor().getEditorComponent();
 
 		assertEquals(
-			"01010... 10001011 11...... 10000001 11101... ........ ........ ........ ........ ",
-			valueField.getText());
+			"01010... 10001011 11...... 10000001 11101... ........ ........ ........ ........",
+			valueField.getText().strip());
 
 	}
 
@@ -153,8 +153,8 @@ public class MnemonicSearchPluginTest extends AbstractGhidraHeadedIntegrationTes
 		JTextField valueField = (JTextField) comboBox.getEditor().getEditorComponent();
 
 		assertEquals(
-			"01010101 10001011 11101100 10000001 11101100 00000100 00000001 00000000 00000000 ",
-			valueField.getText());
+			"01010101 10001011 11101100 10000001 11101100 00000100 00000001 00000000 00000000",
+			valueField.getText().strip());
 	}
 
 	/**


### PR DESCRIPTION
Sometimes, for example, I want to copy a number from the Ghidra Listing View and paste it into the Search Memory window to find similar values, but usually I can't do it right away. I need to either recopy it properly without the hex prefix or postfix or edit it in the closest text editor. Only then I will be able to paste it successfully. This process may be quite frustrating, especially when Ghidra silently eats pasted values without showing any error message, so that I don't know whether the number is really bad or my clipboard is just empty for some reason.

Maybe it would be even better to accept any string and then simply filter out invalid characters.

Before: 
![before](https://user-images.githubusercontent.com/8329446/192736507-78df0e20-8264-4123-ab89-b23fd3568a06.gif)
After:
![after](https://user-images.githubusercontent.com/8329446/192736543-476ebc23-7e9c-438c-90cd-9cd621891def.gif)

