### PR TITLE
Fix sort by comment column in the Enum Editor

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/editor/EnumTableModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/datamgr/editor/EnumTableModel.java
@@ -200,7 +200,10 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 		if (columnIndex == NAME_COL) {
 			return new EnumNameComparator();
 		}
-		return new EnumValueComparator();
+		else if (columnIndex == VALUE_COL) {
+			return new EnumValueComparator();
+		}
+		return new EnumCommentComparator();
 	}
 
 	EnumDataType getEnum() {
@@ -364,6 +367,13 @@ class EnumTableModel extends AbstractSortedTableModel<EnumEntry> {
 		@Override
 		public int compare(EnumEntry entry1, EnumEntry entry2) {
 			return Long.valueOf(entry1.getValue()).compareTo(Long.valueOf(entry2.getValue()));
+		}
+	}
+
+	private class EnumCommentComparator implements Comparator<EnumEntry> {
+		@Override
+		public int compare(EnumEntry entry1, EnumEntry entry2) {
+			return entry1.getComment().compareTo(entry2.getComment());
 		}
 	}
 

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/datamgr/editor/EnumEditor2Test.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/datamgr/editor/EnumEditor2Test.java
@@ -104,9 +104,9 @@ public class EnumEditor2Test extends AbstractGhidraHeadedIntegrationTest {
 				.getDataTypeManager()
 				.getCategory(new CategoryPath(CategoryPath.ROOT, "Category1"));
 		final Enum enumm = new EnumDataType("Colors", 1);
-		enumm.add("Red", 0);
-		enumm.add("Green", 0x10);
-		enumm.add("Blue", 0x20);
+		enumm.add("Red", 0, "Lycoris");
+		enumm.add("Green", 0x10, "Angelica");
+		enumm.add("Blue", 0x20, "Chicory");
 
 		int transactionID = program.startTransaction("Test");
 		final Enum enummDt = (Enum) cat.addDataType(enumm, DataTypeConflictHandler.DEFAULT_HANDLER);
@@ -139,6 +139,15 @@ public class EnumEditor2Test extends AbstractGhidraHeadedIntegrationTest {
 		assertEquals("Red", model.getValueAt(0, EnumTableModel.NAME_COL));
 		assertEquals("Green", model.getValueAt(1, EnumTableModel.NAME_COL));
 		assertEquals("Blue", model.getValueAt(2, EnumTableModel.NAME_COL));
+
+		// sort by Comment
+		rect = header.getHeaderRect(EnumTableModel.COMMENT_COL);
+		clickMouse(header, 1, rect.x, rect.y, 1, 0);
+		waitForSwing();
+
+		assertEquals("Green", model.getValueAt(0, EnumTableModel.NAME_COL));
+		assertEquals("Blue", model.getValueAt(1, EnumTableModel.NAME_COL));
+		assertEquals("Red", model.getValueAt(2, EnumTableModel.NAME_COL));
 	}
 
 	@Test


### PR DESCRIPTION
I added an **EnumCommentComparator** to compare the comments and sort them appropriately.

I have also added a test.

closes=#4693