### PR TITLE
Allow Gradle to use VS Build Tools to build C++

### DIFF
--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -52,6 +52,13 @@ model {
 				}
 			}
 		}
+		if (isCurrentWindows()) {
+			// specify installDir because Gradle doesn't find VS Build Tools.
+			// See https://github.com/gradle/gradle-native/issues/617#issuecomment-575735288
+			visualCpp(VisualCpp) {
+				installDir VISUAL_STUDIO_INSTALL_DIR
+			}
+		}
 	}
 }
 

--- a/GPL/vsconfig.gradle
+++ b/GPL/vsconfig.gradle
@@ -32,7 +32,7 @@ def configureVisualStudio() {
 			println "Visual Studio not found!"
 			return
 		}
-		def vswhereOutput = "${vswherePath} -latest -format json".execute().text.trim()
+		def vswhereOutput = "${vswherePath} -products * -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format json".execute().text.trim()
 		def vswhereJson = new groovy.json.JsonSlurper().parseText(vswhereOutput);
 		if (vswhereJson.isEmpty()) {
 			println "Visual Studio not found!"

--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -326,7 +326,8 @@ system:</p>
   <li>make, gcc, and g++ (Linux/macOS-only)</li>
   <li>
     <a href="https://visualstudio.microsoft.com/vs/community/">Microsoft Visual Studio</a>
-    2017 or later (Windows-only)
+    2017 or later, or <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">
+    Microsoft C++ Build Tools</a> (Windows-only)
   </li>
 </ul>
 <p>To build the native binaries for your current platform, execute the following script:</p>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To create the latest development build for your platform from this source reposi
 * [JDK 17 64-bit][jdk17]
 * [Gradle 7.3+][gradle]
 * make, gcc, and g++ (Linux/macOS-only)
-* [Microsoft Visual Studio][vs] (Windows-only)
+* [Microsoft Visual Studio][vs] or [Microsoft C++ Build Tools][vcbuildtools] (Windows-only)
 
 ##### Download and extract the source:
 [Download from GitHub][master]
@@ -116,6 +116,7 @@ source project.
 [jdk17]: https://adoptium.net/temurin/releases
 [gradle]: https://gradle.org/releases/
 [vs]: https://visualstudio.microsoft.com/vs/community/
+[vcbuildtools]: https://visualstudio.microsoft.com/visual-cpp-build-tools/
 [eclipse]: https://www.eclipse.org/downloads/packages/
 [master]: https://github.com/NationalSecurityAgency/ghidra/archive/refs/heads/master.zip
 [security]: https://github.com/NationalSecurityAgency/ghidra/security/advisories


### PR DESCRIPTION
vswhere can find Visual Studio Build Tools if "-products *" is specified. Gradle doesn't use Build Tools unless we set "installDir" to the Build Tools' install directory.

Related links
* #2942
* #3045
* https://github.com/microsoft/vswhere/wiki/Find-VC
* https://github.com/microsoft/vswhere/issues/235
* https://github.com/gradle/gradle-native/issues/617
* https://docs.gradle.org/current/userguide/native_software.html#example_defining_tool_chains