### PR TITLE
Stub Cell-specific altivec instructions

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/altivec.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/altivec.sinc
@@ -12,6 +12,8 @@ define pcodeop loadVectorForShiftLeft;
 define pcodeop loadVectorForShiftRight;
 define pcodeop loadVectorIndexed;
 define pcodeop loadVectorIndexedLRU;
+define pcodeop loadVectorLeftIndexed;
+define pcodeop loadVectorRightIndexed;
 define pcodeop moveFromVectorStatusAndControlRegister;
 define pcodeop moveToVectorStatusAndControlRegister;
 define pcodeop storeVectorElementByteIndexed;
@@ -244,6 +246,16 @@ define pcodeop vectorUnpackLowSignedHalfWord;
 :lvxl vrD,A,B		is OP=31 & vrD & A & B & XOP_1_10=359 & Rc=0
 {   # TODO definition
 	vrD = loadVectorIndexedLRU(A,B);
+}
+
+:lvlx vrD,RA_OR_ZERO,B      is OP=31 & vrD & RA_OR_ZERO & B & XOP_1_10=519 & Rc=0
+{
+    vrD = loadVectorLeftIndexed(RA_OR_ZERO,B);
+}
+
+:lvrx vrD,RA_OR_ZERO,B      is OP=31 & vrD & RA_OR_ZERO & B & XOP_1_10=551 & Rc=0
+{
+    vrD = loadVectorRightIndexed(RA_OR_ZERO,B);
 }
 
 :mfvscr vrD			is OP=4 & vrD & vrAR=0 & vrBR=0 & XOP_1_10=770 & Rc=0


### PR DESCRIPTION
Had these changes locally for a long time, time to upstream.
These instructions tend to break disassembly and decompilation of many PS3 executables without this change.
I've never seen the store variants or the last variants used in any ps3 executable so I've left those out.
Not sure if I can show them being used since I only have examples from my dumped commercial games but here's some documentation from ibm where you can read about them on page 102 and 104 (122 and 124 in pdf) http://ilab.usc.edu/packages/cell-processor/docs/Language_Extensions_for_CBEA_2.4.pdf