### PR TITLE
Fix icmpapi.h parsing error in example GDT script

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/CreateExampleGDTArchiveScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/CreateExampleGDTArchiveScript.java
@@ -203,7 +203,7 @@ public class CreateExampleGDTArchiveScript extends GhidraScript {
 				"certif.h",
 				"certmod.h",
 				"certpol.h",
-				"certpoleng.h   ",
+				"certpoleng.h",
 				"certsrv.h",
 				"certview.h",
 				"credssp.h",
@@ -422,12 +422,12 @@ public class CreateExampleGDTArchiveScript extends GhidraScript {
 				"#http.h", // included by something else
 				
 				"# IP Helper",
-				"#icmpapi.h",  // Something wrong with IP_ADDR
 				"ifdef.h",
 				"inaddr.h",
 				"ip2string.h",
 				"ipexport.h",
 				"iphlpapi.h",
+				"icmpapi.h",  // Must be included after iphlpapi.h
 				"iprtrmib.h",
 				"iptypes.h",
 				"netioapi.h",


### PR DESCRIPTION
According to the Microsoft [document](https://learn.microsoft.com/en-us/windows/win32/api/icmpapi/nf-icmpapi-icmpsendecho2ex), icmpapi.h must be included after iphlpapi.h:

> Note that the include directive for Iphlpapi.h header file must be placed before the Icmpapi.h header file.

If you change the order of the inclusion of icmpapi.h, the C Parser will have no problem parsing icmpapi.h.