### PR TITLE
Fix issue with vcvt being identified as cdp in thumb mode

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -1505,7 +1505,8 @@ define pcodeop VectorFloatSingleToDouble;
 # VCVT (between double-precision and single-precision)
 #
 
-:vcvt^COND^".f32.f64" Sd,Dm		is $(AMODE) & COND & ARMcond=1 & c2327=0x1d & c1621=0x37 & Sd & c0911=5 & c0808=1 & c0607=3 & c0404=0 & Dm
+:vcvt^COND^".f32.f64" Sd,Dm		is COND & (($(AMODE) & ARMcond=1 & c2327=0x1d & c1621=0x37 & c0911=5 & c0808=1 & c0607=3 & c0404=0) |
+                                        ($(TMODE_E) & thv_c2327=0x1d & thv_c1621=0x37 & thv_c0911=5 & thv_c0808=1 & thv_c0607=3 &thv_c0404=0)) & Sd & Dm
 {
 	build COND;
 	build Sd;
@@ -1513,7 +1514,8 @@ define pcodeop VectorFloatSingleToDouble;
 	Sd = float2float(Dm);
 }
 
-:vcvt^COND^".f64.f32" Dd,Sm		is $(AMODE) & COND & ARMcond=1 & c2327=0x1d & c1621=0x37 & Dd & c0911=5 & c0808=0 & c0607=3 & c0404=0 & Sm
+:vcvt^COND^".f64.f32" Dd,Sm		is COND & (($(AMODE) & ARMcond=1 & c2327=0x1d & c1621=0x37 & c0911=5 & c0808=0 & c0607=3 & c0404=0) |
+                                        ($(TMODE_E) & thv_c2327=0x1d & thv_c1621=0x37 & thv_c0911=5 & thv_c0808=0 & thv_c0607=3 &thv_c0404=0)) & Dd & Sm
 {
 	build COND;
 	build Dd;


### PR DESCRIPTION
When running analysis of an ARMv7 binary the `float2float` instruction `vcvt.f64.f32` was being identified as `cdp`.

This PR fixes the detection of these two instructions. This is my first time using Ghidra so I think I've stuck to how other identifications are handled.

The sample file I was disassembling is [here](https://github.com/YuzhongHuangCS/GPSParser/blob/main/app/src/main/jniLibs/armeabi-v7a/libsungps.so) and the incorrect disassembly can be seen at address `0x00012926`

![Screenshot-20221001205718-432x91](https://user-images.githubusercontent.com/4218833/193426396-b53af098-193b-4fe3-a852-42dbc8e8ce24.png)

Thanks