### PR TITLE
fix building with clang15

### DIFF
--- a/GPL/DemanglerGnu/src/demangler_gnu_v2_33_1/c/missing.c
+++ b/GPL/DemanglerGnu/src/demangler_gnu_v2_33_1/c/missing.c
@@ -65,7 +65,7 @@ xmalloc (size)
 
 void *
 xrealloc (ptr, size)
-  
+  void* ptr;
   size_t size;
 {
   register void * value = realloc (ptr, size);


### PR DESCRIPTION
on clang 14 `-Wint-conversion` parameter emits warning

starting from clang 15 - same parameter throws an error

UPD:
Proof - https://godbolt.org/z/j7K9xoxab