### PR TITLE
Fix several Gradle 8.x compatibility issues

### DIFF
--- a/Ghidra/Features/Decompiler/build.gradle
+++ b/Ghidra/Features/Decompiler/build.gradle
@@ -157,10 +157,10 @@ task buildDecompilerHelpHtml(type: Exec) {
 	// Print the output of the commands and check the return value.
 	doLast {
 		println output()
-		if (execResult.exitValue) {
+		if (executionResult.get().getExitValue()) {
 			logger.error("$it.name: An error occurred. Here is the output:\n" + output())
 			throw new TaskExecutionException( it, new Exception("'$it.name': The command: '${commandLine.join(' ')}'" +
-				" task \nfailed with exit code $execResult.exitValue; see task output for details."))
+				" task \nfailed with exit code ${executionResult.get().getExitValue()}; see task output for details."))
 		}
 	}
 }
@@ -214,7 +214,7 @@ task buildDecompilerHelpPdf(type: Exec) {
 	// Print the output of the commands and check the return value.
 	doLast {
 		println output()
-		if (execResult.exitValue) {
+		if (executionResult.get().getExitValue()) {
 			println "$it.name: An error occurred with this task. Here is the output:\n" + output()
 			println "Skipping task $it.name\n"
 		}
@@ -284,7 +284,7 @@ task buildDecompilerDocumentationPdfs(type: Exec) {
 	// Print the output of the commands and check the return value.
 	doLast {
 		println output()
-		if (execResult.exitValue) {
+		if (executionResult.get().getExitValue()) {
 			println "$it.name: An error occurred with this task. Here is the output:\n" + output()
 			println "Skipping task $it.name\n"
 		}
@@ -370,11 +370,11 @@ task buildDecompilerDocumentationHtml(type: Exec) {
 		// Print the output of the commands and check the return value.
 		doLast {
 			println output()
-			if (execResult.exitValue) {
+			if (executionResult.get().getExitValue()) {
 				logger.error("$it.name: An error occurred. Here is the output:\n" + output())
 				throw new TaskExecutionException( it,
 					new Exception( "$it.name: The command: '${commandLine.join(' ')}'" +
-						"\nfailed with exit code $execResult.exitValue; see task output for details." )
+						"\nfailed with exit code ${executionResult.get().getExitValue()}; see task output for details." )
 			)
 		}
 	}

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -139,12 +139,12 @@ configurations {
 }
 
 task testJar(type: Jar) {
-	classifier "test" // value part of file name
+	archiveClassifier.set("test") // value part of file name
 	from sourceSets.test.output
 }
 
 task integrationTestJar(type: Jar) {
-	classifier "integrationTest" // value part of file name
+	archiveClassifier.set("integrationTest") // value part of file name
 	from sourceSets.integrationTest.output
 }
 artifacts {

--- a/gradle/root/jacoco.gradle
+++ b/gradle/root/jacoco.gradle
@@ -22,14 +22,6 @@ dependencies {
    jacocoAgent 'org.jacoco:org.jacoco.agent:0.8.8'
 }
 
-def String jacocoRootExecPath = "$buildDir/jacoco/jacocoMerge.exec"
-
-delete new File(jacocoRootExecPath) // If the merged exec file (output from jacocoMerge) exists,
-                				    // jacocoReport & jacocoBranchReport tasks are skipped and 
-				                    // the report is not generated.
-				                    // So always delete the merged file before the determination
-				                    // to skip a task is made.
-
 /*********************************************************************************
   * Generate the Jacoco excludes list from file (this will strip out comments and
   * whitespace).
@@ -72,26 +64,18 @@ def shouldIgnoreLine(line) {
 List excludesList = generateExcludesList()
 
 /*********************************************************************************
- * Task to merge multiple jacoco execution data files into one
- *********************************************************************************/
-task jacocoMerge(type: JacocoMerge) {
-   description = 'Task to merge multiple jacoco execution data files into one.'
-   destinationFile = new File(jacocoRootExecPath)
-   dependsOn { subprojects.findAll { p -> p.plugins.hasPlugin('jacoco') }.test }
-   dependsOn { subprojects.findAll { p -> p.plugins.hasPlugin('jacoco') }.integrationTest }
-   executionData fileTree(rootDir) {
-     include '**/*.exec'
-   }
-}
-
-/*********************************************************************************
  * Task to generate an aggregate jacoco report from subprojects with 
  * Java sourceSets
  *********************************************************************************/
 task jacocoReport(type: JacocoReport, group: 'Coverage reports') {
    description = 'Generates an aggregate Jacoco report from all subprojects'
-   dependsOn 'jacocoMerge'
-   executionData new File(jacocoRootExecPath)
+
+   dependsOn { subprojects.findAll { p -> p.plugins.hasPlugin('jacoco') }.test }
+   dependsOn { subprojects.findAll { p -> p.plugins.hasPlugin('jacoco') }.integrationTest }
+
+   executionData fileTree(rootDir) {
+     include '**/*.exec'
+   }
    
    // Setting these source/class dirs MUST be done in the configuration phase (we used
    // to do it in a doFirst block but that was deprecated in later gradle builds). However,


### PR DESCRIPTION
Addressed the following deprecations:

* [JacocoMerge task removed](https://docs.gradle.org/current/userguide/upgrading_version_7.html#jacocomerge_task_removed) - deleted jacocoMerge task, moved its inputs to jacocoReport.
* [`classifier` property removed from archive tasks](https://docs.gradle.org/current/userguide/upgrading_version_7.html#abstractarchivetask_api_cleanup) - replaced `classifier` calls with `archiveClassifier.set`.
* [execResult getter property removed from exec tasks](https://docs.gradle.org/current/userguide/upgrading_version_7.html#abstractexectask_api_cleanup) - replaced with `executionResult.get`.

With these changes, I managed to run build commands from DevGuide with no build issues, so this should address #3527.
However I might miss something (or break something on the way). 