### PR TITLE
decompiler: Don't propagate types through call clobbers

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/heritage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/heritage.cc
@@ -1315,6 +1315,7 @@ void Heritage::guardCalls(uint4 fl,const Address &addr,int4 size,vector<Varnode 
     // We do not guard the call if the effect is "unaffected" or "reload"
     if ((effecttype == EffectRecord::unknown_effect)||(effecttype == EffectRecord::return_address)) {
       indop = fd->newIndirectOp(fc->getOp(),addr,size,0);
+      indop->setStopTypePropagation();
       indop->getIn(0)->setActiveHeritage();
       indop->getOut()->setActiveHeritage();
       write.push_back(indop->getOut());
@@ -1325,6 +1326,7 @@ void Heritage::guardCalls(uint4 fl,const Address &addr,int4 size,vector<Varnode 
     }
     else if (effecttype == EffectRecord::killedbycall) {
       indop = fd->newIndirectCreation(fc->getOp(),addr,size,possibleoutput);
+      indop->setStopTypePropagation();
       indop->getOut()->setActiveHeritage();
       write.push_back(indop->getOut());
     }


### PR DESCRIPTION
INDIRECT ops that model call-clobbered registers indicate that the value
may be changed arbitrarily by the call, so it doesn't make sense to
propagate types through them to the value it had before the call.

Fixes: #4639

Sponsored-by: RCS Lab at University of Waterloo, NSERC, WHJIL
