### PR TITLE
Update Module.manifest after upgrading protobuf to 3.21.8

### DIFF
--- a/Ghidra/Debug/Debugger-gadp/Module.manifest
+++ b/Ghidra/Debug/Debugger-gadp/Module.manifest
@@ -1,1 +1,1 @@
-MODULE FILE LICENSE: lib/protobuf-java-3.21.6.jar BSD-3-GOOGLE
+MODULE FILE LICENSE: lib/protobuf-java-3.21.8.jar BSD-3-GOOGLE


### PR DESCRIPTION
Fixes:
Execution failed for task ':Debugger-gadp:ip'.
> No License specified for external library: lib/protobuf-java-3.21.8.jar in module /tmp/ghidra/Ghidra/Debug/Debugger-gadp. Expression: map.containsKey(relativePath)