### PR TITLE
Fix build error.

### DIFF
--- a/Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c
@@ -21,14 +21,14 @@ pthread_t thread;
 void* work(void* param) {
     printf("I'm %d, PID: %d\n", (int)param, getpid());
     if (param == NULL) {
-        return 1;
+        return (void*)1;
     } else {
         //sleep(10);
-        return 2;
+        return (void*)2;
     }
 }
 
 int main() {
     pthread_create(&thread, NULL, work, (void*)1);
-    return work(NULL);
+    return (int)work(NULL);
 }


### PR DESCRIPTION
```
  Task :Framework-Debugging:compileExpCloneExitExecutableExpCloneExitC FAILED
Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c:22:33: warning: cast to smaller integer type 'int' from 'void *' [-Wvoid-pointer-to-int-cast]
    printf("I'm %d, PID: %d\n", (int)param, getpid());
                                ^~~~~~~~~~
Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c:22:45: warning: call to undeclared function 'getpid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    printf("I'm %d, PID: %d\n", (int)param, getpid());
                                            ^
Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c:24:16: error: incompatible integer to pointer conversion returning 'int' from a function with result type 'void *' [-Wint-conversion]
        return 1;
               ^
Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c:27:16: error: incompatible integer to pointer conversion returning 'int' from a function with result type 'void *' [-Wint-conversion]
        return 2;
               ^
Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c:33:12: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'int' [-Wint-conversion]
    return work(NULL);
           ^~~~~~~~~~
2 warnings and 3 errors generated.
```