### PR TITLE
Python Interpreter: Show in the CodeCompletion window all names containing the given string

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java
@@ -283,6 +283,11 @@ public class InterpreterPanel extends JPanel implements OptionsChangeListener {
 						completionWindow.setVisible(false);
 						e.consume();
 						break;
+					case KeyEvent.VK_KP_LEFT, KeyEvent.VK_KP_RIGHT, KeyEvent.VK_HOME:
+					case KeyEvent.VK_LEFT, KeyEvent.VK_RIGHT, KeyEvent.VK_END:
+						// regenerate completions on the caret movement
+						updateCompletionList();
+						break;
 					default:
 
 						// Check for the completion window trigger on input that contains text
@@ -293,7 +298,6 @@ public class InterpreterPanel extends JPanel implements OptionsChangeListener {
 							break;
 						}
 
-						updateCompletionList();
 						// and let the key go through to the text input field
 				}
 			}

--- a/Ghidra/Features/Python/src/main/java/ghidra/python/PythonPlugin.java
+++ b/Ghidra/Features/Python/src/main/java/ghidra/python/PythonPlugin.java
@@ -74,6 +74,16 @@ public class PythonPlugin extends ProgramPlugin
 	private final static boolean INCLUDE_BUILTINS_DEFAULT = true;
 	private boolean includeBuiltins = INCLUDE_BUILTINS_DEFAULT;
 
+	private final static String INCLUDE_ONLY_PREFIX_COMPLETIONS_LABEL =
+		"Only include completions with matching prefix";
+	private final static String INCLUDE_ONLY_PREFIX_COMPLETIONS_DESCRIPTION =
+		"If set, the code completion window will contain only those entries that begin with " +
+			"the entered string. For example, if the string 'add' is entered, the list of " +
+			"possible completions may contain '<i>add</i>EntryPoint' or '<i>Add</i>ressMap' " +
+			"but not 'current<i>Add</i>ress'.";
+	private final static boolean INCLUDE_ONLY_PREFIX_COMPLETIONS_DEFAULT = true;
+	private boolean includeOnlyPrefixCompletions = INCLUDE_ONLY_PREFIX_COMPLETIONS_DEFAULT;
+
 	/**
 	 * Creates a new PythonPlugin object.
 	 * 
@@ -195,6 +205,12 @@ public class PythonPlugin extends ProgramPlugin
 			includeBuiltins = options.getBoolean(INCLUDE_BUILTINS_LABEL, INCLUDE_BUILTINS_DEFAULT);
 			options.registerOption(INCLUDE_BUILTINS_LABEL, INCLUDE_BUILTINS_DEFAULT, null,
 				INCLUDE_BUILTINS_DESCRIPTION);
+
+			includeOnlyPrefixCompletions = options.getBoolean(
+				INCLUDE_ONLY_PREFIX_COMPLETIONS_LABEL, INCLUDE_ONLY_PREFIX_COMPLETIONS_DEFAULT);
+			options.registerOption(INCLUDE_ONLY_PREFIX_COMPLETIONS_LABEL,
+				INCLUDE_ONLY_PREFIX_COMPLETIONS_DEFAULT, null,
+				INCLUDE_ONLY_PREFIX_COMPLETIONS_DESCRIPTION);
 			options.addOptionsChangeListener(this);
 
 			interpreter = GhidraPythonInterpreter.get();
@@ -253,6 +269,9 @@ public class PythonPlugin extends ProgramPlugin
 		else if (optionName.equals(INCLUDE_BUILTINS_LABEL)) {
 			includeBuiltins = ((Boolean) newValue).booleanValue();
 		}
+		else if (optionName.equals(INCLUDE_ONLY_PREFIX_COMPLETIONS_LABEL)) {
+			includeOnlyPrefixCompletions = ((Boolean) newValue).booleanValue();
+		}
 	}
 
 	/**
@@ -282,7 +301,8 @@ public class PythonPlugin extends ProgramPlugin
 				currentSelection, currentHighlight),
 			interactiveTaskMonitor, console.getOutWriter());
 
-		return interpreter.getCommandCompletions(cmd, includeBuiltins, caretPos);
+		return interpreter.getCommandCompletions(cmd, includeBuiltins, caretPos,
+			includeOnlyPrefixCompletions);
 	}
 
 	@Override


### PR DESCRIPTION
My suggestion is to extend the completion functionality to include all names that contain the entered string, not just those that start with it. Essentially like all IDEs and text editors do nowadays.

![nonprefix_completions](https://user-images.githubusercontent.com/8329446/202133722-d900be88-216d-4a48-82a1-11fe7a9650da.gif)

I find the code completion feature in IDEs a generally good way to learn and discover new APIs. It saves me from having to look into the actual documentation. But for that to work best, the suggested code completions should not be restricted to those that strictly start with any particular string. Silly example: I want to get the current address, but I don't know its specific name. Currently, the code completion will only tell me the answer when I enter "current", but then I should already know the first part of the name (i.e. 'current'). Ideally, I could just type "address" and it would show me the desired variable name.

There is a couple of important points:

---

![image](https://user-images.githubusercontent.com/8329446/202133913-7f7247f0-04ab-477c-b8e2-4cc00ebc67d8.png)

I use bold to highlight the matching part of the entered string in the CodeCompletion window.
That could be achieved with Html. But the problem is that Html is very slow. It takes about ten times longer to create than a simple JLabel. These numbers don't mean much, but creating 300 JLabels takes about 35 ms on average without Html and 200-250 ms with Html, which is unacceptable.

So I've implemented a new small label class with the `paintComponent()` method overridden. 
While I was trying to mimic the standard Look&Feel settings, I discovered a related problem that can be addressed as well.

---

![image](https://user-images.githubusercontent.com/8329446/202134040-7f5bc762-7b1d-4ae1-ba6f-0a96caa73e78.png)

The code completion entries look almost unreadable with some Look&Feels because of the color choices. Since I had already implemented my own label class, I decided to fix it a bit and add some code to change the text color to white or black at runtime, in case the current color's not contrasting enough. The approach is very crude, as the originally selected colors are mostly erased in the process, but I couldn't think of anything better.  I've tested it with all look&feels available to me. The before/after results are below. 

<details>
  <summary>Look and Feel tests</summary>


The popup with the list selection background color is shown at the top row (painted specifically for the demonstration), and without it at the bottom. The latter turned out to be meaningless, though, since there are no changes.

**GTK+ (on KDE Plasma)**

![image](https://user-images.githubusercontent.com/8329446/202134521-a08e397f-9691-4a26-ab0d-f100932d9b1d.png)

---

**Metal**

![image](https://user-images.githubusercontent.com/8329446/202134637-4b9d3a06-3c9c-46fd-b885-89502dd3993d.png)

---

**Nimbus**

This one has a different selection color, but that's what `getBackground()` gives us. Funnily enough, I've stumbled upon [one stackoverflow post](https://stackoverflow.com/questions/25685269/wrong-colors-in-jlist-when-using-nimbus-and-java-8u20) that actually described this behavior as a bug. In that case, my version is supposed to be the correct one.

![image](https://user-images.githubusercontent.com/8329446/202134765-bb71ea1c-0c75-4da5-b101-0b23f66c161d.png)

---

**CDE/Motif**

Anti-aliasing wasn't enabled on the "before" one. And now it is.

![image](https://user-images.githubusercontent.com/8329446/202134896-3a95b0f1-8b7c-4f75-9b6e-d9825238ccc8.png)

---

**Windows (on Windows 10)**

![image](https://user-images.githubusercontent.com/8329446/202134999-d182b2f3-7bd7-4966-928d-84bff6631e53.png)

---

**Windows Classic (on Windows 10)**

![image](https://user-images.githubusercontent.com/8329446/202135086-009d2b1f-25bc-4833-bbf5-4ce9066cee73.png)

---

**GTK+ with GNOME 4**

Gnome provides the ability to change the system theme (to dark or light) and select so-called accent colors. These options affect the background and list selection colors in the GTK+ look&feel. I haven't noticed similar behavior in Windows 10 and KDE Plasma, even though they also allow us to change these settings. Here is an example with a pink accent color:

![image](https://user-images.githubusercontent.com/8329446/202135209-ec4282a7-3ffe-456b-bbac-ff33f700592a.png)

</details>

---
---

IDEs usually have some sort of completion prioritization feature, where the most useful suggestions may end up at the top of the list. In this PR, similar thing is accomplished by separating completions logically into two groups: those that strictly (letter case matters) start with the entered string, and all others.

![image](https://user-images.githubusercontent.com/8329446/202135307-8fabfe8d-288a-4bc2-bab1-0589b25f74bf.png)

---

Currently, the completion generation code is called twice for every input change. Once from the functions ["insertString", "replace" and "remove"](https://github.com/NationalSecurityAgency/ghidra/blob/97097daa681d43ee3a57c10523c382ec7cfafa88/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java#L183), that cover cases like character insertion, deletion and copy/pasting. That part is okay.  What's not okay is the second call that comes from the ["keyPressed"](https://github.com/NationalSecurityAgency/ghidra/blob/97097daa681d43ee3a57c10523c382ec7cfafa88/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/interpreter/InterpreterPanel.java#L296) listener function. I've failed to comprehend the reason behind it. I believe it's a bug, since there's no reason to update completions literally every time any key is pressed (ctrl, alt, f2, num lock, ...). The only visible change after removing it is that completions are no longer updated when I move the caret with the arrow keys. To remedy this I moved that functionality to a separate switch-case statement.
