### PR TITLE
Refactor the audio player class and fix resource leaks.

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AIFFDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AIFFDataType.java
@@ -15,18 +15,10 @@
  */
 package ghidra.program.model.data;
 
-import java.awt.event.MouseEvent;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-
-import javax.sound.sampled.*;
-import javax.swing.ImageIcon;
-
 import ghidra.docking.settings.Settings;
 import ghidra.program.model.mem.MemBuffer;
 import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.util.Msg;
-import resources.ResourceManager;
 
 public class AIFFDataType extends BuiltIn implements Dynamic {
 
@@ -104,37 +96,6 @@ public class AIFFDataType extends BuiltIn implements Dynamic {
 		return "<AIFF-Representation>";
 	}
 
-	private static class AIFFData implements Playable {
-
-		private static final ImageIcon AUDIO_ICON =
-			ResourceManager.loadImage("images/audio-volume-medium.png");
-		private byte[] bytes;
-
-		public AIFFData(byte[] bytes) {
-			this.bytes = bytes;
-		}
-
-		@Override
-		public void clicked(MouseEvent event) {
-
-			try {
-				Clip clip = AudioSystem.getClip();
-				AudioInputStream ais =
-					AudioSystem.getAudioInputStream(new ByteArrayInputStream(bytes));
-				clip.open(ais);
-				clip.start();
-			}
-			catch (UnsupportedAudioFileException | IOException | LineUnavailableException e) {
-				Msg.debug(this, "Unable to play audio", e);
-			}
-		}
-
-		@Override
-		public ImageIcon getImageIcon() {
-			return AUDIO_ICON;
-		}
-	}
-
 	@Override
 	public Object getValue(MemBuffer buf, Settings settings, int length) {
 		byte[] data = new byte[length];
@@ -142,12 +103,12 @@ public class AIFFDataType extends BuiltIn implements Dynamic {
 			Msg.error(this, "AIFF-Sound error: Not enough bytes in memory");
 			return null;
 		}
-		return new AIFFData(data);
+		return new DefaultAudioPlayer(data);
 	}
 
 	@Override
 	public Class<?> getValueClass(Settings settings) {
-		return AIFFData.class;
+		return DefaultAudioPlayer.class;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AIFFDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AIFFDataType.java
@@ -103,12 +103,12 @@ public class AIFFDataType extends BuiltIn implements Dynamic {
 			Msg.error(this, "AIFF-Sound error: Not enough bytes in memory");
 			return null;
 		}
-		return new DefaultAudioPlayer(data);
+		return new AudioPlayer(data);
 	}
 
 	@Override
 	public Class<?> getValueClass(Settings settings) {
-		return DefaultAudioPlayer.class;
+		return AudioPlayer.class;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AUDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AUDataType.java
@@ -15,19 +15,11 @@
  */
 package ghidra.program.model.data;
 
-import java.awt.event.MouseEvent;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-
-import javax.sound.sampled.*;
-import javax.swing.ImageIcon;
-
 import ghidra.docking.settings.Settings;
 import ghidra.program.model.mem.MemBuffer;
 import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.util.GhidraBigEndianDataConverter;
 import ghidra.util.Msg;
-import resources.ResourceManager;
 
 public class AUDataType extends BuiltIn implements Dynamic {
 	public static byte[] MAGIC = new byte[] { (byte) '.', (byte) 's', (byte) 'n', (byte) 'd' };
@@ -108,37 +100,6 @@ public class AUDataType extends BuiltIn implements Dynamic {
 		return "<AU-Representation>";
 	}
 
-	private static class AUData implements Playable {
-
-		private static final ImageIcon AUDIO_ICON =
-			ResourceManager.loadImage("images/audio-volume-medium.png");
-		private byte[] bytes;
-
-		public AUData(byte[] bytes) {
-			this.bytes = bytes;
-		}
-
-		@Override
-		public void clicked(MouseEvent event) {
-
-			try {
-				Clip clip = AudioSystem.getClip();
-				AudioInputStream ais =
-					AudioSystem.getAudioInputStream(new ByteArrayInputStream(bytes));
-				clip.open(ais);
-				clip.start();
-			}
-			catch (UnsupportedAudioFileException | IOException | LineUnavailableException e) {
-				Msg.debug(this, "Unable to play audio", e);
-			}
-		}
-
-		@Override
-		public ImageIcon getImageIcon() {
-			return AUDIO_ICON;
-		}
-	}
-
 	@Override
 	public Object getValue(MemBuffer buf, Settings settings, int length) {
 		byte[] data = new byte[length];
@@ -146,12 +107,12 @@ public class AUDataType extends BuiltIn implements Dynamic {
 			Msg.error(this, "AU-DataTpe Error: Not enough bytes in memory");
 			return null;
 		}
-		return new AUData(data);
+		return new DefaultAudioPlayer(data);
 	}
 
 	@Override
 	public Class<?> getValueClass(Settings settings) {
-		return AUData.class;
+		return DefaultAudioPlayer.class;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AUDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AUDataType.java
@@ -107,12 +107,12 @@ public class AUDataType extends BuiltIn implements Dynamic {
 			Msg.error(this, "AU-DataTpe Error: Not enough bytes in memory");
 			return null;
 		}
-		return new DefaultAudioPlayer(data);
+		return new AudioPlayer(data);
 	}
 
 	@Override
 	public Class<?> getValueClass(Settings settings) {
-		return DefaultAudioPlayer.class;
+		return AudioPlayer.class;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AudioPlayer.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AudioPlayer.java
@@ -32,14 +32,14 @@ import javax.swing.ImageIcon;
 import ghidra.util.Msg;
 import resources.ResourceManager;
 
-public class DefaultAudioPlayer implements Playable, LineListener {
+public class AudioPlayer implements Playable, LineListener {
 
 	private static final ImageIcon AUDIO_ICON =
 			ResourceManager.loadImage("images/audio-volume-medium.png");
 
 	private byte[] bytes;
 	
-	public DefaultAudioPlayer(byte[] bytes) {
+	public AudioPlayer(byte[] bytes) {
 		this.bytes = bytes;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DefaultAudioPlayer.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DefaultAudioPlayer.java
@@ -1,0 +1,77 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.program.model.data;
+
+import java.awt.event.MouseEvent;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Clip;
+import javax.sound.sampled.LineEvent;
+import javax.sound.sampled.LineEvent.Type;
+import javax.sound.sampled.LineListener;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import javax.swing.ImageIcon;
+
+import ghidra.util.Msg;
+import resources.ResourceManager;
+
+public class DefaultAudioPlayer implements Playable, LineListener {
+
+	private static final ImageIcon AUDIO_ICON =
+			ResourceManager.loadImage("images/audio-volume-medium.png");
+
+	private byte[] bytes;
+	
+	public DefaultAudioPlayer(byte[] bytes) {
+		this.bytes = bytes;
+	}
+
+	@Override
+	public ImageIcon getImageIcon() {
+		return AUDIO_ICON;
+	}
+
+	@Override
+	public void clicked(MouseEvent event) {
+		try (AudioInputStream stream = AudioSystem.getAudioInputStream(new ByteArrayInputStream(bytes))) {
+			Clip clip = AudioSystem.getClip();
+			clip.addLineListener(this);
+			clip.open(stream);
+			clip.start();
+		}
+		catch (UnsupportedAudioFileException | IOException | LineUnavailableException e) {
+			Msg.debug(this, "Unable to play audio", e);
+		}
+	}
+
+	@Override
+	public void update(LineEvent event) {
+		LineEvent.Type eventType = event.getType();
+
+		if (eventType != Type.STOP && eventType != Type.CLOSE) {
+			return;
+		}
+
+		if (event.getSource() instanceof Clip clip) {
+			clip.removeLineListener(this);
+			clip.close();
+		}		
+	}
+}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/WAVEDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/WAVEDataType.java
@@ -15,18 +15,10 @@
  */
 package ghidra.program.model.data;
 
-import java.awt.event.MouseEvent;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-
-import javax.sound.sampled.*;
-import javax.swing.ImageIcon;
-
 import ghidra.docking.settings.Settings;
 import ghidra.program.model.mem.MemBuffer;
 import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.util.Msg;
-import resources.ResourceManager;
 
 public class WAVEDataType extends BuiltIn implements Dynamic {
 	public static byte[] MAGIC = new byte[] { (byte) 'R', (byte) 'I', (byte) 'F', (byte) 'F',
@@ -101,37 +93,6 @@ public class WAVEDataType extends BuiltIn implements Dynamic {
 		return "<WAVE-Resource>";
 	}
 
-	private static class WAVEData implements Playable {
-
-		private static final ImageIcon AUDIO_ICON =
-			ResourceManager.loadImage("images/audio-volume-medium.png");
-		private byte[] bytes;
-
-		public WAVEData(byte[] bytes) {
-			this.bytes = bytes;
-		}
-
-		@Override
-		public void clicked(MouseEvent event) {
-
-			try {
-				Clip clip = AudioSystem.getClip();
-				AudioInputStream ais =
-					AudioSystem.getAudioInputStream(new ByteArrayInputStream(bytes));
-				clip.open(ais);
-				clip.start();
-			}
-			catch (UnsupportedAudioFileException | IOException | LineUnavailableException e) {
-				Msg.debug(this, "Unable to play audio", e);
-			}
-		}
-
-		@Override
-		public ImageIcon getImageIcon() {
-			return AUDIO_ICON;
-		}
-	}
-
 	@Override
 	public Object getValue(MemBuffer buf, Settings settings, int length) {
 		byte[] data = new byte[length];
@@ -139,13 +100,12 @@ public class WAVEDataType extends BuiltIn implements Dynamic {
 			Msg.error(this, "WAVE-Sound error: " + "Not enough bytes!");
 			return null;
 		}
-		WAVEData waveData = new WAVEData(data);
-		return waveData;
+		return new DefaultAudioPlayer(data);
 	}
 
 	@Override
 	public Class<?> getValueClass(Settings settings) {
-		return WAVEData.class;
+		return DefaultAudioPlayer.class;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/WAVEDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/WAVEDataType.java
@@ -100,12 +100,12 @@ public class WAVEDataType extends BuiltIn implements Dynamic {
 			Msg.error(this, "WAVE-Sound error: " + "Not enough bytes!");
 			return null;
 		}
-		return new DefaultAudioPlayer(data);
+		return new AudioPlayer(data);
 	}
 
 	@Override
 	public Class<?> getValueClass(Settings settings) {
-		return DefaultAudioPlayer.class;
+		return AudioPlayer.class;
 	}
 
 	@Override


### PR DESCRIPTION
Extract the same `Playable` implementation used in the audio data types into its own class, and make it available to external audio data types.  Plus, audio resources on the Java audio stack weren't released upon playback end - the fix is already applied to the refactored class.

If `DefaultAudioPlayer` isn't appropriate for the class name, feel free to let me know what it should be called instead.

This is a follow up to #4753, which only featured the resources leak fix.

