### PR TITLE
prevent out-of-bounds access in findSymbol()

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.hh
@@ -90,7 +90,7 @@ public:
   SleighSymbol *findSymbol(const string &nm) const { return findSymbolInternal(curscope,nm); }
   SleighSymbol *findSymbol(const string &nm,int4 skip) const { return findSymbolInternal(skipScope(skip),nm); }
   SleighSymbol *findGlobalSymbol(const string &nm) const { return findSymbolInternal(table[0],nm); }
-  SleighSymbol *findSymbol(uintm id) const { return symbollist[id]; }
+  SleighSymbol *findSymbol(uintm id) const { if (id < symbollist.size()) return symbollist[id]; else return NULL; }
   void replaceSymbol(SleighSymbol *a,SleighSymbol *b);
   void saveXml(ostream &s) const;
   void restoreXml(const Element *el,SleighBase *trans);


### PR DESCRIPTION
While working on [a minified version of my VAX processor description](https://github.com/kkaempf/ghidra_vax/blob/issue-4606/VAX/data/languages/vax-mini.slaspec) to fix #4606, I encountered crashes when loading the `.sla` file.

This PR makes my example working.

Note: `sleigh` does not complain when compiling the `.slaspec`, the crash occurs during `OperandSymbol::restoreXml`

The actual problem is in sleigh as it creates and invalid `.sla` file.

Signed-off-by: Klaus Kämpf <kkaempf@gmail.com>