### PR TITLE
Add type selection fallback for fs open.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemService.java
@@ -962,4 +962,17 @@ public class FileSystemService {
 		return new CryptoProviderSessionChildImpl(currentCryptoSession);
 	}
 
+	/**
+	 * Adds the given {@link GFileSystem} instance to the managed filesystems list.
+	 *
+	 * @param fs {@link GFileSystem} to add to the managed filesystems list.
+	 */
+	public void addFileSystem(GFileSystem fs) {
+		synchronized (fsInstanceManager) {
+			if (!isFilesystemMountedAt(fs.getFSRL())) {
+				fsInstanceManager.add(fs);
+			}
+		}
+	}
+
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/factory/FileSystemFactoryMgr.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/factory/FileSystemFactoryMgr.java
@@ -347,4 +347,12 @@ public class FileSystemFactoryMgr {
 
 	}
 
+	/**
+	 * Returns the filesystem providers available to this factory.
+	 *
+	 * @return a copy of the available filesystem providers.
+	 */
+	public Map<String, FileSystemInfoRec> getFileSystemInfoRecs() {
+		return new HashMap<>(fsByType);
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/factory/GFileSystemProbeManual.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/factory/GFileSystemProbeManual.java
@@ -1,0 +1,24 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.formats.gfilesystem.factory;
+
+/**
+ * A {@link GFileSystemProbe} interface for filesystems that can be directly
+ * chosen by the user as a fallback if automatic filesystem detection fails.
+ */
+public interface GFileSystemProbeManual extends GFileSystemProbe {
+	// Empty interface.
+}


### PR DESCRIPTION
Right now it is not possible to either force or to pick a filesystem provider that does not have content probing facilities.  This patch adds a fallback filesystem provider selection choice screen populated with filesystems that are available but do not probe their contents if no probing filesystem claimed the resource in question.

This fixes #4448.