### PR TITLE
elf: Refactoring to enable creation of ELF files from scratch

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
@@ -143,8 +143,8 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 		for (ElfSectionHeader stringSection : stringSections) {
 			monitor.checkCanceled();
 			try {
-				Address addr = addr(stringSection.getOffset());
-				Address maxAddr = addr.addNoWrap(stringSection.getSize() - 1);
+				Address addr = addr(stringSection.getFileOffset());
+				Address maxAddr = addr.addNoWrap(stringSection.getMemorySize() - 1);
 
 				MemoryBlock block = memory.getBlock(addr);
 				if (block == null) {
@@ -188,15 +188,15 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 
 			CodeUnit cu = listing.getCodeUnitAt(addr(offset));
 			cu.setComment(CodeUnit.PLATE_COMMENT,
-				"#" + i + ") " + name + " at 0x" + Long.toHexString(sections[i].getAddress()));
+				"#" + i + ") " + name + " at 0x" + Long.toHexString(sections[i].getVirtualAddress()));
 
 			if (sections[i].getType() == ElfSectionHeaderConstants.SHT_NOBITS ||
-				sections[i].getSize() == 0 || sections[i].isInvalidOffset()) {
+				sections[i].getMemorySize() == 0 || sections[i].isInvalidOffset()) {
 				continue;
 			}
 
-			Address dataStart = addr(sections[i].getOffset());
-			createFragment(name + "_DATA", dataStart, sections[i].getSize());
+			Address dataStart = addr(sections[i].getFileOffset());
+			createFragment(name + "_DATA", dataStart, sections[i].getMemorySize());
 
 			try {
 				createLabel(dataStart, name, true, SourceType.ANALYSIS);
@@ -207,7 +207,7 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 
 			cu = listing.getCodeUnitAt(dataStart);
 			cu.setComment(CodeUnit.PRE_COMMENT, sections[i].getNameAsString() + " Size: 0x" +
-				Long.toHexString(sections[i].getSize()));
+				Long.toHexString(sections[i].getMemorySize()));
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
@@ -83,7 +83,6 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 			MemoryByteProvider.createDefaultAddressSpaceByteProvider(program, false);
 		try {
 			ElfHeader elf = new ElfHeader(provider, msg -> messages.appendMsg(msg));
-			elf.parse();
 
 			processElfHeader(elf, listing);
 			processProgramHeaders(elf, listing);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
@@ -324,7 +324,7 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 			BinaryReader reader, Program program) {
 		ElfStringTable dynamicStringTable = elf.getDynamicStringTable();
 		if (dynamicStringTable != null) {
-			String str = dynamicStringTable.readString(reader, dynamic.getValue());
+			String str = dynamicStringTable.readString(dynamic.getValue());
 			if (str != null && str.length() != 0) {
 				data.setComment(CodeUnit.EOL_COMMENT, str);
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
@@ -233,7 +233,7 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 			Data d = array.getComponent(i);
 			d.setComment(CodeUnit.EOL_COMMENT, programHeaders[i].getComment());
 
-			Address addr = addr(programHeaders[i].getOffset());
+			Address addr = addr(programHeaders[i].getFileOffset());
 
 			createLabel(addr, programHeaders[i].getTypeAsString(), true, SourceType.ANALYSIS);
 		}
@@ -244,7 +244,7 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 		for (ElfProgramHeader programHeader : elf.getProgramHeaders(
 			ElfProgramHeaderConstants.PT_INTERP)) {
 			monitor.checkCanceled();
-			long offset = programHeader.getOffset();
+			long offset = programHeader.getFileOffset();
 			if (offset == 0) {
 				Msg.warn(this, " Dynamic table appears to have been stripped from binary");
 				return;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
@@ -407,14 +407,14 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 		ElfRelocationTable[] relocationTables = elf.getRelocationTables();
 		for (ElfRelocationTable relocationTable : relocationTables) {
 			monitor.checkCanceled();
-			ElfSectionHeader relocationSection = relocationTable.getTableSectionHeader();
+			ElfFileSection relocationSection = relocationTable.getFileSection();
 			String relocSectionName = "<section-not-found>";
-			if (relocationSection != null) {
-				relocSectionName = relocationSection.getNameAsString();
+			if (relocationSection instanceof ElfSectionHeader) {
+				relocSectionName = ((ElfSectionHeader) relocationSection).getNameAsString();
 			}
 
 			//		elf.getSection(relocationTable.getFileOffset()); // may be null
-			Address relocationTableAddress = addr(relocationTable.getFileOffset());
+			Address relocationTableAddress = addr(relocationSection.getFileOffset());
 			try {
 				DataType dataType = relocationTable.toDataType();
 				if (dataType != null) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
@@ -362,7 +362,7 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 		for (ElfSymbolTable symbolTable2 : symbolTables) {
 			monitor.checkCanceled();
 
-			Address symbolTableAddr = addr(symbolTable2.getFileOffset());
+			Address symbolTableAddr = addr(symbolTable2.getFileSection().getFileOffset());
 
 			try {
 				DataType symbolTableDT = symbolTable2.toDataType();
@@ -386,7 +386,7 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 				}
 
 				try {
-					Address currAddr = symbolTableAddr.add(j * symbolTable2.getEntrySize());
+					Address currAddr = symbolTableAddr.add(j * symbolTable2.getFileSection().getEntrySize());
 					listing.setComment(currAddr, CodeUnit.EOL_COMMENT,
 						name + " at 0x" + Long.toHexString(symbols[j].getValue()));
 				}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/formats/ElfBinaryAnalysisCommand.java
@@ -270,7 +270,7 @@ public class ElfBinaryAnalysisCommand extends FlatProgramAPI
 		}
 
 		try {
-			Address addr = addr(dynamicTable.getFileOffset());
+			Address addr = addr(dynamicTable.getFileSection().getFileOffset());
 
 			program.getSymbolTable().createLabel(addr, "_DYNAMIC", SourceType.ANALYSIS);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/ByteArrayMutableByteProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/ByteArrayMutableByteProvider.java
@@ -1,0 +1,111 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * An implementation of ByteProvider where the underlying bytes are held in-
+ * memory with a byte buffer. The buffer grows automatically as needed to fit
+ * written data.
+ */
+public class ByteArrayMutableByteProvider implements MutableByteProvider {
+    private byte[] data;
+
+    private void ensureCapacity(int newCapacity) {
+        if (data.length < newCapacity) {
+            data = Arrays.copyOf(data, newCapacity);
+        }
+    }
+
+    /**
+     * Create an empty ByteArrayMutableByteProvider.
+     */
+    public ByteArrayMutableByteProvider() {
+        data = new byte[0];
+    }
+
+    /**
+     * Create a ByteArrayMutableByteProvider initialized with the given array
+     * @param bytes Initial content of the ByteArrayMutableByteProvider.
+     */
+    public ByteArrayMutableByteProvider(byte[] bytes) {
+        data = Arrays.copyOf(bytes, bytes.length);
+    }
+
+    @Override
+    public File getFile() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getAbsolutePath() {
+        return null;
+    }
+
+    @Override
+    public long length() throws IOException {
+        return data.length;
+    }
+
+    @Override
+    public boolean isValidIndex(long index) {
+        return index < data.length;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public byte readByte(long index) throws IOException {
+        try {
+            return data[(int) index];
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public byte[] readBytes(long index, long length) throws IOException {
+        try {
+            return Arrays.copyOfRange(data, (int) index, (int) (index + length));
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void writeByte(long index, byte value) throws IOException {
+        ensureCapacity((int) (index + 1));
+        data[(int) index] = value;
+    }
+
+    @Override
+    public void writeBytes(long index, byte[] values) throws IOException {
+        ensureCapacity((int) (index + values.length));
+        System.arraycopy(values, 0, data, (int) index, values.length);
+    }
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDefaultGotPltMarkup.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDefaultGotPltMarkup.java
@@ -375,7 +375,7 @@ public class ElfDefaultGotPltMarkup {
 			long imageBaseAdj = elfLoadHelper.getImageBaseWordAdjustmentOffset();
 			if (dynamicTable != null && imageBaseAdj != 0) {
 				long entry1Value = elfLoadHelper.getOriginalValue(gotStart, false);
-				if (entry1Value == dynamicTable.getAddressOffset()) {
+				if (entry1Value == dynamicTable.getVirtualAddress()) {
 					// TODO: record artificial relative relocation for reversion/export concerns
 					entry1Value += imageBaseAdj; // adjust first entry value
 					if (elf.is64Bit()) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDefaultGotPltMarkup.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDefaultGotPltMarkup.java
@@ -375,7 +375,7 @@ public class ElfDefaultGotPltMarkup {
 			long imageBaseAdj = elfLoadHelper.getImageBaseWordAdjustmentOffset();
 			if (dynamicTable != null && imageBaseAdj != 0) {
 				long entry1Value = elfLoadHelper.getOriginalValue(gotStart, false);
-				if (entry1Value == dynamicTable.getVirtualAddress()) {
+				if (entry1Value == dynamicTable.getFileSection().getVirtualAddress()) {
 					// TODO: record artificial relative relocation for reversion/export concerns
 					entry1Value += imageBaseAdj; // adjust first entry value
 					if (elf.is64Bit()) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicTable.java
@@ -190,7 +190,7 @@ public class ElfDynamicTable implements ElfFileSection {
 	}
 
 	@Override
-	public long getAddressOffset() {
+	public long getVirtualAddress() {
 		return addrOffset;
 	}
 
@@ -240,12 +240,12 @@ public class ElfDynamicTable implements ElfFileSection {
 	}
 
 	@Override
-	public long getLength() {
+	public long getFileSize() {
 		return dynamics.size() * getEntrySize();
 	}
 
 	@Override
-	public int getEntrySize() {
+	public long getEntrySize() {
 		return header.is32Bit() ? 8 : 16;
 	}
 
@@ -256,8 +256,8 @@ public class ElfDynamicTable implements ElfFileSection {
 	 */
 	public byte[] toBytes(DataConverter dc)
 			throws ArrayIndexOutOfBoundsException {
-		byte[] data = new byte[(int) getLength()];
-		int entrySize = getEntrySize();
+		byte[] data = new byte[(int) getFileSize()];
+		int entrySize = (int) getEntrySize();
 		for (int i = 0; i < dynamics.size(); i++) {
 			ElfDynamic dyn = dynamics.get(i);
 			dyn.write(data, i * entrySize, dc);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicTable.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.*;
 
 import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.StructConverter;
 import ghidra.program.model.data.*;
 import ghidra.util.DataConverter;
 import ghidra.util.exception.DuplicateNameException;
@@ -34,7 +35,7 @@ import ghidra.util.exception.NotFoundException;
  * using {@link ElfHeader#adjustAddressForPrelink(long)}.  If a pre-link adjustment is not applicable, 
  * this adjustment will have no affect.
  */
-public class ElfDynamicTable implements ElfFileSection {
+public class ElfDynamicTable implements StructConverter {
 
 	private List<ElfDynamic> dynamics = new ArrayList<ElfDynamic>();
 
@@ -184,12 +185,10 @@ public class ElfDynamicTable implements ElfFileSection {
 		return getDynamicValue(type.value);
 	}
 
-	@Override
 	public long getFileOffset() {
 		return fileOffset;
 	}
 
-	@Override
 	public long getVirtualAddress() {
 		return addrOffset;
 	}
@@ -239,12 +238,10 @@ public class ElfDynamicTable implements ElfFileSection {
 		return dynamicTagEnum;
 	}
 
-	@Override
 	public long getFileSize() {
 		return dynamics.size() * getEntrySize();
 	}
 
-	@Override
 	public long getEntrySize() {
 		return header.is32Bit() ? 8 : 16;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfDynamicTable.java
@@ -40,20 +40,13 @@ public class ElfDynamicTable implements StructConverter {
 	private List<ElfDynamic> dynamics = new ArrayList<ElfDynamic>();
 
 	private ElfHeader header;
-	private long fileOffset;
-	private long addrOffset;
+	private ElfFileSection fileSection;
 
-	public ElfDynamicTable(BinaryReader reader, ElfHeader header,
-			long fileOffset, long addrOffset) throws IOException {
-
-		long oldptr = reader.getPointerIndex();
-
+	public ElfDynamicTable(ElfHeader header, ElfFileSection fileSection) throws IOException {
 		this.header = header;
-		this.fileOffset = fileOffset;
-		this.addrOffset = addrOffset;
+		this.fileSection = fileSection;
 
-		reader.setPointerIndex(fileOffset);
-
+		BinaryReader reader = fileSection.getReader();
 		// Collect set of all _DYNAMIC array tags specified in .dynamic section
 		while (true) {
 			ElfDynamic dyn = new ElfDynamic(reader, header);
@@ -62,8 +55,6 @@ public class ElfDynamicTable implements StructConverter {
 				break;
 			}
 		}
-
-		reader.setPointerIndex(oldptr);
 	}
 
 	/**
@@ -185,12 +176,8 @@ public class ElfDynamicTable implements StructConverter {
 		return getDynamicValue(type.value);
 	}
 
-	public long getFileOffset() {
-		return fileOffset;
-	}
-
-	public long getVirtualAddress() {
-		return addrOffset;
+	public ElfFileSection getFileSection() {
+		return fileSection;
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
@@ -25,7 +25,7 @@ public interface ElfFileSection extends StructConverter {
 	 * applied, although will not reflect any change in the image base.
 	 * @return default memory address offset where data should be loaded
 	 */
-	public long getAddressOffset();
+	public long getVirtualAddress();
 
 	/**
 	 * Offset within file where section bytes are specified
@@ -37,12 +37,12 @@ public interface ElfFileSection extends StructConverter {
 	 * Length of file section in bytes
 	 * @return length of file section in bytes
 	 */
-	public long getLength();
+	public long getFileSize();
 	
 	/**
 	 * Size of each structured entry in bytes
 	 * @return entry size or -1 if variable
 	 */
-	public int getEntrySize();
+	public long getEntrySize();
 
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
@@ -15,6 +15,8 @@
  */
 package ghidra.app.util.bin.format.elf;
 
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.bin.format.MemoryLoadable;
 
 public interface ElfFileSection extends MemoryLoadable {
@@ -38,11 +40,57 @@ public interface ElfFileSection extends MemoryLoadable {
 	 * @return length of file section in bytes
 	 */
 	public long getFileSize();
-	
+
+	/**
+	 * Length of memory section in bytes
+	 * @return length of memory section in bytes
+	 */
+	default public long getMemorySize() {
+		return getFileSize();
+	}
+
 	/**
 	 * Size of each structured entry in bytes
 	 * @return entry size or -1 if variable
 	 */
 	public long getEntrySize();
 
+	/**
+	 * Binary reader for this file section
+	 * @return Binary reader
+	 */
+	public BinaryReader getReader();
+
+	/**
+	 * Byte provider for this file section
+	 * @return Byte provider
+	 */
+	default public ByteProvider getByteProvider() {
+		return getReader().getByteProvider();
+	}
+
+	/**
+	 * Create a subsection from this file section
+	 * @param offset Offset of subsection from beginning of this file section
+	 * @param size Length of subsection
+	 * @return file subsection
+	 */
+	default public ElfFileSection subSection(long offset, long size) {
+		return subSection(offset, size, getEntrySize());
+	}
+
+	/**
+	 * Create a subsection from this file section
+	 * @param offset Offset of subsection from beginning of this file section
+	 * @param size Length of subsection
+	 * @param entrySize Entry size for this subsection
+	 * @return file subsection
+	 */
+	default public ElfFileSection subSection(long offset, long size, long entrySize) {
+		if (offset == 0 && size == getMemorySize() && entrySize == getEntrySize()) {
+			return this;
+		}
+
+		return new ElfFileSectionWrapper(this, offset, size, entrySize);
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
@@ -51,9 +51,11 @@ public interface ElfFileSection extends MemoryLoadable {
 
 	/**
 	 * Size of each structured entry in bytes
-	 * @return entry size or -1 if variable
+	 * @return entry size or 0 if variable
 	 */
-	public long getEntrySize();
+	default public long getEntrySize() {
+		return 0;
+	}
 
 	/**
 	 * Binary reader for this file section

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSection.java
@@ -15,9 +15,9 @@
  */
 package ghidra.app.util.bin.format.elf;
 
-import ghidra.app.util.bin.StructConverter;
+import ghidra.app.util.bin.format.MemoryLoadable;
 
-public interface ElfFileSection extends StructConverter {
+public interface ElfFileSection extends MemoryLoadable {
 	
 	/**
 	 * Preferred memory address offset where data should be loaded.

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSectionWrapper.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfFileSectionWrapper.java
@@ -1,0 +1,74 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.elf;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.UnlimitedByteProviderWrapper;
+
+public class ElfFileSectionWrapper implements ElfFileSection {
+    private ElfFileSection section;
+    private long subOffset;
+    private long subLength;
+    private long entrySize;
+    private BinaryReader reader;
+
+    public ElfFileSectionWrapper(ElfFileSection section, long subOffset, long subLength) {
+        this(section, subOffset, subLength, section.getEntrySize());
+    }
+
+    public ElfFileSectionWrapper(ElfFileSection section, long subOffset, long subLength,
+            long entrySize) {
+        this.section = section;
+        this.subOffset = subOffset;
+        this.subLength = subLength;
+        this.entrySize = entrySize;
+
+        ByteProvider provider =
+            new UnlimitedByteProviderWrapper(section.getByteProvider(), subOffset, subLength);
+        this.reader = new BinaryReader(provider, section.getReader().isLittleEndian());
+    }
+
+    @Override
+    public long getVirtualAddress() {
+        return section.getVirtualAddress() + subOffset;
+    }
+
+    @Override
+    public long getFileOffset() {
+        return section.getFileOffset() + subOffset;
+    }
+
+    @Override
+    public long getFileSize() {
+        return Math.min(Math.max(section.getFileSize() - subOffset, 0), subLength);
+    }
+
+    @Override
+    public long getMemorySize() {
+        return subLength;
+    }
+
+    @Override
+    public long getEntrySize() {
+        return entrySize;
+    }
+
+    @Override
+    public BinaryReader getReader() {
+        return reader.clone(0);
+    }
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -756,7 +756,7 @@ public class ElfHeader implements StructConverter, Writeable {
 					stringTableSectionHeader.getOffset(), stringTableSectionHeader.getAddress(),
 					stringTableSectionHeader.getSize());
 				stringTableList.add(stringTable);
-				if (stringTable.getAddressOffset() == dynamicStringTableAddr) {
+				if (stringTable.getVirtualAddress() == dynamicStringTableAddr) {
 					dynamicStringTable = stringTable;
 				}
 			}
@@ -900,7 +900,7 @@ public class ElfHeader implements StructConverter, Writeable {
 					symbolTableSectionHeader.getEntrySize(), stringTable, symbolSectionIndexTable,
 					isDyanmic);
 				symbolTableList.add(symbolTable);
-				if (symbolTable.getAddressOffset() == dynamicSymbolTableAddr) {
+				if (symbolTable.getVirtualAddress() == dynamicSymbolTableAddr) {
 					dynamicSymbolTable = symbolTable; // remember dynamic symbol table
 				}
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -1726,7 +1726,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	 */
 	public ElfStringTable getStringTable(ElfSectionHeader section) {
 		for (ElfStringTable stringTable : stringTables) {
-			if (stringTable.getFileSection().getFileOffset() == section.getFileOffset()) {
+			if (stringTable.getFileSection() == section) {
 				return stringTable;
 			}
 		}
@@ -1752,15 +1752,15 @@ public class ElfHeader implements StructConverter, Writeable {
 	/**
 	 * Returns the symbol table associated to the specified section header.
 	 * Or, null if one does not exist.
-	 * @param symbolTableSection symbol table section header
+	 * @param section symbol table section header
 	 * @return the symbol table associated to the specified section header
 	 */
-	public ElfSymbolTable getSymbolTable(ElfSectionHeader symbolTableSection) {
-		if (symbolTableSection == null) {
+	public ElfSymbolTable getSymbolTable(ElfSectionHeader section) {
+		if (section == null) {
 			return null;
 		}
 		for (ElfSymbolTable symbolTable : symbolTables) {
-			if (symbolTable.getFileSection().getFileOffset() == symbolTableSection.getFileOffset()) {
+			if (symbolTable.getFileSection() == section) {
 				return symbolTable;
 			}
 		}
@@ -1778,11 +1778,19 @@ public class ElfHeader implements StructConverter, Writeable {
 	/**
 	 * Returns the relocation table associated to the specified section header,
 	 * or null if one does not exist.
-	 * @param relocSection section header corresponding to relocation table
+	 * @param section section header corresponding to relocation table
 	 * @return the relocation table associated to the specified section header
 	 */
-	public ElfRelocationTable getRelocationTable(ElfSectionHeader relocSection) {
-		return getRelocationTableAtOffset(relocSection.getFileOffset());
+	public ElfRelocationTable getRelocationTable(ElfSectionHeader section) {
+		if (section == null) {
+			return null;
+		}
+		for (ElfRelocationTable relocationTable : relocationTables) {
+			if (relocationTable.getFileSection() == section) {
+				return relocationTable;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -75,9 +75,6 @@ public class ElfHeader implements StructConverter, Writeable {
 
 	private Structure headerStructure;
 
-	private boolean parsed = false;
-	private boolean parsedSectionHeaders = false;
-
 	private Long preLinkImageBase = null;
 	private ElfSectionHeader section0 = null;
 	private ElfSectionHeader[] sectionHeaders = new ElfSectionHeader[0];
@@ -104,30 +101,32 @@ public class ElfHeader implements StructConverter, Writeable {
 	 * @param provider byte provider
 	 * @param errorConsumer error consumer
 	 * @throws ElfException if header parse failed
+	 * @throws IOException if file IO error occurs
 	 */
-	public ElfHeader(ByteProvider provider, Consumer<String> errorConsumer) throws ElfException {
+	public ElfHeader(ByteProvider provider, Consumer<String> errorConsumer) throws ElfException, IOException {
 		this.provider = provider;
 		this.errorConsumer = errorConsumer != null ? errorConsumer : msg -> {
 			/* no logging if errorConsumer was null */
 		};
 		initElfHeader();
-	}
 
-	/**
-	 * Returns the unconstrained binary reader (i.e., reads beyond EOF
-	 * will return 0-bytes).
-	 * @return the binary reader
-	 */
-	public BinaryReader getReader() {
-		return reader;
-	}
+		initElfLoadAdapter();
 
-	/**
-	 * Returns the byte provider
-	 * @return the byte provider
-	 */
-	public ByteProvider getByteProvider() {
-		return provider;
+		parsePreLinkImageBase();
+
+		parseProgramHeaders();
+
+		parseSectionHeaders();
+
+		parseDynamicTable();
+
+		parseStringTables();
+		parseDynamicLibraryNames();
+		parseSymbolTables();
+		parseRelocationTables();
+
+		parseGNU_d();
+		parseGNU_r();
 	}
 
 	void logError(String msg) {
@@ -292,40 +291,6 @@ public class ElfHeader implements StructConverter, Writeable {
 			extensionAdapter.addDynamicTypes(dynamicTypeMap);
 			elfLoadAdapter = extensionAdapter;
 		}
-	}
-
-	/**
-	 * Perform parse of all supported headers.
-	 * @throws IOException if file IO error occurs
-	 */
-	public void parse() throws IOException {
-
-		if (reader == null) {
-			throw new IOException("ELF binary reader is null!");
-		}
-		if (parsed) {
-			return;
-		}
-
-		initElfLoadAdapter();
-
-		parsed = true;
-
-		parsePreLinkImageBase();
-
-		parseProgramHeaders();
-
-		parseSectionHeaders();
-
-		parseDynamicTable();
-
-		parseStringTables();
-		parseDynamicLibraryNames();
-		parseSymbolTables();
-		parseRelocationTables();
-
-		parseGNU_d();
-		parseGNU_r();
 	}
 
 	/**
@@ -1078,14 +1043,6 @@ public class ElfHeader implements StructConverter, Writeable {
 
 	protected void parseSectionHeaders()
 			throws IOException {
-		if (reader == null) {
-			throw new IOException("ELF binary reader is null!");
-		}
-		if (parsedSectionHeaders) {
-			return;
-		}
-
-		parsedSectionHeaders = true;
 		boolean missing = false;
 		sectionHeaders = new ElfSectionHeader[e_shnum];
 		for (int i = 0; i < e_shnum; ++i) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -2070,14 +2070,14 @@ public class ElfHeader implements StructConverter, Writeable {
 			throw new IOException(
 				"Unsupported program header count serialization: " + e_phnum);
 		}
-		raf.write(dc.getBytes(e_phnum));
+		raf.write(dc.getBytes((short) e_phnum));
 		raf.write(dc.getBytes(e_shentsize));
 		if (e_shnum >= Short.toUnsignedInt(ElfSectionHeaderConstants.SHN_LORESERVE)) {
 			throw new IOException(
 				"Unsupported section header count serialization: " + e_shnum);
 		}
-		raf.write(dc.getBytes(e_shnum));
-		raf.write(dc.getBytes(e_shstrndx));
+		raf.write(dc.getBytes((short) e_shnum));
+		raf.write(dc.getBytes((short) e_shstrndx));
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -236,7 +236,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	private int readExtendedProgramHeaderCount() throws IOException {
 		ElfSectionHeader s = getSection0();
 		if (s != null && s.getType() == ElfSectionHeaderConstants.SHT_NULL) {
-			int val = s.getInfo();
+			int val = s.sh_info;
 			return val < 0 ? 0 : val;
 		}
 		return 0;
@@ -252,7 +252,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	private int readExtendedSectionHeaderCount() throws IOException {
 		ElfSectionHeader s = getSection0();
 		if (s != null && s.getType() == ElfSectionHeaderConstants.SHT_NULL) {
-			long val = s.getSize();
+			long val = s.sh_size;
 			return (val < 0 || val > Integer.MAX_VALUE) ? 0 : (int) val;
 		}
 		return 0;
@@ -268,7 +268,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	private int readExtendedSectionHeaderStringTableIndex() throws IOException {
 		ElfSectionHeader s = getSection0();
 		if (s != null && s.getType() == ElfSectionHeaderConstants.SHT_NULL) {
-			int val = s.getLink();
+			int val = s.sh_link;
 			return val < 0 ? 0 : val;
 		}
 		return 0;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -682,7 +682,7 @@ public class ElfHeader implements StructConverter, Writeable {
 			if (dynamicStringTable != null) {
 				try {
 					dynamicLibraryNames[i] =
-						dynamicStringTable.readString(reader, needed[i].getValue());
+						dynamicStringTable.readString(needed[i].getValue());
 				}
 				catch (Exception e) {
 					// ignore
@@ -743,11 +743,9 @@ public class ElfHeader implements StructConverter, Writeable {
 		ArrayList<ElfStringTable> stringTableList = new ArrayList<>();
 		for (ElfSectionHeader stringTableSectionHeader : sectionHeaders) {
 			if (stringTableSectionHeader.getType() == ElfSectionHeaderConstants.SHT_STRTAB) {
-				ElfStringTable stringTable = new ElfStringTable(this, stringTableSectionHeader,
-					stringTableSectionHeader.getFileOffset(), stringTableSectionHeader.getVirtualAddress(),
-					stringTableSectionHeader.getFileSize());
+				ElfStringTable stringTable = new ElfStringTable(this, stringTableSectionHeader);
 				stringTableList.add(stringTable);
-				if (stringTable.getVirtualAddress() == dynamicStringTableAddr) {
+				if (stringTableSectionHeader.getVirtualAddress() == dynamicStringTableAddr) {
 					dynamicStringTable = stringTable;
 				}
 			}
@@ -788,9 +786,8 @@ public class ElfHeader implements StructConverter, Writeable {
 				return null;
 			}
 
-			return new ElfStringTable(this, null,
-				stringTableLoadHeader.getOffset(dynamicStringTableAddr), dynamicStringTableAddr,
-				stringTableSize);
+			ElfFileSection fileSection = stringTableLoadHeader.subSection(dynamicStringTableAddr - stringTableLoadHeader.getVirtualAddress(), stringTableSize);
+			return new ElfStringTable(this, fileSection);
 		}
 		catch (NotFoundException e) {
 			throw new AssertException(e);
@@ -1790,7 +1787,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	 */
 	public ElfStringTable getStringTable(ElfSectionHeader section) {
 		for (ElfStringTable stringTable : stringTables) {
-			if (stringTable.getFileOffset() == section.getFileOffset()) {
+			if (stringTable.getFileSection().getFileOffset() == section.getFileOffset()) {
 				return stringTable;
 			}
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -708,7 +708,7 @@ public class ElfHeader implements StructConverter, Writeable {
 
 			ElfProgramHeader loadHeader = getProgramLoadHeaderContaining(vaddr);
 			if (loadHeader != null) {
-				long dynamicTableOffset = loadHeader.getOffset() +
+				long dynamicTableOffset = loadHeader.getFileOffset() +
 					(dynamicHeaders[0].getVirtualAddress() - loadHeader.getVirtualAddress());
 				dynamicTable = new ElfDynamicTable(reader, this, dynamicTableOffset,
 					dynamicHeaders[0].getVirtualAddress());
@@ -725,7 +725,7 @@ public class ElfHeader implements StructConverter, Writeable {
 			ElfProgramHeader loadHeader =
 				getProgramLoadHeaderContaining(dynamicSections[0].getAddress());
 			if (loadHeader != null) {
-				long dynamicTableOffset = loadHeader.getOffset() +
+				long dynamicTableOffset = loadHeader.getFileOffset() +
 					(dynamicSections[0].getAddress() - loadHeader.getVirtualAddress());
 				dynamicTable = new ElfDynamicTable(reader, this, dynamicTableOffset,
 					dynamicSections[0].getAddress());
@@ -1758,7 +1758,7 @@ public class ElfHeader implements StructConverter, Writeable {
 				programHeader.isInvalidOffset()) {
 				continue;
 			}
-			long start = programHeader.getOffset();
+			long start = programHeader.getFileOffset();
 			long end = start + (programHeader.getFileSize() - 1);
 			if (offset >= start && offset <= end) {
 				return programHeader;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -491,7 +491,7 @@ public class ElfHeader implements StructConverter, Writeable {
 				sectionHeaderType == ElfSectionHeaderConstants.SHT_ANDROID_RELR) {
 
 				for (ElfRelocationTable relocTable : relocationTableList) {
-					if (relocTable.getFileOffset() == section.getFileOffset()) {
+					if (relocTable.getFileSection().getFileOffset() == section.getFileOffset()) {
 						return; // skip reloc table previously parsed as dynamic entry
 					}
 				}
@@ -544,10 +544,8 @@ public class ElfHeader implements StructConverter, Writeable {
 					format = TableFormat.RELR;
 				}
 
-				ElfRelocationTable relocTable = new ElfRelocationTable(reader,
-					this, section, section.getFileOffset(), section.getVirtualAddress(), section.getFileSize(),
-					section.getEntrySize(), addendTypeReloc, symbolTable, sectionToBeRelocated,
-					format);
+				ElfRelocationTable relocTable = new ElfRelocationTable(this, section,
+					addendTypeReloc, symbolTable, sectionToBeRelocated, format);
 
 				relocationTableList.add(relocTable);
 			}
@@ -618,7 +616,7 @@ public class ElfHeader implements StructConverter, Writeable {
 
 			long relocTableOffset = relocTableLoadHeader.getOffset(relocTableAddr);
 			for (ElfRelocationTable relocTable : relocationTableList) {
-				if (relocTable.getFileOffset() == relocTableOffset) {
+				if (relocTable.getFileSection().getFileOffset() == relocTableOffset) {
 					return; // skip reloc table previously parsed
 				}
 			}
@@ -636,8 +634,8 @@ public class ElfHeader implements StructConverter, Writeable {
 				format = TableFormat.RELR;
 			}
 
-			ElfRelocationTable relocTable = new ElfRelocationTable(reader,
-				this, null, relocTableOffset, relocTableAddr, tableSize, tableEntrySize,
+			ElfFileSection fileSection = relocTableLoadHeader.subSection(relocTableAddr - relocTableLoadHeader.getVirtualAddress(), tableSize, tableEntrySize);
+			ElfRelocationTable relocTable = new ElfRelocationTable(this, fileSection,
 				addendTypeReloc, dynamicSymbolTable, null, format);
 			relocationTableList.add(relocTable);
 		}
@@ -1847,7 +1845,7 @@ public class ElfHeader implements StructConverter, Writeable {
 	 */
 	public ElfRelocationTable getRelocationTableAtOffset(long fileOffset) {
 		for (ElfRelocationTable relocationTable : relocationTables) {
-			if (relocationTable.getFileOffset() == fileOffset) {
+			if (relocationTable.getFileSection().getFileOffset() == fileOffset) {
 				return relocationTable;
 			}
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfProgramHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfProgramHeader.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 
 import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.ByteProviderWrapper;
 import ghidra.app.util.bin.StructConverter;
-import ghidra.app.util.bin.format.MemoryLoadable;
+import ghidra.app.util.bin.UnlimitedByteProviderWrapper;
 import ghidra.app.util.bin.format.Writeable;
 import ghidra.program.model.data.*;
 import ghidra.util.DataConverter;
@@ -66,7 +68,7 @@ import ghidra.util.StringUtilities;
  * </pre>
  */
 public class ElfProgramHeader
-		implements StructConverter, Comparable<ElfProgramHeader>, Writeable, MemoryLoadable {
+		implements ElfFileSection, StructConverter, Comparable<ElfProgramHeader>, Writeable {
 
 	protected ElfHeader header;
 
@@ -84,7 +86,6 @@ public class ElfProgramHeader
 	public ElfProgramHeader(BinaryReader reader, ElfHeader header)
 			throws IOException {
 		this.header = header;
-		this.reader = reader;
 
 		if (header.is32Bit()) {
 			p_type = reader.readNextInt();
@@ -107,14 +108,22 @@ public class ElfProgramHeader
 			p_align = reader.readNextLong();
 		}
 
-		if (p_memsz > p_filesz) {
-			//This case occurs when the data segment has both
-			//initialized and uninitialized sections.
-			//For example, the data program header may be comprised
-			//of ".data", ".dynamic", ".ctors", ".dtors", ".jcr", 
-			//and ".bss".
-			//TODO Err.warn(this, "Program Header: extra bytes");
+		ByteProvider provider;
+		if (p_type == ElfProgramHeaderConstants.PT_NULL) {
+			provider = ByteProvider.EMPTY_BYTEPROVIDER;
 		}
+		else {
+			provider = new UnlimitedByteProviderWrapper(reader.getByteProvider(), p_offset, p_filesz);
+			if (p_memsz > p_filesz) {
+				//This case occurs when the data segment has both
+				//initialized and uninitialized sections.
+				//For example, the data program header may be comprised
+				//of ".data", ".dynamic", ".ctors", ".dtors", ".jcr",
+				//and ".bss".
+				provider = new UnlimitedByteProviderWrapper(provider, 0, p_memsz);
+			}
+		}
+		this.reader = new BinaryReader(provider, reader.isLittleEndian());
 	}
 
 	/**
@@ -312,7 +321,7 @@ public class ElfProgramHeader
 	 * the first byte of the segment resides.
 	 * @return the offset from the beginning of the file
 	 */
-	public long getOffset() {
+	public long getFileOffset() {
 		return p_offset;
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocation.java
@@ -98,7 +98,7 @@ public class ElfRelocation implements ByteArrayConverter, StructConverter {
 	 * @return ELF relocation object
 	 * @throws IOException if an IO or parse error occurs
 	 */
-	static ElfRelocation createElfRelocation(BinaryReader reader,
+	public static ElfRelocation createElfRelocation(BinaryReader reader,
 			ElfHeader elfHeader, int relocationIndex, boolean withAddend) throws IOException {
 		Class<? extends ElfRelocation> elfRelocationClazz = getElfRelocationClass(elfHeader);
 		ElfRelocation elfRelocation = getInstance(elfRelocationClazz);
@@ -118,7 +118,7 @@ public class ElfRelocation implements ByteArrayConverter, StructConverter {
 	 * @return ELF relocation object
 	 * @throws IOException if an IO or parse error occurs
 	 */
-	static ElfRelocation createElfRelocation(ElfHeader elfHeader,
+	public static ElfRelocation createElfRelocation(ElfHeader elfHeader,
 			int relocationIndex, boolean withAddend, long r_offset, long r_info, long r_addend)
 			throws IOException {
 		Class<? extends ElfRelocation> elfRelocationClazz = getElfRelocationClass(elfHeader);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocation.java
@@ -376,10 +376,16 @@ public class ElfRelocation implements ByteArrayConverter, StructConverter {
 		if (is32bit) {
 			dc.putInt(bytes, 0, (int) r_offset);
 			dc.putInt(bytes, 4, (int) r_info);
+			if (hasAddend) {
+				dc.putInt(bytes, 8, (int) r_addend);
+			}
 		}
 		else {
 			dc.putLong(bytes, 0, r_offset);
 			dc.putLong(bytes, 8, r_info);
+			if (hasAddend) {
+				dc.putLong(bytes, 16, r_addend);
+			}
 		}
 		return bytes;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocationTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocationTable.java
@@ -253,6 +253,13 @@ public class ElfRelocationTable implements ByteArrayConverter, StructConverter {
 		return relocations;
 	}
 
+	public void addRelocation(ElfRelocation relocation) {
+		ElfRelocation[] tmp = new ElfRelocation[relocs.length + 1];
+		System.arraycopy(relocs, 0, tmp, 0, relocs.length);
+		tmp[tmp.length - 1] = relocation;
+		relocs = tmp;
+	}
+
 	/**
 	 * @return true if has addend relocations, otherwise addend extraction from
 	 * relocation target may be required

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocationTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocationTable.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteArrayConverter;
+import ghidra.app.util.bin.StructConverter;
 import ghidra.app.util.bin.format.dwarf4.LEB128;
 import ghidra.program.model.data.ArrayDataType;
 import ghidra.program.model.data.DataType;
@@ -30,7 +31,7 @@ import ghidra.util.Msg;
 /**
  * A container class to hold ELF relocations.
  */
-public class ElfRelocationTable implements ElfFileSection, ByteArrayConverter {
+public class ElfRelocationTable implements ByteArrayConverter, StructConverter {
 
 	public enum TableFormat {
 		DEFAULT, ANDROID, RELR;
@@ -323,12 +324,10 @@ public class ElfRelocationTable implements ElfFileSection, ByteArrayConverter {
 		return bytes;
 	}
 
-	@Override
 	public long getFileSize() {
 		return length;
 	}
 
-	@Override
 	public long getVirtualAddress() {
 		return addrOffset;
 	}
@@ -346,12 +345,10 @@ public class ElfRelocationTable implements ElfFileSection, ByteArrayConverter {
 		return format == TableFormat.RELR;
 	}
 
-	@Override
 	public long getFileOffset() {
 		return fileOffset;
 	}
 
-	@Override
 	public long getEntrySize() {
 		return entrySize;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocationTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfRelocationTable.java
@@ -324,12 +324,12 @@ public class ElfRelocationTable implements ElfFileSection, ByteArrayConverter {
 	}
 
 	@Override
-	public long getLength() {
+	public long getFileSize() {
 		return length;
 	}
 
 	@Override
-	public long getAddressOffset() {
+	public long getVirtualAddress() {
 		return addrOffset;
 	}
 
@@ -352,8 +352,8 @@ public class ElfRelocationTable implements ElfFileSection, ByteArrayConverter {
 	}
 
 	@Override
-	public int getEntrySize() {
-		return (int) entrySize;
+	public long getEntrySize() {
+		return entrySize;
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeader.java
@@ -190,6 +190,20 @@ public class ElfSectionHeader implements ElfFileSection, StructConverter, Writea
 		sh_offset = -1;
 	}
 
+	ElfSectionHeader(ElfHeader header, String name, int type, long flags, int link, int info,
+			long addressAlignment, long entrySize, ByteProvider data) {
+		this.sh_type = type;
+		this.sh_flags = flags;
+		this.sh_link = link;
+		this.sh_info = info;
+		this.sh_addralign = addressAlignment;
+		this.sh_entsize = entrySize;
+
+		this.header = header;
+		this.name = name;
+		this.reader = new BinaryReader(data, header.isLittleEndian());
+	}
+
 	/**
 	 * Return ElfHeader associated with this section
 	 * @return ElfHeader

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSectionHeader.java
@@ -72,16 +72,16 @@ import ghidra.util.StringUtilities;
 
 public class ElfSectionHeader implements StructConverter, Writeable, MemoryLoadable {
 
-	private int sh_name;
-	private int sh_type;
-	private long sh_flags;
-	private long sh_addr;
-	private long sh_offset;
-	private long sh_size;
-	private int sh_link;
-	private int sh_info;
-	private long sh_addralign;
-	private long sh_entsize;
+	int sh_name;
+	int sh_type;
+	long sh_flags;
+	long sh_addr;
+	long sh_offset;
+	long sh_size;
+	int sh_link;
+	int sh_info;
+	long sh_addralign;
+	long sh_entsize;
 
 	private BinaryReader reader;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfStringTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfStringTable.java
@@ -18,10 +18,11 @@ package ghidra.app.util.bin.format.elf;
 import java.io.IOException;
 
 import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.StructConverter;
 import ghidra.program.model.data.DataType;
 import ghidra.util.exception.DuplicateNameException;
 
-public class ElfStringTable implements ElfFileSection {
+public class ElfStringTable implements StructConverter {
 
 	private ElfHeader header;
 
@@ -71,7 +72,6 @@ public class ElfStringTable implements ElfFileSection {
 		return null;
 	}
 
-	@Override
 	public long getVirtualAddress() {
 		return header.adjustAddressForPrelink(addrOffset);
 	}
@@ -85,17 +85,14 @@ public class ElfStringTable implements ElfFileSection {
 		return stringTableSection;
 	}
 
-	@Override
 	public long getFileOffset() {
 		return fileOffset;
 	}
 
-	@Override
 	public long getFileSize() {
 		return length;
 	}
 
-	@Override
 	public long getEntrySize() {
 		return -1;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfStringTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfStringTable.java
@@ -72,7 +72,7 @@ public class ElfStringTable implements ElfFileSection {
 	}
 
 	@Override
-	public long getAddressOffset() {
+	public long getVirtualAddress() {
 		return header.adjustAddressForPrelink(addrOffset);
 	}
 
@@ -91,12 +91,12 @@ public class ElfStringTable implements ElfFileSection {
 	}
 
 	@Override
-	public long getLength() {
+	public long getFileSize() {
 		return length;
 	}
 
 	@Override
-	public int getEntrySize() {
+	public long getEntrySize() {
 		return -1;
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfStringTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfStringTable.java
@@ -16,8 +16,11 @@
 package ghidra.app.util.bin.format.elf;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.MutableByteProvider;
 import ghidra.app.util.bin.StructConverter;
 import ghidra.program.model.data.DataType;
 import ghidra.util.exception.DuplicateNameException;
@@ -58,6 +61,24 @@ public class ElfStringTable implements StructConverter {
 					" within String Table at offset 0x" + Long.toHexString(fileSection.getFileOffset()));
 		}
 		return null;
+	}
+
+	/**
+	 * Append a string at the end of the string table
+	 * @param str String to append
+	 * @return index of string
+	 */
+	public int add(String str) throws IOException {
+		ByteProvider byteProvider = reader.getByteProvider();
+		if (!(byteProvider instanceof MutableByteProvider)) {
+			throw new IOException("Backing byte provider isn't mutable");
+		}
+
+		MutableByteProvider mutableByteProvider = (MutableByteProvider) byteProvider;
+		int strIndex = (int) mutableByteProvider.length();
+		mutableByteProvider.writeBytes(strIndex, StandardCharsets.UTF_8.encode(str + '\0').array());
+
+		return strIndex;
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbol.java
@@ -232,7 +232,7 @@ public class ElfSymbol implements ByteArrayConverter {
 	 */
 	public void initSymbolName(BinaryReader reader, ElfStringTable stringTable) {
 		if (nameAsString == null && stringTable != null) {
-			nameAsString = stringTable.readString(reader, st_name);
+			nameAsString = stringTable.readString(st_name);
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbol.java
@@ -148,6 +148,48 @@ public class ElfSymbol implements ByteArrayConverter {
 		return new ElfSymbol(header, "", 0, 0, 0, (byte) 0, (byte) 0, (short) 0, 0, null);
 	}
 
+	/**
+	 * Creates a new defined symbol, related to a section.
+	 * @param header the corresponding ELF header
+	 * @param symbolTable the symbol table
+	 * @param nameAsString name of the symbol
+	 * @param name index of the symbol's name in the string table
+	 * @param value value of this symbol
+	 * @param size size of this symbol
+	 * @param type type of this symbol
+	 * @param binding binding for this symbol
+	 * @param visibility visibility for this symbol
+	 * @param sectionHeaderIndex index of the section header that contains this symbol
+	 * @param symbolIndex index of this symbol in the symbol table
+	 * @return created symbol
+	 */
+	public static ElfSymbol createDefinedSymbol(ElfHeader header, ElfSymbolTable symbolTable,
+			String nameAsString, int name, long value, long size, byte type, byte binding,
+			byte visibility, short sectionHeaderIndex, int symbolIndex) {
+		byte info = (byte) (type | (binding << 4));
+		byte other = visibility;
+
+		return new ElfSymbol(header, nameAsString, name, value, size, info, other,
+			sectionHeaderIndex, symbolIndex, symbolTable);
+	}
+
+	/**
+	 * Creates a new undefined symbol
+	 * @param header the corresponding ELF header
+	 * @param symbolTable the symbol table
+	 * @param nameAsString name of the symbol
+	 * @param name index of the symbol's name in the string table
+	 * @param symbolIndex index of this symbol in the symbol table
+	 * @return created symbol
+	 */
+	public static ElfSymbol createUndefinedSymbol(ElfHeader header, ElfSymbolTable symbolTable,
+			String nameAsString, int name, int symbolIndex) {
+		byte info = (byte) (STT_NOTYPE | (STB_GLOBAL << 4));
+
+		return new ElfSymbol(header, nameAsString, name, 0, 0, info, STV_DEFAULT, (short) 0,
+			symbolIndex, symbolTable);
+	}
+
 	private ElfSymbol(ElfHeader header, String nameAsString, int name, long value, long size,
 			byte info, byte other, short sectionHeaderIndex, int symbolIndex,
 			ElfSymbolTable symbolTable) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbolTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbolTable.java
@@ -294,12 +294,12 @@ public class ElfSymbolTable implements ElfFileSection, ByteArrayConverter {
 	}
 
 	@Override
-	public long getLength() {
+	public long getFileSize() {
 		return length;
 	}
 
 	@Override
-	public long getAddressOffset() {
+	public long getVirtualAddress() {
 		return addrOffset;
 	}
 
@@ -318,8 +318,8 @@ public class ElfSymbolTable implements ElfFileSection, ByteArrayConverter {
 	}
 
 	@Override
-	public int getEntrySize() {
-		return (int) entrySize;
+	public long getEntrySize() {
+		return entrySize;
 	}
 
 // Comments are repetitive - should refer to Elf documentation 
@@ -349,7 +349,7 @@ public class ElfSymbolTable implements ElfFileSection, ByteArrayConverter {
 			struct.add(QWORD, "st_value", null);
 			struct.add(QWORD, "st_size", null);
 		}
-		int sizeRemaining = getEntrySize() - struct.getLength();
+		int sizeRemaining = (int) getEntrySize() - struct.getLength();
 		if (sizeRemaining > 0) {
 			struct.add(new ArrayDataType(ByteDataType.dataType, sizeRemaining, 1), "st_unknown",
 				null);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbolTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbolTable.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteArrayConverter;
+import ghidra.app.util.bin.StructConverter;
 import ghidra.program.model.data.*;
 import ghidra.util.DataConverter;
 import ghidra.util.exception.DuplicateNameException;
@@ -29,7 +30,7 @@ import ghidra.util.exception.DuplicateNameException;
 /**
  * A container class to hold ELF symbols.
  */
-public class ElfSymbolTable implements ElfFileSection, ByteArrayConverter {
+public class ElfSymbolTable implements ByteArrayConverter, StructConverter {
 
 	private ElfStringTable stringTable;
 	private ElfSectionHeader symbolTableSection; // may be null
@@ -293,12 +294,10 @@ public class ElfSymbolTable implements ElfFileSection, ByteArrayConverter {
 		return bytes;
 	}
 
-	@Override
 	public long getFileSize() {
 		return length;
 	}
 
-	@Override
 	public long getVirtualAddress() {
 		return addrOffset;
 	}
@@ -312,12 +311,10 @@ public class ElfSymbolTable implements ElfFileSection, ByteArrayConverter {
 		return symbolTableSection;
 	}
 
-	@Override
 	public long getFileOffset() {
 		return fileOffset;
 	}
 
-	@Override
 	public long getEntrySize() {
 		return entrySize;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/extend/ElfLoadAdapter.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/extend/ElfLoadAdapter.java
@@ -216,7 +216,7 @@ public class ElfLoadAdapter {
 
 		AddressSpace space = getPreferredSectionAddressSpace(elfLoadHelper, elfSectionHeader);
 
-		long addrWordOffset = elfSectionHeader.getAddress();
+		long addrWordOffset = elfSectionHeader.getVirtualAddress();
 
 		if (space == program.getAddressFactory().getDefaultAddressSpace()) {
 			addrWordOffset += elfLoadHelper.getImageBaseWordAdjustmentOffset();
@@ -469,7 +469,7 @@ public class ElfLoadAdapter {
 	 * @return preferred memory block size in bytes which corresponds to the specified section header
 	 */
 	public long getAdjustedSize(ElfSectionHeader section) {
-		return section.getSize();
+		return section.getFileSize();
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfDataType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfDataType.java
@@ -56,7 +56,6 @@ public class ElfDataType extends FactoryStructureDataType {
 	        ByteArrayProvider bap = new ByteArrayProvider(bytes);
 
 			ElfHeader elf = new ElfHeader(bap, null);
-			elf.parse();
 
 	        struct.add(elf.toDataType());
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoader.java
@@ -143,8 +143,7 @@ public class ElfLoader extends AbstractLibrarySupportLoader {
 			throws IOException, CancelledException {
 
 		try {
-			ElfHeader elf = new ElfHeader(provider, msg -> log.appendMsg(msg));
-			ElfProgramBuilder.loadElf(elf, program, options, log, monitor);
+			ElfProgramBuilder.loadElf(provider, program, options, log, monitor);
 		}
 		catch (ElfException e) {
 			throw new IOException(e.getMessage());

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
@@ -61,7 +61,7 @@ public class ElfLoaderOptionsFactory {
 
 		ElfHeader elf = new ElfHeader(provider, null);
 
-		long imageBase = elf.findImageBase();
+		long imageBase = elf.getImageBase();
 		if (imageBase == 0 && (elf.isRelocatable() || elf.isSharedObject())) {
 			imageBase = elf.is64Bit() ? IMAGE64_BASE_DEFAULT : IMAGE_BASE_DEFAULT;
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfLoaderOptionsFactory.java
@@ -15,6 +15,7 @@
  */
 package ghidra.app.util.opinion;
 
+import java.io.IOException;
 import java.util.List;
 
 import ghidra.app.util.Option;
@@ -51,7 +52,7 @@ public class ElfLoaderOptionsFactory {
 	}
 
 	static void addOptions(List<Option> options, ByteProvider provider, LoadSpec loadSpec)
-			throws ElfException, LanguageNotFoundException {
+			throws ElfException, IOException {
 
 		// NOTE: add-to-program is not supported
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
@@ -910,7 +910,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 			Address sectionLoadAddr = findLoadAddress(sectionToBeRelocated, 0);
 			if (sectionLoadAddr == null) {
 				log("Failed to identify relocation base address for relocation table 0x" +
-					relocationTable.getAddressOffset() + " [section: " +
+					relocationTable.getVirtualAddress() + " [section: " +
 					sectionToBeRelocated.getNameAsString() + "]");
 				monitor.incrementProgress(relocationTable.getRelocationCount());
 				return;
@@ -1527,7 +1527,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 			}
 			else {
 				symbolTableAddr =
-					findLoadAddress(elfSymbolTable.getFileOffset(), elfSymbolTable.getLength());
+					findLoadAddress(elfSymbolTable.getFileOffset(), elfSymbolTable.getFileSize());
 			}
 
 			ElfSymbol[] symbols = elfSymbolTable.getSymbols();
@@ -2687,7 +2687,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 
 		long totalLength = 0;
 		for (ElfStringTable stringTable : stringTables) {
-			totalLength += stringTable.getLength();
+			totalLength += stringTable.getFileSize();
 		}
 		monitor.initialize(totalLength);
 
@@ -2706,17 +2706,17 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 			if (stringTableAddr == null) {
 //				log("Failed to locate string table at file offset 0x" +
 //					Long.toHexString(stringTable.getFileOffset()));
-				monitor.incrementProgress(stringTable.getLength()); // skipping table
+				monitor.incrementProgress(stringTable.getFileSize()); // skipping table
 				continue;
 			}
 
 			AddressRange rangeConstraint = getMarkupMemoryRangeConstraint(stringTableAddr);
 			if (rangeConstraint == null) {
-				monitor.incrementProgress(stringTable.getLength()); // skipping table
+				monitor.incrementProgress(stringTable.getFileSize()); // skipping table
 				continue;
 			}
 
-			long tblLength = stringTable.getLength();
+			long tblLength = stringTable.getFileSize();
 			long limit = Math.min(tblLength, rangeConstraint.getLength());
 			if (limit < tblLength) {
 				monitor.incrementProgress(tblLength - limit);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
@@ -2588,10 +2588,10 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 				return;
 			}
 
-			dynamicTableAddress = findLoadAddress(dynamicTable.getFileOffset(), 1);
+			dynamicTableAddress = findLoadAddress(dynamicTable.getFileSection().getFileOffset(), 1);
 			if (dynamicTableAddress == null) {
 				log("Failed to locate dynamic table at file offset 0x" +
-					Long.toHexString(dynamicTable.getFileOffset()));
+					Long.toHexString(dynamicTable.getFileSection().getFileOffset()));
 				return;
 			}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
@@ -882,12 +882,12 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 
 		Address relocTableAddr = null;
 
-		ElfSectionHeader section = relocationTable.getTableSectionHeader();
-		if (section != null) {
+		ElfFileSection section = relocationTable.getFileSection();
+		if (section instanceof ElfSectionHeader) {
 			relocTableAddr = findLoadAddress(section, 0);
 		}
 		else {
-			relocTableAddr = findLoadAddress(relocationTable.getFileOffset(), 1);
+			relocTableAddr = findLoadAddress(section.getFileOffset(), 1);
 		}
 
 		/**
@@ -910,7 +910,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 			Address sectionLoadAddr = findLoadAddress(sectionToBeRelocated, 0);
 			if (sectionLoadAddr == null) {
 				log("Failed to identify relocation base address for relocation table 0x" +
-					relocationTable.getVirtualAddress() + " [section: " +
+					relocationTable.getFileSection().getVirtualAddress() + " [section: " +
 					sectionToBeRelocated.getNameAsString() + "]");
 				monitor.incrementProgress(relocationTable.getRelocationCount());
 				return;
@@ -945,9 +945,10 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 
 		boolean unableToApplyRelocs = relocationTable.isMissingRequiredSymbolTable();
 		if (unableToApplyRelocs) {
-			ElfSectionHeader tableSectionHeader = relocationTable.getTableSectionHeader();
-			String relocTableName =
-				tableSectionHeader != null ? tableSectionHeader.getNameAsString() : "dynamic";
+			ElfFileSection tableSectionHeader = relocationTable.getFileSection();
+			String relocTableName = tableSectionHeader instanceof ElfSectionHeader
+				? ((ElfSectionHeader) tableSectionHeader).getNameAsString()
+				: "dynamic";
 			ElfSectionHeader sectionToBeRelocated = relocationTable.getSectionToBeRelocated();
 			String relocaBaseName =
 				sectionToBeRelocated != null ? sectionToBeRelocated.getNameAsString() : "PT_LOAD";

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
@@ -233,7 +233,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 				segment.isInvalidOffset() || size <= 0) {
 				continue;
 			}
-			long offset = segment.getOffset();
+			long offset = segment.getFileOffset();
 			fileMap.paintRange(offset, offset + size - 1, -2); // -2: used by segment
 		}
 
@@ -794,12 +794,12 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 		ElfProgramHeader[] interpProgramHeaders =
 			elf.getProgramHeaders(ElfProgramHeaderConstants.PT_INTERP);
 		if (interpProgramHeaders.length != 0) {
-			long offset = interpProgramHeaders[0].getOffset();
+			long offset = interpProgramHeaders[0].getFileOffset();
 			if (offset == 0) {
 				log("ELF PT_INTERP appears to have been stripped from binary");
 				return;
 			}
-			interpStrAddr = findLoadAddress(interpProgramHeaders[0].getOffset(), 1);
+			interpStrAddr = findLoadAddress(interpProgramHeaders[0].getFileOffset(), 1);
 		}
 
 		if (interpStrAddr == null) {
@@ -1185,7 +1185,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 				if (programHeaders[i].getType() == ElfProgramHeaderConstants.PT_NULL) {
 					continue;
 				}
-				if (programHeaders[i].getOffset() == 0) {
+				if (programHeaders[i].getFileOffset() == 0) {
 					continue; // has been stripped
 				}
 				Address segmentAddr = findLoadAddress(programHeaders[i], 0);
@@ -2951,10 +2951,10 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 				segment.isInvalidOffset()) {
 				continue;
 			}
-			long startOffset = segment.getOffset();
+			long startOffset = segment.getFileOffset();
 			long endOffset = startOffset + segment.getFileSize() - 1;
 			if (fileOffset >= startOffset && headerEndOffset <= endOffset) {
-				headerAddr = findLoadAddress(segment, fileOffset - segment.getOffset());
+				headerAddr = findLoadAddress(segment, fileOffset - segment.getFileOffset());
 				if (headerAddr != null && segment.getType() == ElfProgramHeaderConstants.PT_LOAD) {
 					return headerAddr;
 				}
@@ -3104,7 +3104,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 			if (elfProgramHeader.getType() == ElfProgramHeaderConstants.PT_NULL) {
 				continue;
 			}
-			long fileOffset = elfProgramHeader.getOffset();
+			long fileOffset = elfProgramHeader.getFileOffset();
 			if (elfProgramHeader.getType() != ElfProgramHeaderConstants.PT_LOAD) {
 				if (!includeOtherBlocks) {
 					continue;
@@ -3189,7 +3189,7 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 
 			String blockName = getSegmentName(elfProgramHeader, segmentNumber);
 			if (loadSizeBytes != 0) {
-				addInitializedMemorySection(elfProgramHeader, elfProgramHeader.getOffset(),
+				addInitializedMemorySection(elfProgramHeader, elfProgramHeader.getFileOffset(),
 					loadSizeBytes, address, blockName, elfProgramHeader.isRead(),
 					elfProgramHeader.isWrite(),
 					maintainExecuteBit ? elfProgramHeader.isExecute() : false, comment,

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java
@@ -1521,13 +1521,13 @@ class ElfProgramBuilder extends MemorySectionResolver implements ElfLoadHelper {
 
 			Address symbolTableAddr = null;
 
-			ElfSectionHeader symbolTableSection = elfSymbolTable.getTableSectionHeader();
-			if (symbolTableSection != null) {
-				symbolTableAddr = findLoadAddress(symbolTableSection, 0);
+			ElfFileSection section = elfSymbolTable.getFileSection();
+			if (section instanceof ElfSectionHeader) {
+				symbolTableAddr = findLoadAddress(section, 0);
 			}
 			else {
 				symbolTableAddr =
-					findLoadAddress(elfSymbolTable.getFileOffset(), elfSymbolTable.getFileSize());
+					findLoadAddress(section.getFileOffset(), section.getFileSize());
 			}
 
 			ElfSymbol[] symbols = elfSymbolTable.getSymbols();

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/android/oat/OatFileSystem.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/android/oat/OatFileSystem.java
@@ -104,11 +104,11 @@ public class OatFileSystem extends GFileSystemBase {
 			if (roDataSection == null) {
 				throw new IOException("rodata section does not exist.");
 			}
-			baseOffset = roDataSection.getOffset();
+			baseOffset = roDataSection.getFileOffset();
 
 			monitor.setMessage("Parsing OAT header...");
 			ByteProviderWrapper wrapper =
-				new ByteProviderWrapper(provider, baseOffset, roDataSection.getSize());
+				new ByteProviderWrapper(provider, baseOffset, roDataSection.getFileSize());
 			BinaryReader reader = new BinaryReader(wrapper, elf.isLittleEndian());
 			OatHeader oatHeader = OatHeaderFactory.newOatHeader(reader);
 			OatHeaderFactory.parseOatHeader(oatHeader, null, reader, monitor, new MessageLog());

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/android/oat/OatFileSystem.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/android/oat/OatFileSystem.java
@@ -55,7 +55,6 @@ public class OatFileSystem extends GFileSystemBase {
 
 			if (magicMatch) {
 				ElfHeader elf = new ElfHeader(provider, null);
-				elf.parse();
 
 				ElfSymbolTable dynamicSymbolTable = elf.getDynamicSymbolTable();
 				if (dynamicSymbolTable != null) {
@@ -97,7 +96,6 @@ public class OatFileSystem extends GFileSystemBase {
 			monitor.setMessage("Parsing ELF header...");
 			monitor.incrementProgress(1);
 			ElfHeader elf = new ElfHeader(provider, null);
-			elf.parse();
 			monitor.incrementProgress(1);
 
 			ElfSectionHeader roDataSection = elf.getSection(ElfSectionHeaderConstants.dot_rodata);

--- a/Ghidra/Processors/ARM/src/main/java/ghidra/app/util/bin/format/elf/extend/ARM_ElfExtension.java
+++ b/Ghidra/Processors/ARM/src/main/java/ghidra/app/util/bin/format/elf/extend/ARM_ElfExtension.java
@@ -85,17 +85,10 @@ public class ARM_ElfExtension extends ElfExtension {
 		// if enabled PC Bias must be factored in explicitly during relocation processing
 		boolean enablePcBiasOption = false;
 
-		try {
-			elf.parse(); // ensure ELF is fully parsed to query section data
-
-			// Enable PC Bias use if Green Hills (GHS) detected
-			ElfSectionHeader section = elf.getSection(".ghsinfo");
-			if (section != null) {
-				enablePcBiasOption = true;
-			}
-		}
-		catch (IOException e) {
-			Msg.warn(this, "Failed to fully parse ELF headers to formulate ARM import options");
+		// Enable PC Bias use if Green Hills (GHS) detected
+		ElfSectionHeader section = elf.getSection(".ghsinfo");
+		if (section != null) {
+			enablePcBiasOption = true;
 		}
 
 		options.add(new Option(APPLY_PC_BIAS_TO_RELATIVE_RELOCATIONS_OPTION_NAME,

--- a/Ghidra/Processors/HCS12/src/main/java/ghidra/app/util/bin/format/elf/extend/HCS12X_ElfExtension.java
+++ b/Ghidra/Processors/HCS12/src/main/java/ghidra/app/util/bin/format/elf/extend/HCS12X_ElfExtension.java
@@ -83,7 +83,7 @@ public class HCS12X_ElfExtension extends ElfExtension {
 
 		AddressSpace space = getPreferredSectionAddressSpace(elfLoadHelper, elfSectionHeader);
 
-		long addrWordOffset = elfSectionHeader.getAddress();
+		long addrWordOffset = elfSectionHeader.getVirtualAddress();
 
 		if (space == program.getAddressFactory().getDefaultAddressSpace()) {
 			addrWordOffset += elfLoadHelper.getImageBaseWordAdjustmentOffset();

--- a/Ghidra/Processors/PIC/src/main/java/ghidra/app/util/bin/format/elf/extend/PIC30_ElfExtension.java
+++ b/Ghidra/Processors/PIC/src/main/java/ghidra/app/util/bin/format/elf/extend/PIC30_ElfExtension.java
@@ -176,7 +176,7 @@ public class PIC30_ElfExtension extends ElfExtension {
 
 	@Override
 	public long getAdjustedSize(ElfSectionHeader section) {
-		long rawSize = section.getSize();
+		long rawSize = section.getFileSize();
 		return isDataLoad(section) ? getAdjustedDataLoadSize(rawSize) : rawSize;
 	}
 


### PR DESCRIPTION
This is a bunch of fixes that I've encountered as part of my ongoing attempt to unlink programs back into relocatable object files (#4922). Since I don't know what changes I've made are acceptable or not for upstreaming, in this PR I've tried to keep them at the absolute bare minimum that my own code can live with.

The changes are intended to support generating ELF files from scratch instead of just parsing an existing ELF file on disk:
 * Removing `BinaryReader` as a class variable of `ElfHeader`. We can no longer assume that we can arbitrarily seek and read bytes from an ELF file except when actually parsing one, so every piece of data we need must be read upfront in the constructor and associated methods.
 * Reworking `ElfFileSection` from an interface that the various ELF table classes to an interface that `ElfSectionHeader` and `ElfProgramHeader` implements. As above, table classes must work within a single ELF section or segment, they can't arbitrarily seek and read bytes around.
 * Adding some support code to add sections and to generate a section name string table (including `ByteArrayMutableByteProvider` as an in-memory backing store for the string table data).
 * Fixing a bunch of serialization bugs/code that assumes sections have distinct file offsets.

The existing ELF serialization code is not used in-tree as far as I can tell, but can be tested with https://github.com/boricj/ghidra/tree/feature/elfrelocatebleobjectexporter, by:
 * Importing an ELF file (preferably relocatable and with debugging symbols),
 * Selecting the various addresses of the sections to export (usually those with the allocated ELF section flag),
 * Using the "ELF relocatable object" exporter (with `Selection only` checked) to create an ELF file.

Note that the exporter is alpha-quality, buggy and incomplete, but the generated ELF file should be valid as far as the ELF specification is concerned. The ELF support code in this PR for generating files is not fully-featured (no support for extended numbers of sections, no attempt to accommodate segments...) but so far works well enough for my purposes.

I did not notice any regressions when importing ELF files as part of my normal Ghidra usage with these changes. Hopefully I haven't introduced new bugs in that area.