### PR TITLE
PowerPC: Fix implementation of fsel[.] instruction

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
@@ -1918,7 +1918,7 @@
 	local tmpfB = fB;
 	zero:4=0;
 	fD=fC;
-	if (tmpfA f> int2float(zero)) goto inst_next;
+	if (tmpfA f>= int2float(zero)) goto inst_next;
 	fD=tmpfB;
 }
 
@@ -1929,9 +1929,10 @@
 	local tmpfB = fB;
 	zero:4=0;
 	fD=fC;
-	cr1flags();
-	if (tmpfA f> int2float(zero)) goto inst_next;
+	if (tmpfA f>= int2float(zero)) goto <end>;
 	fD=tmpfB;
+<end>
+	cr1flags();
 }
 
 #fsqrt f0r,fr0	0xfc 00 00 2c


### PR DESCRIPTION
According to page 121 in [the PowerPC instruction set manual](https://math-atlas.sourceforge.net/devel/assembly/ppc_isa.pdf), the `fsel` instruction should set `fD` to `fC` if `fA >= 0` and to `fB` else, whereas the current implementation instead sets `fD` to `fC` if `fA > 0`.

Note that `fD` should also be set to `fB` if `fA == NaN`. This is still correct as `(NaN >= 0) == false`.

Additionally, for the `fsel.` instruction, the CR1 registers are currently only being correctly set if `fD` gets set to `fC`, this has also been fixed.