### PR TITLE
OMF format: Add symbols from LPUBDEF to symbol list

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
@@ -338,6 +338,7 @@ public class OmfFileHeader extends OmfRecord {
 				header.externsymbols.add((OmfExternalSymbol)record);
 				break;
 			case PUBDEF:
+			case LPUBDEF:
 				header.symbols.add((OmfSymbolRecord)record);
 				break;
 			case LINNUM:


### PR DESCRIPTION
When parsing a OMF format file, LPUBDEF symbols should be added to the list of symbols