### PR TITLE
Fix screenShots compilation and testing

### DIFF
--- a/Ghidra/Features/FunctionGraph/src/test.slow/java/ghidra/app/plugin/core/functiongraph/AbstractFunctionGraphTest.java
+++ b/Ghidra/Features/FunctionGraph/src/test.slow/java/ghidra/app/plugin/core/functiongraph/AbstractFunctionGraphTest.java
@@ -564,7 +564,8 @@ public abstract class AbstractFunctionGraphTest extends AbstractGhidraHeadedInte
 
 	protected void installTestGraphLayout(FGProvider provider) {
 		FGActionManager actionManager = provider.getActionManager();
-		List<FGLayoutProvider> layouts = List.of(new TestFGLayoutProvider());
+		List<FGLayoutProvider> layouts = new ArrayList<>(List.of(new TestFGLayoutProvider()));
+		layouts.addAll(graphPlugin.getLayoutProviders());
 		runSwing(() -> actionManager.setLayouts(layouts));
 	}
 

--- a/Ghidra/Test/IntegrationTest/build.gradle
+++ b/Ghidra/Test/IntegrationTest/build.gradle
@@ -61,6 +61,8 @@ dependencies {
 	testImplementation project(path: ':FunctionGraph', configuration: 'testArtifacts')	
 	testImplementation project(path: ':PDB', configuration: 'testArtifacts')
 	testImplementation project(path: ':GnuDemangler', configuration: 'testArtifacts')
+
+	screenShotsImplementation project(path: ':FunctionGraph', configuration: 'integrationTestArtifacts')
 }
 
 // For Java 9, we must explicitly export references to the internal classes we are using.

--- a/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/FunctionGraphPluginScreenShots.java
+++ b/Ghidra/Test/IntegrationTest/src/screen/java/help/screenshot/FunctionGraphPluginScreenShots.java
@@ -162,6 +162,7 @@ public class FunctionGraphPluginScreenShots extends AbstractFunctionGraphTest {
 		drawRectangleAroundMessageText();
 	}
 
+	@Test
 	public void testFunctionGraph_Vertex_Header() {
 		String address = "406630";
 		go(address);// _strlen function
@@ -784,14 +785,14 @@ public class FunctionGraphPluginScreenShots extends AbstractFunctionGraphTest {
 
 		Object actionManager = getInstanceField("actionManager", graphProvider);
 		@SuppressWarnings("unchecked")
-		final MultiStateDockingAction<Class<? extends FGLayoutProvider>> action =
-			(MultiStateDockingAction<Class<? extends FGLayoutProvider>>) getInstanceField(
+		final MultiStateDockingAction<FGLayoutProvider> action =
+			(MultiStateDockingAction<FGLayoutProvider>) getInstanceField(
 				"layoutAction", actionManager);
 		runSwing(() -> {
-			List<ActionState<Class<? extends FGLayoutProvider>>> states =
+			List<ActionState<FGLayoutProvider>> states =
 				action.getAllActionStates();
-			for (ActionState<Class<? extends FGLayoutProvider>> state : states) {
-				Class<? extends FGLayoutProvider> layoutClass = state.getUserData();
+			for (ActionState<FGLayoutProvider> state : states) {
+				Class<? extends FGLayoutProvider> layoutClass = state.getUserData().getClass();
 				if (layoutClass.getSimpleName().equals("DecompilerNestedLayoutProvider")) {
 					action.setCurrentActionState(state);
 					return;

--- a/gradle/javaTestProject.gradle
+++ b/gradle/javaTestProject.gradle
@@ -75,6 +75,26 @@ task integrationTest (type: Test) { t ->
 	}
 }
 
+tasks.register('screenShots', Test) { t ->
+	group "screenShots"
+	dependsOn { project(":FunctionID").unpackFidDatabases }
+	testClassesDirs = files sourceSets.screenShots.output.classesDirs
+
+	classpath = sourceSets.screenShots.runtimeClasspath
+
+	// Enable if you want to force Gradle to launch a new JVM for each test.
+	forkEvery 1
+
+	initTestJVM(t, rootProject.ext.testRootDirName)
+
+	doFirst {
+		startTestTimer(t)
+	}
+	doLast {
+		endTestTimer(t)
+	}
+}
+
 task pcodeTest (type: Test) { t ->	
     group "pcodeTest"	
     dependsOn { project(":FunctionID").unpackFidDatabases }	


### PR DESCRIPTION
Added a Test task for running screenShots tests from the command-line.

Also fixes a runtime bug.

The `screenshot` directories run many interesting graphical tests and have been useful for me to understand the `FunctionGraphPlugin`. It would be nice to expose these tests to gradle for running from the command line.

Running the screenShots test(s)
-------------------------------

!!!Only tested with the FunctionGraphPluginScreenShots tests!!! (other tests might require more fixes)

Prerequisite 'Ghidra/Test/TestResources/data/WinHelloCPP.exe.gzf' needs to be present before running this test.

Created with the following steps:

1. Build Ghidra
2. Install it
3. Create and open a new project
4. Import 'GhidraDocs/GhidraClass/ExerciseFiles/WinhelloCPP/WinHelloCPP.exe'
5. Run auto-analysis
6. Save
7. Close CodeBrowser screen
8. Right-click on WinHelloCPP.exe from project screen and "Export..." as "Ghidra Zip File" to 'Ghidra/Test/TestResources/data'

A single test can then be run:

    gradle :IntegrationTest:screenShots \
      --tests help.screenshot.FunctionGraphPluginScreenShots.testFunctionGraph_Vertex_Drop_Shadow

All tests can be run:

    gradle :IntegrationTest:screenShots \
      --tests help.screenshot.FunctionGraphPluginScreenShots