### PR TITLE
fix: incorrect sleigh in e_stmvsprw for PPC VLE

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -400,14 +400,14 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	#TODO  SEE TODO in e_ldmvsprw
 	# storeReg(CR);
 	local tmpCR:4 = 0;
-	tmpCR = tmpCR | zext((cr0 & 0xf) << 0);
-	tmpCR = tmpCR | zext((cr1 & 0xf) << 4);
-	tmpCR = tmpCR | zext((cr2 & 0xf) << 8);
-	tmpCR = tmpCR | zext((cr3 & 0xf) << 12);
-	tmpCR = tmpCR | zext((cr4 & 0xf) << 16);
-	tmpCR = tmpCR | zext((cr5 & 0xf) << 20);
-	tmpCR = tmpCR | zext((cr6 & 0xf) << 24);
-	tmpCR = tmpCR | zext((cr7 & 0xf) << 28);
+	tmpCR = tmpCR | (zext(cr0 & 0xf) << 0);
+	tmpCR = tmpCR | (zext(cr1 & 0xf) << 4);
+	tmpCR = tmpCR | (zext(cr2 & 0xf) << 8);
+	tmpCR = tmpCR | (zext(cr3 & 0xf) << 12);
+	tmpCR = tmpCR | (zext(cr4 & 0xf) << 16);
+	tmpCR = tmpCR | (zext(cr5 & 0xf) << 20);
+	tmpCR = tmpCR | (zext(cr6 & 0xf) << 24);
+	tmpCR = tmpCR | (zext(cr7 & 0xf) << 28);
 	*:4 tea = tmpCR;
 	tea = tea + 4;
 	storeReg(LR);


### PR DESCRIPTION
The cr bits are 1 byte which means they can't be shifted more than 8 bits. 
```
        40001b38 18 21 11 14     e_stmvsprw local_3c(r1)
                                                      $U6c580:8 = INT_ADD r1, 20:8
                                                      tea = COPY $U6c580:8
                                                      $U6fe80:4 = COPY 0:4
                                                      $U6ff00:1 = INT_AND cr0, 15:1
                                                      $U6ff80:1 = INT_LEFT $U6ff00:1, 0:4
                                                      $U70000:4 = INT_ZEXT $U6ff80:1
                                                      $U6fe80:4 = INT_OR $U6fe80:4, $U70000:4
                                                      $U70100:1 = INT_AND cr1, 15:1
                                                      $U70180:1 = INT_LEFT $U70100:1, 4:4
                                                      $U70200:4 = INT_ZEXT $U70180:1
                                                      $U6fe80:4 = INT_OR $U6fe80:4, $U70200:4
                                                      $U70300:1 = INT_AND cr2, 15:1
                                                      $U70380:1 = INT_LEFT $U70300:1, 8:4
                                                      $U70400:4 = INT_ZEXT $U70380:1
                                                      $U6fe80:4 = INT_OR $U6fe80:4, $U70400:4
                                                      $U70500:1 = INT_AND cr3, 15:1
                                                      $U70580:1 = INT_LEFT $U70500:1, 12:4
                                                      $U70600:4 = INT_ZEXT $U70580:1
                                                      $U6fe80:4 = INT_OR $U6fe80:4, $U70600:4
                                                      $U70700:1 = INT_AND cr4, 15:1
                                                      $U70780:1 = INT_LEFT $U70700:1, 16:4
                                                      $U70800:4 = INT_ZEXT $U70780:1
                                                      $U6fe80:4 = INT_OR $U6fe80:4, $U70800:4
                                                      $U70900:1 = INT_AND cr5, 15:1
                                                      $U70980:1 = INT_LEFT $U70900:1, 20:4
                                                      $U70a00:4 = INT_ZEXT $U70980:1
                                                      $U6fe80:4 = INT_OR $U6fe80:4, $U70a00:4
                                                      $U70b00:1 = INT_AND cr6, 15:1
                                                      $U70b80:1 = INT_LEFT $U70b00:1, 24:4
                                                      $U70c00:4 = INT_ZEXT $U70b80:1

```
They should be zero extended first and then shifted.