### PR TITLE
Fix pea SP instruction bug on 68000 processor

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -1610,7 +1610,7 @@ macro negResFlags(result) {
 	Txb = result:1;
 }
 
-:pea eaptr			is (opbig=0x48 & op67=1 & $(CTL_ADDR_MODES))... & eaptr			{ SP = SP-4; *SP = eaptr; }
+:pea eaptr			is (opbig=0x48 & op67=1 & $(CTL_ADDR_MODES))... & eaptr			{ value:4 = eaptr; SP = SP-4; *SP = value; }
 
 @ifdef MC68040
 


### PR DESCRIPTION
The `pea` instruction adjusts `SP`, but the address may be `SP`-based. Ghidra was evaluating the effective address after adjusting `SP`, but the address should be evaluated before `SP` is changed. For example, `pea (SP)` should result in a pointer to the previous stack entry, rather than a pointer to itself.

> Before submission, please squash your commits to using a message that starts with the issue number and a description of the changes.

I was not sure what to do for the issue number; there is no corresponding issue.