### PR TITLE
gradle: Fix bundle_examples compilation

### DIFF
--- a/Ghidra/Extensions/bundle_examples/build.gradle
+++ b/Ghidra/Extensions/bundle_examples/build.gradle
@@ -36,15 +36,33 @@ dependencies {
 
 def srcDirs =  []
 file(project.projectDir).eachDirMatch(~/.*scripts_.*/) { srcDirs << it.name }
+// Create all source sets first
+srcDirs.each{ dirName -> sourceSets.create(dirName) }
 
-srcDirs.each {dirName ->
-	sourceSets.create(dirName) {
-		java {
-			srcDir {
-				dirName
-			}
+// Examples that depend on 'org.other.lib' in 'scripts_lib'
+def script_lib_dependents = ["scripts_with_manifest", "scripts_lib_user"] as Set
+// Examples that depend on 'org.jarlib.JarUtil' in 'scripts_jar'
+def script_jar_dependents = ["scripts_uses_jar", "scripts_uses_jar_version"] as Set
+// Fixup each of the sourceSets
+srcDirs.each{ dirName ->
+	def sourceSet = sourceSets.named(dirName).get()
+	sourceSet.java {
+		srcDir {
+			dirName
 		}
 	}
+	sourceSet.compileClasspath += sourceSets.main.output
+
+	if (script_lib_dependents.contains(dirName)) {
+		sourceSet.compileClasspath += sourceSets.scripts_lib.output
+	}
+	if (script_jar_dependents.contains(dirName)) {
+		// Only use jar1 because jar2 conflicts
+		sourceSet.compileClasspath += sourceSets.scripts_jar1.output
+	}
+
+	def baseImplementation = project.configurations.maybeCreate(sourceSets.main.implementationConfigurationName)
+	project.configurations.maybeCreate(sourceSet.implementationConfigurationName).extendsFrom(baseImplementation)
 }
 
 // create and return a jar task for the given source directory


### PR DESCRIPTION
Similar to #4974, without these fixes, gradle compilation for the relevant tasks fails on the command line.

The `bundle_examples` project dynamically creates sourceSets for each directory in `Ghidra/Extensions/bundle_examples`, but it fails to set up the compile classpath dependencies between those sourceSets.

The list of the 8 created sourceSets is as follows: `scripts_jar1`, `scripts_jar2`, `scripts_lib`, `scripts_lib_user`, `scripts_uses_jar`, `scripts_uses_jar_version`, `scripts_with_activator`, `scripts_with_manifest`.

To test that this PR fixes the compilation, we can run a simple bash script
```bash
declare -a SOURCE_SETS=(scripts_jar1 scripts_jar2 scripts_lib scripts_lib_user scripts_uses_jar scripts_uses_jar_version scripts_with_activator scripts_with_manifest)

declare -a TASKS=()
for sourceSet in "${SOURCE_SETS[@]}"
do
    TASKS+=(":bundle_examples:compile${sourceSet}java")
done

gradle --continue --rerun-tasks "${TASKS[@]}"
```

On `master` branch, I see 6 task failures due to missing dependencies on the compilation classpath. On this branch, everything passes.