### PR TITLE
6502 TSX instruction needs to set N and Z flags

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -479,6 +479,7 @@ ADDRI:  (imm16)   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 :TSX     is op=0xBA
 {
 	X = S;
+    resultFlags(X);	
 }
 
 :TXA     is op=0x8A


### PR DESCRIPTION
The TSX instruction should update flags, but currently doesn't (note: the TXS instruction does not update flags).  The fix is a one-line change to the 6502.slaspec file.  I've written demonstration code to show the before and after:

```python
"""
bug_TSX_flags.py program output:

    bug_TSX_flags.py> Running...
    after "LDX #0xff" N=1 Z=0
    after "TXS" N=1 Z=0
    after "LDX #0x0" N=0 Z=1
    after "TSX" N=0 Z=1
    bug_TSX_flags.py> Finished!

After applying patch:

    bug_TSX_flags.py> Running...
    after "LDX #0xff" N=1 Z=0
    after "TXS" N=1 Z=0
    after "LDX #0x0" N=0 Z=1
    after "TSX" N=1 Z=0
    bug_TSX_flags.py> Finished!
"""

import ghidra.app.util.importer.MessageLog as MessageLog
from   ghidra.app.util.MemoryBlockUtils import createInitializedBlock
from   ghidra.app.plugin.assembler.Assemblers import getAssembler
from   ghidra.app.emulator import EmulatorHelper

def run():
    # test code
    addr = toAddr(0x8000)
    createInitializedBlock(currentProgram, False, "txs_demo", addr, 0x8, "txs_demo", "", True, True, True, MessageLog())
    asm = getAssembler(currentProgram)
    asm.assemble(addr,
        'LDX #0xFF',
        'TXS',
        'LDX #0x00',
        'TSX')

    # emulate
    emu = EmulatorHelper(currentProgram)
    emu.writeRegister('PC', addr.getOffset())
    emu.writeRegister('SP', 0x1ff)
    for i in range(4):
        pc = toAddr(emu.readRegister('PC'))
        inst = getInstructionAt(pc)
        emu.step(monitor)
        print('after "%s" N=%d Z=%d' % (inst, emu.readRegister('N'), emu.readRegister('Z')))

run()
```
