### PR TITLE
Fix NPE in CParser#defineNamedComposite (see #4903)

### DIFF
--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
@@ -426,7 +426,7 @@ public class CParser {
 
                     hasNoComponents = (dtComp.getNumDefinedComponents() == 0 ? true : false);
 
-                    hasSameSourceArchive = dt.getSourceArchive().equals(dtMgr.getLocalSourceArchive());
+                    hasSameSourceArchive = Objects.equals(dt.getSourceArchive(), dtMgr.getLocalSourceArchive());
             }
 
             // make sure comp is a Composite, if existing dt is empty, in same category and archive


### PR DESCRIPTION
I ran `gradle test` on Ghidra Base: 1297 tests completed, 16 failed, 1 skipped
These failed, not sure if related to my change (I doubt it):
```
    PreProcessorTest. testDefines
    PreProcessorTest. testDefinesArgDef
    PreProcessorTest. testDefinesArgEmpty
    PreProcessorTest. testDefinesArgIsDefDef
    PreProcessorTest. testDefinesArgIsDefEmpty
    PreProcessorTest. testDefinesArgIsDefValue
    PreProcessorTest. testDefinesArgValue
    PreProcessorTest. testDefinesFileDef
    PreProcessorTest. testDefinesFileEmpty
    PreProcessorTest. testDefinesFileIsDefDef
    PreProcessorTest. testDefinesFileIsDefEmpty
    PreProcessorTest. testDefinesFileIsDefValue
    PreProcessorTest. testFileDefinesValue
    PreProcessorTest. testHeaderParsed
    PreProcessorTest. testQuotedQuote
    PreProcessorTest. testVarags
```


The related issue #4903 is probably not entirely fixed yet because CParser seems to also return different DataTypes from its parse method than before, however that should probably be a separate issue.