### PR TITLE
Allow C++ Namespaces in xml DATATYPEs

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/util/data/DataTypeParser.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/data/DataTypeParser.java
@@ -483,6 +483,12 @@ public class DataTypeParser {
 				continue;
 			}
 
+			char n = nextIndex + 1 < dataTypeString.length() ? dataTypeString.charAt(nextIndex + 1) : '\0';
+			if (c == ':' && n == ':') {
+				nextIndex += 2;
+				continue;
+			}
+
 			if (c == '*' || c == '[' || c == ':' || c == '{') {
 				return dataTypeString.substring(0, nextIndex).trim();
 			}


### PR DESCRIPTION
Given this example XML file:
```xml
<?xml version="1.0" standalone="yes"?>
<?program_dtd version="1"?>
<PROGRAM NAME="Example">
	<PROCESSOR NAME="metapc" ENDIAN="little" ADDRESS_MODEL="32-bit" />
	<DATATYPES>
		<FUNCTION_DEF NAME="ExportClass::method" NAMESPACE="/Example/ExportClass">
			<RETURN_TYPE DATATYPE="vector&lt;int&gt; *" DATATYPE_NAMESPACE="/Example" SIZE="4" />
			<PARAMETER ORDINAL="0" DATATYPE="ExportClass*" DATATYPE_NAMESPACE="/Example" NAME="this" SIZE="4" />
		</FUNCTION_DEF>
		<STRUCTURE NAME="vector&lt;int&gt;" NAMESPACE="/Example" SIZE="0xc">
			<MEMBER OFFSET="0x0" DATATYPE="int *" DATATYPE_NAMESPACE="/" NAME="mpBegin" SIZE="4" />
			<MEMBER OFFSET="0x4" DATATYPE="int" DATATYPE_NAMESPACE="/" NAME="mTestData" SIZE="4" />
			<MEMBER OFFSET="0x8" DATATYPE="int" DATATYPE_NAMESPACE="/" NAME="mTest2" SIZE="4" />
		</STRUCTURE>
		<STRUCTURE NAME="ExportClass__vftable" NAMESPACE="/Example/ExportClass" SIZE="0x4">
			<MEMBER OFFSET="0x0" DATATYPE="ExportClass::method *" DATATYPE_NAMESPACE="/Example/ExportClass" NAME="method" SIZE="4" />
		</STRUCTURE>
		<STRUCTURE NAME="ExportClass" NAMESPACE="/Example" SIZE="16">
			<MEMBER OFFSET="0" DATATYPE="ExportClass__vftable*" DATATYPE_NAMESPACE="/Example/ExportClass" SIZE="4" />
			<MEMBER OFFSET="4" DATATYPE="vector&lt;int&gt;" DATATYPE_NAMESPACE="/Example" NAME="intVector" SIZE="12" />
		</STRUCTURE>
	</DATATYPES>
</PROGRAM>
```

Importing it with ghidra will currently have an error because of this structure:
```xml
<STRUCTURE NAME="ExportClass__vftable" NAMESPACE="/Example/ExportClass" SIZE="0x4">
	<MEMBER OFFSET="0x0" DATATYPE="ExportClass::method *" DATATYPE_NAMESPACE="/Example/ExportClass" NAME="method" SIZE="4" />
</STRUCTURE>
```
Specifically, `DATATYPE="ExportClass::method *"` fails because the parser interprets `:` for bit fields, causing it to not find the valid type.
This patch just adds support for namespaces (`::`) by making `getBaseString` skip over them when finding sub data types.
With these changes the xml file will now import properly.