### PR TITLE
Update help pages for Function ID 

### DIFF
--- a/Ghidra/Features/FunctionID/src/main/doc/fid.xml
+++ b/Ghidra/Features/FunctionID/src/main/doc/fid.xml
@@ -336,7 +336,7 @@ Function ID plugin. To do this, from the Code Browser select
   <emphasis role="bold">File -> Configure</emphasis>
   </informalexample>
 Then click on the <emphasis>Configure</emphasis> link under the
-<emphasis role="bold">Function ID</emphasis> section and check the box
+<emphasis role="bold">Ghidra Core</emphasis> section and check the box
 next to "FidPlugin".
 </para>
 </section>
@@ -748,7 +748,7 @@ In order to access the Debug options, the plug-in must be enabled. To do this, f
   <informalexample>
   <emphasis role="bold">File -> Configure</emphasis>
   </informalexample>
-Then click on <emphasis>Configure</emphasis> link under the <emphasis role="bold">Experimental</emphasis>
+Then click on <emphasis>Configure</emphasis> link under the <emphasis role="bold">Developer</emphasis>
 section and check the box next to "FidDebugPlugin".
 </para>
 </section>

--- a/Ghidra/Features/FunctionID/src/main/help/help/topics/FunctionID/FunctionIDDebug.html
+++ b/Ghidra/Features/FunctionID/src/main/help/help/topics/FunctionID/FunctionIDDebug.html
@@ -13,9 +13,9 @@
 <tr><th colspan="3" align="center">Function ID Debug Plug-in</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="FunctionIDPlugin.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> </td>
+<a accesskey="p" href="FunctionIDPlugin.html">Prev</a>ï¿½</td>
+<th width="60%" align="center">ï¿½</th>
+<td width="20%" align="right">ï¿½</td>
 </tr>
 </table>
 <hr>
@@ -41,7 +41,7 @@ In order to access the Debug options, the plug-in must be enabled. To do this, f
   </p>
 <div class="informalexample"><span class="bold"><strong>File -&gt; Configure</strong></span></div>
 <p>
-Then click on <span class="emphasis"><em>Configure</em></span> link under the <span class="bold"><strong>Experimental</strong></span>
+Then click on <span class="emphasis"><em>Configure</em></span> link under the <span class="bold"><strong>Developer</strong></span>
 section and check the box next to "FidDebugPlugin".
 </p>
 </div>
@@ -220,14 +220,14 @@ present readable values. The only meaningful table is likely to be the
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="FunctionIDPlugin.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> </td>
+<a accesskey="p" href="FunctionIDPlugin.html">Prev</a>ï¿½</td>
+<td width="20%" align="center">ï¿½</td>
+<td width="40%" align="right">ï¿½</td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">Function ID Plug-in </td>
+<td width="40%" align="left" valign="top">Function ID Plug-inï¿½</td>
 <td width="20%" align="center"></td>
-<td width="40%" align="right" valign="top"> </td>
+<td width="40%" align="right" valign="top">ï¿½</td>
 </tr>
 </table>
 </div>

--- a/Ghidra/Features/FunctionID/src/main/help/help/topics/FunctionID/FunctionIDPlugin.html
+++ b/Ghidra/Features/FunctionID/src/main/help/help/topics/FunctionID/FunctionIDPlugin.html
@@ -14,9 +14,9 @@
 <tr><th colspan="3" align="center">Function ID Plug-in</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="FunctionID.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="FunctionIDDebug.html">Next</a>
+<a accesskey="p" href="FunctionID.html">Prev</a>ï¿½</td>
+<th width="60%" align="center">ï¿½</th>
+<td width="20%" align="right">ï¿½<a accesskey="n" href="FunctionIDDebug.html">Next</a>
 </td>
 </tr>
 </table>
@@ -59,7 +59,7 @@ Function ID plugin. To do this, from the Code Browser select
 <div class="informalexample"><span class="bold"><strong>File -&gt; Configure</strong></span></div>
 <p>
 Then click on the <span class="emphasis"><em>Configure</em></span> link under the
-<span class="bold"><strong>Function ID</strong></span> section and check the box
+<span class="bold"><strong>Ghidra Core</strong></span> section and check the box
 next to "FidPlugin".
 </p>
 </div>
@@ -397,15 +397,15 @@ script.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="FunctionID.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="FunctionIDDebug.html">Next</a>
+<a accesskey="p" href="FunctionID.html">Prev</a>ï¿½</td>
+<td width="20%" align="center">ï¿½</td>
+<td width="40%" align="right">ï¿½<a accesskey="n" href="FunctionIDDebug.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">Function ID </td>
+<td width="40%" align="left" valign="top">Function IDï¿½</td>
 <td width="20%" align="center"></td>
-<td width="40%" align="right" valign="top"> Function ID Debug Plug-in</td>
+<td width="40%" align="right" valign="top">ï¿½Function ID Debug Plug-in</td>
 </tr>
 </table>
 </div>


### PR DESCRIPTION
Update help pages for Function ID to properly reflect the plugin's configuration location in the tool configuration menu. 
Closes #4768 