### PR TITLE
Python Interpreter: Fix a bug in the code completion functionality

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/console/CodeCompletion.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/console/CodeCompletion.java
@@ -24,17 +24,28 @@ import javax.swing.JComponent;
  * 
  * It is intended to be used by the code completion process, especially the
  * CodeCompletionWindow.  It encapsulates:
- * - a description of the completion (what are you completing?)
- * - the actual String that will be inserted
- * - an optional Component that will be in the completion List
- * 
- * 
- *
+ * <ul>
+ * <li> a description of the completion (what are you completing?)
+ * <li> the actual String that will be inserted
+ * <li> an optional Component that will be in the completion List
+ * <li> the number of characters to remove before the insertion of the completion
+ * </ul>
+ * <p>
+ * For example, if one wants to autocomplete a string "Runscr" into "runScript", 
+ * the fields may look as follows:
+ * <ul>
+ * <li> description: "runScript (Method)"
+ * <li> insertion: "runScript"
+ * <li> component: null or JLabel("runScript (Method)")
+ * <li> charsToRemove: 6 (i.e. the length of "Runscr", 
+ *      as it may be required later to correctly replace the string)
+ * </ul>
  */
 public class CodeCompletion implements Comparable<CodeCompletion> {
 	private String description;
 	private String insertion;
 	private JComponent component;
+	private int charsToRemove;
 
 	
 	/**
@@ -60,6 +71,24 @@ public class CodeCompletion implements Comparable<CodeCompletion> {
 		this.description = description;
 		this.insertion = insertion;
 		this.component = comp;
+		this.charsToRemove = 0;
+	}
+
+
+	/**
+	 * Construct a new CodeCompletion.
+	 * 
+	 * @param description description of this completion
+	 * @param insertion what will be inserted (or null)
+	 * @param comp (optional) Component to appear in completion List (or null)
+	 * @param charsToRemove the number of characters that should be removed before the insertion
+	 */
+	public CodeCompletion(String description, String insertion,
+			JComponent comp, int charsToRemove) {
+		this.description = description;
+		this.insertion = insertion;
+		this.component = comp;
+		this.charsToRemove = charsToRemove;
 	}
 
 	
@@ -92,6 +121,16 @@ public class CodeCompletion implements Comparable<CodeCompletion> {
 	 */
 	public String getInsertion() {
 		return insertion;
+	}
+	
+	/**
+	 * Returns the number of characters to remove from the input before the insertion
+	 * of the code completion
+	 * 
+	 * @return the number of characters to remove
+	 */
+	public int getCharsToRemove() {
+		return charsToRemove;
 	}
 	
 	

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java
@@ -624,16 +624,21 @@ public class InterpreterPanel extends JPanel implements OptionsChangeListener {
 		String insertion = completion.getInsertion();
 
 		/* insert completion string */
-		setInputTextPaneText(text.substring(0, position) + insertion + text.substring(position));
+		int insertedTextStart = position - completion.getCharsToRemove();
+		int insertedTextEnd = insertedTextStart + insertion.length();
+		var inputText = text.substring(0, insertedTextStart) + insertion + text.substring(position);
+		setInputTextPaneText(inputText);
 
 		/* Select what we inserted so that the user can easily
 		 * get rid of what they did (in case of a mistake). */
 		if (highlightCompletion) {
-			inputTextPane.setSelectionStart(position);
+			inputTextPane.setSelectionStart(insertedTextStart);
+			inputTextPane.moveCaretPosition(insertedTextEnd);
+		} else {
+			/* Then put the caret right after what we inserted. */
+			inputTextPane.setCaretPosition(insertedTextEnd);
 		}
-
-		/* Then put the caret right after what we inserted. */
-		inputTextPane.moveCaretPosition(position + insertion.length());
+	
 		updateCompletionList();
 	}
 

--- a/Ghidra/Features/Python/python-src/introspect.py
+++ b/Ghidra/Features/Python/python-src/introspect.py
@@ -74,8 +74,9 @@ def getAutoCompleteList(command='', locals=None, includeMagic=1,
                     pyObj = locals[attribute]
                 completion_list.append(PythonCodeCompletionFactory.
                                        newCodeCompletion(attribute,
-                                                         attribute[len(filter):],
-                                                         pyObj))
+                                                         attribute, 
+                                                         pyObj,
+                                                         filter))
             except:
                 # hmm, problem evaluating?  Examples of this include
                 # inner classes, e.g. access$0, which aren't valid Python

--- a/Ghidra/Features/Python/src/main/java/ghidra/python/PythonCodeCompletionFactory.java
+++ b/Ghidra/Features/Python/src/main/java/ghidra/python/PythonCodeCompletionFactory.java
@@ -183,9 +183,28 @@ public class PythonCodeCompletionFactory {
 	 * @param insertion what will be inserted to make the code complete
 	 * @param pyObj a Python Object
 	 * @return A new CodeCompletion from the given Python objects.
+	 * @deprecated use {@link #newCodeCompletion(String, String, PyObject, String)} instead,
+	 *             it allows creation of substituting code completions
 	 */
+	@Deprecated
 	public static CodeCompletion newCodeCompletion(String description, String insertion,
 			PyObject pyObj) {
+		return newCodeCompletion(description, insertion, pyObj, "");
+	}
+	
+	/**
+	 * Creates a new CodeCompletion from the given Python objects.
+	 * 
+	 * @param description description of the new CodeCompletion
+	 * @param insertion what will be inserted to make the code complete
+	 * @param pyObj a Python Object
+	 * @param userInput a word we want to complete, can be an empty string.
+	 *        It's used to determine which part (if any) of the input should be 
+	 *        removed before the insertion of the completion
+	 * @return A new CodeCompletion from the given Python objects.
+	 */
+	public static CodeCompletion newCodeCompletion(String description, String insertion,
+			PyObject pyObj, String userInput) {
 		JComponent comp = null;
 
 		if (pyObj != null) {
@@ -213,7 +232,9 @@ public class PythonCodeCompletionFactory {
 				}
 			}
 		}
-		return new CodeCompletion(description, insertion, comp);
+		
+		int charsToRemove = userInput.length();
+		return new CodeCompletion(description, insertion, comp, charsToRemove);
 	}
 
 	/**

--- a/Ghidra/Features/Python/src/test.slow/java/ghidra/python/PythonCodeCompletionTest.java
+++ b/Ghidra/Features/Python/src/test.slow/java/ghidra/python/PythonCodeCompletionTest.java
@@ -1,0 +1,147 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.python;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+
+import generic.jar.ResourceFile;
+import ghidra.app.plugin.core.console.CodeCompletion;
+import ghidra.app.plugin.core.osgi.BundleHost;
+import ghidra.app.script.GhidraScriptUtil;
+import ghidra.test.AbstractGhidraHeadedIntegrationTest;
+
+/**
+ * Tests for the Ghidra Python Interpreter's code completion functionality.
+ */
+public class PythonCodeCompletionTest extends AbstractGhidraHeadedIntegrationTest {
+
+	private String simpleTestProgram = """
+			my_int = 32
+			my_bool = True
+			my_string = 'this is a string'
+			my_list = ["a", 2, 5.3, my_string]
+			my_tuple = (1, 2, 3)
+			my_dictionary = {"key1": "1", "key2": 2, "key3": my_list}
+			mY_None = None
+			i = 5
+
+			def factorial(n):
+			    return 1 if n == 0 else n * factorial(n-1)
+			def error_function():
+			    raise IOError("An IO error occurred!")
+
+			class Employee:
+			    def __init__(self, id, name):
+			        self.id = id
+			        self.name = name
+			    def getId(self):
+			        return self.id
+			    def getName(self):
+			        return self.name
+
+			employee = Employee(42, "Bob")
+				""".stripIndent();
+
+	@Rule
+	public TemporaryFolder tempScriptFolder = new TemporaryFolder();
+
+	private GhidraPythonInterpreter interpreter;
+
+	@Before
+	public void setUp() throws Exception {
+		GhidraScriptUtil.initialize(new BundleHost(), null);
+		interpreter = GhidraPythonInterpreter.get();
+		executePythonProgram(simpleTestProgram);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		interpreter.cleanup();
+		GhidraScriptUtil.dispose();
+	}
+
+	@Test
+	public void testBasicCodeCompletion() {
+		// test the "insertion" field
+		// it should be equal to the full name of a variable we want to complete
+
+		List<String> completions = List.of("my_bool", "my_dictionary", "my_int",
+				"my_list", "mY_None", "my_string", "my_tuple");
+		assertCompletionsInclude("My", completions);
+		assertCompletionsInclude("employee.Get", List.of("getId", "getName"));
+		assertCompletionsInclude("('noise', (1 + fact", List.of("factorial"));
+	}
+
+	@Test
+	public void testCharsToRemoveField() {
+		// 'charsToRemove' field should be equal to the length of
+		// a part of variable/function/method name we are trying to complete here.
+		// This allows us to correctly put a completion in cases when we really
+		// just want to replace a piece of text (i.e. "CURRENTAddress" => "currentAddress")
+		// rather than simply 'complete' it.
+
+		assertCharsToRemoveEqualsTo("my_int", "my_int".length());
+		assertCharsToRemoveEqualsTo("employee.get", "get".length());
+		assertCharsToRemoveEqualsTo("('noise', (1 + fact", "fact".length());
+
+		assertCharsToRemoveEqualsTo("employee.", 0);
+		assertCharsToRemoveEqualsTo("employee.getId(", 0);
+	}
+
+	private void assertCompletionsInclude(String command, 
+			Collection<String> expectedCompletions) {
+		Set<String> completions = interpreter.getCommandCompletions(command, false)
+				.stream()
+				.map(c -> c.getInsertion())
+				.collect(Collectors.toSet());
+
+		var missing = new HashSet<String>(expectedCompletions);
+		missing.removeAll(completions);
+		if (!missing.isEmpty()) {
+			Assert.fail("Could't find these completions: " + missing);
+		}
+	}
+
+	private void assertCharsToRemoveEqualsTo(String command, int expectedCharsToRemove) {
+		for (CodeCompletion comp : interpreter.getCommandCompletions(command, false)) {
+			assertEquals(String.format("%s; field 'charsToRemove' ", comp),
+					expectedCharsToRemove, comp.getCharsToRemove());
+		}
+	}
+
+	private void executePythonProgram(String code) {
+		try {
+			File tempFile = tempScriptFolder.newFile();
+			FileUtils.writeStringToFile(tempFile, code, Charset.defaultCharset());
+			interpreter.execFile(new ResourceFile(tempFile), null);
+		} catch (IOException e) {
+			fail("couldn't create a test script: " + e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
There is a bug, sort of. The code completion in the Python Interpreter Window incorrectly inserts completions, or rather "incorrectly" by the standards of modern IDEs. Nowadays, a completion usually represents a general substitution of one piece of text with another, like "addr" => "currentAddress". But here it's done differently, a string is completed literally, without taking into account the case of its previous letters. 

![completion_insertion2](https://user-images.githubusercontent.com/8329446/196642349-8e25cf2b-4669-418a-8d51-7674b3d20ba5.gif)

So, to make this work, I introduced an optional field "charsToRemove" to the code completion class for storing the number of characters that needs to be deleted from the input string before the insertion. Now, at least in the Python Interpreter's case, the "insertion" field will store a completion fully, not just its ending, and "charsToRemove", respectively, the length of a matching prefix.

Unfortunately, there is one problem. Because of its public accessibility, I believe I cannot remove nor "fix" the method ["PythonCodeCompletionFactory.newCodeCompletion"](https://github.com/NationalSecurityAgency/ghidra/blob/480f1e3a8bed20854bf5c2ac68f2ee48a33db966/Ghidra/Features/Python/src/main/java/ghidra/python/PythonCodeCompletionFactory.java#L187).  It would be possible to change it, though, if the description field always began with an actual completion (to extract the length of a matching prefix). It was true in our case, but may not be in others. Thus, for now, I've just left the method functionality-wise unchanged and marked it as deprecated.

I also added a couple of tests, there were none