### PR TITLE
65C02: Fix TRB/TSB instructions, fixes #4921

### DIFF
--- a/Ghidra/Processors/6502/data/languages/65c02.slaspec
+++ b/Ghidra/Processors/6502/data/languages/65c02.slaspec
@@ -208,7 +208,8 @@ ADDRIX: (imm16,X) is X; imm16     { addr:2 = imm16 + zext(X); tmp:2 = *:2 addr; 
 :TRB OPTB                      is (tcc=0 & taaa=0 & td=1) ... & OPTB
 {
     local op1 = OPTB;
-    local result = A & ~op1;
+    local result = op1 & ~A;
+    OPTB = result;
     Z = result == 0;
 }
 
@@ -216,5 +217,6 @@ ADDRIX: (imm16,X) is X; imm16     { addr:2 = imm16 + zext(X); tmp:2 = *:2 addr; 
 {
     local op1 = OPTB;
     local result = A | op1;
+    OPTB = result;
     Z = result == 0;
 }


### PR DESCRIPTION
Fixes incorrect SLEIGH descriptions of the TRB and TSB instructions on the 65C02. See #4921.