### PR TITLE
Python Interpreter: Allow code completion to be started from anywhere in the input string

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterConnection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterConnection.java
@@ -45,6 +45,23 @@ public interface InterpreterConnection {
 	 * 
 	 * @param cmd The command to get code completions for
 	 * @return A {@link List} of {@link CodeCompletion code completions} for the given command
+	 * @deprecated Additionally implement {@link #getCompletions(String, int)} 
+	 *             and consider generating completions relative to the caret position
 	 */
+	@Deprecated
 	public List<CodeCompletion> getCompletions(String cmd);
+
+	/**
+	 * Gets a {@link List} of {@link CodeCompletion code completions} for the given command
+	 * relative to the given caret position.
+	 * 
+	 * @param cmd The command to get code completions for
+	 * @param caretPos The position of the caret in the input string 'cmd'.
+	 *                 It should satisfy the constraint {@literal "0 <= caretPos <= cmd.length()"}
+	 * @return A {@link List} of {@link CodeCompletion code completions} for the given command
+	 */
+	public default List<CodeCompletion> getCompletions(String cmd, int caretPos) {
+		// to preserve backward compatibility with existent implementations
+		return getCompletions(cmd);
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java
@@ -76,6 +76,7 @@ public class InterpreterPanel extends JPanel implements OptionsChangeListener {
 
 	private CompletionWindowTrigger completionWindowTrigger = CompletionWindowTrigger.TAB;
 	private boolean highlightCompletion = false;
+	private int completionInsertionPosition;
 
 	private boolean caretGuard = true;
 	private PluginTool tool;
@@ -482,9 +483,13 @@ public class InterpreterPanel extends JPanel implements OptionsChangeListener {
 				return;
 			}
 
+			// We save the position of the caret here in advance because the user can move it
+			// later (but before the insertion takes place) and make the completions invalid.
+			completionInsertionPosition = inputTextPane.getCaretPosition();
+
 			String text = getInputTextPaneText();
-			List<CodeCompletion> completions =
-				InterpreterPanel.this.interpreter.getCompletions(text);
+			List<CodeCompletion> completions = InterpreterPanel.this.interpreter.getCompletions(
+				text, completionInsertionPosition);
 			completionWindow.updateCompletionList(completions);
 		});
 	}
@@ -620,11 +625,11 @@ public class InterpreterPanel extends JPanel implements OptionsChangeListener {
 		}
 
 		String text = getInputTextPaneText();
-		int position = inputTextPane.getCaretPosition();
+		int position = completionInsertionPosition;
 		String insertion = completion.getInsertion();
 
 		/* insert completion string */
-		int insertedTextStart = position - completion.getCharsToRemove();
+		int insertedTextStart = Math.max(0, position - completion.getCharsToRemove());
 		int insertedTextEnd = insertedTextStart + insertion.length();
 		String inputText =
 			text.substring(0, insertedTextStart) + insertion + text.substring(position);

--- a/Ghidra/Features/Python/python-src/jintrospect.py
+++ b/Ghidra/Features/Python/python-src/jintrospect.py
@@ -166,7 +166,7 @@ def getCallTipJava(command='', locals=None):
                 for args in object.argslist:
                     if args is not None:
                         # for now
-                        tipList.append(str(args.data))
+                        tipList.append(str(args.method))
 #            elif callable(object):
 #                argspec = str(object.__call__)
 #                # these don't seem to be very accurate

--- a/Ghidra/Features/Python/src/main/java/ghidra/python/GhidraPythonInterpreter.java
+++ b/Ghidra/Features/Python/src/main/java/ghidra/python/GhidraPythonInterpreter.java
@@ -442,10 +442,18 @@ public class GhidraPythonInterpreter extends InteractiveInterpreter {
 	 *
 	 * @param cmd The command line.
 	 * @param includeBuiltins True if we should include python built-ins; otherwise, false.
+	 * @param caretPos The position of the caret in the input string 'cmd'
 	 * @return A list of possible command completions.  Could be empty if there aren't any.
 	 * @see PythonPlugin#getCompletions
 	 */
-	List<CodeCompletion> getCommandCompletions(String cmd, boolean includeBuiltins) {
+	List<CodeCompletion> getCommandCompletions(String cmd, boolean includeBuiltins, int caretPos) {
+		// At this point the caret is assumed to be positioned right after the value we need to
+		// complete (example: "[complete.Me<caret>, rest, code]"). To make the completion work
+		// in our case, it's sufficient (albeit naive) to just remove the text on the right side
+		// of our caret. The later code (on the python's side) will parse the rest properly
+		// and will generate the completions.
+		cmd = cmd.substring(0, caretPos);
+
 		if ((cmd.length() > 0) && (cmd.charAt(cmd.length() - 1) == '(')) {
 			return getMethodCommandCompletions(cmd);
 		}

--- a/Ghidra/Features/Python/src/main/java/ghidra/python/PythonPlugin.java
+++ b/Ghidra/Features/Python/src/main/java/ghidra/python/PythonPlugin.java
@@ -263,6 +263,18 @@ public class PythonPlugin extends ProgramPlugin
 	 */
 	@Override
 	public List<CodeCompletion> getCompletions(String cmd) {
+		return getCompletions(cmd, cmd.length());
+	}
+
+	/**
+	 * Returns a list of possible command completion values at the given position.
+	 * 
+	 * @param cmd current command line (without prompt)
+	 * @param caretPos The position of the caret in the input string 'cmd'
+	 * @return A list of possible command completion values. Could be empty if there aren't any.
+	 */
+	@Override
+	public List<CodeCompletion> getCompletions(String cmd, int caretPos) {
 		// Refresh the environment
 		interactiveScript.setSourceFile(new ResourceFile(new File("python")));
 		interactiveScript.set(
@@ -270,7 +282,7 @@ public class PythonPlugin extends ProgramPlugin
 				currentSelection, currentHighlight),
 			interactiveTaskMonitor, console.getOutWriter());
 
-		return interpreter.getCommandCompletions(cmd, includeBuiltins);
+		return interpreter.getCommandCompletions(cmd, includeBuiltins, caretPos);
 	}
 
 	@Override


### PR DESCRIPTION
There is a small problem in the completion insertion functionality. The demonstration's in the gif below.

<details>
  <summary>Bug Gif (in Ghidra 10.1.5)</summary>

  ![insertion-in-the-middle](https://user-images.githubusercontent.com/8329446/198896262-846dfaaf-f496-40bc-b8f7-bbe11943be9f.gif)

</details>

In addition I managed to exacerbate it in [my last PR](https://github.com/NationalSecurityAgency/ghidra/pull/4678). Now the completions can not only insert text in inappropriate places but also inappropriately delete important text, which is rather frustrating without Ctrl+Z.

<details>
  <summary>Bug Gif (after my PR)</summary>

![insertion-in-the-middle_2](https://user-images.githubusercontent.com/8329446/198896280-45fe970a-533b-42c3-8883-305a0063e72b.gif)

</details>

It happens because there is a certain discrepancy between the completion generation and insertion. We generate completions relative to the end of the input (I assume that because we don't give implementations any information about the name we're completing). But the completion insertion, on the other hand, happens at the caret's position, which actually may be anywhere in the input string, and can even move after we update them (with an accidental mouse click, for example). 

The solution is to either always insert completions at the end or generate them at the caret's position. Clearly, the latter is the only sane approach. I had to add a new default method `getCompletions` to the interface to pass the caret position. I marked the old method as deprecated, because if the clients continue to use it, we will return to the error described above.

The Python completion process is quite trivial, just one line of code. We simply cut off a part of the text to the right of the caret. Everything else will work itself out automagically. Sure, this is an extremely naive method, as in that case the completion window can pop up inside a string literal and maybe some other inappropriate places. But I think that's fine, since the window cannot annoyingly appear by itself, without pressing Ctrl+Space or Tab. 

I also sort of fixed the autocomplete for method parameters. [Some years ago](https://github.com/jython/jython/commit/dfc4d786a18d1059d848d077c977db73ab307edb?diff=unified#diff-28f48d806261c8588506d18edded52193168996a88c7f59dafe4ba25878692c0L6-R16) Jython's devs renamed the "data" property to "method".

<details>
  <summary>how the parameter completion looks like</summary>

![Pasted image 20221029143354](https://user-images.githubusercontent.com/8329446/198896315-6a78ea23-2d90-40c4-ae01-9bea2fcd260f.png)

</details>

![insert-in-any-place](https://user-images.githubusercontent.com/8329446/198896321-e7b6cd48-5ebd-49f0-8e10-d3e448fcf261.gif)
