### PR TITLE
Make the title bar adaptable to macOS theme

### DIFF
--- a/Ghidra/RuntimeScripts/Common/support/launch.properties
+++ b/Ghidra/RuntimeScripts/Common/support/launch.properties
@@ -62,6 +62,9 @@ VMARGS_MACOS=-Declipse.filelock.disable=true
 # Where the menu bar is displayed on macOS
 VMARGS_MACOS=-Dapple.laf.useScreenMenuBar=false
 
+# Make the title bar adaptable to macOS theme
+VMARGS_MACOS=-Dapple.awt.application.appearance=system
+
 # Prevent log4j from using the Jansi DLL on Windows.
 VMARGS_WINDOWS=-Dlog4j.skipJansi=true
 


### PR DESCRIPTION
Title bar on macOS now responds to theme changes and supports dark mode like in #4145

<img width="912" alt="Screenshot 2022-11-21 at 9 46 38 PM" src="https://user-images.githubusercontent.com/56265039/203155534-b44acf9c-2970-40bb-b5b6-d95dac08d8cb.png">
