### PR TITLE
OMF format: Refactor relocation code and add type 2 and 3

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfCommentRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfCommentRecord.java
@@ -47,6 +47,9 @@ public class OmfCommentRecord extends OmfRecord {
 			case COMMENT_CLASS_LIBMOD:
 				value = readString(reader);
 				break;
+			default:
+				reader.setPointerIndex(reader.getPointerIndex() + getRecordLength() - 3);
+				break;
 		}
 		readCheckSumByte(reader);
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfData.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfData.java
@@ -22,17 +22,37 @@ import ghidra.app.util.bin.BinaryReader;
 /**
  * Object representing data loaded directly into the final image.
  */
-public interface OmfData extends Comparable<OmfData> {
+public abstract class OmfData extends OmfRecord implements Comparable<OmfData> {
+	protected int segmentIndex;
+	protected long dataOffset;
+
+	/**
+	 * @return get the segments index for this datablock
+	 */
+	public int getSegmentIndex() {
+		return segmentIndex;
+	}
 
 	/**
 	 * @return the starting offset, within the loaded image, of this data
 	 */
-	public long getDataOffset();
+	public long getDataOffset() {
+		return dataOffset;
+	}
+
+	/**
+	 * Compare datablocks by data offset
+	 * @return -1 for lower address, 0 for same adress, 1 for higher address
+	 */
+	@Override
+	public int compareTo(OmfData o) {
+		return Long.compare(dataOffset, o.dataOffset);
+	}
 
 	/**
 	 * @return the length of this data in bytes
 	 */
-	public int getLength();
+	abstract public int getLength();
 
 	/**
 	 * Create a byte array holding the data represented by this object. The length
@@ -41,10 +61,10 @@ public interface OmfData extends Comparable<OmfData> {
 	 * @return allocated and filled byte array
 	 * @throws IOException for problems accessing data through the reader
 	 */
-	public byte[] getByteArray(BinaryReader reader) throws IOException;
+	abstract public byte[] getByteArray(BinaryReader reader) throws IOException;
 
 	/**
 	 * @return true if this is a block entirely of zeroes
 	 */
-	public boolean isAllZeroes();
+	abstract public boolean isAllZeroes();
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfEnumeratedData.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfEnumeratedData.java
@@ -19,9 +19,7 @@ import java.io.IOException;
 
 import ghidra.app.util.bin.BinaryReader;
 
-public class OmfEnumeratedData extends OmfRecord implements OmfData {
-	private int segmentIndex;
-	private long dataOffset;
+public class OmfEnumeratedData extends OmfData {
 	private long streamOffset;		// Position in stream where data starts
 	private int streamLength;		// Number of bytes of data
 
@@ -36,29 +34,18 @@ public class OmfEnumeratedData extends OmfRecord implements OmfData {
 		readCheckSumByte(reader);
 	}
 
-	public int getSegmentIndex() {
-		return segmentIndex;
-	}
-
-	@Override
-	public long getDataOffset() {
-		return dataOffset;
-	}
-
+	/**
+	 * @return The length of the block
+	 */
 	@Override
 	public int getLength() {
 		return streamLength;
 	}
 
-	@Override
-	public int compareTo(OmfData o) {
-		long otherOffset = o.getDataOffset();
-		if (otherOffset == dataOffset) {
-			return 0;
-		}
-		return (dataOffset < otherOffset) ? -1 : 1;
-	}
-
+	/**
+	 * @param The inputfile to read from
+	 * @return The array of bytes
+	 */
 	@Override
 	public byte[] getByteArray(BinaryReader reader) throws IOException {
 		reader.setPointerIndex(streamOffset);
@@ -66,6 +53,10 @@ public class OmfEnumeratedData extends OmfRecord implements OmfData {
 		return buffer;
 	}
 
+	/**
+	 * Assume that all zeros are done with OmfIteratedData
+	 * @return True if the block is all zeroes
+	 */
 	@Override
 	public boolean isAllZeroes() {
 		return false;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
@@ -306,7 +306,7 @@ public class OmfFileHeader extends OmfRecord {
 			throw new OmfException("Object file does not start with proper header");
 		}
 		OmfFileHeader header = (OmfFileHeader) record;
-		Object lastDataBlock = null;
+		OmfData lastDataBlock = null;
 
 		while (true) {
 			record = OmfRecord.readRecord(reader);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFixupRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFixupRecord.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,310 +19,175 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import ghidra.app.util.bin.BinaryReader;
-import ghidra.program.model.address.Address;
-import ghidra.program.model.lang.Language;
 
 public class OmfFixupRecord extends OmfRecord {
+	private final Subrecord[] subrecs;
+	private OmfData lastData = null;
 
-	private Subrecord[] subrecs;
-	private OmfEnumeratedData lastLEData = null;
-	private OmfIteratedData lastLIData = null;
-
+	/**
+	 * Read a Fixup record from the input reader
+	 * @param reader The actual reader
+	 * @throws IOException
+	 */
 	public OmfFixupRecord(BinaryReader reader) throws IOException {
 		ArrayList<Subrecord> subreclist = new ArrayList<Subrecord>();
-		boolean hasBigFields = ((getRecordType() & 1) != 0);
 
 		readRecordHeader(reader);
 		long max = reader.getPointerIndex() + getRecordLength() - 1;
 		while (reader.getPointerIndex() < max) {
-			byte peek = reader.peekNextByte();
-			if ((peek & 0x80) == 0) {
-				ThreadSubrecord subrec = ThreadSubrecord.readThreadSubrecord(reader, hasBigFields);
-				subreclist.add(subrec);
-			}
-			else {
-				FixupSubrecord subrec = FixupSubrecord.readFixupSubrecord(reader, hasBigFields);
-				subreclist.add(subrec);
-			}
+			subreclist.add(Subrecord.readSubrecord(reader, hasBigFields()));
 		}
 		subrecs = new Subrecord[subreclist.size()];
 		subreclist.toArray(subrecs);
 		readCheckSumByte(reader);
 	}
 
-	public void setDataBlock(Object last) {
-		if (last instanceof OmfEnumeratedData) {
-			lastLEData = (OmfEnumeratedData) last;
-			lastLIData = null;
-		}
-		else {
-			lastLIData = (OmfIteratedData) last;
-			lastLEData = null;
-		}
+	/**
+	 * @param last The Datablock this fixup record is meant for
+	 */
+	public void setDataBlock(OmfData last) {
+		lastData = last;
 	}
 
+	/**
+	 * @return The datablock this fixup record is meant for
+	 */
+	public OmfData getDataBlock() {
+		return lastData;
+	}
+
+	/**
+	 * @return The array of subrecords
+	 */
 	public Subrecord[] getSubrecords() {
 		return subrecs;
 	}
 
-	public static class FixupState {
-		public Language language;
-		OmfFileHeader header;
-		public ThreadSubrecord[] frameThreads = new ThreadSubrecord[4];
-		public ThreadSubrecord[] targetThreads = new ThreadSubrecord[4];
-		public OmfFixupRecord currentFixupRecord;
-		public ArrayList<OmfGroupRecord> groups;
-		public ArrayList<OmfSymbol> externals;
-		public int frameState;			// Frame of item being referred to
-		public long targetState;		// Address of item being referred to
-		public Address locAddress;		// Location of data to be patched
-		public boolean M;				// true for segment-relative, false for self-relative
-		public int locationType;
-
-		public FixupState(OmfFileHeader header, ArrayList<OmfSymbol> externsyms, Language lang) {
-			for (int i = 0; i < 4; ++i) {
-				frameThreads[i] = null;
-				targetThreads[i] = null;
-			}
-			this.header = header;
-			groups = header.getGroups();
-			externals = externsyms;
-			language = lang;
-		}
-
-		public void clear() {
-			targetState = -1;
-			locAddress = null;
-			locationType = -1;
-		}
-	}
-
 	public static class Subrecord {
-		private boolean isThread;
-
-		public Subrecord(boolean isthread) {
-			isThread = isthread;
-		}
-
-		public boolean isThread() {
-			return isThread;
-		}
-	}
-
-	public static class ThreadSubrecord extends Subrecord {
-		private byte type;
-		private int index;
-
-		public ThreadSubrecord() {
-			super(true);
-		}
-
-		public int getMethod() {
-			return (type >> 2) & 7;
-		}
-
-		public int getIndex() {
-			return index;
-		}
-
-		public boolean isFrameThread() {
-			return ((type >> 6) & 1) != 0;
-		}
-
-		public int getThreadNum() {
-			return (type & 3);
-		}
-
-		public void updateState(FixupState state) {
-			if (isFrameThread()) {
-				state.frameThreads[getThreadNum()] = this;
-			}
-			else {
-				state.targetThreads[getThreadNum()] = this;
-			}
-		}
-
-		public static ThreadSubrecord readThreadSubrecord(BinaryReader reader, boolean hasBigFields)
-				throws IOException {
-			ThreadSubrecord thread = new ThreadSubrecord();
-			thread.type = reader.readNextByte();
-			int method = thread.getMethod();
-			if (method >= 4 && thread.isFrameThread()) {
-				thread.index = -1;
-			}
-			else {
-				thread.index = OmfRecord.readInt1Or2(reader, hasBigFields);
-			}
-			return thread;
-		}
-	}
-
-	public static class FixupTarget {
+		private byte first;
+		private byte hiFixup;
 		private byte fixData;
+		private int index;
 		private int frameDatum;
 		private int targetDatum;
 		private int targetDisplacement;
 
+		/**
+		 * Read the next subrecord from the input reader
+		 *
+		 * @param reader The input file
+		 * @param hasBigFields Is this 16 or 32 bit values
+		 * @return The read subrecord
+		 * @throws IOException
+		 */
+		public static Subrecord readSubrecord(BinaryReader reader, boolean hasBigFields)
+				throws IOException {
+			int method;
+			final var rec = new Subrecord();
+			rec.first = reader.readNextByte();
+			rec.index = -1;
+			if (rec.isThreadSubrecord()) {
+				method = rec.getThreadMethod();
+				if (method < 4) {
+					rec.index = readIndex(reader);
+				}
+				return rec;
+			}
+			rec.targetDisplacement = 0;
+			rec.targetDatum = 0;
+			rec.hiFixup = reader.readNextByte();
+			rec.fixData = reader.readNextByte();
+			method = rec.getFrameMethod();
+			if (!rec.isFrameThread() && method < 3) { // F=0  (explicit frame method (and datum))
+				rec.frameDatum = readIndex(reader);
+			}
+			if (!rec.isTargetThread()) { // T=0  (explicit target)
+				rec.targetDatum = readIndex(reader);
+			}
+			if ((rec.fixData & 0x04) == 0) { // P=0
+				rec.targetDisplacement = readInt2Or4(reader, hasBigFields);
+			}
+			return rec;
+		}
+
+		/**
+		 * @return True if this is a Thread subrecord type
+		 */
+		public boolean isThreadSubrecord() {
+			return (first & 0x80) == 0;
+		}
+
+		/**
+		 * @return The method value from a Thread subrecord
+		 */
+		public int getThreadMethod() {
+			return first >> 2 & 7;
+		}
+
+		/**
+		 * @return True if this is a frame reference
+		 */
+		public boolean isFrameInSubThread() {
+			return (first & 0x40) != 0;
+		}
+
+		/**
+		 * @return Get the index for explicit thread or frame
+		 */
+		public int getIndex() {
+			return index;
+		}
+
+		/**
+		 * @return Get the thread index from flag
+		 */
+		public int getThreadNum() {
+			return first & 3;
+		}
+
 		public boolean isFrameThread() {
-			return ((fixData >> 7) & 1) != 0;
+			return (fixData & 0x80) != 0;
 		}
 
 		public boolean isTargetThread() {
-			return ((fixData >> 3) & 1) != 0;
+			return (fixData & 0x08) != 0;
 		}
 
 		public int getFrameMethod() {
-			return ((fixData >> 4) & 7);
+			return fixData >> 4 & 7;
 		}
 
-		public int getP() {
-			int res = (fixData >> 2) & 1;
-			return res;
+		public int getFixThreadNum() {
+			return fixData & 3;
 		}
 
-		public void resolveFrame(FixupState state) throws OmfException {
-			int method;
-			int index;
-			if (isFrameThread()) {
-				// Frame datum from a thread
-				int threadnum = ((fixData >> 4) & 3);
-				ThreadSubrecord subrec = state.frameThreads[threadnum];
-				method = subrec.getMethod();
-				index = subrec.getIndex();
-			}
-			else {
-				method = getFrameMethod();
-				index = frameDatum;
-			}
-			switch (method) {
-				case 0:				// Index is for a segment
-					state.frameState = state.header.resolveSegment(index).getFrameDatum();
-					break;
-				case 1:				// Index is for a group
-					state.frameState = state.groups.get(index - 1).getFrameDatum();
-					break;
-				case 2:				// Index is for an external symbol
-					state.frameState = state.externals.get(index - 1).getFrameDatum();
-					break;
-				case 4:				// Segment Index grabbed from datablock
-					if (state.currentFixupRecord.lastLEData != null) {
-						index = state.currentFixupRecord.lastLEData.getSegmentIndex();
-					}
-					else {
-						index = state.currentFixupRecord.lastLIData.getSegmentIndex();
-					}
-					state.frameState = state.header.resolveSegment(index).getFrameDatum();
-					break;
-				case 5:				// Frame determined by target
-					// TODO:  Fill this in properly
-					break;
-				default:
-					state.frameState = -1;			// Indicate an error condition
-			}
+		public int getFixMethodWithSub(Subrecord rec) {
+			return fixData & 0x04 | rec.getThreadMethod() & 0x3;
 		}
 
-		public void resolveTarget(FixupState state) throws OmfException {
-			int method;
-			int index;
-			if (isTargetThread()) {
-				int threadnum = fixData & 3;
-				ThreadSubrecord subrec = state.targetThreads[threadnum];
-				method = getP();		// Most significant bit is frame fixup subrecord
-				method <<= 2;
-				method |= subrec.getMethod();	// Least significant 2 bits are from the thread
-				index = subrec.getIndex();
-			}
-			else {
-				method = fixData & 7;
-				index = targetDatum;
-			}
-
-			switch (method) {
-				case 0:			// Index is for a segment
-					state.targetState = state.header.resolveSegment(index).getStartAddress();
-					state.targetState += targetDisplacement;
-					break;
-				case 1:			// Index is for a group
-					state.targetState = state.groups.get(index - 1).getStartAddress();
-					state.targetState += targetDisplacement;
-					break;
-				case 2:			// Index is for an external symbol
-					state.targetState = state.externals.get(index - 1).getAddress().getOffset();
-					state.targetState += targetDisplacement;
-					break;
-				//	case 3:			// Not supported by many linkers
-				case 4:			// segment only, no displacement
-					state.targetState = state.header.resolveSegment(index).getStartAddress();
-					break;
-				case 5:			// group only, no displacement
-					state.targetState = state.groups.get(index - 1).getStartAddress();
-					break;
-				case 6:			// external only, no displacement
-					state.targetState = state.externals.get(index - 1).getAddress().getOffset();
-					break;
-				default:
-					state.targetState = -1;			// This indicates an unresolved target
-			}
+		public int getFixMethod() {
+			return fixData & 7;
 		}
 
-		public static FixupTarget readFixupTarget(BinaryReader reader, boolean hasBigFields)
-				throws IOException {
-			FixupTarget fixupTarget = new FixupTarget();
-			fixupTarget.fixData = reader.readNextByte();
-			if ((fixupTarget.fixData & 0x80) == 0) {		// F=0  (explicit frame method (and datum))
-				int method = (fixupTarget.fixData >> 4) & 7;
-				if (method < 3) {
-					fixupTarget.frameDatum = OmfRecord.readIndex(reader);
-				}
-			}
-			if ((fixupTarget.fixData & 0x08) == 0) {		// T=0  (explicit target)
-				fixupTarget.targetDatum = OmfRecord.readIndex(reader);
-			}
-			if ((fixupTarget.fixData & 0x04) == 0)		// P=0
-				fixupTarget.targetDisplacement = OmfRecord.readInt2Or4(reader, hasBigFields);
-			return fixupTarget;
+		public int getTargetDatum() {
+			return targetDatum;
+		}
+
+		public int getTargetDisplacement() {
+			return targetDisplacement;
+		}
+
+		public int getLocationType() {
+			return first >> 2 & 0xf;
+		}
+
+		public int getDataRecordOffset() {
+			return (first & 3) << 8 | hiFixup & 0xff;
+		}
+
+		public boolean isSegmentRelative() {
+			return (first & 0x40) != 0;
 		}
 	}
 
-	public static class FixupSubrecord extends Subrecord {
-		private byte lobyte;			// lo-byte of location
-		private byte hibyte;			// hi-byte of location
-		private FixupTarget target;
-
-		public FixupSubrecord() {
-			super(false);
-		}
-
-		public void resolveFixup(FixupState state) throws OmfException {
-
-			target.resolveTarget(state);		// Resolve target first as frame may need to reference results
-			target.resolveFrame(state);
-			state.M = ((lobyte >> 6) & 1) != 0;
-			state.locationType = ((lobyte >> 2) & 0xf);
-			int dataRecordOffset = lobyte & 3;
-			dataRecordOffset <<= 8;
-			dataRecordOffset |= (hibyte) & 0xff;
-			long blockDisplace;
-			int segIndex;
-			if (state.currentFixupRecord.lastLEData != null) {
-				blockDisplace = state.currentFixupRecord.lastLEData.getDataOffset();
-				segIndex = state.currentFixupRecord.lastLEData.getSegmentIndex();
-			}
-			else {
-				blockDisplace = state.currentFixupRecord.lastLIData.getDataOffset();
-				segIndex = state.currentFixupRecord.lastLIData.getSegmentIndex();
-			}
-			OmfSegmentHeader seg = state.header.resolveSegment(segIndex);
-			state.locAddress = seg.getAddress(state.language).add(blockDisplace + dataRecordOffset);
-		}
-
-		public static FixupSubrecord readFixupSubrecord(BinaryReader reader, boolean hasBigFields)
-				throws IOException {
-			FixupSubrecord fixupSubrecord = new FixupSubrecord();
-			fixupSubrecord.lobyte = reader.readNextByte();
-			fixupSubrecord.hibyte = reader.readNextByte();
-			fixupSubrecord.target = FixupTarget.readFixupTarget(reader, hasBigFields);
-			return fixupSubrecord;
-		}
-	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfIteratedData.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfIteratedData.java
@@ -20,11 +20,9 @@ import java.util.ArrayList;
 
 import ghidra.app.util.bin.BinaryReader;
 
-public class OmfIteratedData extends OmfRecord implements OmfData {
+public class OmfIteratedData extends OmfData {
 
 	public static final int MAX_ITERATED_FILL = 0x100000;	// Maximum number of bytes in expanded form
-	private int segmentIndex;
-	private long dataOffset;
 	private DataBlock[] datablock;
 
 	public OmfIteratedData(BinaryReader reader) throws IOException {
@@ -43,15 +41,9 @@ public class OmfIteratedData extends OmfRecord implements OmfData {
 		blocklist.toArray(datablock);
 	}
 
-	public int getSegmentIndex() {
-		return segmentIndex;
-	}
-
-	@Override
-	public long getDataOffset() {
-		return dataOffset;
-	}
-
+	/**
+	 * @return true if the block is all zeros
+	 */
 	@Override
 	public boolean isAllZeroes() {
 		for (int i = 0; i < datablock.length; ++i) {
@@ -62,6 +54,9 @@ public class OmfIteratedData extends OmfRecord implements OmfData {
 		return true;
 	}
 
+	/**
+	 * @return the length of the block after expansion
+	 */
 	@Override
 	public int getLength() {
 		int length = 0;
@@ -71,6 +66,10 @@ public class OmfIteratedData extends OmfRecord implements OmfData {
 		return length;
 	}
 
+	/**
+	 * @param reader The file to read from
+	 * @return The block created from the read data
+	 */
 	@Override
 	public byte[] getByteArray(BinaryReader reader) throws IOException {
 		int length = getLength();
@@ -85,15 +84,10 @@ public class OmfIteratedData extends OmfRecord implements OmfData {
 		return buffer;
 	}
 
-	@Override
-	public int compareTo(OmfData o) {
-		long otherOffset = o.getDataOffset();
-		if (dataOffset == otherOffset) {
-			return 0;
-		}
-		return (dataOffset < otherOffset) ? -1 : 1;
-	}
-
+	/**
+	 * Contain the definition of one part of a datablock with possible recursion
+	 * 
+	 */
 	public static class DataBlock {
 		private int repeatCount;
 		private int blockCount;
@@ -120,6 +114,12 @@ public class OmfIteratedData extends OmfRecord implements OmfData {
 			return subblock;
 		}
 
+		/**
+		 * Fill part of the buffer
+		 * @param buffer The buffer to fill
+		 * @param pos The next position to fill
+		 * @return The position after the block
+		 */
 		public int fillBuffer(byte[] buffer, int pos) {
 			for (int i = 0; i < repeatCount; ++i) {
 				if (simpleBlock != null) {
@@ -137,6 +137,9 @@ public class OmfIteratedData extends OmfRecord implements OmfData {
 			return pos;
 		}
 
+		/**
+		 * @return The length of this block
+		 */
 		public int getLength() {
 			int length = 0;
 			if (simpleBlock != null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfModuleEnd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfModuleEnd.java
@@ -1,4 +1,5 @@
 /* ###
+,
  * IP: GHIDRA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,18 +21,24 @@ import java.io.IOException;
 import ghidra.app.util.bin.BinaryReader;
 
 public class OmfModuleEnd extends OmfRecord {
-	private byte moduleType;
-	private OmfFixupRecord.FixupTarget startAddress;
+	//private byte moduleType;
+	//private OmfFixupRecord.FixupTarget startAddress;
 
 	public OmfModuleEnd(BinaryReader reader) throws IOException {
 		readRecordHeader(reader);
+		/* The record type is not handled so simply skip the information 
 		moduleType = reader.readNextByte();
 		if (hasStartAddress()) {
-			startAddress = OmfFixupRecord.FixupTarget.readFixupTarget(reader, hasBigFields());
+			endData = reader.readNextByte();
+			frameDatum = readInt1Or2(reader, hasBigFields());
+			targetDatum = readInt1Or2(reader, hasBigFields());
+			targetDisplacement readInt2Or4(reader, hasBigFields());
 		}
 		readCheckSumByte(reader);
+		*/
+		reader.setPointerIndex(reader.getPointerIndex() + getRecordLength());
 	}
-
+/*
 	public boolean isMainProgramModule() {
 		return ((moduleType & 0x80) != 0);
 	}
@@ -39,4 +46,5 @@ public class OmfModuleEnd extends OmfRecord {
 	public boolean hasStartAddress() {
 		return ((moduleType & 0x40) != 0);
 	}
+*/
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfRecord.java
@@ -247,6 +247,6 @@ public abstract class OmfRecord {
 	@Override
 	public String toString() {
 		return String.format("name: %s, type: 0x%x, offset: 0x%x, length: 0x%x",
-			getRecordName(recordType & 0xfe), recordType, recordOffset, recordLength);
+			getRecordName(recordType & (byte)0xfe), recordType, recordOffset, recordLength);
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfSymbol.java
@@ -15,6 +15,8 @@
  */
 package ghidra.app.util.bin.format.omf;
 
+import java.util.Set;
+
 import ghidra.program.model.address.Address;
 
 public class OmfSymbol {
@@ -25,6 +27,15 @@ public class OmfSymbol {
 	private int segmentRef = 0;	// Symbol is really reference to extra segment
 	private long offset;
 	private Address address;
+
+	/**
+	 * These names were taken from the OpenWatcom source code
+	 * https://github.com/open-watcom/open-watcom-v2/blob/master/bld/watcom/h/fppatche.h
+	 */
+	private static final Set<String> FLOATINGPOINT_SPECIALNAMES = Set.of(
+		"FIWRQQ", "FIDRQQ", "FIERQQ", "FICRQQ", "FJCRQQ", "FISRQQ",
+		"FJSRQQ", "FIARQQ", "FJARQQ", "FIFRQQ", "FJFRQQ", "FIGRQQ",
+		"FJGRQQ");
 
 	public OmfSymbol(String name, int type, long off, int dT, int bL) {
 		symbolName = name;
@@ -64,5 +75,9 @@ public class OmfSymbol {
 
 	public int getFrameDatum() {
 		return 0;					// This is currently unused
+	}
+	
+	public boolean isFloatingPointSpecial() {
+		return FLOATINGPOINT_SPECIALNAMES.contains(symbolName);
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfSymbolRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfSymbolRecord.java
@@ -17,6 +17,7 @@ package ghidra.app.util.bin.format.omf;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import ghidra.app.util.bin.BinaryReader;
 
@@ -70,4 +71,9 @@ public class OmfSymbolRecord extends OmfRecord {
 	public OmfSymbol getSymbol(int i) {
 		return symbol[i];
 	}
+
+	public List<OmfSymbol> getSymbols() {
+		return List.of(symbol);
+	}
+
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
@@ -221,6 +221,9 @@ public class OmfLoader extends AbstractProgramWrapperLoader {
 							case 2:			// Index is for an external symbol
 							case 6:			// external only, no displacement
 								OmfSymbol symbol = externsyms.get(index - 1);
+								if (symbol.isFloatingPointSpecial()) {
+									continue;
+								}
 								targetAddr = symbol.getAddress().getOffset();
 								break;
 							case 3:			// Not supported by many linkers


### PR DESCRIPTION
This is a refactoring of the code that do OMF relocations.
This is based on comments from Ryan, saying that handling should be move towards the loader class.
Also relocation type 2, segment relocation and type 3 segment:offset is implemented, which was the base goal.

Moving the code means that the special state class is unneeded, as variables can now be local inside the relocation function.
Also the fixuptarget class is unneeded, but was used by OmfModuleEnd.
But since that OmfModuleEnd isn't using the information, it is changed to simply skip the information rather than reading it. 
This could be split to a separate commit.

Also OmfData is changed to a abstract class, as some functions are identical in OmfIterationData and OmfEnumerationData.
It also makes keeping the link for the lastdata block simpler.

resolveFrame is simply removed as the information wasn't used in later processing.

I have added a catch of IndexArrayOutOfBounds in the relocation code. This may be a bad idea as this will try to recover a pass of  a bad file, rather than just failing.

The file attached to #4793 also shows another special thing. Some symbols are present in both an EXTDEF and PUBDEF, meaning that the current code, will procedure the same name both as a label inside the code, and as an external thunk.
The relocations in this case points to the external symbol, so all calls points there although the code exists.
So processing order is changed to public first, then externals, allowing externals to check for a PUBDEF definition and reusing the symbol, rather than creating an external thunk, which is what a linker would do.
For now the search loops through all PUBDEFs record to check the symbol. This could be optimized by creating a list of public symbols or try using the program symboltable. But the current implementation works.

In #4777 some relocations points to external names like 'FIWRQQ', which are handled special by linkers.
So an array of these are created in OmfSymbol and the relocation code for external target checks for these names, and skip the relocation if a matching name is found. This could be an arraylist instead.
This could be split to a follow up commit, rather than being a part of this.

Can I find the eclipse formatter in git repo, so I do proper formatting?
If not which format of "if" constructs are preferred, with {} or without for one liners?

(Fixes: #4777, #4793)