### PR TITLE
Fix Frida debugger agent executableJar build

### DIFF
--- a/Ghidra/Debug/Debugger-agent-frida/FridaNotes.txt
+++ b/Ghidra/Debug/Debugger-agent-frida/FridaNotes.txt
@@ -14,6 +14,7 @@ Ghidra needs a dynamically-loadable version of libfrida-core.a which you can gen
 
 On macOS you will need to also link Objective-C, libresolv and the AppKit and Foundation frameworks:
 	clang++ -lobjc -lresolv -framework Foundation -framework AppKit -shared ghidra_wrapper.c ./libfrida-core.a -o libfrida-core.so
+An example compiler invocation is available in the example from the Frida devkit at the top of the example C file.
 
 Libfrida-core.so should then be added to the jna.library.path or put someplace like /usr/lib/x86_64-linux-gnu, where it will get picked up by Native.load().
 

--- a/Ghidra/Debug/Debugger-agent-frida/FridaNotes.txt
+++ b/Ghidra/Debug/Debugger-agent-frida/FridaNotes.txt
@@ -9,7 +9,7 @@ Random Notes on the Implementation of Debugger-agent-frida
 	
 Ghidra needs a dynamically-loadable version of libfrida-core.a which you can generate by something like:
 
-	cp ghidra_wrapper.c into the directory with libfrida-core.a and frida-core.h (distro or DEVKIT)
+	cp ghidra_wrapper.c into the directory with libfrida-core.a and frida-core.h (distro or DEVKIT). Do not copy the devkit into the `src/main/cpp/` directory, otherwise you will get build failures due to missing Ghidra IP headers.
 	g++ -shared ghidra_wrapper.c ./libfrida-core.a -o libfrida-core.so
 
 On macOS you will need to also link Objective-C, libresolv and the AppKit and Foundation frameworks:

--- a/Ghidra/Debug/Debugger-agent-frida/FridaNotes.txt
+++ b/Ghidra/Debug/Debugger-agent-frida/FridaNotes.txt
@@ -12,6 +12,9 @@ Ghidra needs a dynamically-loadable version of libfrida-core.a which you can gen
 	cp ghidra_wrapper.c into the directory with libfrida-core.a and frida-core.h (distro or DEVKIT)
 	g++ -shared ghidra_wrapper.c ./libfrida-core.a -o libfrida-core.so
 
+On macOS you will need to also link Objective-C, libresolv and the AppKit and Foundation frameworks:
+	clang++ -lobjc -lresolv -framework Foundation -framework AppKit -shared ghidra_wrapper.c ./libfrida-core.a -o libfrida-core.so
+
 Libfrida-core.so should then be added to the jna.library.path or put someplace like /usr/lib/x86_64-linux-gnu, where it will get picked up by Native.load().
 
 - Frida Functionality

--- a/Ghidra/Debug/Debugger-agent-frida/build.gradle
+++ b/Ghidra/Debug/Debugger-agent-frida/build.gradle
@@ -64,7 +64,7 @@ task nodepJar(type: Jar) {
 	inputs.file(file(jar.archivePath))
 	dependsOn(configureNodepJar)
 	dependsOn(jar)
-	
+	duplicatesStrategy = 'exclude'
 	archiveAppendix = 'nodep'
 	manifest {
 		attributes['Main-Class'] = 'agent.lldb.gadp.FridaGadpServer'
@@ -77,6 +77,7 @@ task executableJar {
 	ext.execsh = file("src/main/sh/execjar.sh")
 	ext.jarfile = file(nodepJar.archivePath)
 	ext.outjar = file("${buildDir}/bin/gadp-agent-frida")
+	ext.unsign_jar = file("unsign_jar.sh")
 	dependsOn(nodepJar)
 	inputs.file(execsh)
 	inputs.file(jarfile)
@@ -92,6 +93,7 @@ task executableJar {
 			}
 		}
 		exec {
+			commandLine(ext.unsign_jar, outjar)
 			commandLine("chmod", "+x", outjar)
 		}
 	}

--- a/Ghidra/Debug/Debugger-agent-frida/src/main/sh/execjar.sh
+++ b/Ghidra/Debug/Debugger-agent-frida/src/main/sh/execjar.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+## ###
+#  IP: GHIDRA
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#       http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##
+# This clever bit can be prepended to a JAR to make it self-executable
+
+set -e
+
+java -jar "$0"
+exit

--- a/Ghidra/Debug/Debugger-agent-frida/src/main/sh/execjar.sh
+++ b/Ghidra/Debug/Debugger-agent-frida/src/main/sh/execjar.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 ## ###
 #  IP: GHIDRA
 # 

--- a/Ghidra/Debug/Debugger-agent-frida/unsign_jar.sh
+++ b/Ghidra/Debug/Debugger-agent-frida/unsign_jar.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+## ###
+#  IP: GHIDRA
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#       http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##
+
+set -e
+echo "Removing signature files from ${1}"
+zip ${1} -d $(unzip -l Debugger-agent-frida-nodep.jar| grep '.SF$' | awk '{ print $4}')

--- a/Ghidra/Debug/Framework-Debugging/Module.manifest
+++ b/Ghidra/Debug/Framework-Debugging/Module.manifest
@@ -1,2 +1,2 @@
-MODULE FILE LICENSE: lib/jna-5.4.0.jar Apache License 2.0
-MODULE FILE LICENSE: lib/jna-platform-5.4.0.jar Apache License 2.0
+MODULE FILE LICENSE: lib/jna-5.7.0.jar Apache License 2.0
+MODULE FILE LICENSE: lib/jna-platform-5.7.0.jar Apache License 2.0

--- a/Ghidra/Debug/Framework-Debugging/build.gradle
+++ b/Ghidra/Debug/Framework-Debugging/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 	api project(':SoftwareModeling')
 	api project(':ProposedUtils')
 	
-	api "net.java.dev.jna:jna:5.4.0"
-	api "net.java.dev.jna:jna-platform:5.4.0"
+	api "net.java.dev.jna:jna:5.7.0"
+	api "net.java.dev.jna:jna-platform:5.7.0"
 
 	testImplementation project(path: ':Framework-AsyncComm', configuration: 'testArtifacts')
 }


### PR DESCRIPTION
- Add missing shell script for executable jar target
- Add exclude for duplicate files, fixes issue with help

Note: The no-dependency jar combines a number of signed jars into the final jar. This breaks the code signature. We can fix this by removing the signature from the final jar:

Essentially we want to do the following, but from inside the build system (or better not include the signature file at all)
```sh
zip Debugger-agent-frida-nodep.jar -d $(unzip -l Debugger-agent-frida-nodep.jar| grep '.SF$' | awk '{ print $4}')
```

Todo:
- [ ] I still need to update from Frida 15 to Frida 16 release.
- [ ] Add a build step to remove signatures from the no-dependency jar