### PR TITLE
Handle conditional computed jumps in SwitchOverride.java

### DIFF
--- a/Ghidra/Features/Decompiler/ghidra_scripts/SwitchOverride.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/SwitchOverride.java
@@ -83,7 +83,7 @@ public class SwitchOverride extends GhidraScript {
 		
 		FlowType flowType = instr.getFlowType();
 		
-		if (flowType == RefType.COMPUTED_JUMP) {
+		if (flowType.isJump() && flowType.isComputed()) {
 			return true;
 		}
 		if (flowType.isCall()) {


### PR DESCRIPTION
Fixes #4747

SwitchOverride.java is one of the recommended ways to fix switch statements in the decompiler when there are too many branches (GhidraDocs/GhidraClass/Advanced/improvingDisassemblyAndDecompilation)

Currently the indirect jump is only allowed to be an unconditional computed jump (or a call). However, compilers can sometimes implement switch statements using conditional indirect jumps (via conditional loads, conditional adds, etc.) if the target architecture supports them (e.g., ARM). In this case, SwitchOverride.java will fail because the instruction flow type will be RefType.CONDITIONAL_COMPUTED_JUMP rather than the expected RefType.COMPUTED_JUMP, even though both should be equally acceptable.