### PR TITLE
IEEE-695 (MUFOM) Binary Format Loader

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomAD.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomAD.java
@@ -1,0 +1,68 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 8.4 AD (address descriptor) Command
+ *
+ * AD-command → “AD” bits-per-MAU (“,” MAUs-per-address) (“,” order)? )? “.”
+ * bits-per-MAU → hexnumber
+ * MAUs-per-address → hexnumber
+ * order → “L” | “M”
+ *
+ * {$EC}{8){4}{$CC}
+ */
+public class MufomAD extends MufomRecord {
+	public static final String NAME = "AD";
+	public static final int record_type = MufomType.MUFOM_CMD_AD;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long bits_per_mau = -1;
+	public long maus_per_address = -1;
+	public int order = -1;
+
+	private void print() {
+		String msg = NAME + ": " + bits_per_mau + " " + maus_per_address;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomAD(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		bits_per_mau = read_int(reader);
+		maus_per_address = read_int(reader);
+		order = read_opt_char(reader);
+		if (MufomType.MUFOM_ID_L == order) {
+			//TODO  little endian
+		} else if (MufomType.MUFOM_ID_M == order) {
+			//TODO  big endian
+		} else {
+			//TODO  unknown
+			Msg.info(this, "Unknown endianess");
+			reader.setPointerIndex(reader.getPointerIndex() - 1);
+		}
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomAS.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomAS.java
@@ -1,0 +1,132 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 12. AS (assignment) Command
+ * 
+ * AS_command ::= "AS" MUFOM_variable "," expression "."
+ *
+ * {$C1}{$D3}
+ */
+public class MufomAS extends MufomRecord {
+	public static final String NAME = "AS";
+	public static final int record_type = MufomType.MUFOM_ID_A;
+	public static final int record_subtype = MufomType.MUFOM_ID_S;
+	public long record_start = -1;
+
+	public MufomAS(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		int section_type = -1;
+		boolean parse_section_type = true;
+		while (parse_section_type) {
+			section_type = read_char(reader);
+			switch (section_type) {
+			case MufomType.MUFOM_ID_W:
+				/* Access: writable (RAM)  This is default if no access attribute is found */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - writable");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_R:
+				/* Access: read only (ROM) */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - read only");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_X:
+				/* Access: Execute only */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - execute only");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_Z:
+				/* Access: zero page */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - zero page");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_A:
+				/* Access: Abs.  There shall be an assignment to the L-variable */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - absolute");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_E:
+				/* Overlap: Equal.  Error if lengths differ */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - equal");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_M:
+				/* Overlap: Max.  Use largest length encountered */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - max");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_U:
+				/* Overlap: Unique.  Name should be unique */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - unique");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_C:
+				/* Overlap: Cumulative.  Concatenate sections */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - cumulative");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_S:
+				/* Overlap: Separate.  No connection between sections */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - separate");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_N:
+				/* Allocate: Now.  This is normal case */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - now");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_P:
+				/* Allocate: Postpone.  re-locator must allocate after all 'now' sections */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - postpone");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_F:
+				/* Overlap: Not filled.  not filled or cleared */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - postpone");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_Y:
+				/* Access: Addressing mode.  section must be located in addressing mode num */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - postpone");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_B:
+				/* Access: blank.  must be initialized to '0' */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - postpone");
+				//TODO
+				break;
+			case MufomType.MUFOM_ID_I:
+				/* Access: initialize.  must be initialized in rom */
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - postpone");
+				//TODO
+				break;
+			default:
+				if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - DONE " + section_type);
+				parse_section_type = false;
+				reader.setPointerIndex(reader.getPointerIndex() - 1);
+				break;
+			}
+		}
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASF.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASF.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * F-variable → 
+ */
+public class MufomASF extends MufomRecord {
+	public static final String NAME = "ASF";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_F;
+	public long record_start = -1;
+
+	public MufomASF(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASG.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASG.java
@@ -1,0 +1,60 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Starting Address (ASG)
+ *
+ * {$E2}{$C7}{$BE}{n1}{$BF}
+ */
+public class MufomASG extends MufomRecord {
+	public static final String NAME = "ASG";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_G;
+	public long record_start = -1;
+	public long starting_address = -1;
+
+	private void print() {
+		String msg = NAME + ": " + Long.toHexString(starting_address);
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomASG(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		if (MufomType.MUFOM_OPEN != read_char(reader)) {
+			Msg.info(null, "Expecting MUFOM_OPEN");
+			throw new IOException();
+		}
+
+		starting_address = read_int(reader);
+
+		if (MufomType.MUFOM_CLOSE != read_char(reader)) {
+			Msg.info(null, "Expecting MUFOM_CLOSE");
+			throw new IOException();
+		}
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASI.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASI.java
@@ -1,0 +1,56 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Value Records (ASI)
+ *
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * I-variable → “I” hexnumber
+ *
+ * {$E2}{$C9}{n1}{n2}
+ */
+public class MufomASI extends MufomRecord {
+	public static final String NAME = "ASI";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_I;
+	public long record_start = -1;
+	public long symbol_name_index = -1;
+	public long symbol_value = -1;
+
+	private void print() {
+		String msg = NAME + ": " + symbol_name_index + " " + symbol_value;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomASI(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		symbol_name_index = read_int(reader);
+		symbol_value = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASL.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASL.java
@@ -1,0 +1,58 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Section Base Address (ASL)
+ *
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * L-variable → “L” section-number?
+ * section-number → hexnumber
+ *
+ * {$E2}{$CC}{n1}{n2}
+ */
+public class MufomASL extends MufomRecord {
+	public static final String NAME = "ASL";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_L;
+	public long record_start = -1;
+	public long section_number = -1;
+	public long section_base_address = -1;
+
+	private void print() {
+		String msg = NAME + ": " + section_number + " 0x" + Long.toHexString(section_base_address);
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomASL(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		section_number = read_int(reader);
+		section_base_address = read_int(reader);
+		print();
+		hexdump(reader, record_start, 0x20);
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASN.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASN.java
@@ -1,0 +1,54 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Value Records (ASN)
+ *
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * N-variable → “N” hexnumber
+ */
+public class MufomASN extends MufomRecord {
+	public static final String NAME = "ASN";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_N;
+	public long record_start = -1;
+	public long symbol_name_index = -1;
+	public long symbol_name_value = -1;
+
+	private void print() {
+		String msg = NAME + ": " + symbol_name_index + " " + symbol_name_value;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomASN(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		symbol_name_index = read_int(reader);
+		symbol_name_value = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASP.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASP.java
@@ -1,0 +1,63 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Set Current PC, absolute code (ASP)
+ *
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * P-variable → “P” section-number?
+ * section-number → hexnumber
+ */
+public class MufomASP extends MufomRecord {
+	public static final String NAME = "ASP";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_P;
+	public long record_start = -1;
+	public long section_index = -1;
+	public long current_pc = -1;
+
+	public static boolean check(BinaryReader reader) throws IOException {
+		long offset = reader.getPointerIndex();
+		if (record_type == reader.readUnsignedByte(offset + 0) &&
+				record_subtype == reader.readUnsignedByte(offset + 1)) {
+			return true;
+		}
+		return false;
+	}
+
+	private void print() {
+		String msg = NAME + ": " + section_index + " " + Long.toHexString(current_pc);
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+	public MufomASP(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		section_index = read_int(reader);
+		current_pc = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASR.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASR.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * R-variable → 
+ */
+public class MufomASR extends MufomRecord {
+	public static final String NAME = "ASR";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_R;
+	public long record_start = -1;
+
+	public MufomASR(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASS.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASS.java
@@ -1,0 +1,57 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Section Size (ASS)
+ *
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * S-variable → “S” section-number?
+ * section-number → hexnumber
+ *
+ * {$E2}{$D3}{n1}{n2}
+ */
+public class MufomASS extends MufomRecord {
+	public static final String NAME = "ASS";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_S;
+	public long record_start = -1;
+	public long section_number = -1;
+	public long section_size = -1;
+
+	private void print() {
+		String msg = NAME + ": " + section_number + " " + section_size;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomASS(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		section_number = read_int(reader);
+		section_size = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASW.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASW.java
@@ -1,0 +1,71 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Assign Value to Variable W
+ *
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * W-variable → “W” hexnumber
+ *
+ * {$E2}{$D7}{00}{n}
+ * {$E2}{$D7}{01}{n}
+ * {$E2}{$D7}{02}{n}
+ * {$E2}{$D7}{03}{n}
+ * {$E2}{$D7}{04}{n}
+ * {$E2}{$D7}{05}{n}
+ * {$E2}{$D7}{06}{n}
+ * {$E2}{$D7}{07}{n}
+ */
+public class MufomASW extends MufomRecord {
+	public static final String NAME = "ASW";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_W;
+	public long record_start = -1;
+	public long asw_index = -1;
+	public long asw_offset = -1;
+
+	private void print() {
+		String msg = NAME + ": " + asw_index + " " + Long.toHexString(asw_offset);
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomASW(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		asw_index = read_int(reader);
+		if (asw_index < 0 || asw_index > 7) {
+			Msg.info(this, "Bad ASW index");
+			throw new IOException();
+		}
+		asw_offset = read_int(reader);
+		if (asw_offset < 0 || asw_offset > reader.length()) {
+			Msg.info(this, "Bad ASW offset");
+			throw new IOException();
+		}
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASX.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomASX.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * AS-command → “AS” MUFOM-variable “,” expression “,”
+ *
+ * X-variable → 
+ */
+public class MufomASX extends MufomRecord {
+	public static final String NAME = "ASX";
+	public static final int record_type = MufomType.MUFOM_CMD_AS;
+	public static final int record_subtype = MufomType.MUFOM_ID_X;
+	public long record_start = -1;
+
+	public MufomASX(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomATI.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomATI.java
@@ -1,0 +1,148 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Attribute Records (ATI)
+ *
+ * AT-command → “AT” variable “,” type-table-entry (“,” lex-level (“,” hexnumber)* )? “.”
+ * variable → I-variable | N-variable | X-variable
+ * type-table-entry → hexnumber
+ * lex-level → hexnumber
+ *
+ * I-variable → “I” hexnumber
+ *
+ * {$F1}{$C9}{n1}{n2}{n3}{n4}
+ */
+public class MufomATI extends MufomRecord {
+	public static final String NAME = "ATI";
+	public static final int record_type = MufomType.MUFOM_CMD_AT;
+	public static final int record_subtype = MufomType.MUFOM_ID_I;
+	public long record_start = -1;
+	public long symbol_name_index = -1;
+	public long symbol_type_index = -1;
+	public long attribute_definition = -1;
+	public long static_symbol = -1;
+	public long number_of_elements = -1;
+
+	private void print() {
+		String msg = NAME + ": " + symbol_name_index + " " + symbol_type_index + " " +
+				attribute_definition + " " + number_of_elements;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomATI(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		symbol_name_index = read_int(reader);
+		symbol_type_index = read_int(reader);
+		switch ((int) symbol_type_index) {
+        case MufomType.MUFOM_BUILTIN_UNK:
+        	Msg.info(this, "TYPE: UNK");
+        	break;
+        case MufomType.MUFOM_BUILTIN_V:
+        	Msg.info(this, "TYPE: V");
+        	break;
+        case MufomType.MUFOM_BUILTIN_B:
+        	Msg.info(this, "TYPE: B");
+        	break;
+        case MufomType.MUFOM_BUILTIN_C:
+        	Msg.info(this, "TYPE: C");
+            break;
+        case MufomType.MUFOM_BUILTIN_H:
+        	Msg.info(this, "TYPE: H");
+            break;
+        case MufomType.MUFOM_BUILTIN_I:
+        	Msg.info(this, "TYPE: I");
+            break;
+        case MufomType.MUFOM_BUILTIN_L:
+        	Msg.info(this, "TYPE: L");
+            break;
+        case MufomType.MUFOM_BUILTIN_M:
+        	Msg.info(this, "TYPE: M");
+            break;
+        case MufomType.MUFOM_BUILTIN_F:
+        	Msg.info(this, "TYPE: F");
+            break;
+        case MufomType.MUFOM_BUILTIN_D:
+        	Msg.info(this, "TYPE: D");
+            break;
+        case MufomType.MUFOM_BUILTIN_K:
+        	Msg.info(this, "TYPE: K");
+            break;
+        case MufomType.MUFOM_BUILTIN_J:
+        	Msg.info(this, "TYPE: J");
+            break;
+        case MufomType.MUFOM_BUILTIN_PUNK:
+        	Msg.info(this, "TYPE: PUNK");
+            break;
+        case MufomType.MUFOM_BUILTIN_PV:
+        	Msg.info(this, "TYPE: PV");
+            break;
+        case MufomType.MUFOM_BUILTIN_PB:
+        	Msg.info(this, "TYPE: PB");
+        	break;
+        case MufomType.MUFOM_BUILTIN_PC:
+        	Msg.info(this, "TYPE: PC");
+        	break;
+        case MufomType.MUFOM_BUILTIN_PH:
+        	Msg.info(this, "TYPE: PH");
+        	break;
+        case MufomType.MUFOM_BUILTIN_PI:
+        	Msg.info(this, "TYPE: PI");
+        	break;
+        case MufomType.MUFOM_BUILTIN_PL:
+        	Msg.info(this, "TYPE: PL");
+            break;
+        case MufomType.MUFOM_BUILTIN_PM:
+        	Msg.info(this, "TYPE: PM");
+            break;
+        case MufomType.MUFOM_BUILTIN_PF:
+        	Msg.info(this, "TYPE: PF");
+            break;
+        case MufomType.MUFOM_BUILTIN_PD:
+        	Msg.info(this, "TYPE: PD");
+            break;
+        case MufomType.MUFOM_BUILTIN_PK:
+        	Msg.info(this, "TYPE: PK");
+        	break;
+        default:
+        	Msg.info(this, "Bad type " + symbol_type_index);
+        	throw new IOException();
+        }
+
+		attribute_definition = read_int(reader);
+		if (MufomType.MUFOM_AD_STATICSYMBOL != attribute_definition) {
+			Msg.info(this, "unkown attribute_definition " + attribute_definition);
+			hexdump(reader, record_offset, 0x10);
+		}
+		static_symbol = read_int(reader);
+		
+		if (MufomType.MUFOM_BUILTIN_UNK != symbol_type_index) {
+			number_of_elements = read_int(reader);
+		}
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomATN.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomATN.java
@@ -1,0 +1,134 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Attribute Records (ATN)
+ *
+ * AT-command → “AT” variable “,” type-table-entry (“,” lex-level (“,” hexnumber)* )? “.”
+ * variable → I-variable | N-variable | X-variable
+ * type-table-entry → hexnumber
+ * lex-level → hexnumber
+ *
+ * N-variable → “N” hexnumber
+ *
+ * {$F1}{$CE}{n1}{n2}{n3}[x1][x2][Id]
+ */
+public class MufomATN extends MufomRecord {
+	public static final String NAME = "ATN";
+	public static final int record_type = MufomType.MUFOM_CMD_AT;
+	public static final int record_subtype = MufomType.MUFOM_ID_N;
+	public long record_start = -1;
+	public long symbol_name_index = -1;
+	public long attribute_definition = -1;
+    public String id = null;
+    public long x1 = -1;
+    public long x2 = -1;
+    public long x3 = -1;
+    public long x4 = -1;
+    public long x5 = -1;
+    public long x6 = -1;
+    public boolean has_asn = false;
+
+    private void print() {
+		String msg = NAME + ": " + symbol_name_index + " " + attribute_definition;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+    public MufomATN(BinaryReader reader) throws IOException {
+    	record_start = reader.getPointerIndex();
+    	read_record_type(reader, record_type, record_subtype, NAME);
+		symbol_name_index = read_int(reader);
+
+		if (read_int(reader) != 0) {
+			Msg.info(this, "Bad lex-level");
+			throw new IOException();
+		}
+		attribute_definition = read_int(reader);
+        switch ((int) attribute_definition) {
+        case MufomType.ieee_unknown_1_enum:
+        	x1 = read_int(reader);
+            break;
+        case MufomType.MUFOM_AD_TYPE:
+            x1 = read_int(reader);
+            //TODO  has_asn?  ASW0 does not
+            break;
+        case MufomType.MUFOM_AD_CASE:
+            x1 = read_int(reader);
+            //TODO  has_asn?  ASW0 does not
+            break;
+        case MufomType.MUFOM_AD_STATUS:
+            x1 = read_int(reader);
+            break;
+        case MufomType.ieee_unknown_56_enum:
+            x1 = read_int(reader);
+            break;
+        case MufomType.MUFOM_AD_ENV:
+            x1 = read_int(reader);
+            break;
+        case MufomType.ieee_unknown_16_enum:
+            x1 = read_int(reader);
+            x2 = read_int(reader);
+            break;
+        case MufomType.MUFOM_AD_STATICSYMBOL:
+            x1 = read_int(reader);
+            x2 = read_int(reader);
+            break;
+        case MufomType.MUFOM_AD_VERSION:
+            x1 = read_int(reader);
+            x2 = read_int(reader);
+            break;
+        case MufomType.ieee_unknown_7_enum:
+            x1 = read_int(reader);
+            x2 = read_int(reader);
+            x3 = read_int(reader);
+            break;
+        case MufomType.ieee_execution_tool_version_enum:
+            x1 = read_int(reader);
+            x2 = read_int(reader);
+            x3 = read_int(reader);
+            break;
+        case MufomType.ieee_unknown_12_enum:
+            x1 = read_int(reader);
+            x2 = read_int(reader);
+            x3 = read_int(reader);
+            x4 = read_int(reader);
+            x5 = read_int(reader);
+            break;
+        case MufomType.MUFOM_AD_DATETIME:
+            x1 = read_int(reader); // year
+            x2 = read_int(reader); // mon
+            x3 = read_int(reader); // day
+            x4 = read_int(reader); // hour
+            x5 = read_int(reader); // min
+            x6 = read_int(reader); // sec
+            break;
+         default:
+            Msg.info(null, "Bad ATN " + symbol_name_index + " " + attribute_definition);
+            throw new IOException();
+         }
+        print();
+    }
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomATX.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomATX.java
@@ -1,0 +1,43 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 11.4 AT (attributes) Command
+ * 
+ * AT_command ::= "AT" variable "," type_table_entry [ "," lex_level [ "," hex_number ]* ]? "."
+ * variable ::= I_variable | N_variable | X_variable
+ * type_table_entry ::= hex_number
+ * lex_level ::= hex_number
+ */
+public class MufomATX extends MufomRecord {
+	public static final String NAME = "AT";
+	public static final int record_type = MufomType.MUFOM_CMD_AT;
+	public static final int record_subtype = MufomType.MUFOM_ID_X;
+	public long record_start = -1;
+
+	public MufomATX(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB.java
@@ -1,0 +1,90 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+public class MufomBB extends MufomRecord {
+	public static final String NAME = "BB";
+	public static final int record_type = MufomType.MUFOM_CMD_SC;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long begin_block = -1;
+	public long block_size = -1;
+	public MufomBB bb1 = null;
+	public MufomBB bb2 = null;
+	public MufomBB bb3 = null;
+	public MufomBB bb4 = null;
+	public MufomBB bb5 = null;
+	public MufomBB bb6 = null;
+	public MufomBB bb10 = null;
+	public MufomBB bb11 = null;
+
+	public long block_start = -1;
+	public long block_end = -1;
+
+	private void print() {
+		String msg = NAME + ": " + begin_block + " 0x" + Long.toHexString(block_size) + " " +
+				Long.toHexString(record_start) + " " + Long.toHexString(block_end) + " " +
+				Long.toHexString(block_end - record_start);
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+
+		begin_block = read_int(reader);
+		block_size = read_int(reader);
+		switch ((int) begin_block) {
+		case MufomType.MUFOM_BB1:
+			new MufomBB1(reader);
+			break;
+		case MufomType.MUFOM_BB2:
+			new MufomBB2(reader);
+			break;
+		case MufomType.MUFOM_BB3:
+			new MufomBB3(reader);
+			break;
+		case MufomType.MUFOM_BB4:
+			new MufomBB4(reader);
+			break;
+		case MufomType.MUFOM_BB5:
+			new MufomBB5(reader);
+			break;
+		case MufomType.MUFOM_BB6:
+			new MufomBB6(reader);
+			break;
+		case MufomType.MUFOM_BB10:
+			new MufomBB10(reader);
+			break;
+		case MufomType.MUFOM_BB11:
+			new MufomBB11(reader);
+			break;
+		default:
+			break;
+		}
+		block_end = reader.getPointerIndex();
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB1.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB1.java
@@ -1,0 +1,47 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Type definitions local to a module.
+ */
+public class MufomBB1 extends MufomRecord {
+	public String module_name = null;
+
+	private void print() {
+		String msg = "";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB1(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB1");
+		if (0 != read_int(reader)) {
+			Msg.info(this, "Bad block size");
+			throw new IOException();
+		}
+		module_name = read_id(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB10.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB10.java
@@ -1,0 +1,70 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+import java.util.Calendar;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * An assembler debugging information block.
+ */
+public class MufomBB10 extends MufomRecord {
+	public String source_filename = null;
+	public long tool_type = -1;
+	public String version = null;
+	public Calendar date;
+
+	private void print() {
+		String msg = "";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB10(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB10");
+		source_filename = read_id(reader);
+		String zero = read_id(reader);
+		if (zero.length() != 0) {
+			Msg.info(this, "Bad zero");
+			throw new IOException();
+		}
+		tool_type = read_int(reader);
+		if (210 == tool_type) {
+
+		} else if (209 == tool_type) {
+
+		} else {
+			Msg.info(this, "bad tool " + tool_type);
+			throw new IOException();
+		}
+		version = read_id(reader);
+
+		int year = (int) read_int(reader);
+		int month = (int) read_int(reader);
+		int day = (int) read_int(reader);
+		int hour = (int) read_int(reader);
+		int minute = (int) read_int(reader);
+		int second = (int) read_int(reader);
+		date.set(year, month, day, hour, minute, second);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB11.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB11.java
@@ -1,0 +1,52 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * The module portion of a section.
+ */
+public class MufomBB11 extends MufomRecord {
+	public long section_type = -1;
+	public long section_number = -1;
+	public long section_offset = -1;
+
+	private void print() {
+		String msg = "";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB11(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB11");
+		String zero = read_id(reader);
+		if (zero.length() != 0) {
+			Msg.info(this, "bad zero");
+			throw new IOException();
+		}
+		section_type = read_int(reader);
+		section_number = read_int(reader);
+		section_offset = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB2.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB2.java
@@ -1,0 +1,43 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Global type definitions.
+ */
+public class MufomBB2 extends MufomRecord {
+	public String module_name = null;
+
+	private void print() {
+		String msg = "BB2: '" + module_name + "'";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB2(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB2");
+		module_name = read_id(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB3.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB3.java
@@ -1,0 +1,45 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * A module. A non-separable unit of code, usually the result of a
+ * single compilation, i.e. the symbols associated with a COFF
+ * .file symbol.
+ */
+public class MufomBB3 extends MufomRecord {
+	public String module_name = null;
+
+	private void print() {
+		String msg = "";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB3(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB3");
+		module_name = read_id(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB4.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB4.java
@@ -1,0 +1,51 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * A global subprogram.
+ */
+public class MufomBB4 extends MufomRecord {
+	public String function_name = null;
+	public long type_index = -1;
+	public long code_block_address = -1;
+
+	private void print() {
+		String msg = "";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB4(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB4");
+		function_name = read_id(reader);
+		if (0 != read_int(reader)) {
+			Msg.info(this, "Bad stack space");
+			throw new IOException();
+		}
+		type_index = read_int(reader);
+		code_block_address = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB5.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB5.java
@@ -1,0 +1,43 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * A source file line number block.
+ */
+public class MufomBB5 extends MufomRecord {
+	public String source_filename = null;
+
+	private void print() {
+		String msg = "";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB5(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB5");
+		source_filename = read_id(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB6.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBB6.java
@@ -1,0 +1,53 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * A local (static) subprogram.
+ */
+public class MufomBB6 extends MufomRecord {
+	public String function_name = null;
+	public long stack_space = -1;
+	public long type_index = -1;
+	public long code_block_offset = -1;
+
+	private void print() {
+		String msg = "";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBB6(BinaryReader reader) throws IOException {
+		Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB6");
+		if (0 != read_int(reader)) {
+			Msg.info(this, "Bad block size");
+			throw new IOException();
+		}
+		function_name = read_id(reader);
+		stack_space = read_int(reader);
+		type_index = read_int(reader);
+		code_block_offset = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBE.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomBE.java
@@ -1,0 +1,63 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * Block End (BE)
+ *
+ * {$F9}[{n1}]
+ */
+public class MufomBE extends MufomRecord {
+	public static final String NAME = "BE";
+	public static final int record_type = MufomType.MUFOM_CMD_LN;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	private void print() {
+		String msg = NAME;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomBE(BinaryReader reader, int bb) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		switch (bb) {
+		case MufomType.MUFOM_BB4:
+		case MufomType.MUFOM_BB6:
+			//TODO Expression defining the ending address of the function (in minimum address units)
+			Msg.info(this, "BE 4 or 6");
+			throw new IOException();
+			//break;
+		case MufomType.MUFOM_BB11:
+			//TODO Expression defining the size in minimum address units of the module section
+			Msg.info(this, "BE 11");
+			throw new IOException();
+			//break;
+		default:
+			break;
+		}
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomCO.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomCO.java
@@ -1,0 +1,42 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 9.1 Comments
+ * 
+ * CO_command ::= "CO" [comment_level]? "," comment_text "."
+ * comment_level ::= hex_number
+ * comment_text ::= char_string
+ */
+public class MufomCO extends MufomRecord {
+	public static final String NAME = "CO";
+	public static final int record_type = MufomType.MUFOM_CMD_CO;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomCO(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomCS.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomCS.java
@@ -1,0 +1,38 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 9.2 CS (checksum) Command
+ */
+public class MufomCS extends MufomRecord {
+	public static final String NAME = "CS";
+	public static final int record_type = MufomType.MUFOM_CMD_CS;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomCS(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomCSS.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomCSS.java
@@ -1,0 +1,38 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 9.2 CCS (checksum with sum) Command
+ */
+public class MufomCSS extends MufomRecord {
+	public static final String NAME = "CSS";
+	public static final int record_type = MufomType.MUFOM_CMD_CSS;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomCSS(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomDT.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomDT.java
@@ -1,0 +1,42 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 8.3 DT (date and time of creation) Command
+ *
+ * DT-command → "DT" digit* “.”
+ * 
+ * "YYYYMMDDHHMMSS"
+ */
+public class MufomDT extends MufomRecord {
+	public static final String NAME = "DT";
+	public static final int record_type = MufomType.MUFOM_CMD_DT;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomDT(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomHeader.java
@@ -1,0 +1,2277 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.function.Consumer;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.program.model.data.DataType;
+import ghidra.util.Msg;
+
+public class MufomHeader {
+	public final static String MUFOM_NAME = "IEEE-695-MUFOM";
+	public BinaryReader reader = null;
+	private Consumer<String> errorConsumer;
+	private boolean do_debug = false;
+
+	public MufomHeaderPart hdr = null;
+	public MufomADExtension asw0 = null;
+	public MufomEnvironment asw1 = null;
+	public MufomSectionDefinition asw2 = null;
+	public MufomExternal asw3 = null;
+	public MufomDebugInformation asw4 = null;
+	public MufomData asw5 = null;
+	public MufomTrailer asw6 = null;
+	public MufomEnd asw7 = null;
+
+	public MufomHeader(ByteProvider bp, Consumer<String> errorConsumer) throws IOException {
+		reader = new BinaryReader(bp, false);
+		reader.setPointerIndex(0);
+		Msg.trace(this, String.format("%08x-%08x ", 0, reader.length()) + "PARSE MUFOM");
+        this.errorConsumer = errorConsumer != null ? errorConsumer : msg -> {
+			/* no logging if errorConsumer was null */
+		};
+        parse();
+    }
+
+	public static String getName() {
+		return MUFOM_NAME;
+	}
+
+	private void parse() throws IOException {
+		hdr = new MufomHeaderPart();
+		if (hdr.asw_offset[0] > 0) {
+			MufomADExtension tmp = null;
+			reader.setPointerIndex(hdr.asw_offset[0]);
+			while (hdr.asw_end[0] > reader.getPointerIndex()) {
+				tmp = new MufomADExtension(tmp);
+				if (null == asw0)
+					asw0 = tmp;
+			}
+		}
+		if (hdr.asw_offset[1] > 0) {
+			MufomEnvironment tmp = null;
+			reader.setPointerIndex(hdr.asw_offset[1]);
+			while (hdr.asw_end[1] > reader.getPointerIndex()) {
+				tmp = new MufomEnvironment(tmp);
+				if (null == asw1)
+					asw1 = tmp;
+			}
+		}
+		if (hdr.asw_offset[2] > 0) {
+			MufomSectionDefinition tmp = null;
+			reader.setPointerIndex(hdr.asw_offset[2]);
+			while (hdr.asw_end[2] > reader.getPointerIndex()) {
+				tmp = new MufomSectionDefinition(tmp);
+				if (null == asw2)
+					asw2 = tmp;
+			}
+		}
+
+		if (hdr.asw_offset[3] > 0) {
+			MufomExternal tmp = null;
+			reader.setPointerIndex(hdr.asw_offset[3]);
+			while (hdr.asw_end[3] > reader.getPointerIndex()) {
+				tmp = new MufomExternal(tmp);
+				if (null == asw3)
+					asw3 = tmp;
+			}
+		}
+		//TODO  This section is too complicated for now
+//		if (hdr.asw_offset[4] > 0) {
+//          MufomDebugInformation tmp = null;
+//			reader.setPointerIndex(hdr.asw_offset[4]);
+//			while (hdr.asw_end[4] > reader.getPointerIndex()) {
+//				tmp = new MufomDebugInformation(tmp);
+//              if (null == asw4)
+//                  asw4 = tmp;
+//			}
+//		}
+		if (hdr.asw_offset[5] > 0) {
+			reader.setPointerIndex(hdr.asw_offset[5]);
+			MufomData tmp = null;
+			while (hdr.asw_end[5] > reader.getPointerIndex()) {
+				tmp = new MufomData(tmp);
+				if (null == asw5)
+					asw5 = tmp;
+			}
+		}
+		if (hdr.asw_offset[6] > 0) {
+			reader.setPointerIndex(hdr.asw_offset[6]);
+			asw6 = new MufomTrailer();
+		}
+		if (hdr.asw_offset[7] > 0) {
+			reader.setPointerIndex(hdr.asw_offset[7]);
+			asw7 = new MufomEnd();
+		}
+	}
+
+	public boolean valid() {
+		if (null == hdr) {
+			Msg.error(this, "invalid header start");
+			return false;
+		} else if (hdr.asw_offset[0] > 0 && null == asw0) {
+			Msg.error(this, "invalid ASW0");
+			return false;
+		} else if (hdr.asw_offset[1] > 0 && null == asw1) {
+			Msg.error(this, "invalid ASW1");
+			return false;
+		} else if (hdr.asw_offset[2] > 0 && null == asw2) {
+			Msg.error(this, "invalid ASW2");
+			return false;
+		} else if (hdr.asw_offset[3] > 0 && null == asw3) {
+			Msg.error(this, "invalid ASW3");
+			return false;
+//		} else if (hdr.asw_offset[4] > 0 && null == asw4) {
+//			Msg.error(this, "invalid ASW4");
+//			return false;
+		} else if (hdr.asw_offset[5] > 0 && null == asw5) {
+			Msg.error(this, "invalid ASW5");
+			return false;
+		} else if (hdr.asw_offset[6] > 0 && null == asw6) {
+			Msg.error(this, "invalid ASW6");
+			return false;
+		} else if (null == asw7) {
+			Msg.error(this, "invalid ASW7");
+			return false;
+		}
+		return true;
+	}
+
+	public boolean is_little() {
+		return (MufomType.MUFOM_ID_L == hdr.ad.order);
+	}
+
+	public boolean is_big() {
+		return (MufomType.MUFOM_ID_M == hdr.ad.order);
+	}
+
+	public String machine() {
+		return hdr.mb.target_machine_configuration;
+	}
+
+	/*
+	 * 8.1 MB (module begin) Command
+	 *
+	 * MB-command → “MB” target-machine-configuration (“,” module-name)? “.”
+	 * target-machine-configuration → identifier
+	 * module-name → char-string
+	 *
+	 * {$E0}{Id1}{Id2}
+	 */
+	public class MufomMB extends MufomRecord {
+		private final String NAME = "MB";
+		private String target_machine_configuration = null;
+		public String module_name = null;
+
+		private void print() {
+			String msg = NAME + ": " + target_machine_configuration + " " + module_name;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+		public MufomMB(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_MB != read_char(reader)) {
+				Msg.info(this, "Bad MB");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			target_machine_configuration = read_id(reader);
+			module_name = read_opt_id(reader);
+			print();
+		}
+	}
+
+	/*
+	 * 8.2 ME (module end) Command
+	 *
+	 * ME-command → “ME.”
+	 *
+	 * {$E1}
+	 */
+	public class MufomME extends MufomRecord {
+		private final String NAME = "ME";
+
+		private void print() {
+			String msg = NAME;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomME(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_ME != read_char(reader)) {
+				Msg.info(this, "bad ME");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			print();
+		}
+	}
+
+	/*
+	 * 8.3 DT (date and time of creation) Command
+	 *
+	 * DT-command → "DT" digit* “.”
+	 */
+	public class MufomDT extends MufomRecord {
+		private final String NAME = "DT";
+		public MufomDT(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 8.4 AD (address descriptor) Command
+	 *
+	 * AD-command → “AD” bits-per-MAU (“,” MAUs-per-address) (“,” order)? )? “.”
+	 * bits-per-MAU → hexnumber
+	 * MAUs-per-address → hexnumber
+	 * order → “L” | “M”
+	 *
+	 * {$EC}{8){4}{$CC}
+	 */
+	public class MufomAD extends MufomRecord {
+		private final String NAME = "AD";
+		public long bits_per_mau = -1;
+		public long maus_per_address = -1;
+		private int order = -1;
+
+		private void print() {
+			String msg = NAME + ": " + bits_per_mau + " " + maus_per_address;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomAD(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AD != read_char(reader)) {
+				Msg.info(this, "Bad AD");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			bits_per_mau = read_int(reader);
+			maus_per_address = read_int(reader);
+			order = read_opt_char(reader);
+			if (MufomType.MUFOM_ID_L == order) {
+				//TODO  little endian
+			} else if (MufomType.MUFOM_ID_M == order) {
+				//TODO  big endian
+			} else if (-1 == order) {
+				//TODO  unknown
+				Msg.info(this, "Unknown endianess");
+			} else {
+				Msg.info(this, "Bad endian " + order);
+				throw new IOException();
+			}
+			print();
+		}
+	}
+
+
+	/*
+	 * 9.1 Comments
+	 */
+	public class MufomCO extends MufomRecord {
+		private final String NAME = "CO";
+		public MufomCO(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 9.2 CS (checksum) Command
+	 */
+	public class MufomCS extends MufomRecord {
+		private final String NAME = "CS";
+		public MufomCS(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 10.1 SB (section begin) Command
+	 *
+	 * SB-command → “SB” section-number “.”
+	 * section-number → hexnumber
+	 *
+	 * {$E5}{n1}
+	 */
+	public class MufomSB extends MufomRecord {
+		private final String NAME = "SB";
+		public long section_number = -1;
+
+		public static boolean check(BinaryReader reader) throws IOException {
+			long offset = reader.getPointerIndex();
+			if (MufomType.MUFOM_CMD_SB == reader.readUnsignedByte(offset + 0)) {
+				return true;
+			}
+			return false;
+		}
+
+		private void print() {
+			String msg = NAME + ": " + section_number;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomSB(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_SB != read_char(reader)) {
+				Msg.info(this, "bad SB");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			section_number = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * 10.2 ST (section type) Command
+	 *
+	 * ST-command → “ST” section-number (“,” section-type)* (“,” section-name)? “.”
+	 * section-number → hexnumber
+	 * section-type → letter
+	 * section-name → char-string
+	 *
+	 * ${E6}{n1}{l}[Id][n2][n3][n4]
+	 */
+	public class MufomST extends MufomRecord {
+		private final String NAME = "ST";
+		public long section_number = -1;
+		public String section_name = null;
+		private MufomAS as = null;
+		private MufomAbsCode code = null;
+		private MufomAbsData data = null;
+		private long n2 = -1;
+		private long n3 = -1;
+		private long n4 = -1;
+
+		private void print() {
+			String msg = NAME + ": " + section_number + " " + section_name + " " + n2 +" "+n3+" "+n4;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomST(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_ST != read_char(reader)) {
+				//TODO  "if no ST-command is given for a section, its type is absolute (A)"
+				Msg.info(this, "Bad ST");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+
+			section_number = read_int(reader);
+			if (0 == section_number) {
+				Msg.info(this, "Bad section");
+				throw new IOException();
+			}
+
+			// one section type: AS, ASP, or ASD
+			if (MufomAbsCode.check(reader)) {
+				code = new MufomAbsCode(reader);
+			} else if (MufomAbsData.check(reader)) {
+				data = new MufomAbsData(reader);
+			} else {
+				as = new MufomAS(reader);
+			}
+
+			section_name = read_opt_id(reader);
+
+			//TODO  what is this
+			n2 = read_int(reader);
+			n3 = read_int(reader);
+			n4 = read_int(reader);
+
+			print();
+		}
+	}
+
+	/*
+	 * 10.3 SA (section alignment) Command
+	 *
+	 * SA-command → “SA” section-number “,” MAU-boundary? ("," page-size)? "."
+	 * MAU-boundary → expression
+	 * page-size → expression
+	 *
+	 * {$E7}{n1}{n2}
+	 */
+	public class MufomSA extends MufomRecord {
+		private final String NAME = "SA";
+		public long section_number = -1;
+		public long mau_boundary = -1;
+		public long page_size = -1;
+
+		private void print() {
+			String msg = NAME + ":" + section_number + " " + mau_boundary + " " + page_size;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomSA(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_SA != read_char(reader)) {
+				Msg.info(this, "Bad SA");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			section_number = read_int(reader);
+			mau_boundary = read_int(reader);
+			page_size = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * 11.1 NI (name of internal symbol) Command
+	 *
+	 * NI-command → “N” I-variable “,” ext-def-name “.”
+	 * I-variable → “I” hexnumber
+	 * ext-def-name → char-string
+	 *
+	 * {$E8}{n}{Id}
+	 */
+	public class MufomNI extends MufomRecord {
+		private final String NAME = "NI";
+		public long symbol_name_index = -1;
+		public String symbol_name = null;
+
+		private void print() {
+			String msg = NAME;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomNI(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_NI != read_char(reader)) {
+				Msg.info(this, "Bad NI");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			symbol_name_index = read_int(reader);
+			symbol_name = read_id(reader);
+			print();
+		}
+	}
+
+	/*
+	 * 11.2 NX (name of external symbol) Command
+	 */
+	public class MufomNX extends MufomRecord {
+		private final String NAME = "NX";
+		public MufomNX(BinaryReader reader) throws IOException {
+			//TODO  is it a $E8 typo or is this $B8?
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 11.3 NN (name) Command
+	 *
+	 * NN-command → “N” N-variable “,” name “.”
+	 * N-variable → “N” hexnumber
+	 * name → char-string
+	 *
+	 * {$F0}{n1}{Id}
+	 */
+	public class MufomNN extends MufomRecord {
+		private final String NAME = "NN";
+		public long symbol_name_index = -1;
+		public String symbol_name = null;
+
+		private void print() {
+			String msg = NAME + ": '" + symbol_name + "' " + symbol_name_index;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomNN(BinaryReader reader, boolean must) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (!must && omit_cmd(reader)) {
+				return;
+			}
+			if (MufomType.MUFOM_CMD_NN != read_char(reader)) {
+				Msg.info(this, "Bad NN");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+
+			symbol_name_index = read_int(reader);
+	        symbol_name = read_id(reader);
+	        print();
+		}
+	}
+
+	/*
+	 * 11.4 AT (attributes) Command
+	 */
+	public class MufomAT extends MufomRecord {
+		private final String NAME = "AT";
+		public MufomAT(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 11.5 TY (type) Command
+	 *
+	 * TY_command       ::= "TY" type_table_entry [ "," parameter ]+ "."
+	 * type_table_entry ::= hex_number
+	 * parameter        ::= hex_number | N_variable | "T" type_table_entry
+	 *
+	 * {$F2}{nl}{$CE}{n2}[n3][n4]...
+	 */
+	public class MufomTY extends MufomRecord {
+		private final String NAME = "TY";
+		public long type_index = -1;
+		public long name_index = -1;
+
+		private void print() {
+			String msg = NAME + ": " + type_index +" " + name_index;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomTY(BinaryReader reader, boolean must) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (!must && omit_cmd(reader)) {
+				return;
+			}
+			if (MufomType.MUFOM_CMD_TY != read_char(reader)) {
+				Msg.info(this, "Bad TY");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			type_index = read_int(reader);
+			if (type_index < 256) {
+				Msg.info(this, "Invalid type index " + type_index);
+				throw new IOException();
+			}
+			int record_type = read_char(reader);
+			if (MufomType.MUFOM_ID_N != record_type) {
+				Msg.info(null, "Expected MUFOM_ID_N, " + record_type);
+			}
+
+			name_index = read_int(reader);
+
+			// variable number of fields
+			// D-7:  19
+			// D-8:
+
+			print();
+		}
+	}
+
+	/*
+	 * 12. AS (assignment) Command
+	 *
+	 * {$C1}{$D3}
+	 */
+	public class MufomAS extends MufomRecord {
+		private final String NAME = "AS";
+
+		public MufomAS(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_ID_A != read_char(reader)) {
+				Msg.info(this, "bad A");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_S != read_char(reader)) {
+				Msg.info(this, "bad S");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+
+			int section_type = -1;
+			boolean parse_section_type = true;
+			while (parse_section_type) {
+				section_type = read_char(reader);
+				switch (section_type) {
+				case MufomType.MUFOM_ID_W:
+					/* Access: writable (RAM)  This is default if no access attribute is found */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - writable");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_R:
+					/* Access: read only (ROM) */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - read only");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_X:
+					/* Access: Execute only */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - execute only");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_Z:
+					/* Access: zero page */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - zero page");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_A:
+					/* Access: Abs.  There shall be an assignment to the L-variable */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - absolute");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_E:
+					/* Overlap: Equal.  Error if lengths differ */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - equal");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_M:
+					/* Overlap: Max.  Use largest length encountered */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - max");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_U:
+					/* Overlap: Unique.  Name should be unique */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - unique");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_C:
+					/* Overlap: Cumulative.  Concatenate sections */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - cumulative");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_S:
+					/* Overlap: Separate.  No connection between sections */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - separate");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_N:
+					/* Allocate: Now.  This is normal case */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - now");
+					//TODO
+					break;
+				case MufomType.MUFOM_ID_P:
+					/* Allocate: Postpone.  relocator must allocate after all 'now' sections */
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - postpone");
+					//TODO
+					break;
+				default:
+					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - DONE " + section_type);
+					parse_section_type = false;
+					reader.setPointerIndex(reader.getPointerIndex() - 1);
+					break;
+				}
+			}
+		}
+	}
+
+	/*
+	 * 13.1 LD (load) Command
+	 *
+	 * LD-command → “LD” load-constant + “.”
+	 * load-constant → hexdigit +
+	 *
+	 * {$ED}{n1}{...}
+	 */
+	public class MufomLD extends MufomRecord {
+		private final String NAME = "LD";
+		private long data_bytes_offset;
+		private long address_units;
+
+		private void print() {
+			String msg = NAME + ": " + data_bytes_offset + " " + address_units;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomLD(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_LD != read_char(reader)) {
+				Msg.info(this, "bad LD");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+
+			address_units = read_int(reader);
+			if (address_units < 1 || address_units > 127) {
+				Msg.info(this, "bad units");
+				throw new IOException();
+			}
+			data_bytes_offset = reader.getPointerIndex();
+			reader.setPointerIndex(data_bytes_offset + address_units);
+			// OR
+			// bytes = reader.readNextByteArray((int) address_units);
+
+			print();
+		}
+	}
+
+	/*
+	 * 13.2 IR (initialize relocation base) Command
+	 */
+	public class MufomIR extends MufomRecord {
+		private final String NAME = "IR";
+		public MufomIR(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 13.3 LR (load relocate) Command
+	 */
+	public class MufomLR extends MufomRecord {
+		private final String NAME = "LR";
+		public MufomLR(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 13.4 RE (replicate) Command
+	 *
+	 * RE-command → “RE” expression “.”
+	 */
+	public class MufomRE extends MufomRecord {
+		private final String NAME = "RE";
+		public long repeat = -1;
+
+		private void print() {
+			String msg = NAME;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomRE(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_RE != read_char(reader)) {
+				Msg.info(this, "bad RE");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			repeat = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * 14.1 RI (retain internal symbol) Command
+	 */
+	public class MufomRI extends MufomRecord {
+		private final String NAME = "RI";
+		public MufomRI(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 14.2 WX (weak external symbol) Command
+	 */
+	public class MufomWX extends MufomRecord {
+		private final String NAME = "WX";
+		public MufomWX(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 15.1 LI (Specify Default Library Search List) Command
+	 */
+	public class MufomLI extends MufomRecord {
+		private final String NAME = "Li";
+		public MufomLI(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	/*
+	 * 15.2 LX (library external) Command
+	 */
+	public class Mufom extends MufomRecord {
+		private final String NAME = "LX";
+		public Mufom(BinaryReader reader) throws IOException {
+			Msg.info(this, "unimplemented " + NAME);
+			throw new IOException();
+		}
+	}
+
+	public class MufomBB extends MufomRecord {
+		private final String NAME = "BB";
+		public long begin_block = -1;
+		public long block_size = -1;
+		public MufomBB bb1 = null;
+		public MufomBB bb2 = null;
+		public MufomBB bb3 = null;
+		public MufomBB bb4 = null;
+		public MufomBB bb5 = null;
+		public MufomBB bb6 = null;
+		public MufomBB bb10 = null;
+		public MufomBB bb11 = null;
+
+		private long block_start = -1;
+		private long block_end = -1;
+
+		private void print() {
+			String msg = NAME + ": " + begin_block + " 0x" + Long.toHexString(block_size) + " " +
+					Long.toHexString(block_start) + " " + Long.toHexString(block_end) + " " +
+					Long.toHexString(block_end - block_start);
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			block_start = reader.getPointerIndex();
+			if (MufomType.MUFOM_CMD_SC != read_char(reader)) {
+				Msg.info(this, "bad SC");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+
+			begin_block = read_int(reader);
+			block_size = read_int(reader);
+			switch ((int) begin_block) {
+			case MufomType.MUFOM_BB1:
+				new MufomBB1(reader);
+				break;
+			case MufomType.MUFOM_BB2:
+				new MufomBB2(reader);
+				break;
+			case MufomType.MUFOM_BB3:
+				new MufomBB3(reader);
+				break;
+			case MufomType.MUFOM_BB4:
+				new MufomBB4(reader);
+				break;
+			case MufomType.MUFOM_BB5:
+				new MufomBB5(reader);
+				break;
+			case MufomType.MUFOM_BB6:
+				new MufomBB6(reader);
+				break;
+			case MufomType.MUFOM_BB10:
+				new MufomBB10(reader);
+				break;
+			case MufomType.MUFOM_BB11:
+				new MufomBB11(reader);
+				break;
+			default:
+				break;
+			}
+			block_end = reader.getPointerIndex();
+			print();
+		}
+	}
+
+	/*
+	 * Type definitions local to a module.
+	 */
+	public class MufomBB1 extends MufomRecord {
+		public String module_name = null;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB1(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB1");
+			if (0 != read_int(reader)) {
+				Msg.info(this, "Bad block size");
+				throw new IOException();
+			}
+			module_name = read_id(reader);
+			print();
+		}
+	}
+
+	/*
+	 * Global type definitions.
+	 */
+	public class MufomBB2 extends MufomRecord {
+		public String module_name = null;
+
+		private void print() {
+			String msg = "BB2: '" + module_name + "'";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB2(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB2");
+			module_name = read_id(reader);
+			print();
+		}
+	}
+
+	/*
+	 * A module. A non-separable unit of code, usually the result of a
+	 * single compilation, i.e. the symbols associated with a COFF
+	 * .file symbol.
+	 */
+	public class MufomBB3 extends MufomRecord {
+		public String module_name = null;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB3(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB3");
+			module_name = read_id(reader);
+			print();
+		}
+	}
+
+	/*
+	 * A global subprogram.
+	 */
+	public class MufomBB4 extends MufomRecord {
+		public String function_name = null;
+		public long type_index = -1;
+		public long code_block_address = -1;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB4(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB4");
+			function_name = read_id(reader);
+			if (0 != read_int(reader)) {
+				Msg.info(this, "Bad stack space");
+				throw new IOException();
+			}
+			type_index = read_int(reader);
+			code_block_address = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * A source file line number block.
+	 */
+	public class MufomBB5 extends MufomRecord {
+		public String source_filename = null;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB5(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB5");
+			source_filename = read_id(reader);
+			print();
+		}
+	}
+
+	/*
+	 * A local (static) subprogram.
+	 */
+	public class MufomBB6 extends MufomRecord {
+		public String function_name = null;
+		public long stack_space = -1;
+		public long type_index = -1;
+		public long code_block_offset = -1;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB6(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB6");
+			if (0 != read_int(reader)) {
+				Msg.info(this, "Bad block size");
+				throw new IOException();
+			}
+			function_name = read_id(reader);
+			stack_space = read_int(reader);
+			type_index = read_int(reader);
+			code_block_offset = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * An assembler debugging information block.
+	 */
+	public class MufomBB10 extends MufomRecord {
+		public String source_filename = null;
+		public long tool_type = -1;
+		public String version = null;
+		public Calendar date;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB10(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB10");
+			source_filename = read_id(reader);
+			String zero = read_id(reader);
+			if (zero.length() != 0) {
+				Msg.info(this, "Bad zero");
+				throw new IOException();
+			}
+			tool_type = read_int(reader);
+			if (210 == tool_type) {
+
+			} else if (209 == tool_type) {
+
+			} else {
+				Msg.info(this, "bad tool");
+				throw new IOException();
+			}
+			version = read_id(reader);
+
+			int year = (int) read_int(reader);
+			int month = (int) read_int(reader);
+			int day = (int) read_int(reader);
+			int hour = (int) read_int(reader);
+			int minute = (int) read_int(reader);
+			int second = (int) read_int(reader);
+			date.set(year, month, day, hour, minute, second);
+			print();
+		}
+	}
+
+	/*
+	 * The module portion of a section.
+	 */
+	public class MufomBB11 extends MufomRecord {
+		public long section_type = -1;
+		public long section_number = -1;
+		public long section_offset = -1;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBB11(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB11");
+			String zero = read_id(reader);
+			if (zero.length() != 0) {
+				Msg.info(this, "bad zero");
+				throw new IOException();
+			}
+			section_type = read_int(reader);
+			section_number = read_int(reader);
+			section_offset = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * Value Records (ASN)
+	 *
+	 * AS-command → “AS” MUFOM-variable “,” expression “,”
+	 *
+	 * N-variable → “N” hexnumber
+	 */
+	public class MufomASN extends MufomRecord {
+		private final String NAME = "ASN";
+		public long symbol_name_index = -1;
+		public long symbol_name_value = -1;
+
+		private void print() {
+			String msg = NAME + ": " + symbol_name_index + " " + symbol_name_value;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomASN(BinaryReader reader, boolean must) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (!must && omit_cmd(reader)) {
+				return;
+			}
+			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
+				Msg.info(this, "Bad AS");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_N != read_char(reader)) {
+				Msg.info(this, "Bad N");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			symbol_name_index = read_int(reader);
+			symbol_name_value = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * Compiler Id
+	 *
+	 * {$F1}{$CE}{n1}{0}{64}{50}{n5}{ASN1}{0}{4}[ATN1][ASN4[ASN5[ASN6[ASN7[ASN8[ASN9]]]]]]
+	 */
+	public class MufomCompiler extends MufomRecord {
+		public MufomNN nn = null;
+		public MufomATN atn = null;
+		public MufomATN atn1 = null;
+		public MufomASN asntool = null;
+		public MufomASN asntype = null;
+		public MufomASN asnsize = null;
+		public MufomASN asnyear = null;
+		public MufomASN asnmonth = null;
+		public MufomASN asnday = null;
+		public MufomASN asnhour = null;
+		public MufomASN asnminute = null;
+		public MufomASN asnsecond = null;
+
+		private void print() {
+			String msg = "";
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomCompiler(BinaryReader reader, boolean must) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomCompiler");
+			if (!must && omit_cmd(reader)) {
+				return;
+			}
+			nn = new MufomNN(reader, true);
+			atn = new MufomATN(reader, true);
+			asntool = new MufomASN(reader, true);
+			asntype = new MufomASN(reader, true);
+			asnsize = new MufomASN(reader, true);
+			atn1 = new MufomATN(reader, false);
+			asnyear = new MufomASN(reader, false);
+			asnmonth = new MufomASN(reader, false);
+			asnday = new MufomASN(reader, false);
+			asnhour = new MufomASN(reader, false);
+			asnminute = new MufomASN(reader, false);
+			asnsecond = new MufomASN(reader, false);
+			print();
+		}
+	}
+
+	/*
+	 * Section Size (ASS)
+	 *
+	 * AS-command → “AS” MUFOM-variable “,” expression “,”
+	 *
+	 * S-variable → “S” section-number?
+	 * section-number → hexnumber
+	 *
+	 * {$E2}{$D3}{n1}{n2}
+	 */
+	public class MufomASS extends MufomRecord {
+		private final String NAME = "ASS";
+		public long section_number = -1;
+		public long section_size = -1;
+
+		private void print() {
+			String msg = NAME + ": " + section_number + " " + section_size;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomASS(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
+				Msg.info(this, "Bad AS");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_S != read_char(reader)) {
+				Msg.info(this, "Bad S");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			section_number = read_int(reader);
+			section_size = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * Section Base Address (ASL)
+	 *
+	 * AS-command → “AS” MUFOM-variable “,” expression “,”
+	 *
+	 * L-variable → “L” section-number?
+	 * section-number → hexnumber
+	 *
+	 * {$E2}{$CC}{n1}{n2}
+	 */
+	public class MufomASL extends MufomRecord {
+		private final String NAME = "ASL";
+		public long section_number = -1;
+		public long section_base_address = -1;
+
+		private void print() {
+			String msg = NAME + ": " + section_number + " 0x" + Long.toHexString(section_base_address);
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomASL(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
+				Msg.info(this, "Bad AS");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_L != read_char(reader)) {
+				Msg.info(this, "Bad L");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			section_number = read_int(reader);
+			section_base_address = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * Value Records (ASI)
+	 *
+	 * AS-command → “AS” MUFOM-variable “,” expression “,”
+	 *
+	 * I-variable → “I” hexnumber
+	 *
+	 * {$E2}{$C9}{n1}{n2}
+	 */
+	public class MufomASI extends MufomRecord {
+		private final String NAME = "ASI";
+		public long symbol_name_index = -1;
+		public long symbol_value = -1;
+
+		private void print() {
+			String msg = NAME + ": " + symbol_name_index + " " + symbol_value;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomASI(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
+				Msg.info(this, "Bad AS");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_I!= read_char(reader)) {
+				Msg.info(this, "Bad I");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			symbol_name_index = read_int(reader);
+			symbol_value = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * Attribute Records (ATI)
+	 *
+	 * AT-command → “AT” variable “,” type-table-entry (“,” lex-level (“,” hexnumber)* )? “.”
+	 * variable → I-variable | N-variable | X-variable
+	 * type-table-entry → hexnumber
+	 * lex-level → hexnumber
+	 *
+	 * I-variable → “I” hexnumber
+	 *
+	 * {$F1}{$C9}{n1}{n2}{n3}{n4}
+	 */
+	public class MufomATI extends MufomRecord {
+		private final String NAME = "ATI";
+		public long symbol_name_index = -1;
+		public long symbol_type_index = -1;
+		public long attribute_definition = -1;
+		public long number_of_elements = -1;
+
+		private void print() {
+			String msg = NAME;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomATI(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AT != read_char(reader)) {
+				Msg.info(this, "Bad AT");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_I!= read_char(reader)) {
+				Msg.info(this, "Bad I");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			symbol_name_index = read_int(reader);
+			symbol_type_index = read_int(reader);
+			switch ((int) symbol_type_index) {
+	        case MufomType.MUFOM_BUILTIN_UNK:
+	        	Msg.info(this, "TYPE: UNK");
+	        	break;
+	        case MufomType.MUFOM_BUILTIN_V:
+	        	Msg.info(this, "TYPE: V");
+	        	break;
+	        case MufomType.MUFOM_BUILTIN_B:
+	        	Msg.info(this, "TYPE: B");
+	        	break;
+	        case MufomType.MUFOM_BUILTIN_C:
+	        	Msg.info(this, "TYPE: C");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_H:
+	        	Msg.info(this, "TYPE: H");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_I:
+	        	Msg.info(this, "TYPE: I");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_L:
+	        	Msg.info(this, "TYPE: L");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_M:
+	        	Msg.info(this, "TYPE: M");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_F:
+	        	Msg.info(this, "TYPE: F");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_D:
+	        	Msg.info(this, "TYPE: D");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_K:
+	        	Msg.info(this, "TYPE: K");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_J:
+	        	Msg.info(this, "TYPE: J");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_PUNK:
+	        	Msg.info(this, "TYPE: PUNK");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_PV:
+	        	Msg.info(this, "TYPE: PV");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_PB:
+	        	Msg.info(this, "TYPE: PB");
+	        	break;
+	        case MufomType.MUFOM_BUILTIN_PC:
+	        	Msg.info(this, "TYPE: PC");
+	        	break;
+	        case MufomType.MUFOM_BUILTIN_PH:
+	        	Msg.info(this, "TYPE: PH");
+	        	break;
+	        case MufomType.MUFOM_BUILTIN_PI:
+	        	Msg.info(this, "TYPE: PI");
+	        	break;
+	        case MufomType.MUFOM_BUILTIN_PL:
+	        	Msg.info(this, "TYPE: PL");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_PM:
+	        	Msg.info(this, "TYPE: PM");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_PF:
+	        	Msg.info(this, "TYPE: PF");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_PD:
+	        	Msg.info(this, "TYPE: PD");
+	            break;
+	        case MufomType.MUFOM_BUILTIN_PK:
+	        	Msg.info(this, "TYPE: PK");
+	        	break;
+	        default:
+	        	Msg.info(this, "Bad type " + symbol_type_index);
+	        	throw new IOException();
+	        }
+
+			attribute_definition = read_int(reader);
+			if (MufomType.MUFOM_BUILTIN_UNK != symbol_type_index) {
+				number_of_elements = read_int(reader);
+			}
+			print();
+		}
+	}
+
+	/*
+	 * Block End (BE)
+	 *
+	 * {$F9}[{n1}]
+	 */
+	public class MufomBE extends MufomRecord {
+		private final String NAME = "BE";
+
+		private void print() {
+			String msg = NAME;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomBE(BinaryReader reader, int bb) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_LN != read_char(reader)) {
+				Msg.info(this, "Bad BE");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			switch (bb) {
+			case MufomType.MUFOM_BB4:
+			case MufomType.MUFOM_BB6:
+				//TODO Expression defining the ending address of the function (in minimum address units)
+				Msg.info(this, "BE 4 or 6");
+				throw new IOException();
+				//break;
+			case MufomType.MUFOM_BB11:
+				//TODO Expression defining the size in minimum address units of the module section
+				Msg.info(this, "BE 11");
+				throw new IOException();
+				//break;
+			default:
+				break;
+			}
+			print();
+		}
+	}
+
+	/*
+	 * Set Current PC, absolute code (ASP)
+	 *
+	 * AS-command → “AS” MUFOM-variable “,” expression “,”
+	 *
+	 * P-variable → “P” section-number?
+	 * section-number → hexnumber
+	 */
+	public class MufomASP extends MufomRecord {
+		private final String NAME = "ASP";
+		private long section_index = -1;
+		private long current_pc = -1;
+
+		public static boolean check(BinaryReader reader) throws IOException {
+			long offset = reader.getPointerIndex();
+			if (MufomType.MUFOM_CMD_AS == reader.readUnsignedByte(offset + 0) &&
+					MufomType.MUFOM_ID_P == reader.readUnsignedByte(offset + 1)) {
+				return true;
+			}
+			return false;
+		}
+
+		private void print() {
+			String msg = NAME + ": " + section_index + " " + Long.toHexString(current_pc);
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+		public MufomASP(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
+				Msg.info(this, "bad P");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_P != read_char(reader)) {
+				Msg.info(this, "bad P");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			section_index = read_int(reader);
+			current_pc = read_int(reader);
+			print();
+		}
+	}
+
+	/*
+	 * Absolute Code
+	 *
+	 * {$C1}{$D3}{$D0}
+	 */
+	public class MufomAbsCode extends MufomRecord {
+
+		public static boolean check(BinaryReader reader) throws IOException {
+			long offset = reader.getPointerIndex();
+			if (MufomType.MUFOM_ID_A == reader.readUnsignedByte(offset + 0) &&
+					MufomType.MUFOM_ID_S == reader.readUnsignedByte(offset + 1) &&
+							MufomType.MUFOM_ID_P == reader.readUnsignedByte(offset + 2)) {
+				return true;
+			}
+			return false;
+		}
+
+		public MufomAbsCode(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomAbsCode");
+			if (MufomType.MUFOM_ID_A != read_char(reader)) {
+				Msg.info(this, "bad A");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_S != read_char(reader)) {
+				Msg.info(this, "bad S");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_P != read_char(reader)) {
+				Msg.info(this, "bad P");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-3, 0x10);
+				throw new IOException();
+			}
+		}
+	}
+
+	/*
+	 * Absolute Data
+	 *
+	 * {$C1}{$D3}{$C4}
+	 */
+	public class MufomAbsData extends MufomRecord {
+
+		public static boolean check(BinaryReader reader) throws IOException {
+			long offset = reader.getPointerIndex();
+			if (MufomType.MUFOM_ID_A == reader.readUnsignedByte(offset + 0) &&
+					MufomType.MUFOM_ID_S == reader.readUnsignedByte(offset + 1) &&
+							MufomType.MUFOM_ID_D == reader.readUnsignedByte(offset + 2)) {
+				return true;
+			}
+			return false;
+		}
+
+		public MufomAbsData(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomAbsData");
+			if (MufomType.MUFOM_ID_A != read_char(reader)) {
+				Msg.info(this, "bad A");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_S != read_char(reader)) {
+				Msg.info(this, "bad S");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_D != read_char(reader)) {
+				Msg.info(this, "bad D");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-3, 0x10);
+				throw new IOException();
+			}
+		}
+	}
+
+	/*
+	 * Assign Value to Variable W
+	 *
+	 * AS-command → “AS” MUFOM-variable “,” expression “,”
+	 *
+	 * W-variable → “W” hexnumber
+	 *
+	 * {$E2}{$D7}{00}{n}
+	 * {$E2}{$D7}{01}{n}
+	 * {$E2}{$D7}{02}{n}
+	 * {$E2}{$D7}{03}{n}
+	 * {$E2}{$D7}{04}{n}
+	 * {$E2}{$D7}{05}{n}
+	 * {$E2}{$D7}{06}{n}
+	 * {$E2}{$D7}{07}{n}
+	 */
+	public class MufomASW extends MufomRecord {
+		private final String NAME = "ASW";
+		public long asw_index = -1;
+		public long asw_offset = -1;
+
+		private void print() {
+			String msg = NAME + ": " + asw_index + " " + Long.toHexString(asw_offset);
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomASW(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
+				Msg.info(this, "Bad AS");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_W != read_char(reader)) {
+				Msg.info(this, "Bad W");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			asw_index = read_int(reader);
+			if (asw_index < 0 || asw_index > 7) {
+				Msg.info(this, "Bad ASW index");
+				throw new IOException();
+			}
+			asw_offset = read_int(reader);
+			if (asw_offset < 0 || asw_offset > reader.length()) {
+				Msg.info(this, "Bad ASW offset");
+				throw new IOException();
+			}
+			print();
+		}
+	}
+
+	/*
+	 * Starting Address (ASG)
+	 *
+	 * {$E2}{$C7}{$BE}{n1}{$BF}
+	 */
+	public class MufomASG extends MufomRecord {
+		private final String NAME = "ASG";
+		public long starting_address = -1;
+
+		private void print() {
+			String msg = NAME + ": " + Long.toHexString(starting_address);
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+		public MufomASG(BinaryReader reader) throws IOException {
+			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
+				Msg.info(this, "bad AS");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_G != read_char(reader)) {
+				Msg.info(this, "bad G");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+
+			if (MufomType.MUFOM_OPEN != read_char(reader)) {
+				Msg.info(null, "Expecting MUFOM_OPEN");
+				throw new IOException();
+			}
+
+			starting_address = read_int(reader);
+
+			if (MufomType.MUFOM_CLOSE != read_char(reader)) {
+				Msg.info(null, "Expecting MUFOM_CLOSE");
+				throw new IOException();
+			}
+			print();
+		}
+	}
+
+	/*
+	 * Attribute Records (ATN)
+	 *
+	 * AT-command → “AT” variable “,” type-table-entry (“,” lex-level (“,” hexnumber)* )? “.”
+	 * variable → I-variable | N-variable | X-variable
+	 * type-table-entry → hexnumber
+	 * lex-level → hexnumber
+	 *
+	 * N-variable → “N” hexnumber
+	 *
+	 * {$F1}{$CE}{n1}{n2}{n3}[x1][x2][Id]
+	 */
+	public class MufomATN extends MufomRecord {
+		private final String NAME = "ATN";
+		public long symbol_name_index = -1;
+		public long attribute_definition = -1;
+        private String id = null;
+        private long x1 = -1;
+        private long x2 = -1;
+        private long x3 = -1;
+        private long x4 = -1;
+        private long x5 = -1;
+        private long x6 = -1;
+        private boolean has_asn = false;
+
+        private void print() {
+			String msg = NAME + ": " + symbol_name_index + " " + attribute_definition;
+			if (do_debug) {
+				Msg.info(this, msg);
+			} else {
+				Msg.trace(this, msg);
+			}
+		}
+
+        public MufomATN(BinaryReader reader, boolean must) throws IOException {
+        	Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
+        	if (!must && omit_cmd(reader)) {
+				return;
+			}
+        	if (MufomType.MUFOM_CMD_AT != read_char(reader)) {
+				Msg.info(this, "Bad AT");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
+				throw new IOException();
+			}
+			if (MufomType.MUFOM_ID_N != read_char(reader)) {
+				Msg.info(this, "Bad N");
+				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
+				throw new IOException();
+			}
+			symbol_name_index = read_int(reader);
+
+			if (read_int(reader) != 0) {
+				Msg.info(this, "Bad lex-level");
+				throw new IOException();
+			}
+			attribute_definition = read_int(reader);
+            switch ((int) attribute_definition) {
+            case MufomType.ieee_unknown_1_enum:
+            	x1 = read_int(reader);
+                break;
+            case MufomType.MUFOM_AD_TYPE:
+                x1 = read_int(reader);
+                //TODO  has_asn?  ASW0 does not
+                break;
+            case MufomType.MUFOM_AD_CASE:
+                x1 = read_int(reader);
+                //TODO  has_asn?  ASW0 does not
+                break;
+            case MufomType.MUFOM_AD_STATUS:
+                x1 = read_int(reader);
+                break;
+            case MufomType.ieee_unknown_56_enum:
+                x1 = read_int(reader);
+                break;
+            case MufomType.MUFOM_AD_ENV:
+                x1 = read_int(reader);
+                break;
+            case MufomType.ieee_unknown_16_enum:
+                x1 = read_int(reader);
+                x2 = read_int(reader);
+                break;
+            case MufomType.ieee_static_variable_enum:
+                x1 = read_int(reader);
+                x2 = read_int(reader);
+                break;
+            case MufomType.MUFOM_AD_VERSION:
+                x1 = read_int(reader);
+                x2 = read_int(reader);
+                break;
+            case MufomType.ieee_unknown_7_enum:
+                x1 = read_int(reader);
+                x2 = read_int(reader);
+                x3 = read_int(reader);
+                break;
+            case MufomType.ieee_execution_tool_version_enum:
+                x1 = read_int(reader);
+                x2 = read_int(reader);
+                x3 = read_int(reader);
+                break;
+            case MufomType.ieee_unknown_12_enum:
+                x1 = read_int(reader);
+                x2 = read_int(reader);
+                x3 = read_int(reader);
+                x4 = read_int(reader);
+                x5 = read_int(reader);
+                break;
+            case MufomType.MUFOM_AD_DATETIME:
+                x1 = read_int(reader); // year
+                x2 = read_int(reader); // mon
+                x3 = read_int(reader); // day
+                x4 = read_int(reader); // hour
+                x5 = read_int(reader); // min
+                x6 = read_int(reader); // sec
+                break;
+             default:
+                Msg.info(null, "Bad ATN " + symbol_name_index + " " + attribute_definition);
+                throw new IOException();
+             }
+            print();
+        }
+	}
+
+	/*
+	 * Module End (ASW7)
+	 *
+	 * Module End (ME) - $E1
+	 */
+	public class MufomEnd {
+		private final int asw_index = 7;
+		public MufomME me = null;
+
+		private void valid() throws IOException {
+			if (reader.getPointerIndex() != reader.length()) {
+				//TODO trailing data?
+			}
+		}
+
+		public MufomEnd() throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomEnd");
+			me = new MufomME(reader);
+			valid();
+		}
+	}
+
+	/*
+	 * Trailer Part (ASW6)
+	 *
+	 * Execution Starting Address (ASG) - $E2C7
+	 */
+	public class MufomTrailer {
+		private final int asw_index = 6;
+		public MufomTrailer next = null;
+		public MufomASG asg = null;
+
+		private void valid() throws IOException {
+
+		}
+
+		public MufomTrailer() throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomTrailer");
+			asg = new MufomASG(reader);
+			valid();
+		}
+	}
+
+	/*
+	 * Data Part (ASW5)
+	 *
+	 * Current Section (SB) - $E5
+	 * Current Section PC (ASP) - $E2D0
+	 * Load Constant MAUs (LD) - $ED
+	 * Repeat Data (RE) - $F7
+	 */
+	public class MufomData {
+		private final int asw_index = 5;
+		public MufomData next = null;
+		public MufomSB sb = null;
+		public MufomASP asp = null;
+		public MufomLD ld = null;
+		public MufomRE re = null;
+
+		private void valid() throws IOException {
+		}
+
+		public long getDataOffset() {
+			return ld.data_bytes_offset;
+		}
+
+		public long getDataLength() {
+			return ld.address_units;
+		}
+
+		public long getSectionNumber() {
+			if (null != sb) {
+				return sb.section_number;
+			}
+			return 0;
+		}
+
+		public long getSectionAddress() {
+			if (null == asp) {
+				// How do you get the section address when ASP is not defined
+				long section_number = getSectionNumber();
+				MufomSectionDefinition tmp = asw2;
+				while (null != tmp) {
+					if (section_number == tmp.getSectionIndex()) {
+						return tmp.getBaseAddress();
+					}
+					tmp = tmp.next;
+				}
+
+				return -1;
+			}
+			return asp.current_pc;
+		}
+
+		public MufomData(MufomData x) throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomData");
+			if (MufomSB.check(reader)) {
+				sb = new MufomSB(reader);
+			} else {
+				// no SB is defined, the current section is 0
+			}
+			if (MufomASP.check(reader)) {
+				asp = new MufomASP(reader);
+			} else {
+				// no ASP is defined, the PC is the start of the section
+			}
+			ld = new MufomLD(reader);
+			//re = new MufomRE(reader);
+			valid();
+			if (null != x) {
+				x.next = this;
+			}
+		}
+	}
+
+	/*
+	 * Debug Information Part (ASW4)
+	 *
+	 * Declare Block Beginning (BB) - $F8
+	 * Declare Type Name, filename, line numbers, function name, variable names, etc. (NN) - $F0
+	 * Define Type Characteristics (TY) - $F2
+	 * Variable Attributes (ATN) - $F1CE
+	 * Variable Values (ASN) - $E2CE
+	 * Declare Block End (BE) - $F9
+	 */
+	public class MufomDebugInformation {
+		private final int asw_index = 4;
+		public MufomDebugInformation next = null;
+		public MufomBB bb = null;
+		public MufomNN nn = null;
+		public MufomTY ty = null;
+		public MufomATN atn = null;
+		public MufomASN asn = null;
+		public MufomCompiler id = null;
+		public MufomBE be = null;
+
+		private void valid() throws IOException {
+
+		}
+
+		public MufomDebugInformation(MufomDebugInformation x) throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomDebugInformation");
+			bb = new MufomBB(reader);
+			nn = new MufomNN(reader, false);
+			ty = new MufomTY(reader, false);
+			atn = new MufomATN(reader, false);
+			asn = new MufomASN(reader, false);
+			id = new MufomCompiler(reader, false);
+			be = new MufomBE(reader, (int) bb.begin_block);
+			valid();
+			if (null != x) {
+				x.next = this;
+			}
+		}
+	}
+
+	/*
+	 * External Part (ASW3)
+	 *
+	 * Public (External) Symbol (NI) - $E8
+	 * Variable Attribute (ATI) - $F1C9
+	 * Variable Values (ASI) - $E2C9
+	 */
+	public class MufomExternal {
+		private final int asw_index = 3;
+		public MufomExternal next = null;
+		public MufomNI ni = null;
+		public MufomATI ati = null;
+		public MufomASI asi = null;
+
+		private void valid() throws IOException {
+			if (ni.symbol_name_index != ati.symbol_name_index ||
+					ni.symbol_name_index != asi.symbol_name_index) {
+				Msg.info(this, "Bad symbol index");
+				throw new IOException();
+			}
+		}
+
+		public String getName() {
+			return ni.symbol_name;
+		}
+
+		public long getIndex() {
+			return ni.symbol_name_index;
+		}
+
+		public long getAddress() {
+			return asi.symbol_value;
+		}
+
+		public DataType getType() {
+			return null;
+		}
+
+		public MufomExternal(MufomExternal x) throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomExternal");
+			ni = new MufomNI(reader);
+			ati = new MufomATI(reader);
+			asi = new MufomASI(reader);
+			valid();
+			if (null != x) {
+				x.next = this;
+			}
+		}
+	}
+
+	/*
+	 * Section Definition Part (ASW2)
+	 *
+	 * Section Type (ST) - $E6
+	 * Section Size (ASS) - $E2D3
+	 * Section Base Address (ASL) - $E2CC
+	 */
+	public class MufomSectionDefinition {
+		private final int asw_index = 2;
+		public MufomSectionDefinition next = null;
+		public MufomST st = null;
+		public MufomSA sa = null;
+		private MufomASS ass = null;
+		private MufomASL asl = null;
+
+		private void valid() throws IOException {
+			if (st.section_number != ass.section_number ||
+					st.section_number != asl.section_number ||
+					st.section_number != sa.section_number) {
+				Msg.info(this, "Bad section index");
+				throw new IOException();
+			}
+		}
+
+		public long getSectionIndex() {
+			return st.section_number;
+		}
+
+		public long getSectionLength() {
+			return ass.section_size;
+		}
+
+		public long getBaseAddress() {
+			return asl.section_base_address;
+		}
+
+		public String getName() {
+			return st.section_name;
+		}
+
+		public MufomSectionDefinition(MufomSectionDefinition x) throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomSectionDefinition");
+			st = new MufomST(reader);
+			sa = new MufomSA(reader);
+			ass = new MufomASS(reader);
+			asl = new MufomASL(reader);
+			valid();
+			if (null != x) {
+				x.next = this;
+			}
+		}
+	}
+
+	/*
+	 * Environment Part (ASW1)
+	 *
+	 * Variable Attributes (NN) - $F0
+	 * Variable Attributes (ATN) - $F1CE
+	 * Variable Values (ASN) - $E2CE
+	 */
+	public class MufomEnvironment {
+		private final int asw_index = 1;
+		public MufomEnvironment next = null;
+		public MufomNN nn = null;
+		public MufomATN atn = null;
+		public MufomASN asn = null;
+
+		private void valid() throws IOException {
+			if (nn.symbol_name_index != atn.symbol_name_index) {
+				Msg.info(this, "Bad symbol_name_index");
+				throw new IOException();
+			}
+		}
+
+		public MufomEnvironment(MufomEnvironment x) throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomEnvironment");
+			if (null == x) {
+				nn = new MufomNN(reader, true);
+			} else {
+				x.next = this;
+				nn = x.nn;
+			}
+			atn = new MufomATN(reader, true);
+			if (atn.has_asn) {
+				asn = new MufomASN(reader, true);
+			}
+			valid();
+		}
+	}
+
+	/*
+	 * AD Extension Part (ASW0)
+	 *
+	 * Variable Attributes (NN) - $F0
+	 * Variable Attributes (ATN) - $F1CE
+	 * Variable Values (ASN) - $E2CE
+	 */
+	public class MufomADExtension {
+		private final int asw_index = 0;
+		public MufomADExtension next = null;
+		public MufomNN nn = null;
+		public MufomATN atn = null;
+		public MufomASN asn = null;
+
+		private void valid() throws IOException {
+			if (nn.symbol_name_index != atn.symbol_name_index) {
+				Msg.info(this, "Bad symbol_name_index");
+				throw new IOException();
+			}
+		}
+
+		public MufomADExtension(MufomADExtension x) throws IOException {
+			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+					hdr.asw_end[asw_index]) + "PARSE MufomADExtension");
+			if (null == x) {
+				nn = new MufomNN(reader, true);
+			} else {
+				x.next = this;
+				nn = x.nn;
+			}
+			atn = new MufomATN(reader, true);
+			if (atn.has_asn) {
+				asn = new MufomASN(reader, true);
+			}
+			valid();
+		}
+	}
+
+	/*
+	 * Module Beginning (MB) - $E0
+	 * Address Descriptor (AD) - $EC
+	 * Assign Value to Variable W0 (ASW0) - $E2D700
+	 * Assign Value to Variable WI (ASW1) - $E2D701
+	 * Assign Value to Variable W2 (ASW2) - $E2D702
+	 * Assign Value to Variable W3 (ASW3) - $E2D703
+	 * Assign Value to Variable W4 (ASW4) - $E2D704
+	 * Assign Value to Variable W5 (ASW5) - $E2D705
+	 * Assign Value to Variable W6 (ASW6) - $E2D706
+	 * Assign Value to Variable W7 (ASW7) - $E2D707
+	 */
+	public class MufomHeaderPart {
+		public MufomMB mb = null;
+		public MufomAD ad = null;
+		public long[] asw_offset = {-1, -1, -1, -1, -1, -1, -1, -1};
+		public long[] asw_end = {-1, -1, -1, -1, -1, -1, -1, -1};
+
+		public MufomHeaderPart() throws IOException {
+			Msg.trace(this, String.format("%08x-%08x ", 0, reader.length()) + "PARSE MufomHeaderPart");
+			mb = new MufomMB(reader);
+			ad = new MufomAD(reader);
+
+			for (int i = 0; i < 8; i++) {
+				MufomASW tmp = new MufomASW(reader);
+				asw_offset[(int) tmp.asw_index] = tmp.asw_offset;
+			}
+			for (int i = 0; i < 8; i++) {
+				if (asw_offset[i] == 0) {
+					asw_end[i] = 0;
+					continue;
+				}
+				for (int j = 0; j < 8; j ++) {
+					if (asw_offset[i] >= asw_offset[j]) {
+						continue;
+					}
+					if (asw_end[i] == -1) {
+						asw_end[i] = asw_offset[j];
+					} else if (asw_end[i] > asw_offset[j]) {
+						asw_end[i] = asw_offset[j];
+					}
+				}
+				if (-1 == asw_end[i]) {
+					asw_end[i] = reader.length();
+				}
+			}
+		}
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomHeader.java
@@ -28,7 +28,6 @@ public class MufomHeader {
 	public final static String MUFOM_NAME = "IEEE-695-MUFOM";
 	public BinaryReader reader = null;
 	private Consumer<String> errorConsumer;
-	private boolean do_debug = false;
 
 	public MufomHeaderPart hdr = null;
 	public MufomADExtension asw0 = null;
@@ -43,7 +42,7 @@ public class MufomHeader {
 	public MufomHeader(ByteProvider bp, Consumer<String> errorConsumer) throws IOException {
 		reader = new BinaryReader(bp, false);
 		reader.setPointerIndex(0);
-		Msg.trace(this, String.format("%08x-%08x ", 0, reader.length()) + "PARSE MUFOM");
+		Msg.warn(this, String.format("%08x-%08x ", 0, reader.length()) + "PARSE MUFOM");
         this.errorConsumer = errorConsumer != null ? errorConsumer : msg -> {
 			/* no logging if errorConsumer was null */
 		};
@@ -166,1036 +165,6 @@ public class MufomHeader {
 		return hdr.mb.target_machine_configuration;
 	}
 
-	/*
-	 * 8.1 MB (module begin) Command
-	 *
-	 * MB-command → “MB” target-machine-configuration (“,” module-name)? “.”
-	 * target-machine-configuration → identifier
-	 * module-name → char-string
-	 *
-	 * {$E0}{Id1}{Id2}
-	 */
-	public class MufomMB extends MufomRecord {
-		private final String NAME = "MB";
-		private String target_machine_configuration = null;
-		public String module_name = null;
-
-		private void print() {
-			String msg = NAME + ": " + target_machine_configuration + " " + module_name;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-		public MufomMB(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_MB != read_char(reader)) {
-				Msg.info(this, "Bad MB");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			target_machine_configuration = read_id(reader);
-			module_name = read_opt_id(reader);
-			print();
-		}
-	}
-
-	/*
-	 * 8.2 ME (module end) Command
-	 *
-	 * ME-command → “ME.”
-	 *
-	 * {$E1}
-	 */
-	public class MufomME extends MufomRecord {
-		private final String NAME = "ME";
-
-		private void print() {
-			String msg = NAME;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomME(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_ME != read_char(reader)) {
-				Msg.info(this, "bad ME");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			print();
-		}
-	}
-
-	/*
-	 * 8.3 DT (date and time of creation) Command
-	 *
-	 * DT-command → "DT" digit* “.”
-	 */
-	public class MufomDT extends MufomRecord {
-		private final String NAME = "DT";
-		public MufomDT(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 8.4 AD (address descriptor) Command
-	 *
-	 * AD-command → “AD” bits-per-MAU (“,” MAUs-per-address) (“,” order)? )? “.”
-	 * bits-per-MAU → hexnumber
-	 * MAUs-per-address → hexnumber
-	 * order → “L” | “M”
-	 *
-	 * {$EC}{8){4}{$CC}
-	 */
-	public class MufomAD extends MufomRecord {
-		private final String NAME = "AD";
-		public long bits_per_mau = -1;
-		public long maus_per_address = -1;
-		private int order = -1;
-
-		private void print() {
-			String msg = NAME + ": " + bits_per_mau + " " + maus_per_address;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomAD(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AD != read_char(reader)) {
-				Msg.info(this, "Bad AD");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			bits_per_mau = read_int(reader);
-			maus_per_address = read_int(reader);
-			order = read_opt_char(reader);
-			if (MufomType.MUFOM_ID_L == order) {
-				//TODO  little endian
-			} else if (MufomType.MUFOM_ID_M == order) {
-				//TODO  big endian
-			} else if (-1 == order) {
-				//TODO  unknown
-				Msg.info(this, "Unknown endianess");
-			} else {
-				Msg.info(this, "Bad endian " + order);
-				throw new IOException();
-			}
-			print();
-		}
-	}
-
-
-	/*
-	 * 9.1 Comments
-	 */
-	public class MufomCO extends MufomRecord {
-		private final String NAME = "CO";
-		public MufomCO(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 9.2 CS (checksum) Command
-	 */
-	public class MufomCS extends MufomRecord {
-		private final String NAME = "CS";
-		public MufomCS(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 10.1 SB (section begin) Command
-	 *
-	 * SB-command → “SB” section-number “.”
-	 * section-number → hexnumber
-	 *
-	 * {$E5}{n1}
-	 */
-	public class MufomSB extends MufomRecord {
-		private final String NAME = "SB";
-		public long section_number = -1;
-
-		public static boolean check(BinaryReader reader) throws IOException {
-			long offset = reader.getPointerIndex();
-			if (MufomType.MUFOM_CMD_SB == reader.readUnsignedByte(offset + 0)) {
-				return true;
-			}
-			return false;
-		}
-
-		private void print() {
-			String msg = NAME + ": " + section_number;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomSB(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_SB != read_char(reader)) {
-				Msg.info(this, "bad SB");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			section_number = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * 10.2 ST (section type) Command
-	 *
-	 * ST-command → “ST” section-number (“,” section-type)* (“,” section-name)? “.”
-	 * section-number → hexnumber
-	 * section-type → letter
-	 * section-name → char-string
-	 *
-	 * ${E6}{n1}{l}[Id][n2][n3][n4]
-	 */
-	public class MufomST extends MufomRecord {
-		private final String NAME = "ST";
-		public long section_number = -1;
-		public String section_name = null;
-		private MufomAS as = null;
-		private MufomAbsCode code = null;
-		private MufomAbsData data = null;
-		private long n2 = -1;
-		private long n3 = -1;
-		private long n4 = -1;
-
-		private void print() {
-			String msg = NAME + ": " + section_number + " " + section_name + " " + n2 +" "+n3+" "+n4;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomST(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_ST != read_char(reader)) {
-				//TODO  "if no ST-command is given for a section, its type is absolute (A)"
-				Msg.info(this, "Bad ST");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-
-			section_number = read_int(reader);
-			if (0 == section_number) {
-				Msg.info(this, "Bad section");
-				throw new IOException();
-			}
-
-			// one section type: AS, ASP, or ASD
-			if (MufomAbsCode.check(reader)) {
-				code = new MufomAbsCode(reader);
-			} else if (MufomAbsData.check(reader)) {
-				data = new MufomAbsData(reader);
-			} else {
-				as = new MufomAS(reader);
-			}
-
-			section_name = read_opt_id(reader);
-
-			//TODO  what is this
-			n2 = read_int(reader);
-			n3 = read_int(reader);
-			n4 = read_int(reader);
-
-			print();
-		}
-	}
-
-	/*
-	 * 10.3 SA (section alignment) Command
-	 *
-	 * SA-command → “SA” section-number “,” MAU-boundary? ("," page-size)? "."
-	 * MAU-boundary → expression
-	 * page-size → expression
-	 *
-	 * {$E7}{n1}{n2}
-	 */
-	public class MufomSA extends MufomRecord {
-		private final String NAME = "SA";
-		public long section_number = -1;
-		public long mau_boundary = -1;
-		public long page_size = -1;
-
-		private void print() {
-			String msg = NAME + ":" + section_number + " " + mau_boundary + " " + page_size;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomSA(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_SA != read_char(reader)) {
-				Msg.info(this, "Bad SA");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			section_number = read_int(reader);
-			mau_boundary = read_int(reader);
-			page_size = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * 11.1 NI (name of internal symbol) Command
-	 *
-	 * NI-command → “N” I-variable “,” ext-def-name “.”
-	 * I-variable → “I” hexnumber
-	 * ext-def-name → char-string
-	 *
-	 * {$E8}{n}{Id}
-	 */
-	public class MufomNI extends MufomRecord {
-		private final String NAME = "NI";
-		public long symbol_name_index = -1;
-		public String symbol_name = null;
-
-		private void print() {
-			String msg = NAME;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomNI(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_NI != read_char(reader)) {
-				Msg.info(this, "Bad NI");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			symbol_name_index = read_int(reader);
-			symbol_name = read_id(reader);
-			print();
-		}
-	}
-
-	/*
-	 * 11.2 NX (name of external symbol) Command
-	 */
-	public class MufomNX extends MufomRecord {
-		private final String NAME = "NX";
-		public MufomNX(BinaryReader reader) throws IOException {
-			//TODO  is it a $E8 typo or is this $B8?
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 11.3 NN (name) Command
-	 *
-	 * NN-command → “N” N-variable “,” name “.”
-	 * N-variable → “N” hexnumber
-	 * name → char-string
-	 *
-	 * {$F0}{n1}{Id}
-	 */
-	public class MufomNN extends MufomRecord {
-		private final String NAME = "NN";
-		public long symbol_name_index = -1;
-		public String symbol_name = null;
-
-		private void print() {
-			String msg = NAME + ": '" + symbol_name + "' " + symbol_name_index;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomNN(BinaryReader reader, boolean must) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (!must && omit_cmd(reader)) {
-				return;
-			}
-			if (MufomType.MUFOM_CMD_NN != read_char(reader)) {
-				Msg.info(this, "Bad NN");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-
-			symbol_name_index = read_int(reader);
-	        symbol_name = read_id(reader);
-	        print();
-		}
-	}
-
-	/*
-	 * 11.4 AT (attributes) Command
-	 */
-	public class MufomAT extends MufomRecord {
-		private final String NAME = "AT";
-		public MufomAT(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 11.5 TY (type) Command
-	 *
-	 * TY_command       ::= "TY" type_table_entry [ "," parameter ]+ "."
-	 * type_table_entry ::= hex_number
-	 * parameter        ::= hex_number | N_variable | "T" type_table_entry
-	 *
-	 * {$F2}{nl}{$CE}{n2}[n3][n4]...
-	 */
-	public class MufomTY extends MufomRecord {
-		private final String NAME = "TY";
-		public long type_index = -1;
-		public long name_index = -1;
-
-		private void print() {
-			String msg = NAME + ": " + type_index +" " + name_index;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomTY(BinaryReader reader, boolean must) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (!must && omit_cmd(reader)) {
-				return;
-			}
-			if (MufomType.MUFOM_CMD_TY != read_char(reader)) {
-				Msg.info(this, "Bad TY");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			type_index = read_int(reader);
-			if (type_index < 256) {
-				Msg.info(this, "Invalid type index " + type_index);
-				throw new IOException();
-			}
-			int record_type = read_char(reader);
-			if (MufomType.MUFOM_ID_N != record_type) {
-				Msg.info(null, "Expected MUFOM_ID_N, " + record_type);
-			}
-
-			name_index = read_int(reader);
-
-			// variable number of fields
-			// D-7:  19
-			// D-8:
-
-			print();
-		}
-	}
-
-	/*
-	 * 12. AS (assignment) Command
-	 *
-	 * {$C1}{$D3}
-	 */
-	public class MufomAS extends MufomRecord {
-		private final String NAME = "AS";
-
-		public MufomAS(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_ID_A != read_char(reader)) {
-				Msg.info(this, "bad A");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_S != read_char(reader)) {
-				Msg.info(this, "bad S");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-
-			int section_type = -1;
-			boolean parse_section_type = true;
-			while (parse_section_type) {
-				section_type = read_char(reader);
-				switch (section_type) {
-				case MufomType.MUFOM_ID_W:
-					/* Access: writable (RAM)  This is default if no access attribute is found */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - writable");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_R:
-					/* Access: read only (ROM) */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - read only");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_X:
-					/* Access: Execute only */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - execute only");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_Z:
-					/* Access: zero page */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - zero page");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_A:
-					/* Access: Abs.  There shall be an assignment to the L-variable */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - absolute");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_E:
-					/* Overlap: Equal.  Error if lengths differ */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - equal");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_M:
-					/* Overlap: Max.  Use largest length encountered */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - max");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_U:
-					/* Overlap: Unique.  Name should be unique */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - unique");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_C:
-					/* Overlap: Cumulative.  Concatenate sections */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - cumulative");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_S:
-					/* Overlap: Separate.  No connection between sections */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - separate");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_N:
-					/* Allocate: Now.  This is normal case */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - now");
-					//TODO
-					break;
-				case MufomType.MUFOM_ID_P:
-					/* Allocate: Postpone.  relocator must allocate after all 'now' sections */
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - postpone");
-					//TODO
-					break;
-				default:
-					if (do_debug) Msg.info(this, String.format("%08x ", reader.getPointerIndex()) + " - DONE " + section_type);
-					parse_section_type = false;
-					reader.setPointerIndex(reader.getPointerIndex() - 1);
-					break;
-				}
-			}
-		}
-	}
-
-	/*
-	 * 13.1 LD (load) Command
-	 *
-	 * LD-command → “LD” load-constant + “.”
-	 * load-constant → hexdigit +
-	 *
-	 * {$ED}{n1}{...}
-	 */
-	public class MufomLD extends MufomRecord {
-		private final String NAME = "LD";
-		private long data_bytes_offset;
-		private long address_units;
-
-		private void print() {
-			String msg = NAME + ": " + data_bytes_offset + " " + address_units;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomLD(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_LD != read_char(reader)) {
-				Msg.info(this, "bad LD");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-
-			address_units = read_int(reader);
-			if (address_units < 1 || address_units > 127) {
-				Msg.info(this, "bad units");
-				throw new IOException();
-			}
-			data_bytes_offset = reader.getPointerIndex();
-			reader.setPointerIndex(data_bytes_offset + address_units);
-			// OR
-			// bytes = reader.readNextByteArray((int) address_units);
-
-			print();
-		}
-	}
-
-	/*
-	 * 13.2 IR (initialize relocation base) Command
-	 */
-	public class MufomIR extends MufomRecord {
-		private final String NAME = "IR";
-		public MufomIR(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 13.3 LR (load relocate) Command
-	 */
-	public class MufomLR extends MufomRecord {
-		private final String NAME = "LR";
-		public MufomLR(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 13.4 RE (replicate) Command
-	 *
-	 * RE-command → “RE” expression “.”
-	 */
-	public class MufomRE extends MufomRecord {
-		private final String NAME = "RE";
-		public long repeat = -1;
-
-		private void print() {
-			String msg = NAME;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomRE(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_RE != read_char(reader)) {
-				Msg.info(this, "bad RE");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			repeat = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * 14.1 RI (retain internal symbol) Command
-	 */
-	public class MufomRI extends MufomRecord {
-		private final String NAME = "RI";
-		public MufomRI(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 14.2 WX (weak external symbol) Command
-	 */
-	public class MufomWX extends MufomRecord {
-		private final String NAME = "WX";
-		public MufomWX(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 15.1 LI (Specify Default Library Search List) Command
-	 */
-	public class MufomLI extends MufomRecord {
-		private final String NAME = "Li";
-		public MufomLI(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	/*
-	 * 15.2 LX (library external) Command
-	 */
-	public class Mufom extends MufomRecord {
-		private final String NAME = "LX";
-		public Mufom(BinaryReader reader) throws IOException {
-			Msg.info(this, "unimplemented " + NAME);
-			throw new IOException();
-		}
-	}
-
-	public class MufomBB extends MufomRecord {
-		private final String NAME = "BB";
-		public long begin_block = -1;
-		public long block_size = -1;
-		public MufomBB bb1 = null;
-		public MufomBB bb2 = null;
-		public MufomBB bb3 = null;
-		public MufomBB bb4 = null;
-		public MufomBB bb5 = null;
-		public MufomBB bb6 = null;
-		public MufomBB bb10 = null;
-		public MufomBB bb11 = null;
-
-		private long block_start = -1;
-		private long block_end = -1;
-
-		private void print() {
-			String msg = NAME + ": " + begin_block + " 0x" + Long.toHexString(block_size) + " " +
-					Long.toHexString(block_start) + " " + Long.toHexString(block_end) + " " +
-					Long.toHexString(block_end - block_start);
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			block_start = reader.getPointerIndex();
-			if (MufomType.MUFOM_CMD_SC != read_char(reader)) {
-				Msg.info(this, "bad SC");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-
-			begin_block = read_int(reader);
-			block_size = read_int(reader);
-			switch ((int) begin_block) {
-			case MufomType.MUFOM_BB1:
-				new MufomBB1(reader);
-				break;
-			case MufomType.MUFOM_BB2:
-				new MufomBB2(reader);
-				break;
-			case MufomType.MUFOM_BB3:
-				new MufomBB3(reader);
-				break;
-			case MufomType.MUFOM_BB4:
-				new MufomBB4(reader);
-				break;
-			case MufomType.MUFOM_BB5:
-				new MufomBB5(reader);
-				break;
-			case MufomType.MUFOM_BB6:
-				new MufomBB6(reader);
-				break;
-			case MufomType.MUFOM_BB10:
-				new MufomBB10(reader);
-				break;
-			case MufomType.MUFOM_BB11:
-				new MufomBB11(reader);
-				break;
-			default:
-				break;
-			}
-			block_end = reader.getPointerIndex();
-			print();
-		}
-	}
-
-	/*
-	 * Type definitions local to a module.
-	 */
-	public class MufomBB1 extends MufomRecord {
-		public String module_name = null;
-
-		private void print() {
-			String msg = "";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB1(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB1");
-			if (0 != read_int(reader)) {
-				Msg.info(this, "Bad block size");
-				throw new IOException();
-			}
-			module_name = read_id(reader);
-			print();
-		}
-	}
-
-	/*
-	 * Global type definitions.
-	 */
-	public class MufomBB2 extends MufomRecord {
-		public String module_name = null;
-
-		private void print() {
-			String msg = "BB2: '" + module_name + "'";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB2(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB2");
-			module_name = read_id(reader);
-			print();
-		}
-	}
-
-	/*
-	 * A module. A non-separable unit of code, usually the result of a
-	 * single compilation, i.e. the symbols associated with a COFF
-	 * .file symbol.
-	 */
-	public class MufomBB3 extends MufomRecord {
-		public String module_name = null;
-
-		private void print() {
-			String msg = "";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB3(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB3");
-			module_name = read_id(reader);
-			print();
-		}
-	}
-
-	/*
-	 * A global subprogram.
-	 */
-	public class MufomBB4 extends MufomRecord {
-		public String function_name = null;
-		public long type_index = -1;
-		public long code_block_address = -1;
-
-		private void print() {
-			String msg = "";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB4(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB4");
-			function_name = read_id(reader);
-			if (0 != read_int(reader)) {
-				Msg.info(this, "Bad stack space");
-				throw new IOException();
-			}
-			type_index = read_int(reader);
-			code_block_address = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * A source file line number block.
-	 */
-	public class MufomBB5 extends MufomRecord {
-		public String source_filename = null;
-
-		private void print() {
-			String msg = "";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB5(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB5");
-			source_filename = read_id(reader);
-			print();
-		}
-	}
-
-	/*
-	 * A local (static) subprogram.
-	 */
-	public class MufomBB6 extends MufomRecord {
-		public String function_name = null;
-		public long stack_space = -1;
-		public long type_index = -1;
-		public long code_block_offset = -1;
-
-		private void print() {
-			String msg = "";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB6(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB6");
-			if (0 != read_int(reader)) {
-				Msg.info(this, "Bad block size");
-				throw new IOException();
-			}
-			function_name = read_id(reader);
-			stack_space = read_int(reader);
-			type_index = read_int(reader);
-			code_block_offset = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * An assembler debugging information block.
-	 */
-	public class MufomBB10 extends MufomRecord {
-		public String source_filename = null;
-		public long tool_type = -1;
-		public String version = null;
-		public Calendar date;
-
-		private void print() {
-			String msg = "";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB10(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB10");
-			source_filename = read_id(reader);
-			String zero = read_id(reader);
-			if (zero.length() != 0) {
-				Msg.info(this, "Bad zero");
-				throw new IOException();
-			}
-			tool_type = read_int(reader);
-			if (210 == tool_type) {
-
-			} else if (209 == tool_type) {
-
-			} else {
-				Msg.info(this, "bad tool");
-				throw new IOException();
-			}
-			version = read_id(reader);
-
-			int year = (int) read_int(reader);
-			int month = (int) read_int(reader);
-			int day = (int) read_int(reader);
-			int hour = (int) read_int(reader);
-			int minute = (int) read_int(reader);
-			int second = (int) read_int(reader);
-			date.set(year, month, day, hour, minute, second);
-			print();
-		}
-	}
-
-	/*
-	 * The module portion of a section.
-	 */
-	public class MufomBB11 extends MufomRecord {
-		public long section_type = -1;
-		public long section_number = -1;
-		public long section_offset = -1;
-
-		private void print() {
-			String msg = "";
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBB11(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomBB11");
-			String zero = read_id(reader);
-			if (zero.length() != 0) {
-				Msg.info(this, "bad zero");
-				throw new IOException();
-			}
-			section_type = read_int(reader);
-			section_number = read_int(reader);
-			section_offset = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * Value Records (ASN)
-	 *
-	 * AS-command → “AS” MUFOM-variable “,” expression “,”
-	 *
-	 * N-variable → “N” hexnumber
-	 */
-	public class MufomASN extends MufomRecord {
-		private final String NAME = "ASN";
-		public long symbol_name_index = -1;
-		public long symbol_name_value = -1;
-
-		private void print() {
-			String msg = NAME + ": " + symbol_name_index + " " + symbol_name_value;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomASN(BinaryReader reader, boolean must) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (!must && omit_cmd(reader)) {
-				return;
-			}
-			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
-				Msg.info(this, "Bad AS");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_N != read_char(reader)) {
-				Msg.info(this, "Bad N");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			symbol_name_index = read_int(reader);
-			symbol_name_value = read_int(reader);
-			print();
-		}
-	}
 
 	/*
 	 * Compiler Id
@@ -1221,371 +190,29 @@ public class MufomHeader {
 			if (do_debug) {
 				Msg.info(this, msg);
 			} else {
-				Msg.trace(this, msg);
+				Msg.warn(this, msg);
 			}
 		}
 
-		public MufomCompiler(BinaryReader reader, boolean must) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomCompiler");
-			if (!must && omit_cmd(reader)) {
-				return;
-			}
-			nn = new MufomNN(reader, true);
-			atn = new MufomATN(reader, true);
-			asntool = new MufomASN(reader, true);
-			asntype = new MufomASN(reader, true);
-			asnsize = new MufomASN(reader, true);
-			atn1 = new MufomATN(reader, false);
-			asnyear = new MufomASN(reader, false);
-			asnmonth = new MufomASN(reader, false);
-			asnday = new MufomASN(reader, false);
-			asnhour = new MufomASN(reader, false);
-			asnminute = new MufomASN(reader, false);
-			asnsecond = new MufomASN(reader, false);
+		public MufomCompiler(BinaryReader reader) throws IOException {
+			Msg.warn(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomCompiler");
+			nn = new MufomNN(reader);
+			atn = new MufomATN(reader);
+			asntool = new MufomASN(reader);
+			asntype = new MufomASN(reader);
+			asnsize = new MufomASN(reader);
+			atn1 = new MufomATN(reader);
+			asnyear = new MufomASN(reader);
+			asnmonth = new MufomASN(reader);
+			asnday = new MufomASN(reader);
+			asnhour = new MufomASN(reader);
+			asnminute = new MufomASN(reader);
+			asnsecond = new MufomASN(reader);
 			print();
 		}
 	}
 
-	/*
-	 * Section Size (ASS)
-	 *
-	 * AS-command → “AS” MUFOM-variable “,” expression “,”
-	 *
-	 * S-variable → “S” section-number?
-	 * section-number → hexnumber
-	 *
-	 * {$E2}{$D3}{n1}{n2}
-	 */
-	public class MufomASS extends MufomRecord {
-		private final String NAME = "ASS";
-		public long section_number = -1;
-		public long section_size = -1;
 
-		private void print() {
-			String msg = NAME + ": " + section_number + " " + section_size;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomASS(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
-				Msg.info(this, "Bad AS");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_S != read_char(reader)) {
-				Msg.info(this, "Bad S");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			section_number = read_int(reader);
-			section_size = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * Section Base Address (ASL)
-	 *
-	 * AS-command → “AS” MUFOM-variable “,” expression “,”
-	 *
-	 * L-variable → “L” section-number?
-	 * section-number → hexnumber
-	 *
-	 * {$E2}{$CC}{n1}{n2}
-	 */
-	public class MufomASL extends MufomRecord {
-		private final String NAME = "ASL";
-		public long section_number = -1;
-		public long section_base_address = -1;
-
-		private void print() {
-			String msg = NAME + ": " + section_number + " 0x" + Long.toHexString(section_base_address);
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomASL(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
-				Msg.info(this, "Bad AS");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_L != read_char(reader)) {
-				Msg.info(this, "Bad L");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			section_number = read_int(reader);
-			section_base_address = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * Value Records (ASI)
-	 *
-	 * AS-command → “AS” MUFOM-variable “,” expression “,”
-	 *
-	 * I-variable → “I” hexnumber
-	 *
-	 * {$E2}{$C9}{n1}{n2}
-	 */
-	public class MufomASI extends MufomRecord {
-		private final String NAME = "ASI";
-		public long symbol_name_index = -1;
-		public long symbol_value = -1;
-
-		private void print() {
-			String msg = NAME + ": " + symbol_name_index + " " + symbol_value;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomASI(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
-				Msg.info(this, "Bad AS");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_I!= read_char(reader)) {
-				Msg.info(this, "Bad I");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			symbol_name_index = read_int(reader);
-			symbol_value = read_int(reader);
-			print();
-		}
-	}
-
-	/*
-	 * Attribute Records (ATI)
-	 *
-	 * AT-command → “AT” variable “,” type-table-entry (“,” lex-level (“,” hexnumber)* )? “.”
-	 * variable → I-variable | N-variable | X-variable
-	 * type-table-entry → hexnumber
-	 * lex-level → hexnumber
-	 *
-	 * I-variable → “I” hexnumber
-	 *
-	 * {$F1}{$C9}{n1}{n2}{n3}{n4}
-	 */
-	public class MufomATI extends MufomRecord {
-		private final String NAME = "ATI";
-		public long symbol_name_index = -1;
-		public long symbol_type_index = -1;
-		public long attribute_definition = -1;
-		public long number_of_elements = -1;
-
-		private void print() {
-			String msg = NAME;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomATI(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AT != read_char(reader)) {
-				Msg.info(this, "Bad AT");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_I!= read_char(reader)) {
-				Msg.info(this, "Bad I");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			symbol_name_index = read_int(reader);
-			symbol_type_index = read_int(reader);
-			switch ((int) symbol_type_index) {
-	        case MufomType.MUFOM_BUILTIN_UNK:
-	        	Msg.info(this, "TYPE: UNK");
-	        	break;
-	        case MufomType.MUFOM_BUILTIN_V:
-	        	Msg.info(this, "TYPE: V");
-	        	break;
-	        case MufomType.MUFOM_BUILTIN_B:
-	        	Msg.info(this, "TYPE: B");
-	        	break;
-	        case MufomType.MUFOM_BUILTIN_C:
-	        	Msg.info(this, "TYPE: C");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_H:
-	        	Msg.info(this, "TYPE: H");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_I:
-	        	Msg.info(this, "TYPE: I");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_L:
-	        	Msg.info(this, "TYPE: L");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_M:
-	        	Msg.info(this, "TYPE: M");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_F:
-	        	Msg.info(this, "TYPE: F");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_D:
-	        	Msg.info(this, "TYPE: D");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_K:
-	        	Msg.info(this, "TYPE: K");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_J:
-	        	Msg.info(this, "TYPE: J");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_PUNK:
-	        	Msg.info(this, "TYPE: PUNK");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_PV:
-	        	Msg.info(this, "TYPE: PV");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_PB:
-	        	Msg.info(this, "TYPE: PB");
-	        	break;
-	        case MufomType.MUFOM_BUILTIN_PC:
-	        	Msg.info(this, "TYPE: PC");
-	        	break;
-	        case MufomType.MUFOM_BUILTIN_PH:
-	        	Msg.info(this, "TYPE: PH");
-	        	break;
-	        case MufomType.MUFOM_BUILTIN_PI:
-	        	Msg.info(this, "TYPE: PI");
-	        	break;
-	        case MufomType.MUFOM_BUILTIN_PL:
-	        	Msg.info(this, "TYPE: PL");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_PM:
-	        	Msg.info(this, "TYPE: PM");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_PF:
-	        	Msg.info(this, "TYPE: PF");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_PD:
-	        	Msg.info(this, "TYPE: PD");
-	            break;
-	        case MufomType.MUFOM_BUILTIN_PK:
-	        	Msg.info(this, "TYPE: PK");
-	        	break;
-	        default:
-	        	Msg.info(this, "Bad type " + symbol_type_index);
-	        	throw new IOException();
-	        }
-
-			attribute_definition = read_int(reader);
-			if (MufomType.MUFOM_BUILTIN_UNK != symbol_type_index) {
-				number_of_elements = read_int(reader);
-			}
-			print();
-		}
-	}
-
-	/*
-	 * Block End (BE)
-	 *
-	 * {$F9}[{n1}]
-	 */
-	public class MufomBE extends MufomRecord {
-		private final String NAME = "BE";
-
-		private void print() {
-			String msg = NAME;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomBE(BinaryReader reader, int bb) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_LN != read_char(reader)) {
-				Msg.info(this, "Bad BE");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			switch (bb) {
-			case MufomType.MUFOM_BB4:
-			case MufomType.MUFOM_BB6:
-				//TODO Expression defining the ending address of the function (in minimum address units)
-				Msg.info(this, "BE 4 or 6");
-				throw new IOException();
-				//break;
-			case MufomType.MUFOM_BB11:
-				//TODO Expression defining the size in minimum address units of the module section
-				Msg.info(this, "BE 11");
-				throw new IOException();
-				//break;
-			default:
-				break;
-			}
-			print();
-		}
-	}
-
-	/*
-	 * Set Current PC, absolute code (ASP)
-	 *
-	 * AS-command → “AS” MUFOM-variable “,” expression “,”
-	 *
-	 * P-variable → “P” section-number?
-	 * section-number → hexnumber
-	 */
-	public class MufomASP extends MufomRecord {
-		private final String NAME = "ASP";
-		private long section_index = -1;
-		private long current_pc = -1;
-
-		public static boolean check(BinaryReader reader) throws IOException {
-			long offset = reader.getPointerIndex();
-			if (MufomType.MUFOM_CMD_AS == reader.readUnsignedByte(offset + 0) &&
-					MufomType.MUFOM_ID_P == reader.readUnsignedByte(offset + 1)) {
-				return true;
-			}
-			return false;
-		}
-
-		private void print() {
-			String msg = NAME + ": " + section_index + " " + Long.toHexString(current_pc);
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-		public MufomASP(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
-				Msg.info(this, "bad P");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_P != read_char(reader)) {
-				Msg.info(this, "bad P");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			section_index = read_int(reader);
-			current_pc = read_int(reader);
-			print();
-		}
-	}
 
 	/*
 	 * Absolute Code
@@ -1593,11 +220,14 @@ public class MufomHeader {
 	 * {$C1}{$D3}{$D0}
 	 */
 	public class MufomAbsCode extends MufomRecord {
+		public static final String NAME = "CODE";
+		public static final int record_type = MufomType.MUFOM_ID_A;
+		public static final int record_subtype = MufomType.MUFOM_ID_S ;
 
 		public static boolean check(BinaryReader reader) throws IOException {
 			long offset = reader.getPointerIndex();
-			if (MufomType.MUFOM_ID_A == reader.readUnsignedByte(offset + 0) &&
-					MufomType.MUFOM_ID_S == reader.readUnsignedByte(offset + 1) &&
+			if (record_type == reader.readUnsignedByte(offset + 0) &&
+					record_subtype == reader.readUnsignedByte(offset + 1) &&
 							MufomType.MUFOM_ID_P == reader.readUnsignedByte(offset + 2)) {
 				return true;
 			}
@@ -1605,13 +235,13 @@ public class MufomHeader {
 		}
 
 		public MufomAbsCode(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomAbsCode");
-			if (MufomType.MUFOM_ID_A != read_char(reader)) {
+			Msg.warn(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomAbsCode");
+			if (record_type != read_char(reader)) {
 				Msg.info(this, "bad A");
 				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
 				throw new IOException();
 			}
-			if (MufomType.MUFOM_ID_S != read_char(reader)) {
+			if (record_subtype != read_char(reader)) {
 				Msg.info(this, "bad S");
 				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
 				throw new IOException();
@@ -1630,11 +260,14 @@ public class MufomHeader {
 	 * {$C1}{$D3}{$C4}
 	 */
 	public class MufomAbsData extends MufomRecord {
+		public static final String NAME = "DATA";
+		public static final int record_type = MufomType.MUFOM_ID_A;
+		public static final int record_subtype = MufomType.MUFOM_ID_S;
 
 		public static boolean check(BinaryReader reader) throws IOException {
 			long offset = reader.getPointerIndex();
-			if (MufomType.MUFOM_ID_A == reader.readUnsignedByte(offset + 0) &&
-					MufomType.MUFOM_ID_S == reader.readUnsignedByte(offset + 1) &&
+			if (record_type == reader.readUnsignedByte(offset + 0) &&
+					record_subtype == reader.readUnsignedByte(offset + 1) &&
 							MufomType.MUFOM_ID_D == reader.readUnsignedByte(offset + 2)) {
 				return true;
 			}
@@ -1642,13 +275,13 @@ public class MufomHeader {
 		}
 
 		public MufomAbsData(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomAbsData");
-			if (MufomType.MUFOM_ID_A != read_char(reader)) {
+			Msg.warn(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER MufomAbsData");
+			if (record_type != read_char(reader)) {
 				Msg.info(this, "bad A");
 				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
 				throw new IOException();
 			}
-			if (MufomType.MUFOM_ID_S != read_char(reader)) {
+			if (record_subtype != read_char(reader)) {
 				Msg.info(this, "bad S");
 				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
 				throw new IOException();
@@ -1661,229 +294,6 @@ public class MufomHeader {
 		}
 	}
 
-	/*
-	 * Assign Value to Variable W
-	 *
-	 * AS-command → “AS” MUFOM-variable “,” expression “,”
-	 *
-	 * W-variable → “W” hexnumber
-	 *
-	 * {$E2}{$D7}{00}{n}
-	 * {$E2}{$D7}{01}{n}
-	 * {$E2}{$D7}{02}{n}
-	 * {$E2}{$D7}{03}{n}
-	 * {$E2}{$D7}{04}{n}
-	 * {$E2}{$D7}{05}{n}
-	 * {$E2}{$D7}{06}{n}
-	 * {$E2}{$D7}{07}{n}
-	 */
-	public class MufomASW extends MufomRecord {
-		private final String NAME = "ASW";
-		public long asw_index = -1;
-		public long asw_offset = -1;
-
-		private void print() {
-			String msg = NAME + ": " + asw_index + " " + Long.toHexString(asw_offset);
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomASW(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
-				Msg.info(this, "Bad AS");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_W != read_char(reader)) {
-				Msg.info(this, "Bad W");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			asw_index = read_int(reader);
-			if (asw_index < 0 || asw_index > 7) {
-				Msg.info(this, "Bad ASW index");
-				throw new IOException();
-			}
-			asw_offset = read_int(reader);
-			if (asw_offset < 0 || asw_offset > reader.length()) {
-				Msg.info(this, "Bad ASW offset");
-				throw new IOException();
-			}
-			print();
-		}
-	}
-
-	/*
-	 * Starting Address (ASG)
-	 *
-	 * {$E2}{$C7}{$BE}{n1}{$BF}
-	 */
-	public class MufomASG extends MufomRecord {
-		private final String NAME = "ASG";
-		public long starting_address = -1;
-
-		private void print() {
-			String msg = NAME + ": " + Long.toHexString(starting_address);
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-		public MufomASG(BinaryReader reader) throws IOException {
-			Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-			if (MufomType.MUFOM_CMD_AS != read_char(reader)) {
-				Msg.info(this, "bad AS");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_G != read_char(reader)) {
-				Msg.info(this, "bad G");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-
-			if (MufomType.MUFOM_OPEN != read_char(reader)) {
-				Msg.info(null, "Expecting MUFOM_OPEN");
-				throw new IOException();
-			}
-
-			starting_address = read_int(reader);
-
-			if (MufomType.MUFOM_CLOSE != read_char(reader)) {
-				Msg.info(null, "Expecting MUFOM_CLOSE");
-				throw new IOException();
-			}
-			print();
-		}
-	}
-
-	/*
-	 * Attribute Records (ATN)
-	 *
-	 * AT-command → “AT” variable “,” type-table-entry (“,” lex-level (“,” hexnumber)* )? “.”
-	 * variable → I-variable | N-variable | X-variable
-	 * type-table-entry → hexnumber
-	 * lex-level → hexnumber
-	 *
-	 * N-variable → “N” hexnumber
-	 *
-	 * {$F1}{$CE}{n1}{n2}{n3}[x1][x2][Id]
-	 */
-	public class MufomATN extends MufomRecord {
-		private final String NAME = "ATN";
-		public long symbol_name_index = -1;
-		public long attribute_definition = -1;
-        private String id = null;
-        private long x1 = -1;
-        private long x2 = -1;
-        private long x3 = -1;
-        private long x4 = -1;
-        private long x5 = -1;
-        private long x6 = -1;
-        private boolean has_asn = false;
-
-        private void print() {
-			String msg = NAME + ": " + symbol_name_index + " " + attribute_definition;
-			if (do_debug) {
-				Msg.info(this, msg);
-			} else {
-				Msg.trace(this, msg);
-			}
-		}
-
-        public MufomATN(BinaryReader reader, boolean must) throws IOException {
-        	Msg.trace(this, String.format("%08x ", reader.getPointerIndex()) + "ENTER " + NAME);
-        	if (!must && omit_cmd(reader)) {
-				return;
-			}
-        	if (MufomType.MUFOM_CMD_AT != read_char(reader)) {
-				Msg.info(this, "Bad AT");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-1, 0x10);
-				throw new IOException();
-			}
-			if (MufomType.MUFOM_ID_N != read_char(reader)) {
-				Msg.info(this, "Bad N");
-				if (do_debug) hexdump(reader, reader.getPointerIndex()-2, 0x10);
-				throw new IOException();
-			}
-			symbol_name_index = read_int(reader);
-
-			if (read_int(reader) != 0) {
-				Msg.info(this, "Bad lex-level");
-				throw new IOException();
-			}
-			attribute_definition = read_int(reader);
-            switch ((int) attribute_definition) {
-            case MufomType.ieee_unknown_1_enum:
-            	x1 = read_int(reader);
-                break;
-            case MufomType.MUFOM_AD_TYPE:
-                x1 = read_int(reader);
-                //TODO  has_asn?  ASW0 does not
-                break;
-            case MufomType.MUFOM_AD_CASE:
-                x1 = read_int(reader);
-                //TODO  has_asn?  ASW0 does not
-                break;
-            case MufomType.MUFOM_AD_STATUS:
-                x1 = read_int(reader);
-                break;
-            case MufomType.ieee_unknown_56_enum:
-                x1 = read_int(reader);
-                break;
-            case MufomType.MUFOM_AD_ENV:
-                x1 = read_int(reader);
-                break;
-            case MufomType.ieee_unknown_16_enum:
-                x1 = read_int(reader);
-                x2 = read_int(reader);
-                break;
-            case MufomType.ieee_static_variable_enum:
-                x1 = read_int(reader);
-                x2 = read_int(reader);
-                break;
-            case MufomType.MUFOM_AD_VERSION:
-                x1 = read_int(reader);
-                x2 = read_int(reader);
-                break;
-            case MufomType.ieee_unknown_7_enum:
-                x1 = read_int(reader);
-                x2 = read_int(reader);
-                x3 = read_int(reader);
-                break;
-            case MufomType.ieee_execution_tool_version_enum:
-                x1 = read_int(reader);
-                x2 = read_int(reader);
-                x3 = read_int(reader);
-                break;
-            case MufomType.ieee_unknown_12_enum:
-                x1 = read_int(reader);
-                x2 = read_int(reader);
-                x3 = read_int(reader);
-                x4 = read_int(reader);
-                x5 = read_int(reader);
-                break;
-            case MufomType.MUFOM_AD_DATETIME:
-                x1 = read_int(reader); // year
-                x2 = read_int(reader); // mon
-                x3 = read_int(reader); // day
-                x4 = read_int(reader); // hour
-                x5 = read_int(reader); // min
-                x6 = read_int(reader); // sec
-                break;
-             default:
-                Msg.info(null, "Bad ATN " + symbol_name_index + " " + attribute_definition);
-                throw new IOException();
-             }
-            print();
-        }
-	}
 
 	/*
 	 * Module End (ASW7)
@@ -1891,7 +301,7 @@ public class MufomHeader {
 	 * Module End (ME) - $E1
 	 */
 	public class MufomEnd {
-		private final int asw_index = 7;
+		private final int asw_index = MufomType.MUFOM_ASW7;
 		public MufomME me = null;
 
 		private void valid() throws IOException {
@@ -1901,9 +311,12 @@ public class MufomHeader {
 		}
 
 		public MufomEnd() throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomEnd");
-			me = new MufomME(reader);
+			MufomRecord record = MufomRecord.readRecord(reader);
+			if (record instanceof MufomME) {
+				me = (MufomME) record;
+			}
 			valid();
 		}
 	}
@@ -1914,7 +327,7 @@ public class MufomHeader {
 	 * Execution Starting Address (ASG) - $E2C7
 	 */
 	public class MufomTrailer {
-		private final int asw_index = 6;
+		private final int asw_index = MufomType.MUFOM_ASW6;
 		public MufomTrailer next = null;
 		public MufomASG asg = null;
 
@@ -1923,9 +336,12 @@ public class MufomHeader {
 		}
 
 		public MufomTrailer() throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomTrailer");
-			asg = new MufomASG(reader);
+			MufomRecord record = MufomRecord.readRecord(reader);
+			if (record instanceof MufomASG) {
+				asg = (MufomASG) record;
+			}
 			valid();
 		}
 	}
@@ -1939,7 +355,7 @@ public class MufomHeader {
 	 * Repeat Data (RE) - $F7
 	 */
 	public class MufomData {
-		private final int asw_index = 5;
+		private final int asw_index = MufomType.MUFOM_ASW5;
 		public MufomData next = null;
 		public MufomSB sb = null;
 		public MufomASP asp = null;
@@ -1982,24 +398,37 @@ public class MufomHeader {
 		}
 
 		public MufomData(MufomData x) throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			long variable_start = reader.getPointerIndex();
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomData");
-			if (MufomSB.check(reader)) {
-				sb = new MufomSB(reader);
-			} else {
-				// no SB is defined, the current section is 0
-			}
-			if (MufomASP.check(reader)) {
-				asp = new MufomASP(reader);
-			} else {
-				// no ASP is defined, the PC is the start of the section
-			}
-			ld = new MufomLD(reader);
-			//re = new MufomRE(reader);
-			valid();
 			if (null != x) {
 				x.next = this;
 			}
+			MufomRecord record = MufomRecord.readRecord(reader);
+			if (record instanceof MufomSB) {
+				sb = (MufomSB) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomASP) {
+				asp = (MufomASP) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomLD) {
+				ld = (MufomLD) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomRE) {
+				re = (MufomRE) record;
+			} else {
+				reader.setPointerIndex(record.record_offset);
+			}
+			valid();
+			long variable_end = reader.getPointerIndex();
+			if (variable_end == variable_start)
+				throw new IOException();
 		}
 	}
 
@@ -2014,7 +443,7 @@ public class MufomHeader {
 	 * Declare Block End (BE) - $F9
 	 */
 	public class MufomDebugInformation {
-		private final int asw_index = 4;
+		private final int asw_index = MufomType.MUFOM_ASW4;
 		public MufomDebugInformation next = null;
 		public MufomBB bb = null;
 		public MufomNN nn = null;
@@ -2029,19 +458,23 @@ public class MufomHeader {
 		}
 
 		public MufomDebugInformation(MufomDebugInformation x) throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			long variable_start = reader.getPointerIndex();
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomDebugInformation");
 			bb = new MufomBB(reader);
-			nn = new MufomNN(reader, false);
-			ty = new MufomTY(reader, false);
-			atn = new MufomATN(reader, false);
-			asn = new MufomASN(reader, false);
-			id = new MufomCompiler(reader, false);
+			nn = new MufomNN(reader);
+			ty = new MufomTY(reader);
+			atn = new MufomATN(reader);
+			asn = new MufomASN(reader);
+			id = new MufomCompiler(reader);
 			be = new MufomBE(reader, (int) bb.begin_block);
 			valid();
 			if (null != x) {
 				x.next = this;
 			}
+			long variable_end = reader.getPointerIndex();
+			if (variable_end == variable_start)
+				throw new IOException();
 		}
 	}
 
@@ -2053,8 +486,9 @@ public class MufomHeader {
 	 * Variable Values (ASI) - $E2C9
 	 */
 	public class MufomExternal {
-		private final int asw_index = 3;
+		private final int asw_index = MufomType.MUFOM_ASW3;
 		public MufomExternal next = null;
+		public MufomSB sb = null;
 		public MufomNI ni = null;
 		public MufomATI ati = null;
 		public MufomASI asi = null;
@@ -2084,15 +518,37 @@ public class MufomHeader {
 		}
 
 		public MufomExternal(MufomExternal x) throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			long variable_start = reader.getPointerIndex();
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomExternal");
-			ni = new MufomNI(reader);
-			ati = new MufomATI(reader);
-			asi = new MufomASI(reader);
-			valid();
 			if (null != x) {
 				x.next = this;
 			}
+			MufomRecord record = MufomRecord.readRecord(reader);
+			if (record instanceof MufomSB) {
+				sb = (MufomSB) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomNI) {
+				ni = (MufomNI) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomATI) {
+				ati = (MufomATI) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomASI) {
+				asi = (MufomASI) record;
+			} else {
+				reader.setPointerIndex(record.record_offset);
+			}
+			valid();
+			long variable_end = reader.getPointerIndex();
+			if (variable_end == variable_start)
+				throw new IOException();
 		}
 	}
 
@@ -2104,7 +560,7 @@ public class MufomHeader {
 	 * Section Base Address (ASL) - $E2CC
 	 */
 	public class MufomSectionDefinition {
-		private final int asw_index = 2;
+		private final int asw_index = MufomType.MUFOM_ASW2;
 		public MufomSectionDefinition next = null;
 		public MufomST st = null;
 		public MufomSA sa = null;
@@ -2112,12 +568,6 @@ public class MufomHeader {
 		private MufomASL asl = null;
 
 		private void valid() throws IOException {
-			if (st.section_number != ass.section_number ||
-					st.section_number != asl.section_number ||
-					st.section_number != sa.section_number) {
-				Msg.info(this, "Bad section index");
-				throw new IOException();
-			}
 		}
 
 		public long getSectionIndex() {
@@ -2137,16 +587,37 @@ public class MufomHeader {
 		}
 
 		public MufomSectionDefinition(MufomSectionDefinition x) throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			long variable_start = reader.getPointerIndex();
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomSectionDefinition");
-			st = new MufomST(reader);
-			sa = new MufomSA(reader);
-			ass = new MufomASS(reader);
-			asl = new MufomASL(reader);
-			valid();
 			if (null != x) {
 				x.next = this;
 			}
+			MufomRecord record = MufomRecord.readRecord(reader);
+			if (record instanceof MufomST) {
+				st = (MufomST) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomSA) {
+				sa = (MufomSA) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomASS) {
+				ass = (MufomASS) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomASL) {
+				asl = (MufomASL) record;
+			} else {
+				reader.setPointerIndex(record.record_offset);
+			}
+			valid();
+			long variable_end = reader.getPointerIndex();
+			if (variable_end == variable_start)
+				throw new IOException();
 		}
 	}
 
@@ -2158,7 +629,7 @@ public class MufomHeader {
 	 * Variable Values (ASN) - $E2CE
 	 */
 	public class MufomEnvironment {
-		private final int asw_index = 1;
+		private final int asw_index = MufomType.MUFOM_ASW1;
 		public MufomEnvironment next = null;
 		public MufomNN nn = null;
 		public MufomATN atn = null;
@@ -2166,25 +637,41 @@ public class MufomHeader {
 
 		private void valid() throws IOException {
 			if (nn.symbol_name_index != atn.symbol_name_index) {
-				Msg.info(this, "Bad symbol_name_index");
+				Msg.info(this, String.format("Bad symbol_name_index %d != %d",
+						nn.symbol_name_index, atn.symbol_name_index));
 				throw new IOException();
 			}
 		}
 
 		public MufomEnvironment(MufomEnvironment x) throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			long variable_start = reader.getPointerIndex();
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomEnvironment");
-			if (null == x) {
-				nn = new MufomNN(reader, true);
-			} else {
+			if (null != x) {
 				x.next = this;
+			}
+			MufomRecord record = MufomRecord.readRecord(reader);
+			if (record instanceof MufomNN) {
+				nn = (MufomNN) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			} else {
 				nn = x.nn;
 			}
-			atn = new MufomATN(reader, true);
-			if (atn.has_asn) {
-				asn = new MufomASN(reader, true);
+			if (record instanceof MufomATN) {
+				atn = (MufomATN) record;
+				if (reader.getPointerIndex() >= hdr.asw_end[asw_index]) return;
+				record = MufomRecord.readRecord(reader);
+			}
+			if (record instanceof MufomASN) {
+				asn = (MufomASN) record;
+			} else {
+				reader.setPointerIndex(record.record_offset);
 			}
 			valid();
+			long variable_end = reader.getPointerIndex();
+			if (variable_end == variable_start)
+				throw new IOException();
 		}
 	}
 
@@ -2196,7 +683,7 @@ public class MufomHeader {
 	 * Variable Values (ASN) - $E2CE
 	 */
 	public class MufomADExtension {
-		private final int asw_index = 0;
+		private final int asw_index = MufomType.MUFOM_ASW0;
 		public MufomADExtension next = null;
 		public MufomNN nn = null;
 		public MufomATN atn = null;
@@ -2204,25 +691,39 @@ public class MufomHeader {
 
 		private void valid() throws IOException {
 			if (nn.symbol_name_index != atn.symbol_name_index) {
-				Msg.info(this, "Bad symbol_name_index");
+				Msg.info(this, String.format("Bad symbol_name_index %d != %d",
+						nn.symbol_name_index, atn.symbol_name_index));
 				throw new IOException();
 			}
 		}
 
 		public MufomADExtension(MufomADExtension x) throws IOException {
-			Msg.trace(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
+			long variable_start = reader.getPointerIndex();
+			Msg.warn(this, String.format("%08x - %08x - %08x ", hdr.asw_offset[asw_index], reader.getPointerIndex(),
 					hdr.asw_end[asw_index]) + "PARSE MufomADExtension");
-			if (null == x) {
-				nn = new MufomNN(reader, true);
-			} else {
+			if (null != x) {
 				x.next = this;
+			}
+			MufomRecord record = MufomRecord.readRecord(reader);
+			if (record instanceof MufomNN) {
+				nn = (MufomNN) record;
+				record = MufomRecord.readRecord(reader);
+			} else {
 				nn = x.nn;
 			}
-			atn = new MufomATN(reader, true);
-			if (atn.has_asn) {
-				asn = new MufomASN(reader, true);
+			if (record instanceof MufomATN) {
+				atn = (MufomATN) record;
+				record = MufomRecord.readRecord(reader);
 			}
-			valid();
+			if (record instanceof MufomASN) {
+				asn = (MufomASN) record;
+			} else {
+				reader.setPointerIndex(record.record_offset);
+			}
+			valid();	
+			long variable_end = reader.getPointerIndex();
+			if (variable_end == variable_start)
+				throw new IOException();
 		}
 	}
 
@@ -2245,7 +746,7 @@ public class MufomHeader {
 		public long[] asw_end = {-1, -1, -1, -1, -1, -1, -1, -1};
 
 		public MufomHeaderPart() throws IOException {
-			Msg.trace(this, String.format("%08x-%08x ", 0, reader.length()) + "PARSE MufomHeaderPart");
+			Msg.warn(this, String.format("%08x-%08x ", 0, reader.length()) + "PARSE MufomHeaderPart");
 			mb = new MufomMB(reader);
 			ad = new MufomAD(reader);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomIR.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomIR.java
@@ -1,0 +1,43 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 13.2 IR (initialize relocation base) Command
+ * 
+ * IR_command ::= "IR" relocation_letter "," relocation_base [ "," number_of_bits ]? "."
+ * relocation_letter ::= nonhex_letter
+ * relocation_base ::= expression
+ * number_of_bits ::= expression
+ */
+public class MufomIR extends MufomRecord {
+	public static final String NAME = "IR";
+	public static final int record_type = MufomType.MUFOM_CMD_IR;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomIR(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLD.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLD.java
@@ -1,0 +1,63 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 13.1 LD (load) Command
+ *
+ * LD-command → “LD” load-constant + “.”
+ * load-constant → hexdigit +
+ *
+ * {$ED}{n1}{...}
+ */
+public class MufomLD extends MufomRecord {
+	public static final String NAME = "LD";
+	public static final int record_type = MufomType.MUFOM_CMD_LD;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long data_bytes_offset;
+	public long address_units;
+
+	private void print() {
+		String msg = NAME + ": " + data_bytes_offset + " " + address_units;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomLD(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		address_units = read_int(reader);
+		if (address_units < 1 || address_units > 127) {
+			Msg.info(this, "bad units");
+			throw new IOException();
+		}
+		data_bytes_offset = reader.getPointerIndex();
+		reader.setPointerIndex(data_bytes_offset + address_units);
+		// OR
+		// bytes = reader.readNextByteArray((int) address_units);
+
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLI.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLI.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 15.1 LI (Specify Default Library Search List) Command
+ * 
+ * LI_command ::= "LI" char_string [ "," char_string ]* "."
+ */
+public class MufomLI extends MufomRecord {
+	public static final String NAME = "Li";
+	public static final int record_type = MufomType.MUFOM_CMD_LI;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomLI(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLN.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLN.java
@@ -1,0 +1,35 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+public class MufomLN extends MufomRecord {
+	public static final String NAME = "LN";
+	public static final int record_type = MufomType.MUFOM_CMD_LN;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomLN(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLR.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLR.java
@@ -1,0 +1,44 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 13.3 LR (load relocate) Command
+ * 
+ * LR_command ::= "LR" [ load_item ]+ "."
+ * load_item ::= relocation_letter offset "," | load_constant |
+ *               "(" expression [ "," number_of_MAUs ]? ")"
+ * load_constant ::= [ hex_digit ]+
+ * number_of_MAUs ::= expression
+ */
+public class MufomLR extends MufomRecord {
+	public static final String NAME = "LR";
+	public static final int record_type = MufomType.MUFOM_CMD_LR;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomLR(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLX.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomLX.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 15.2 LX (library external) Command
+ * 
+ * LX_command ::= "L" X_variable [ "," char_string ]+ "."
+ */
+public class MufomLX extends MufomRecord {
+	public static final String NAME = "LX";
+	public static final int record_type = MufomType.MUFOM_CMD_LX;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomLX(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomMB.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomMB.java
@@ -1,0 +1,55 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 8.1 MB (module begin) Command
+ *
+ * MB-command → “MB” target-machine-configuration (“,” module-name)? “.”
+ * target-machine-configuration → identifier
+ * module-name → char-string
+ *
+ * {$E0}{Id1}{Id2}
+ */
+public class MufomMB extends MufomRecord {
+	public static final String NAME = "MB";
+	public static final int record_type = MufomType.MUFOM_CMD_MB;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public String target_machine_configuration = null;
+	public String module_name = null;
+
+	public void print() {
+		String msg = NAME + ": " + target_machine_configuration + " " + module_name;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+	public MufomMB(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		target_machine_configuration = read_id(reader);
+		module_name = read_opt_id(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomME.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomME.java
@@ -1,0 +1,50 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 8.2 ME (module end) Command
+ *
+ * ME-command → “ME.”
+ *
+ * {$E1}
+ */
+public class MufomME extends MufomRecord {
+	public static final String NAME = "ME";
+	public static final int record_type = MufomType.MUFOM_CMD_ME;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	private void print() {
+		String msg = NAME;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomME(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomNI.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomNI.java
@@ -1,0 +1,56 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 11.1 NI (name of internal symbol) Command
+ *
+ * NI-command → “N” I-variable “,” ext-def-name “.”
+ * I-variable → “I” hexnumber
+ * ext-def-name → char-string
+ *
+ * {$E8}{n}{Id}
+ */
+public class MufomNI extends MufomRecord {
+	public static final String NAME = "NI";
+	public static final int record_type = MufomType.MUFOM_CMD_NI;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long symbol_name_index = -1;
+	public String symbol_name = null;
+
+	private void print() {
+		String msg = NAME;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomNI(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		symbol_name_index = read_int(reader);
+		symbol_name = read_id(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomNN.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomNN.java
@@ -1,0 +1,57 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 11.3 NN (name) Command
+ *
+ * NN-command → “N” N-variable “,” name “.”
+ * N-variable → “N” hexnumber
+ * name → char-string
+ *
+ * {$F0}{n1}{Id}
+ */
+public class MufomNN extends MufomRecord {
+	public static final String NAME = "NN";
+	public static final int record_type = MufomType.MUFOM_CMD_NN;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long symbol_name_index = -1;
+	public String symbol_name = null;
+	public boolean missing = false;
+
+	private void print() {
+		String msg = NAME + ": '" + symbol_name + "' " + symbol_name_index;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomNN(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		symbol_name_index = read_int(reader);
+        symbol_name = read_id(reader);
+        print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomNX.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomNX.java
@@ -1,0 +1,41 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 11.2 NX (name of external symbol) Command
+ * 
+ * NX_command ::= "N" X_variable "," char_string "."
+ */
+public class MufomNX extends MufomRecord {
+	public static final String NAME = "NX";
+	public static final int record_type = MufomType.MUFOM_CMD_NX;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomNX(BinaryReader reader) throws IOException {
+		//TODO  is it a $E8 typo or is this $B8?
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRE.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRE.java
@@ -1,0 +1,50 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 13.4 RE (replicate) Command
+ *
+ * RE-command → “RE” expression “.”
+ */
+public class MufomRE extends MufomRecord {
+	public static final String NAME = "RE";
+	public static final int record_type = MufomType.MUFOM_CMD_RE;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long repeat = -1;
+
+	private void print() {
+		String msg = NAME;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomRE(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		repeat = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRI.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRI.java
@@ -1,0 +1,41 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 14.1 RI (retain internal symbol) Command
+ * 
+ * RI_command ::= "R" I_variable [ "," level_number ]? "."
+ * level_number ::= hex_number
+ */
+public class MufomRI extends MufomRecord {
+	public static final String NAME = "RI";
+	public static final int record_type = MufomType.MUFOM_CMD_RI;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomRI(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRecord.java
@@ -1,0 +1,151 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+public abstract class MufomRecord {
+
+	protected long read_integer(BinaryReader reader, boolean must) throws IOException {
+		long offset = reader.getPointerIndex();
+		long result = reader.readUnsignedByte(offset);
+		if (result <= 0x7f) {
+			reader.readNextUnsignedByte();
+			return result;
+		} else if (result >= 0x80 && result <= 0x88) {
+			long size = result - 0x80;
+			reader.readNextUnsignedByte();
+			result = 0;
+			for (long i = 0; i < size; i++) {
+				result = (result << 8) | reader.readNextUnsignedByte();
+			}
+			return result;
+		} else {
+			if (must) {
+				Msg.info(null, "Failed to parse int " + result);
+				throw new IOException();
+			}
+			return -1;
+		}
+	}
+
+	protected void hexdump(BinaryReader reader, long position, long length) throws IOException {
+		long current = reader.getPointerIndex();
+		if (position > 0) {
+			reader.setPointerIndex(position);
+		}
+		long start = reader.getPointerIndex();
+
+		if (start + length > reader.length()) {
+			length = reader.length() - start;
+		}
+
+		String x = " " + Long.toHexString(position) + " " + length + " " +
+				Long.toHexString(current) + " 0x" + Long.toHexString(start) + "\n";
+		for (long i = 0; i < length; i++) {
+			x = x + " 0x" + Long.toHexString(0xff & reader.readUnsignedByte(start + i));
+			if (((i + 1) % 16) == 0) x = x + '\n';
+		}
+		x = x + '\n';
+		reader.setPointerIndex(start);
+		for (long i = 0; i < length; i++) {
+			int val = reader.readUnsignedByte(start + i);
+			if (val > 127 || val < 32) val = '.';
+			x = x + " " + (char)val;
+			if (((i + 1) % 16) == 0) x = x + '\n';
+		}
+		Msg.info(null, x);
+		reader.setPointerIndex(current);
+	}
+
+	protected String read_string(BinaryReader reader, boolean must) throws IOException {
+		int len = reader.readUnsignedByte(reader.getPointerIndex());
+		if (0x7f >= len) {
+			reader.readNextUnsignedByte();
+		} else if (MufomType.MUFOM_EXTB == len) {
+			reader.readNextUnsignedByte();
+			len = reader.readNextUnsignedByte();
+		} else if (MufomType.MUFOM_EXTH == len) {
+			reader.readNextUnsignedByte();
+			len = reader.readNextUnsignedShort();
+		} else {
+			if (must) {
+				throw new IOException();
+			}
+			return null;
+		}
+		long offset = reader.getPointerIndex();
+		if (offset + len > reader.length()) {
+			Msg.info(null, "Bad pascal string "+ len +" + " + offset + " > " + reader.length());
+			throw new IOException();
+		}
+		String x = new String(reader.readNextByteArray(len));
+		return x;
+	}
+
+	protected String read_id(BinaryReader reader) throws IOException {
+		return read_string(reader, true);
+	}
+
+	protected String read_opt_id(BinaryReader reader) throws IOException {
+		return read_string(reader, false);
+	}
+
+	protected long read_int(BinaryReader reader) throws IOException {
+		return read_integer(reader, true);
+	}
+
+	protected long read_opt_int(BinaryReader reader) throws IOException {
+		return read_integer(reader, false);
+	}
+
+	protected int read_letter(BinaryReader reader, boolean must) throws IOException {
+		int letter = reader.readUnsignedByte(reader.getPointerIndex());
+
+		//TODO
+//		if (MufomType.MUFOM_ID_A > letter || letter > MufomType.MUFOM_ID_Z) {
+//			if (must) {
+//				Msg.info(this, "Bad letter");
+//				throw new IOException();
+//			} else {
+//				return -1;
+//			}
+//		}
+
+		reader.readNextUnsignedByte();
+		return letter;
+	}
+
+	protected int read_char(BinaryReader reader) throws IOException {
+		return read_letter(reader, true);
+	}
+
+	protected int read_opt_char(BinaryReader reader) throws IOException {
+		return read_letter(reader, false);
+	}
+
+	protected boolean omit_cmd(BinaryReader reader) throws IOException {
+		int tmp = reader.readUnsignedByte(reader.getPointerIndex());
+		if (MufomType.MUFOM_OMITTED == tmp) {
+			reader.readNextUnsignedByte();
+			return true;
+		}
+		return false;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomRecord.java
@@ -21,6 +21,8 @@ import ghidra.app.util.bin.BinaryReader;
 import ghidra.util.Msg;
 
 public abstract class MufomRecord {
+	public static boolean do_debug = true;
+	public static long record_offset = -1;
 
 	protected long read_integer(BinaryReader reader, boolean must) throws IOException {
 		long offset = reader.getPointerIndex();
@@ -39,13 +41,14 @@ public abstract class MufomRecord {
 		} else {
 			if (must) {
 				Msg.info(null, "Failed to parse int " + result);
+				if (do_debug) hexdump(reader, record_offset, 0x10);
 				throw new IOException();
 			}
 			return -1;
 		}
 	}
 
-	protected void hexdump(BinaryReader reader, long position, long length) throws IOException {
+	public static void hexdump(BinaryReader reader, long position, long length) throws IOException {
 		long current = reader.getPointerIndex();
 		if (position > 0) {
 			reader.setPointerIndex(position);
@@ -86,6 +89,8 @@ public abstract class MufomRecord {
 			len = reader.readNextUnsignedShort();
 		} else {
 			if (must) {
+				Msg.info(this, "Failed to read string");
+				if (do_debug) hexdump(reader, record_offset, 0x10);
 				throw new IOException();
 			}
 			return null;
@@ -93,6 +98,7 @@ public abstract class MufomRecord {
 		long offset = reader.getPointerIndex();
 		if (offset + len > reader.length()) {
 			Msg.info(null, "Bad pascal string "+ len +" + " + offset + " > " + reader.length());
+			if (do_debug) hexdump(reader, record_offset, 0x10);
 			throw new IOException();
 		}
 		String x = new String(reader.readNextByteArray(len));
@@ -147,5 +153,129 @@ public abstract class MufomRecord {
 			return true;
 		}
 		return false;
+	}
+	
+	protected void read_record_type(BinaryReader reader, int record_type, int record_subtype, String name)
+			throws IOException {
+		int tmp_type = -1;
+
+		Msg.warn(this, String.format("%08x ENTER %s", reader.getPointerIndex(), name));
+		tmp_type = read_char(reader);
+		if (record_type != tmp_type) {
+			Msg.info(this, String.format("Bad type %u != %u, %s", tmp_type, record_type, name));
+			if (do_debug) hexdump(reader, record_offset, 0x10);
+			throw new IOException();
+		}
+		if (-1 != record_subtype) {
+			int tmp_subtype = read_char(reader);
+			if (record_subtype != tmp_subtype) {
+				Msg.info(this, String.format("Bad subtype %u != %u, %s", tmp_subtype, record_subtype, name));
+				if (do_debug) hexdump(reader, record_offset, 0x10);
+				throw new IOException();
+			}
+		}
+	}
+	
+	public static MufomRecord readRecord(BinaryReader reader) throws IOException {
+		record_offset = reader.getPointerIndex();
+		int record_type = reader.readUnsignedByte(record_offset);
+		int record_subtype = -1;
+
+		switch (record_type) {
+		case MufomType.MUFOM_OMITTED:
+			reader.readNextUnsignedByte();
+			return null;
+		case MufomType.MUFOM_CMD_MB:
+			return new MufomMB(reader);
+		case MufomType.MUFOM_CMD_ME:
+			return new MufomME(reader);
+		case MufomType.MUFOM_CMD_AS:
+			record_subtype = reader.readUnsignedByte(record_offset + 1);
+			switch (record_subtype) {
+			case MufomType.MUFOM_ID_G:
+				return new MufomASG(reader);
+			case MufomType.MUFOM_ID_I:
+				return new MufomASI(reader);
+			case MufomType.MUFOM_ID_L:
+				return new MufomASL(reader);
+			case MufomType.MUFOM_ID_N:
+				return new MufomASN(reader);
+			case MufomType.MUFOM_ID_P:
+				return new MufomASP(reader);
+			case MufomType.MUFOM_ID_R:
+				return new MufomASR(reader);
+			case MufomType.MUFOM_ID_S:
+				return new MufomASS(reader);
+			case MufomType.MUFOM_ID_W:
+				return new MufomASW(reader);
+			case MufomType.MUFOM_ID_X:
+				return new MufomASX(reader);
+			case MufomType.MUFOM_ID_F:
+				return new MufomASF(reader);
+			default:
+				if (do_debug) hexdump(reader, record_offset, 0x10);
+				throw new IOException();
+			}
+		case MufomType.MUFOM_CMD_IR:
+			return new MufomIR(reader);
+		case MufomType.MUFOM_CMD_LR:
+			return new MufomLR(reader);
+		case MufomType.MUFOM_CMD_SB:
+			return new MufomSB(reader);
+		case MufomType.MUFOM_CMD_ST:
+			return new MufomST(reader);
+		case MufomType.MUFOM_CMD_SA:
+			return new MufomSA(reader);
+		case MufomType.MUFOM_CMD_NI:
+			return new MufomNI(reader);
+		case MufomType.MUFOM_CMD_NX:
+			return new MufomNX(reader);
+		case MufomType.MUFOM_CMD_CO:
+			return new MufomCO(reader);
+		case MufomType.MUFOM_CMD_DT:
+			return new MufomDT(reader);
+		case MufomType.MUFOM_CMD_AD:
+			return new MufomAD(reader);
+		case MufomType.MUFOM_CMD_LD:
+			return new MufomLD(reader);
+		case MufomType.MUFOM_CMD_CSS:
+			return new MufomCSS(reader);
+		case MufomType.MUFOM_CMD_CS:
+			return new MufomCS(reader);
+		case MufomType.MUFOM_CMD_NN:
+			return new MufomNN(reader);
+		case MufomType.MUFOM_CMD_AT:
+			record_subtype = reader.readUnsignedByte(record_offset + 1);
+			switch (record_subtype) {
+			case MufomType.MUFOM_ID_I:
+				return new MufomATI(reader);
+			case MufomType.MUFOM_ID_N:
+				return new MufomATN(reader);
+			case MufomType.MUFOM_ID_X:
+				return new MufomATX(reader);
+			default:
+				if (do_debug) hexdump(reader, record_offset, 0x10);
+				throw new IOException();
+			}
+		case MufomType.MUFOM_CMD_TY:
+			return new MufomTY(reader);
+		case MufomType.MUFOM_CMD_RI:
+			return new MufomRI(reader);
+		case MufomType.MUFOM_CMD_WX:
+			return new MufomWX(reader);
+		case MufomType.MUFOM_CMD_LI:
+			return new MufomLI(reader);
+		case MufomType.MUFOM_CMD_LX:
+			return new MufomLX(reader);
+		case MufomType.MUFOM_CMD_RE:
+			return new MufomRE(reader);
+		case MufomType.MUFOM_CMD_SC:
+			return new MufomBB(reader);
+		case MufomType.MUFOM_CMD_LN:
+			return new MufomLN(reader);
+		default:
+			if (do_debug) hexdump(reader, record_offset, 0x10);
+			throw new IOException();
+		}
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomSA.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomSA.java
@@ -1,0 +1,58 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 10.3 SA (section alignment) Command
+ *
+ * SA-command → “SA” section-number “,” MAU-boundary? ("," page-size)? "."
+ * MAU-boundary → expression
+ * page-size → expression
+ *
+ * {$E7}{n1}{n2}
+ */
+public class MufomSA extends MufomRecord {
+	public static final String NAME = "SA";
+	public static final int record_type = MufomType.MUFOM_CMD_SA;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long section_number = -1;
+	public long mau_boundary = -1;
+	public long page_size = -1;
+
+	private void print() {
+		String msg = NAME + ": " + section_number + " " + mau_boundary + " " + page_size;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomSA(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		section_number = read_int(reader);
+		mau_boundary = read_int(reader);
+		page_size = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomSB.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomSB.java
@@ -1,0 +1,61 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 10.1 SB (section begin) Command
+ *
+ * SB-command → “SB” section-number “.”
+ * section-number → hexnumber
+ *
+ * {$E5}{n1}
+ */
+public class MufomSB extends MufomRecord {
+	public static final String NAME = "SB";
+	public static final int record_type = MufomType.MUFOM_CMD_SB;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long section_number = -1;
+
+	public static boolean check(BinaryReader reader) throws IOException {
+		long offset = reader.getPointerIndex();
+		if (record_type == reader.readUnsignedByte(offset + 0)) {
+			return true;
+		}
+		return false;
+	}
+
+	private void print() {
+		String msg = NAME + ": " + section_number;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomSB(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		section_number = read_int(reader);
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomST.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomST.java
@@ -1,0 +1,86 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.format.mufom.MufomHeader.MufomAbsCode;
+import ghidra.app.util.bin.format.mufom.MufomHeader.MufomAbsData;
+import ghidra.util.Msg;
+
+/*
+ * 10.2 ST (section type) Command
+ *
+ * ST-command → “ST” section-number (“,” section-type)* (“,” section-name)? “.”
+ * section-number → hexnumber
+ * section-type → letter
+ * section-name → char-string
+ *
+ * ${E6}{n1}{l}[Id][n2][n3][n4]
+ */
+public class MufomST extends MufomRecord {
+	public static final String NAME = "ST";
+	public static final int record_type = MufomType.MUFOM_CMD_ST;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long section_number = -1;
+	public long section_type = -1;
+	public String section_name = null;
+	private MufomAS as = null;
+	private MufomAbsCode code = null;
+	private MufomAbsData data = null;
+	public long n2 = -1;
+	public long n3 = -1;
+	public long n4 = -1;
+
+	private void print() {
+		String msg = NAME + " : " + section_number + " " + section_name.length() + " '" + section_name + "' (" + 
+				n2 +", " + n3 + ", " + n4 + ")";
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomST(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		hexdump(reader, record_offset, 0x20);
+		read_record_type(reader, record_type, record_subtype, NAME);
+
+		section_number = read_int(reader);
+		if (0 == section_number) {
+			Msg.info(this, "Bad section");
+			if (do_debug) hexdump(reader, record_offset, 0x10);
+			throw new IOException();
+		}
+
+		// if section start address is an obsolute number, section is absolute, else relocatable
+		// if not yet known, its relocatable
+		
+		as = new MufomAS(reader);
+
+		section_name = read_opt_id(reader);
+
+		//TODO  what is this
+		n2 = read_int(reader);
+		n3 = read_int(reader);
+		n4 = read_int(reader);
+
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomTY.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomTY.java
@@ -1,0 +1,70 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 11.5 TY (type) Command
+ *
+ * TY_command       ::= "TY" type_table_entry [ "," parameter ]+ "."
+ * type_table_entry ::= hex_number
+ * parameter        ::= hex_number | N_variable | "T" type_table_entry
+ *
+ * {$F2}{nl}{$CE}{n2}[n3][n4]...
+ */
+public class MufomTY extends MufomRecord {
+	public static final String NAME = "TY";
+	public static final int record_type = MufomType.MUFOM_CMD_TY;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+	public long type_index = -1;
+	public long name_index = -1;
+
+	private void print() {
+		String msg = NAME + ": " + type_index +" " + name_index;
+		if (do_debug) {
+			Msg.info(this, msg);
+		} else {
+			Msg.trace(this, msg);
+		}
+	}
+
+	public MufomTY(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		type_index = read_int(reader);
+		if (type_index < 256) {
+			Msg.info(this, "Invalid type index " + type_index);
+			throw new IOException();
+		}
+		int record_type = read_char(reader);
+		if (MufomType.MUFOM_ID_N != record_type) {
+			Msg.info(null, "Expected MUFOM_ID_N, " + record_type);
+		}
+
+		name_index = read_int(reader);
+
+		// variable number of fields
+		// D-7:  19
+		// D-8:
+
+		print();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomType.java
@@ -1,0 +1,494 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+public abstract class MufomType {
+
+	/* 0x00 - 0x7f - regular string or one byte number */
+
+	/* 0x80 - omitted optional number field */
+	public static final int MUFOM_OMITTED = 0x80;
+
+	/* 0x81 - 0x88 - numbers outside range of 0-127 */
+
+	/* 0x89 - 0x8f - unused  */
+
+	/* 0x90 - 0xa0 - user defined function codes */
+
+	/* 0xdb - 0xdd - unused */
+
+	/* 0xfa - 0xff - unused */
+
+	/* Function @F */
+	public static final int MUFOM_FUNC_F = 0xa0;
+
+	/* Function @T */
+	public static final int MUFOM_FUNC_T = 0xa1;
+
+	/* Function @ABS */
+	public static final int MUFOM_FUNC_ABS = 0xa2;
+
+	/* Function @NEG */
+	public static final int MUFOM_FUNC_NEG = 0xa3;
+
+	/* Function @NOT */
+	public static final int MUFOM_FUNC_NOT = 0xa4;
+
+	/* Function + */
+	public static final int MUFOM_FUNC_ADD = 0xa5;
+
+	/* Function - */
+	public static final int MUFOM_FUNC_SUB = 0xa6;
+
+	/* Function / */
+	public static final int MUFOM_FUNC_DIV = 0xa7;
+
+	/* Function * */
+	public static final int MUFOM_FUNC_MUL = 0xa8;
+
+	/* Function @MAX */
+	public static final int MUFOM_FUNC_MAX = 0xa9;
+
+	/* Function @MIN */
+	public static final int MUFOM_FUNC_MIN = 0xaa;
+
+	/* Function @MOD */
+	public static final int MUFOM_FUNC_MOD = 0xab;
+
+	/* Function < */
+	public static final int MUFOM_FUNC_LT = 0xac;
+
+	/* Function > */
+	public static final int MUFOM_FUNC_GT = 0xad;
+
+	/* Function = */
+	public static final int MUFOM_FUNC_EQ = 0xae;
+
+	/* Function != */
+	public static final int MUFOM_FUNC_NEQ = 0xaf;
+
+	/* Function @AND */
+	public static final int MUFOM_FUNC_AND = 0xb0;
+
+	/* Function @OR */
+	public static final int MUFOM_FUNC_OR = 0xb1;
+
+	/* Function @XOR */
+	public static final int MUFOM_FUNC_XOR = 0xb2;
+
+	/* Function @EXT */
+	public static final int MUFOM_FUNC_EXT = 0xb3;
+
+	/* Function @INS */
+	public static final int MUFOM_FUNC_INS = 0xb4;
+
+	/* Function @ERR */
+	public static final int MUFOM_FUNC_ERR = 0xb5;
+
+	/* Function @IF */
+	public static final int MUFOM_FUNC_IF = 0xb6;
+
+	/* Function @ELSE */
+	public static final int MUFOM_FUNC_ELSE = 0xb7;
+
+	/* Function @END */
+	public static final int MUFOM_FUNC_END = 0xb8;
+
+	/* Function @ISDEF */
+	public static final int MUFOM_FUNC_ISDEF = 0xb9;
+
+	/* Identifier NULL */
+	public static final int MUFOM_ID_NULL = 0xc0;
+
+	/* Identifier A */
+	public static final int MUFOM_ID_A = 0xc1;
+
+	/* Identifier B */
+	public static final int MUFOM_ID_B = 0xc2;
+
+	/* Identifier C */
+	public static final int MUFOM_ID_C = 0xc3;
+
+	/* Identifier D */
+	public static final int MUFOM_ID_D = 0xc4;
+
+	/* Identifier E */
+	public static final int MUFOM_ID_E = 0xc5;
+
+	/* Identifier F */
+	public static final int MUFOM_ID_F = 0xc6;
+
+	/*
+	 * Identifier G
+	 * Execution starting address
+	 */
+	public static final int MUFOM_ID_G = 0xc7;
+
+	/* Identifier H */
+	public static final int MUFOM_ID_H = 0xc8;
+
+	/*
+	 * Identifier I
+	 * Address of public symbol
+	 */
+	public static final int MUFOM_ID_I = 0xc9;
+
+	/* Identifier J */
+	public static final int MUFOM_ID_J = 0xca;
+
+	/* Identifier K */
+	public static final int MUFOM_ID_K = 0xcb;
+
+	/* Identifier L */
+	public static final int MUFOM_ID_L = 0xcc;
+
+	/* Identifier M */
+	public static final int MUFOM_ID_M = 0xcd;
+
+	/*
+	 * Identifier N
+	 * Address of local symbol
+	 */
+	public static final int MUFOM_ID_N = 0xce;
+
+	/*
+	 * Attribute Definition - Static symbol
+	 * [x1] and [x2] - record and address
+	 */
+	public static final int MUFOM_AD_STATICSYMBOL = 0x13;
+
+	/*
+	 * Attribute Definition - Object format version number
+	 * [x1] and [x2] defining version number and revision
+	 */
+	public static final int MUFOM_AD_VERSION = 0x25;
+
+	/*
+	 * Attribute Definition - Object format type
+	 * [x1] defining type, 1 Absolute
+	 */
+	public static final int MUFOM_AD_TYPE = 0x26;
+
+	/*
+	 * Attribute Definition - Case sensitivity
+	 * [x1] defining sensitivity, 2 Do not change the case of symbols
+	 */
+	public static final int MUFOM_AD_CASE = 0x27;
+
+	/*
+	 * Attribute Definition - Creation date and time
+	 * [x1], [x2], [x3], [x4], [x5], [x6], year/month/day/hour/minute/second
+	 * No ASN
+	 */
+	public static final int MUFOM_AD_DATETIME = 0x32;
+
+	/*
+	 * Attribute Definition - Command line text
+	 * [id] command line
+	 * No ASN
+	 */
+	public static final int MUFOM_AD_COMMANDLINE = 0x33;
+
+	/*
+	 * Attribute Definition - Execution status
+	 * [x1] 0 Success
+	 * No ASN
+	 */
+	public static final int MUFOM_AD_STATUS = 0x34;
+
+	/*
+	 * Attribute Definition - Host environment
+	 * [x1]
+	 * No ASN
+	 */
+	public static final int MUFOM_AD_ENV = 0x35;
+
+	/*
+	 * Attribute Definition - Tool and version number
+	 * [x1], [x2], and [x3] (optional [x4] revision level) tool, version, revision
+	 * No ASN
+	 */
+	public static final int MUFOM_AD_TOOLVERSION = 0x36;
+
+	/*
+	 * Attribute Definition - Comments
+	 * [id] comments
+	 * No ASN
+	 */
+	public static final int MUFOM_AT_COMMENT = 0x37;
+
+	/* Identifier O */
+	public static final int MUFOM_ID_O = 0xcf;
+
+	/*
+	 * Identifier P
+	 * The program counter for section
+	 * Implicitly changes with each LR, LD, or LT
+	 */
+	public static final int MUFOM_ID_P = 0xd0;
+
+	/* Identifier Q */
+	public static final int MUFOM_ID_Q = 0xd1;
+
+	/* Identifier R */
+	public static final int MUFOM_ID_R = 0xd2;
+
+	/*
+	 * Identifier S
+	 * The size in minimum address units
+	 */
+	public static final int MUFOM_ID_S = 0xd3;
+
+	/* Identifier T */
+	public static final int MUFOM_ID_T = 0xd4;
+
+	/* Identifier U */
+	public static final int MUFOM_ID_U = 0xd5;
+
+	/* Identifier V */
+	public static final int MUFOM_ID_V = 0xd6;
+
+	/*
+	 * Identifier W
+	 * The file offset in bytes of the part of the object file from the
+	 * beginning of the file
+	 */
+	public static final int MUFOM_ID_W = 0xd7;
+
+	/* Assign Value to Variable W0 (ASW0) - AD Extension Part*/
+	public static final int MUFOM_ASW0 = 0x00;
+
+	/* Assign Value to Variable W1 (ASW1) - Environment Part */
+	public static final int MUFOM_ASW1 = 0x01;
+
+	/* Assign Value to Variable W2 (ASW2) - Section Definition Part */
+	public static final int MUFOM_ASW2 = 0x02;
+
+	/* Assign Value to Variable W3 (ASW3) - External Part */
+	public static final int MUFOM_ASW3 = 0x03;
+
+	/* Assign Value to Variable W4 (ASW4) - Debug Information Definition Part */
+	public static final int MUFOM_ASW4 = 0x04;
+
+	/* Assign Value to Variable W5 (ASW5) - Data Part */
+	public static final int MUFOM_ASW5 = 0x05;
+
+	/* Assign Value to Variable W6 (ASW6) - Trailer Part */
+	public static final int MUFOM_ASW6 = 0x06;
+
+	/* Assign Value to Variable W7 (ASW7) */
+	public static final int MUFOM_ASW7 = 0x07;
+
+	/* Identifier X */
+	public static final int MUFOM_ID_X = 0xd8;
+
+	/* Identifier Y */
+	public static final int MUFOM_ID_Y = 0xd9;
+
+	/* Identifier Z */
+	public static final int MUFOM_ID_Z = 0xda;
+
+	/* Extension length 1-byte */
+	public static final int MUFOM_EXTB = 0xde;
+
+	/* Extension length 2-byte */
+	public static final int MUFOM_EXTH = 0xdf;
+
+	/* Command MB - Module begin */
+	public static final int MUFOM_CMD_MB = 0xe0;
+
+	/* Command ME - Module end */
+	public static final int MUFOM_CMD_ME = 0xe1;
+
+	/* Command AS - Assign */
+	public static final int MUFOM_CMD_AS = 0xe2;
+
+	/* Command IR - Initialize relocation base */
+	public static final int MUFOM_CMD_IR = 0xe3;
+
+	/* Command LR - Load with relocation */
+	public static final int MUFOM_CMD_LR = 0xe4;
+
+	/* Command SB - Section begin */
+	public static final int MUFOM_CMD_SB = 0xe5;
+
+	/* Command ST - Section type */
+	public static final int MUFOM_CMD_ST = 0xe6;
+
+	/* Command SA - Section alignment */
+	public static final int MUFOM_CMD_SA = 0xe7;
+
+	/* Command NI - Internal name */
+	public static final int MUFOM_CMD_NI = 0xe8;
+
+	/* Command NX - External name */
+	public static final int MUFOM_CMD_NX = 0xe9;
+
+	/* Command CO - Comment */
+	public static final int MUFOM_CMD_CO = 0xea;
+
+	/* Command DT - Date and time */
+	public static final int MUFOM_CMD_DT = 0xeb;
+
+	/* Command AD - Address description */
+	public static final int MUFOM_CMD_AD = 0xec;
+
+	/* Command LD - Load */
+	public static final int MUFOM_CMD_LD = 0xed;
+
+	/* Command CS (with sum) - Checksum followed by sum value */
+	public static final int MUFOM_CMD_CSS = 0xee;
+
+	/* Command CS - Checksum (reset sum to 0) */
+	public static final int MUFOM_CMD_CS = 0xef;
+
+	/* Command NN - Name */
+	public static final int MUFOM_CMD_NN = 0xf0;
+
+	/* Built-in Types ?, unknown type, 'UNKNOWN TYPE' */
+	public static final int MUFOM_BUILTIN_UNK = 0x00;
+
+	/* Built-in Types void, procedure returning void, 'void' */
+	public static final int MUFOM_BUILTIN_V = 0x01;
+
+	/* Built-in Types byte, 8-bit signed, 'signed char' */
+	public static final int MUFOM_BUILTIN_B = 0x02;
+
+	/* Built-in Types char, 8-bit unsigned, 'unsigned char' */
+	public static final int MUFOM_BUILTIN_C = 0x03;
+
+	/* Built-in Types halfword, 16-bit signed, 'signed short int' */
+	public static final int MUFOM_BUILTIN_H = 0x04;
+
+	/* Built-in Types int, 16-bit unsigned, 'unsigned short int' */
+	public static final int MUFOM_BUILTIN_I = 0x05;
+
+	/* Built-in Types long, 32-bit signed, 'signed long' */
+	public static final int MUFOM_BUILTIN_L = 0x06;
+
+	/* Built-in Types , 32-bit unsigned, 'unsigned long' */
+	public static final int MUFOM_BUILTIN_M = 0x07;
+
+	/* Built-in Types float, 32-bit floating point, 'float' */
+	public static final int MUFOM_BUILTIN_F = 0x0a;
+
+	/* Built-in Types double, 64-bit floating point, 'double' */
+	public static final int MUFOM_BUILTIN_D = 0x0b;
+
+	/* Built-in Types king size, extended precision floating point, 'long double' */
+	public static final int MUFOM_BUILTIN_K = 0x0c;
+
+	/* Built-in Types jump to, code location, 'instruction address' */
+	public static final int MUFOM_BUILTIN_J = 0x0f;
+
+	/* Built-in Pointer Types ?, unknown type, 'UNKNOWN TYPE' */
+	public static final int MUFOM_BUILTIN_PUNK = 0x20;
+
+	/* Built-in Pointer Types void, procedure returning void, 'void' */
+	public static final int MUFOM_BUILTIN_PV = 0x21;
+
+	/* Built-in Pointer Types byte, 8-bit signed, 'signed char' */
+	public static final int MUFOM_BUILTIN_PB = 0x22;
+
+	/* Built-in Pointer Types char, 8-bit unsigned, 'unsigned char' */
+	public static final int MUFOM_BUILTIN_PC = 0x23;
+
+	/* Built-in Pointer Types halfword, 16-bit signed, 'signed short int' */
+	public static final int MUFOM_BUILTIN_PH = 0x24;
+
+	/* Built-in Pointer Types int, 16-bit unsigned, 'unsigned short int' */
+	public static final int MUFOM_BUILTIN_PI = 0x25;
+
+	/* Built-in Pointer Types long, 32-bit signed, 'signed long' */
+	public static final int MUFOM_BUILTIN_PL = 0x26;
+
+	/* Built-in Pointer Types , 32-bit unsigned, 'unsigned long' */
+	public static final int MUFOM_BUILTIN_PM = 0x27;
+
+	/* Built-in Pointer Types float, 32-bit floating point, 'float' */
+	public static final int MUFOM_BUILTIN_PF = 0x2a;
+
+	/* Built-in Pointer Types double, 64-bit floating point, 'double' */
+	public static final int MUFOM_BUILTIN_PD = 0x2b;
+
+	/* Built-in Pointer Types king size, extended precision floating point, 'long double' */
+	public static final int MUFOM_BUILTIN_PK = 0x2c;
+
+	/* Command AT - Attribute */
+	public static final int MUFOM_CMD_AT = 0xf1;
+
+	/* Command TY - Type */
+	public static final int MUFOM_CMD_TY = 0xf2;
+
+	/* Command RI - Retain internal symbol */
+	public static final int MUFOM_CMD_RI = 0xf3;
+
+	/* Command WX - Weak external */
+	public static final int MUFOM_CMD_WX = 0xf4;
+
+	/* Command LI - Library search list*/
+	public static final int MUFOM_CMD_LI = 0xf5;
+
+	/* Command LX - Library external */
+	public static final int MUFOM_CMD_LX = 0xf6;
+
+	/* Command RE - Replicate */
+	public static final int MUFOM_CMD_RE = 0xf7;
+
+	/* Command SC - Scope definition */
+	public static final int MUFOM_CMD_SC = 0xf8;
+
+	/* Command LN - Line number */
+	public static final int MUFOM_CMD_LN = 0xf9;
+
+	public static final int ieee_number_start_enum = 0x00;
+	public static final int ieee_unknown_1_enum = 0x01;
+	public static final int ieee_unknown_7_enum = 0x07;
+	public static final int ieee_unknown_12_enum = 0x0c;
+	public static final int ieee_unknown_16_enum = 0x10;
+	public static final int ieee_static_variable_enum = 0x13;
+
+	public static final int ieee_execution_tool_version_enum = 0x36;
+	public static final int ieee_unknown_56_enum = 0x38;
+	public static final int ieee_number_repeat_start_enum = 0x80;
+	public static final int ieee_number_repeat_1_enum = 0x81;
+	public static final int ieee_number_repeat_2_enum = 0x82;
+	public static final int ieee_number_repeat_3_enum = 0x83;
+	public static final int ieee_number_repeat_4_enum = 0x84;
+	public static final int ieee_number_repeat_end_enum = 0x88;
+
+	public static final int ieee_function_signed_open_b_enum = 0xba;
+	public static final int ieee_function_signed_close_b_enum = 0xbb;
+	public static final int ieee_function_unsigned_open_b_enum = 0xbc;
+	public static final int ieee_function_unsigned_close_b_enum = 0xbd;
+	public static final int MUFOM_OPEN = 0xbe;
+	public static final int MUFOM_CLOSE = 0xbf;
+
+
+	public static final int ieee_record_seperator_enum = 0xdb;
+
+	public static final int ieee_attribute_record_enum = 0xc9;
+
+	public static final int MUFOM_BB1 = 0x01;
+	public static final int MUFOM_BB2 = 0x02;
+	public static final int MUFOM_BB3 = 0x03;
+	public static final int MUFOM_BB4 = 0x04;
+	public static final int MUFOM_BB5 = 0x05;
+	public static final int MUFOM_BB6 = 0x06;
+	public static final int MUFOM_BB10 = 0x0a;
+	public static final int MUFOM_BB11 = 0x0b;
+
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomType.java
@@ -459,7 +459,6 @@ public abstract class MufomType {
 	public static final int ieee_unknown_7_enum = 0x07;
 	public static final int ieee_unknown_12_enum = 0x0c;
 	public static final int ieee_unknown_16_enum = 0x10;
-	public static final int ieee_static_variable_enum = 0x13;
 
 	public static final int ieee_execution_tool_version_enum = 0x36;
 	public static final int ieee_unknown_56_enum = 0x38;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomWX.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/mufom/MufomWX.java
@@ -1,0 +1,41 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License; Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing; software
+ * distributed under the License is distributed on an "AS IS" BASIS;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.mufom;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.util.Msg;
+
+/*
+ * 14.2 WX (weak external symbol) Command
+ * 
+ * WX_command ::= "W" X_variable [ "," default_value ]? "."
+ * default_value ::= expression
+ */
+public class MufomWX extends MufomRecord {
+	public static final String NAME = "WX";
+	public static final int record_type = MufomType.MUFOM_CMD_WX;
+	public static final int record_subtype = -1;
+	public long record_start = -1;
+
+	public MufomWX(BinaryReader reader) throws IOException {
+		record_start = reader.getPointerIndex();
+		read_record_type(reader, record_type, record_subtype, NAME);
+		Msg.info(this, "unimplemented " + NAME);
+		throw new IOException();
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MufomLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MufomLoader.java
@@ -1,0 +1,196 @@
+package ghidra.app.util.opinion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import ghidra.app.util.MemoryBlockUtils;
+import ghidra.app.util.Option;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.format.mufom.MufomHeader;
+import ghidra.app.util.bin.format.mufom.MufomHeader.MufomData;
+import ghidra.app.util.bin.format.mufom.MufomHeader.MufomExternal;
+import ghidra.app.util.bin.format.mufom.MufomHeader.MufomSectionDefinition;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.framework.store.LockException;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.lang.Endian;
+import ghidra.program.model.listing.Listing;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.mem.MemoryAccessException;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.mem.MemoryBlockException;
+import ghidra.program.model.symbol.SourceType;
+import ghidra.program.model.symbol.SymbolTable;
+import ghidra.util.Msg;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.exception.InvalidInputException;
+import ghidra.util.exception.NotFoundException;
+import ghidra.util.task.TaskMonitor;
+
+public class MufomLoader extends AbstractLibrarySupportLoader {
+
+	private Program program;
+	private Memory memory;
+	private Listing listing;
+	private MessageLog log;
+	private MufomHeader curr;
+
+	public MufomLoader() {
+
+	}
+
+	@Override
+	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
+		List<LoadSpec> loadSpecs = new ArrayList<>();
+
+		MufomHeader mufom = new MufomHeader(provider, null);
+		if (mufom.valid()) {
+			List<QueryResult> results =
+					QueryOpinionService.query(getName(), mufom.machine(), null);
+			for (QueryResult result : results) {
+				boolean add = true;
+				if (mufom.is_little() && result.pair.getLanguageDescription().getEndian() != Endian.LITTLE) {
+					add = false;
+				}
+				if (mufom.is_big() && result.pair.getLanguageDescription().getEndian() != Endian.BIG) {
+					add = false;
+				}
+				if (add) {
+					loadSpecs.add(new LoadSpec(this, 0, result));
+				}
+			}
+			if (loadSpecs.isEmpty()) {
+				loadSpecs.add(new LoadSpec(this, 0, true));
+			}
+		}
+		return loadSpecs;
+	}
+
+	@Override
+	public String getName() {
+		return MufomHeader.getName();
+	}
+
+	private void createLabels() throws InvalidInputException {
+		SymbolTable symbolTable = program.getSymbolTable();
+		MufomExternal asw3 = curr.asw3;
+		Address addr = null;
+
+		while (asw3 != null) {
+			addr = getDefaultAddressSpace().getAddress(asw3.getAddress());
+			if (null != addr) {
+				symbolTable.createLabel(addr, asw3.getName(), null, SourceType.IMPORTED);
+			}
+			asw3 = asw3.next;
+		}
+	}
+
+	private void fillSections() throws IOException, MemoryAccessException {
+		MufomData asw5 = curr.asw5;
+		Address addr = null;
+		while (asw5 != null) {
+			long address = asw5.getSectionAddress();
+			long offset = asw5.getDataOffset();
+			long length = asw5.getDataLength();
+
+			if (address > 0) {
+				addr = getDefaultAddressSpace().getAddress(address);
+			}
+			
+			if (memory.contains(addr, addr.add(length - 1))) {
+				byte[] data = curr.reader.readByteArray(offset, (int) length);
+				program.getMemory().setBytes(addr, data);
+				addr = addr.add(length);
+			}
+			asw5 = asw5.next;
+		}
+	}
+
+	private void createSections(MessageLog log) throws MemoryBlockException, LockException, NotFoundException {
+		MufomSectionDefinition asw2 = curr.asw2;
+		MemoryBlock blockStart;
+		MemoryBlock blockEnd;
+		MemoryBlock blockNew;
+		Address addr = null;
+		long address;
+		long len;
+
+		while (asw2 != null) {
+			address = asw2.getBaseAddress();
+			len = asw2.getSectionLength();
+			if (address >= 0 && len > 0) {
+				addr = getDefaultAddressSpace().getAddress(address);
+	
+				blockNew = null;
+				blockStart = memory.getBlock(addr);
+				blockEnd = memory.getBlock(addr.add(len - 1));
+	
+				// There are attributes that describe if some of this should happen, but depending on when
+				// the section gets added that logic may be difficult to tell.
+				if (null == blockStart && null == blockEnd) {
+					// No section contains this address, create a new block
+					blockNew = MemoryBlockUtils.createInitializedBlock(program, false, asw2.getName(), addr, len,
+							"Section: 0x" + Long.toHexString(asw2.getSectionIndex()), null, true, true, true, log);
+					//TODO  join if next to each other?
+				} else if (null == blockStart && null != blockEnd) {
+					// blockNew overlaps the end of a section
+					len = addr.subtract(blockEnd.getEnd().add(1));
+					addr = blockEnd.getEnd().add(1);
+					blockNew = MemoryBlockUtils.createInitializedBlock(program, false, asw2.getName(), addr, len,
+							"Section: 0x" + Long.toHexString(asw2.getSectionIndex()), null, true, true, true, log);
+					memory.join(blockEnd, blockNew);
+				} else if (null != blockStart && null == blockEnd) {
+					// blockNew overlaps the start of a section
+					len = blockStart.getStart().subtract(addr);
+					blockNew = MemoryBlockUtils.createInitializedBlock(program, false, asw2.getName(), addr, len,
+							"Section: 0x" + Long.toHexString(asw2.getSectionIndex()), null, true, true, true, log);
+					memory.join(blockNew, blockStart);
+				} else if (null != blockStart && null != blockEnd) {
+					// blockNew is inside a section
+				}
+			}
+			asw2 = asw2.next;
+		}
+	}
+
+	private void load(MufomHeader mufom,Program program, TaskMonitor monitor,
+			MessageLog log) throws IOException, InvalidInputException, MemoryAccessException, LockException, NotFoundException {
+		this.program = program;
+		this.memory = program.getMemory();
+		this.listing = program.getListing();
+		this.curr = mufom;
+		this.log = log;
+
+		createSections(log);
+		fillSections();
+		createLabels();
+		//throw new IOException();
+	}
+
+	@Override
+	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program,
+			TaskMonitor monitor, MessageLog log) throws CancelledException, IOException {
+		// TODO Auto-generated method stub
+		MufomHeader mufom = new MufomHeader(provider, msg -> log.appendMsg(msg));
+		try {
+			load(mufom, program, monitor, log);
+		} catch (InvalidInputException e) {
+			//
+		} catch (MemoryAccessException e) {
+			//
+		} catch (NotFoundException e) {
+			//
+		} catch (LockException e) {
+			//
+		}
+	}
+
+	private AddressSpace getDefaultAddressSpace() {
+		return program.getAddressFactory().getDefaultAddressSpace();
+	}
+
+}


### PR DESCRIPTION
Adds support for loading the binary format for IEEE-695 (MUFOM)

The ASCII format is defined in IEEE Std 695-1990 "IEEE Standard for Microprocessor Universal Format for Object Modules"

I found various datasheets with a description of the binary format
* i960 Processor Software Utilities User’s Guide
* S5U1C88000C Manual I (Integrated Tool Package for S1C88 Family)

ieee was dropped from binutils after 2.30 looks like