### PR TITLE
Improve analysis performance by removing bubble sort

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/datastruct/Algorithms.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/datastruct/Algorithms.java
@@ -112,8 +112,15 @@ public class Algorithms {
 
 		monitor.setProgress(low);
 		int length = high - low;
-		if (length < 7) {
-			doBubbleSort(dest, low, high - 1, c, monitor);
+
+		// The only reason this method exists is because we want progress
+		// updates as we sort the list. Java can sort fairly large collections
+		// instantaeously, far better than we can hope to do, so we should
+		// really try to send reasonably large "chunks" to Collections.sort and
+		// track progress at a fairly high level. The number below was chosen on
+		// a whim and gives pretty decent performance.
+		if (length < 1024) {
+			dest.subList(low, high).sort(c);
 			return;
 		}
 

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/datastruct/Algorithms.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/datastruct/Algorithms.java
@@ -62,33 +62,6 @@ public class Algorithms {
 		return 0; // this means that the search text matches the first element in the lists
 	}
 
-	public static <T> void bubbleSort(List<T> data, int low, int high, Comparator<T> comparator) {
-		try {
-			doBubbleSort(data, low, high, comparator, TaskMonitorAdapter.DUMMY_MONITOR);
-		}
-		catch (CancelledException e) {
-			// do nothing--cancelled
-		}
-	}
-
-	private static <T> void doBubbleSort(List<T> data, int low, int high, Comparator<T> comparator,
-			TaskMonitor monitor) throws CancelledException {
-		for (int i = high; i > low; --i) {
-			monitor.checkCanceled();
-
-			boolean swapped = false;
-			for (int j = low; j < i; j++) {
-				if (comparator.compare(data.get(j), data.get(j + 1)) > 0) {
-					Collections.swap(data, j, j + 1);
-					swapped = true;
-				}
-			}
-			if (!swapped) {
-				return;
-			}
-		}
-	}
-
 	public static <T> void mergeSort(List<T> data, Comparator<T> c, TaskMonitor monitor) {
 		List<T> aux = new ArrayList<T>(data);
 		mergeSort(aux, data, 0, data.size(), c, monitor);
@@ -116,9 +89,9 @@ public class Algorithms {
 		// The only reason this method exists is because we want progress
 		// updates as we sort the list. Java can sort fairly large collections
 		// instantaeously, far better than we can hope to do, so we should
-		// really try to send reasonably large "chunks" to Collections.sort and
-		// track progress at a fairly high level. The number below was chosen on
-		// a whim and gives pretty decent performance.
+		// really try to send reasonably large "chunks" to List's sort and track
+		// progress at a fairly high level. The number below was chosen on a
+		// whim and gives pretty decent performance.
 		if (length < 1024) {
 			dest.subList(low, high).sort(c);
 			return;

--- a/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/AlgorithmsTest.java
+++ b/Ghidra/Framework/Generic/src/test/java/ghidra/util/datastruct/AlgorithmsTest.java
@@ -54,18 +54,6 @@ public class AlgorithmsTest extends AbstractGenericTest {
 	}
 
 	@Test
-	public void testBubbleSort() {
-		List<Long> data = getList(new long[] { 5, 8, 10, 2, 10, 3, 3, 7, 10, 23, 0, 15, 22 });
-		int low = 3;
-		int high = 8;
-		Algorithms.bubbleSort(data, low, high, comparator);
-		long[] expected = new long[] { 5, 8, 10, 2, 3, 3, 7, 10, 10, 23, 0, 15, 22 };
-		for (int i = 0; i < expected.length; i++) {
-			assertEquals(new Long(expected[i]), data.get(i));
-		}
-	}
-
-	@Test
 	public void testmergeSort() {
 		List<Long> data = getList(new long[] { 5, 8, 10, 2, 10, 3, 3, 7, 10, 23, 0, 15, 22 });
 		Algorithms.mergeSort(data, comparator, TaskMonitorAdapter.DUMMY_MONITOR);


### PR DESCRIPTION
Hi! I'm looking into performance bottlenecks in Ghidra and decided to pick up some easy low-hanging fruit that I came across. This change removes the bubble sort base case from `Algorithms#doMergeSort`. It came up when I profiled Ghidra when analyzing a moderately-sized binary, since it's used to update the function list by keeping it sorted. This change speeds up the sort by about 30x on a list of about 500k functions.

I had originally thought that this would be a nice but minor benefit but in my tests this also speeds up certain phases of analysis by about 30-50%, apparently because the sort takes a lock on the database which the analysis would also contends on. So hopefully it's a win all around?

I'm new to this part of the codebase, so please do check that I didn't actually break something important with this change :P I'm always concerned when making changes like these for the first time because it's hard to know the context for why it was added. Hopefully the comment I've written is accurate. Also, I added a commit to remove the bubble sort entirely because I couldn't find any reason for it to stick around; feel free to request it be dropped if you're not comfortable with that change.