### PR TITLE
Removed unnecessary Javadoc option

### DIFF
--- a/gradle/root/distribution.gradle
+++ b/gradle/root/distribution.gradle
@@ -124,11 +124,6 @@ task createJavadocs(type: Javadoc, description: 'Generate javadocs for all proje
 	// Must add classpath for main and test source sets. Javadoc will fail if it cannot
 	// find referenced classes.
 	classpath =  rootProject.ext.ghidraPath
-	
-	// If we don't exclude module directories, the javascript search feature doesn't work
-	if (JavaVersion.current().isJava11()) {
-		options.addBooleanOption("-no-module-directories", true)
-	}
 
 	// generate documentation using html5
 	options.addBooleanOption("html5", true)


### PR DESCRIPTION
https://github.com/NationalSecurityAgency/ghidra/blob/5b1eb8ef32152627d4d5f39e20cbd23b43e68572/gradle/root/distribution.gradle#L128-L131

It's not Java 11, trust me ;)