### PR TITLE
6502 PHP should push flags with B always set to 1

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -30,12 +30,14 @@ define token data (16)
 	imm16 = (0,15)
 ;
 
+# PLP and RTI ignore b5 (unused) and b4 (B flag) as neither bit has storage on chip
+# and only exist in stack data.
 macro popSR() {
 	SP = SP + 1;
 	local ccr = *:1 SP;
 	N = ccr[7,1];
 	V = ccr[6,1];
-	B = ccr[4,1];
+	B = ccr[4,1];   # consider commenting out this B assignment
 	D = ccr[3,1];
 	I = ccr[2,1];
 	Z = ccr[1,1];
@@ -46,7 +48,7 @@ macro pushSR() {
 	local ccr:1 = 0xff;
 	ccr[7,1] = N;
 	ccr[6,1] = V;
-	ccr[4,1] = B;
+	# ccr[4,1] = B;  # always set B flag to 1
 	ccr[3,1] = D;
 	ccr[2,1] = I;
 	ccr[1,1] = Z;
@@ -194,7 +196,6 @@ ADDRI:  (imm16)   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 {
 	*:2 (SP - 1) = inst_next;
 	SP = SP - 2;
-	B = 1;
 	pushSR();
 	I = 1;
 	local target:2 = 0xFFFE;


### PR DESCRIPTION
Background:
- Instructions (BRK and PHP) that push flags on to the stack will set bit 5 (unused) and the B flag (bit 4) to 1.  (In contrast, a hardware interrupt will push a byte having B=0, but that's out of scope here)
- Instructions (PLP and RTI) that pop a byte from the stack to put into the flags will ignore bit 5 and the B flag, as neither has storage on the 6502.  Specifically, the B flag only exists in data stored on the stack.

The 6502 SLEIGH treats the B flag as if it has storage on the chip; this isn't a problem as long as the instruction semantics are correct.

SLEIGH change recommendations:
- pushSR() (used by BRK and PHP): change to always set the B flag to 1
- popSR() (used by PLP and RTI): recommend ignoring the B flag (don't set it at all), as is already done with bit 5.  This is according to spec.

What follows is demonstration code showing the behavior both before and after the pull-request patch:

```python
'''
bug_push_pull_flags.py program output:

    bug_push_pull_flags.py> Running...
    after "NOP", stack val is nv1bdizc:00000000
    after "PHP", stack val is nv1bdizc:00100000
    after "PLA", stack val is nv1bdizc:00100000
    after "AND #0x30", stack val is nv1bdizc:00100000
    Result: acc = 0x20 (should be 0x30)
    bug_push_pull_flags.py> Finished!

After applying patch:

    bug_push_pull_flags.py> Running...
    after "NOP", stack val is nv1bdizc:00000000
    after "PHP", stack val is nv1bdizc:00110000
    after "PLA", stack val is nv1bdizc:00110000
    after "AND #0x30", stack val is nv1bdizc:00110000
    Result: acc = 0x30 (should be 0x30)
    bug_push_pull_flags.py> Finished!

'''

import ghidra.app.util.importer.MessageLog as MessageLog
from   ghidra.app.util.MemoryBlockUtils import createInitializedBlock
from   ghidra.app.plugin.assembler.Assemblers import getAssembler
from   ghidra.app.emulator import EmulatorHelper

def run():
    # test code
    addr = toAddr(0x8000)
    createInitializedBlock(currentProgram, False, "flags_demo", addr, 0x7, "flags_demo", "", True, True, True, MessageLog())
    asm = getAssembler(currentProgram)
    asm.assemble(addr,
        'NOP',
        'PHP',
        'PLA',
        'AND #0x30')

    # emulate
    emu = EmulatorHelper(currentProgram)
    emu.writeRegister('PC', addr.getOffset())
    emu.writeRegister('SP', 0x1ff)
    stack_addr = toAddr(0x1ff)
    for i in range(4):
        pc = toAddr(emu.readRegister('PC'))
        inst = getInstructionAt(pc)
        emu.step(monitor)
        print('after "%s", stack val is %s' %
            (inst, "nv1bdizc:{0:08b}".format(emu.readMemoryByte(stack_addr))))
    print("Result: acc = 0x%02x (should be 0x30)" % emu.readRegister('A'))

run()

```