### PR TITLE
Fix broken build in locales with non-default capitalization maps (e.g. tr_TR)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 # Increase maximum Gradle heap size (default is 1G)
-org.gradle.jvmargs=-Xmx2G
+# And fix build in locales with non-default capitalizations (e.g. tr_TR)
+org.gradle.jvmargs=-Xmx2G -Duser.language=en -Duser.country=US


### PR DESCRIPTION
There's a very common pattern across many projects that String.toLower() and friends are used without taking locales into consideration. This problem is amplified by the fact that there is often little indication that such a widely-used method could break on many systems.

It may be a surprise to learn that some locales override the common Latin alphabet mappings. A widely reported example of this is the tr_TR locale. There's even a phrase coined for the testing of the problem! (https://www.moserware.com/2008/02/does-your-code-pass-turkey-test.html)

The problem stems from two characters in the Turkish alphabet: i and ı. Yes, the second character has no dot, even called Latin Small Letter Dotless I in Unicode. "Latin Small Letter Dotless I" maps to you guessed it, Latin Capital Letter Dotless I (not a real name) or the regular character we all know and love: I. You might see where this is going: the reverse procedure breaks all kinds of stuff in Turkey: I maps to ı. And the uppercasing is similar with i. i maps to Latin Capital Letter I With Dot Above, which is İ. This also breaks all kinds of stuff.

Ghidra, the program, is saved by https://github.com/NationalSecurityAgency/ghidra/blob/5b543c184716075274bc101dfaf1cdb88631d672/Ghidra/RuntimeScripts/Common/support/launch.properties#L13 from what I can tell.

Ghidra, the source, is sadly not. `gradle buildGhidra` is broken in Turkey. This PR should fix that.

After committing the minimal changes in order support building in Turkey, I realized there might be some build tasks I wasn't hitting with buildGhidra so I also added the all-powerful locale jvmargs in gradle.properties. [EDIT: this also masks away underlying problems as a potentially unwanted side-effect and obviates the need for the tests I've written, as tr_TR locale would never be hit when building. I think they're still nice to have but they can be removed on your judgement.]

It might be a good idea to include `LC_MESSAGES=en_US.UTF-8` in gradle.properties in a similar vein to fix what https://github.com/NationalSecurityAgency/ghidra/blob/5b543c184716075274bc101dfaf1cdb88631d672/DevGuide.md?plain=1#L79-L82 is referring to. 

In addition to the changes here, it might be a good idea to change all .toLowerCase and .toUpperCase invocations used in parsing to include Locale.ROOT and leave them as-is if used in user-facing displays. I doubt many user-facing displays are happening in the build process so most if not all invocations in the build system could be changed into using Locale.ROOT. Additionally, all the displaying in the built program is happening under the en_US locale, so Locale.ROOT shouldn't change anything in that department as well. So instead of setting Locale.ROOT on some calls, it might be a possibility to set Locale.ENGLISH on _all_ calls but that might be a problem for future translation efforts.


Tests under this PR:
```bash
LC_MESSAGES=en_US.UTF-8 gradle -Duser.country=US -Duser.language=en --warning-mode=all buildNatives > buildNativesENUS.log 2>&1
LC_MESSAGES=en_US.UTF-8 gradle -Duser.country=US -Duser.language=en --warning-mode=all buildGhidra > buildGhidraENUS.log 2>&1
gradle clean
gradle --warning-mode=all buildNatives > buildNativesTRTR.log 2>&1
gradle --warning-mode=all buildGhidra > buildGhidraTRTR.log 2>&1
diff <(sort buildGhidraTRTR.log) <(sort buildGhidraENUS.log)
303a304
> 
1534c1535
< BUİLD SUCCESSFUL in 5m 33s
---
> BUILD SUCCESSFUL in 5m 7s
1956c1957
< The archives configuration has been deprecated for resolutıon. This will fail with an error in Gradle 8.0. Please resolve the compileClasspath or runtimeClasspath configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
---
> The archives configuration has been deprecated for resolution. This will fail with an error in Gradle 8.0. Please resolve the compileClasspath or runtimeClasspath configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
diff buildNativesTRTR.log buildNativesENUS.log
42c42
< BUİLD SUCCESSFUL in 15s
---
> BUILD SUCCESSFUL in 18s
```