### PR TITLE
Fix `nor.t` output size in TriCore Sleigh

### DIFF
--- a/Ghidra/Processors/tricore/data/languages/tricore.sinc
+++ b/Ghidra/Processors/tricore/data/languages/tricore.sinc
@@ -6824,9 +6824,9 @@ macro multiply_u_u(mres0, rega, regb, n) {
 # NOR.T D[c], D[a], pos1, D[b], pos2 (BIT)
 :nor.t Rd2831,Rd0811,const1620Z,Rd1215,const2327Z is PCPMode=0 & Rd0811 & Rd1215 & op0007=0x87 ; Rd2831 & const1620Z & const2327Z & op2122=0x2
 {
-	local tmp = (Rd0811 >> const1620Z) & 1;
-	local tmp2 = (Rd1215 >> const2327Z) & 1;
-	Rd2831 = ~(tmp | tmp2);
+	local tmp = Rd0811 >> const1620Z;
+	local tmp2 = Rd1215 >> const2327Z;
+	Rd2831 = ~(tmp | tmp2) & 1;
 }
 
 @if defined(TRICORE_RIDER_B) || defined(TRICORE_RIDER_D) || defined(TRICORE_V2)


### PR DESCRIPTION
`nor.t` should output a single bit, zero-extended to the full register. Previously, the Sleigh code sign-extended it to the full register, resulting in incorrect decompilation.

Example:
```
87 ff 40 f0     nor.t      d15,d15,#0x0,d15,#0x0
ee 03           jnz        d15,XYZ
```

Decompilation without this patch:
```C
if ((x & 1 | x & 1) == 0xffffffff) {
```

With this patch:
```C
if ((~(x & 1U) & 1) == 0) {
```

Optimally, it should be just `if (x & 1)`, but that part is probably unrelated and has to be improved on higher layers of the decompiler engine (i.e. simplification of such expressions). Anyways, now at least the decompiled code is correct.