### PR TITLE
Fix directory for PDB.exe in createPdbXmlFiles.bat script

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/support/createPdbXmlFiles.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/createPdbXmlFiles.bat
@@ -30,7 +30,7 @@ for /f "delims=" %%i in ("%GHIDRA_DIR%") do set GHIDRA_DIR=%%~fi
 
 REM Determine if 64-bit or 32-bit
 if exist "%PROGRAMFILES(X86)%" (
-	set OS_TYPE=win64
+	set OS_TYPE=win_x86_64
 ) else (
 	set OS_TYPE=win32
 )

--- a/Ghidra/RuntimeScripts/Windows/support/createPdbXmlFiles.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/createPdbXmlFiles.bat
@@ -28,14 +28,7 @@ set OS_DIR=build\os
 REM create absolute path
 for /f "delims=" %%i in ("%GHIDRA_DIR%") do set GHIDRA_DIR=%%~fi
 
-REM Determine if 64-bit or 32-bit
-if exist "%PROGRAMFILES(X86)%" (
-	set OS_TYPE=win_x86_64
-) else (
-	set OS_TYPE=win32
-)
-
-set "PDB_EXE=%GHIDRA_DIR%\Features\PDB\%OS_DIR%\%OS_TYPE%\pdb.exe"
+set "PDB_EXE=%GHIDRA_DIR%\Features\PDB\%OS_DIR%\win_x86_64\pdb.exe"
 
 if not exist "%PDB_EXE%" (
 	echo "%PDB_EXE% not found"


### PR DESCRIPTION
Due to [pdb.vcxproj](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/PDB/src/pdb/pdb.vcxproj) pointing to `win_x86_64`, the `createPdbXmlFiles.bat` cannot locate the file in the release build. This fixes the directory location for x64 systems.