### PR TITLE
Fix 64 bits Ext4 inode table offset calculation.

### DIFF
--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/Ext4Analyzer.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/Ext4Analyzer.java
@@ -130,7 +130,7 @@ public class Ext4Analyzer extends FileFormatAnalyzer {
 			monitor.checkCanceled();
 			long inodeTableBlockOffset = groupDescriptors[i].getBg_inode_table_lo() & 0xffffffffL;
 			if( is64Bit ) {
-				inodeTableBlockOffset = (groupDescriptors[i].getBg_inode_table_hi() << 32) | inodeTableBlockOffset;
+				inodeTableBlockOffset = (((long) groupDescriptors[i].getBg_inode_table_hi()) << 32) | inodeTableBlockOffset;
 			}
 			long offset = inodeTableBlockOffset * blockSize;
 			reader.setPointerIndex(offset);

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/NewExt4Analyzer.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ext4/NewExt4Analyzer.java
@@ -228,7 +228,7 @@ public class NewExt4Analyzer extends FileFormatAnalyzer {
 			monitor.checkCanceled( );
 			long inodeTableBlockOffset = groupDescriptors[ i ].getBg_inode_table_lo( ) & 0xffffffffL;
 			if ( is64Bit ) {
-				inodeTableBlockOffset = ( groupDescriptors[ i ].getBg_inode_table_hi( ) << 32 ) | inodeTableBlockOffset;
+				inodeTableBlockOffset = ( ((long) groupDescriptors[ i ].getBg_inode_table_hi( )) << 32 ) | inodeTableBlockOffset;
 			}
 			long offset = inodeTableBlockOffset * blockSize;
 			reader.setPointerIndex( offset );


### PR DESCRIPTION
Ext4 analysis fails to calculate inode table block offsets on 64 bits filesystems due to missing type promotion.

Not sure if 64 bits Ext4 partitions are common, as I only bumped into one sample that triggered the issue in question.