### PR TITLE
Store original hostname for new projects

### DIFF
--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
@@ -108,7 +108,7 @@ public class ClientUtil {
 
 		host = host.trim().toLowerCase();
 		try {
-			host = InetNameLookup.getCanonicalHostName(host);
+			InetNameLookup.getCanonicalHostName(host);
 		}
 		catch (UnknownHostException e) {
 			Msg.warn(ClientUtil.class, "Failed to resolve hostname for " + host);
@@ -151,7 +151,7 @@ public class ClientUtil {
 		host = host.trim().toLowerCase();
 		String hostAddr = host;
 		try {
-			hostAddr = InetNameLookup.getCanonicalHostName(host);
+			InetNameLookup.getCanonicalHostName(host);
 		}
 		catch (UnknownHostException e) {
 			throw new IOException("Repository server lookup failed: " + host);

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
@@ -106,9 +106,11 @@ public class ClientUtil {
 		// ensure that default callback is setup if possible
 		getClientAuthenticator();
 
+		String canonicalHost = null;
+
 		host = host.trim().toLowerCase();
 		try {
-			host = InetNameLookup.getCanonicalHostName(host);
+			canonicalHost = InetNameLookup.getCanonicalHostName(host);
 		}
 		catch (UnknownHostException e) {
 			Msg.warn(ClientUtil.class, "Failed to resolve hostname for " + host);
@@ -118,7 +120,7 @@ public class ClientUtil {
 			port = GhidraServerHandle.DEFAULT_PORT;
 		}
 
-		ServerInfo server = new ServerInfo(host, port);
+		ServerInfo server = new ServerInfo(host, canonicalHost, port);
 
 		RepositoryServerAdapter rsa;
 		synchronized (serverHandles) {
@@ -160,7 +162,7 @@ public class ClientUtil {
 		if (port == 0) {
 			port = GhidraServerHandle.DEFAULT_PORT;
 		}
-		ServerInfo server = new ServerInfo(hostAddr, port);
+		ServerInfo server = new ServerInfo(hostAddr, null, port);
 		RepositoryServerAdapter serverAdapter = serverHandles.remove(server);
 		if (serverAdapter != null) {
 			serverAdapter.disconnect();

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
@@ -108,7 +108,7 @@ public class ClientUtil {
 
 		host = host.trim().toLowerCase();
 		try {
-			InetNameLookup.getCanonicalHostName(host);
+			host = InetNameLookup.getCanonicalHostName(host);
 		}
 		catch (UnknownHostException e) {
 			Msg.warn(ClientUtil.class, "Failed to resolve hostname for " + host);
@@ -151,7 +151,7 @@ public class ClientUtil {
 		host = host.trim().toLowerCase();
 		String hostAddr = host;
 		try {
-			InetNameLookup.getCanonicalHostName(host);
+			hostAddr = InetNameLookup.getCanonicalHostName(host);
 		}
 		catch (UnknownHostException e) {
 			throw new IOException("Repository server lookup failed: " + host);

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ClientUtil.java
@@ -162,7 +162,7 @@ public class ClientUtil {
 		if (port == 0) {
 			port = GhidraServerHandle.DEFAULT_PORT;
 		}
-		ServerInfo server = new ServerInfo(hostAddr, null, port);
+		ServerInfo server = new ServerInfo(hostAddr, port);
 		RepositoryServerAdapter serverAdapter = serverHandles.remove(server);
 		if (serverAdapter != null) {
 			serverAdapter.disconnect();

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
@@ -123,16 +123,6 @@ class ServerConnectTask extends Task {
 		return subj;
 	}
 
-	private static String getPreferredHostname(String name) {
-		try {
-			return InetNameLookup.getCanonicalHostName(name);
-		}
-		catch (UnknownHostException e) {
-			Msg.warn(ServerConnectTask.class, "Failed to resolve hostname for " + name);
-		}
-		return name;
-	}
-
 	private static boolean isSSLHandshakeCancelled(SSLHandshakeException e) throws IOException {
 		if (e.getMessage().indexOf("bad_certificate") > 0) {
 			if (ApplicationKeyManagerFactory.getPreferredKeyStore() == null) {
@@ -275,7 +265,7 @@ class ServerConnectTask extends Task {
 				}
 			}
 
-			String serverName = getPreferredHostname(server.getServerName());
+			String serverName = server.getServerName();
 			AnonymousCallback onlyAnonymousCb = null;
 			while (true) {
 				try {

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
@@ -123,6 +123,16 @@ class ServerConnectTask extends Task {
 		return subj;
 	}
 
+	private static String getPreferredHostname(String name) {
+		try {
+			return InetNameLookup.getCanonicalHostName(name);
+		}
+		catch (UnknownHostException e) {
+			Msg.warn(ServerConnectTask.class, "Failed to resolve hostname for " + name);
+		}
+		return name;
+	}
+
 	private static boolean isSSLHandshakeCancelled(SSLHandshakeException e) throws IOException {
 		if (e.getMessage().indexOf("bad_certificate") > 0) {
 			if (ApplicationKeyManagerFactory.getPreferredKeyStore() == null) {
@@ -265,7 +275,7 @@ class ServerConnectTask extends Task {
 				}
 			}
 
-			String serverName = server.getServerName();
+			String serverName = getPreferredHostname(server.getServerName());
 			AnonymousCallback onlyAnonymousCb = null;
 			while (true) {
 				try {

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/model/ServerInfo.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/model/ServerInfo.java
@@ -25,23 +25,37 @@ import java.io.Serializable;
 public class ServerInfo implements Serializable {
 
 	private final String host;
+	private final String originalHost;
 	private final int portNumber;
 	
 	/**
 	 * Construct a new ServerInfo object
-	 * @param host host name
+	 * @param originalHost original host name (as entered by a user)
+	 * @param host host name (potentially canonicalized)
 	 * @param portNumber port number
 	 */
-	public ServerInfo(String host, int portNumber) {
+	public ServerInfo(String originalHost, String host, int portNumber) {
+		this.originalHost = originalHost;
 		this.host = host;
 		this.portNumber = portNumber;
 	}
+
+	public ServerInfo(String host, int portNumber) {
+		this(host, host, portNumber);
+	}
 	
 	/**
-	 * Get the server name.
+	 * Get the (canonical) server name.
 	 */
 	public String getServerName() {
 		return host;
+	}
+
+	/**
+	 * Get the (original) server name.
+	 */
+	public String getOriginalServerName() {
+		return this.originalHost;
 	}
 
 	/**

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/ProjectFileManager.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/ProjectFileManager.java
@@ -360,7 +360,7 @@ public class ProjectFileManager implements ProjectData {
 		if (info == null) {
 			return;
 		}
-		properties.putString(SERVER_NAME, info.getServerName());
+		properties.putString(SERVER_NAME, info.getOriginalServerName());
 		properties.putString(REPOSITORY_NAME, rep.getName());
 		properties.putInt(PORT_NUMBER, info.getPortNumber());
 		properties.writeState();

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/ProjectInfoDialog.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/ProjectInfoDialog.java
@@ -221,7 +221,7 @@ public class ProjectInfoDialog extends DialogComponentProvider {
 		boolean isConnected = false;
 		if (repository != null) {
 			info = repository.getServerInfo();
-			serverName = info.getServerName();
+			serverName = info.getOriginalServerName();
 			repositoryName = repository.getName();
 			portNumberStr = Integer.toString(info.getPortNumber());
 			isConnected = repository.isConnected();


### PR DESCRIPTION
Addresses https://github.com/NationalSecurityAgency/ghidra/issues/4924

The net effect of this change is that Ghidra will store in it's .prp file the hostname the user entered, rather then the canonical name that was discovered for the IP that was associated with the hostname that the user entered. If there are users who expect this behaviour, they will encounter altered behaviour. Ghidra will still lookup the canonical name when using `RepositoryManager.getRMIClient` but the value in the prp file will be the original hostname the user entered.

I left the checks `InetNameLookup.getCanonicalHostName(host);` in ClientUtil to ensure that the hostname that is entered can be resolved. 

I tested and verified this change with a ghidra server in running in AWS. 