### PR TITLE
Fix interrupt vectors on ARM Cortex

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMCortex.pspec
+++ b/Ghidra/Processors/ARM/data/languages/ARMCortex.pspec
@@ -31,10 +31,8 @@
     <symbol name="Reserved3" address="ram:0x24" entry="true" type="code_ptr"/>
     <symbol name="Reserved4" address="ram:0x28" entry="true" type="code_ptr"/>
     <symbol name="SVCall" address="ram:0x2c" entry="true" type="code_ptr"/>
-    
-    <symbol name="Reserved5" address="ram:0x28" entry="true" type="code_ptr"/>
-    <symbol name="Reserved6" address="ram:0x28" entry="true" type="code_ptr"/>
-    
+    <symbol name="Reserved5" address="ram:0x30" entry="true" type="code_ptr"/>
+    <symbol name="Reserved6" address="ram:0x34" entry="true" type="code_ptr"/>
     <symbol name="PendSV" address="ram:0x38" entry="true" type="code_ptr"/>
     <symbol name="SysTick" address="ram:0x3C" entry="true" type="code_ptr"/>
     <symbol name="IRQ" address="ram:0x40" entry="true" type="code_ptr"/>


### PR DESCRIPTION
Trivial patch to fix the interrupt vectors on ARM Cortex.

The offset of some interrupt vectors were not modified after a copy/paste, resulting in identical offsets.