### PR TITLE
relocations: Implement removal & events

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clear/ClearDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clear/ClearDialog.java
@@ -32,13 +32,14 @@ import ghidra.util.HelpLocation;
 
 /**
  * Dialog that shows options for "Clear All." User can choose to clear
- * symbols, comments, properties, code, and functions.
+ * symbols, relocations, comments, properties, code, and functions.
  */
 public class ClearDialog extends DialogComponentProvider {
 
 	private ClearPlugin plugin;
 	private JPanel panel;
 	private JCheckBox symbolsCb;
+	private JCheckBox relocationsCb;
 	private JCheckBox commentsCb;
 	private JCheckBox propertiesCb;
 	private JCheckBox codeCb;
@@ -76,6 +77,7 @@ public class ClearDialog extends DialogComponentProvider {
 
 		opts.setClearCode(codeCb.isSelected());
 		opts.setClearSymbols(symbolsCb.isSelected());
+		opts.setClearRelocations(relocationsCb.isSelected());
 		opts.setClearComments(commentsCb.isSelected());
 		opts.setClearProperties(propertiesCb.isSelected());
 		opts.setClearFunctions(functionsCb.isSelected());
@@ -123,6 +125,7 @@ public class ClearDialog extends DialogComponentProvider {
 		cbPanel.setLayout(bl);
 
 		symbolsCb = new GCheckBox("Symbols");
+		relocationsCb = new GCheckBox("Relocations");
 		commentsCb = new GHtmlCheckBox(
 			"<HTML>Comments <FONT SIZE=\"2\">(does not affect automatic comments)</FONT>");
 		commentsCb.setVerticalTextPosition(SwingConstants.TOP);
@@ -139,6 +142,8 @@ public class ClearDialog extends DialogComponentProvider {
 
 		symbolsCb.setSelected(true);
 		symbolsCb.addKeyListener(listener);
+		relocationsCb.setSelected(true);
+		relocationsCb.addKeyListener(listener);
 		commentsCb.setSelected(true);
 		commentsCb.addKeyListener(listener);
 		propertiesCb.setSelected(true);
@@ -163,6 +168,7 @@ public class ClearDialog extends DialogComponentProvider {
 		bookmarksCb.addKeyListener(listener);
 
 		cbPanel.add(symbolsCb);
+		cbPanel.add(relocationsCb);
 		cbPanel.add(commentsCb);
 		cbPanel.add(propertiesCb);
 		cbPanel.add(codeCb);
@@ -207,6 +213,7 @@ public class ClearDialog extends DialogComponentProvider {
 		// record the checkboxes for later use
 		final List<JCheckBox> checkBoxList = new ArrayList<>(10);
 		checkBoxList.add(symbolsCb);
+		checkBoxList.add(relocationsCb);
 		checkBoxList.add(commentsCb);
 		checkBoxList.add(propertiesCb);
 		checkBoxList.add(codeCb);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clear/ClearOptions.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clear/ClearOptions.java
@@ -25,6 +25,7 @@ public class ClearOptions {
 
     private boolean code;
     private boolean symbols;
+    private boolean relocations;
     private boolean comments;
     private boolean properties;
     private boolean functions;
@@ -46,11 +47,13 @@ public class ClearOptions {
 	public ClearOptions( boolean defaultClearValue ) {
 	    this(defaultClearValue, defaultClearValue, defaultClearValue, defaultClearValue, 
 	        defaultClearValue, defaultClearValue, defaultClearValue, defaultClearValue, 
-	        defaultClearValue, defaultClearValue, defaultClearValue, defaultClearValue);
+	        defaultClearValue, defaultClearValue, defaultClearValue, defaultClearValue,
+	        defaultClearValue);
 	}
 	
     private ClearOptions(boolean code,
                 		boolean symbols,
+                		boolean relocations,
                 		boolean comments,
                 		boolean properties,
                 		boolean functions,
@@ -63,6 +66,7 @@ public class ClearOptions {
                 		boolean bookmarks) {
         this.code = code;
         this.symbols = symbols;
+        this.relocations = relocations;
         this.comments = comments;
         this.properties = properties;
         this.functions = functions;
@@ -81,6 +85,10 @@ public class ClearOptions {
 
     public void setClearSymbols( boolean symbols ) {
         this.symbols = symbols;
+    }
+
+    public void setClearRelocations( boolean relocations ) {
+        this.relocations = relocations;
     }
 
     public void setClearComments( boolean comments ) {
@@ -135,6 +143,9 @@ public class ClearOptions {
     boolean clearSymbols() {
         return symbols;
     }
+    boolean clearRelocations() {
+        return relocations;
+    }
     boolean clearFunctions() {
         return functions;
     }
@@ -178,7 +189,7 @@ public class ClearOptions {
     }
 
     boolean clearAny() {
-        return code || symbols || comments || properties || functions
+        return code || symbols || relocations || comments || properties || functions
                 || registers || equates || userReferences || analysisReferences
                 || importReferences || defaultReferences || bookmarks;
     }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/reloc/RelocationProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/reloc/RelocationProvider.java
@@ -25,6 +25,7 @@ import ghidra.app.services.GoToService;
 import ghidra.framework.plugintool.ComponentProviderAdapter;
 import ghidra.framework.plugintool.ServiceProvider;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.reloc.Relocation;
 import ghidra.util.HelpLocation;
 import ghidra.util.table.*;
 
@@ -112,5 +113,17 @@ class RelocationProvider extends ComponentProviderAdapter {
 		threadedPanel.dispose();
 		tableFilterPanel.dispose();
 
+	}
+
+	void relocationAdded(Relocation relocation) {
+		if (isVisible()) {
+			tableModel.relocationAdded(relocation);
+		}
+	}
+
+	void relocationRemoved(Relocation relocation) {
+		if (isVisible()) {
+			tableModel.relocationRemoved(relocation);
+		}
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/reloc/RelocationTableModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/reloc/RelocationTableModel.java
@@ -67,6 +67,8 @@ class RelocationTableModel extends AddressBasedTableModel<RelocationRowObject> {
 	static final String RELOCATION_CURRENT_BYTES = "Current Bytes";
 	static final String RELOCATION_NAME = "Name";
 
+	private int relocationIndex = 0;
+
 	public RelocationTableModel(ServiceProvider serviceProvider, Program program,
 			TaskMonitor monitor) {
 		super("Relocation Table Model", serviceProvider, program, monitor);
@@ -110,7 +112,7 @@ class RelocationTableModel extends AddressBasedTableModel<RelocationRowObject> {
 			return;
 		}
 
-		int relocationIndex = 0;
+		relocationIndex = 0;
 		RelocationTable relocationTable = getProgram().getRelocationTable();
 		Iterator<Relocation> iterator = relocationTable.getRelocations();
 		while (iterator.hasNext()) {
@@ -159,6 +161,20 @@ class RelocationTableModel extends AddressBasedTableModel<RelocationRowObject> {
 		public RelocationRowObject(Relocation r, int relocationIndex) {
 			this.relocationIndex = relocationIndex;
 			this.relocation = r;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof RelocationRowObject)) {
+				return false;
+			}
+			RelocationRowObject other = (RelocationRowObject) obj;
+			return relocation.equals(other.relocation);
+		}
+
+		@Override
+		public int hashCode() {
+			return relocation.hashCode();
 		}
 	}
 
@@ -280,5 +296,13 @@ class RelocationTableModel extends AddressBasedTableModel<RelocationRowObject> {
 			return rowObject.relocation.getSymbolName();
 		}
 
+	}
+
+	public void relocationAdded(Relocation relocation) {
+		addObject(new RelocationRowObject(relocation, ++relocationIndex));
+	}
+
+	public void relocationRemoved(Relocation relocation) {
+		removeObject(new RelocationRowObject(relocation, -1));
 	}
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ProgramDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ProgramDB.java
@@ -54,6 +54,7 @@ import ghidra.program.model.listing.*;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.mem.MemoryConflictException;
 import ghidra.program.model.pcode.Varnode;
+import ghidra.program.model.reloc.Relocation;
 import ghidra.program.model.symbol.*;
 import ghidra.program.model.util.AddressSetPropertyMap;
 import ghidra.program.model.util.PropertyMapManager;
@@ -1013,6 +1014,20 @@ public class ProgramDB extends DomainObjectAdapterDB implements Program, ChangeM
 		}
 		changed = true;
 		fireEvent(new ProgramChangeRecord(type, addr, addr, null, oldValue, newValue));
+	}
+
+	public void relocationAdded(Relocation relocation) {
+		Address addr = relocation.getAddress();
+
+		changed = true;
+		fireEvent(new ProgramChangeRecord(ChangeManager.DOCR_RELOCATION_ADDED, addr, addr, null, null, relocation));
+	}
+
+	public void relocationRemoved(Relocation relocation) {
+		Address addr = relocation.getAddress();
+
+		changed = true;
+		fireEvent(new ProgramChangeRecord(ChangeManager.DOCR_RELOCATION_REMOVED, addr, addr, relocation, relocation, null));
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapter.java
@@ -219,6 +219,13 @@ abstract class RelocationDBAdapter {
 			String symbolName) throws IOException;
 
 	/**
+	 * Remove a relocation record.
+	 * @param id the relocation id to remove
+	 * @throws IOException if a database error occurs
+	 */
+	abstract void remove(long id) throws IOException;
+
+	/**
 	 * Iterator over all records in address order.
 	 * @return record iterator
 	 * @throws IOException if a database error occurs

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterNoTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterNoTable.java
@@ -49,6 +49,11 @@ class RelocationDBAdapterNoTable extends RelocationDBAdapter {
 	}
 
 	@Override
+	void remove(long id) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	int getRecordCount() {
 		return 0;
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV1.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV1.java
@@ -61,6 +61,11 @@ class RelocationDBAdapterV1 extends RelocationDBAdapter {
 	}
 
 	@Override
+	void remove(long id) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	int getRecordCount() {
 		return relocTable.getRecordCount();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV2.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV2.java
@@ -62,6 +62,11 @@ class RelocationDBAdapterV2 extends RelocationDBAdapter {
 	}
 
 	@Override
+	void remove(long id) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	int getRecordCount() {
 		return relocTable.getRecordCount();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV3.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV3.java
@@ -65,6 +65,11 @@ class RelocationDBAdapterV3 extends RelocationDBAdapter {
 	}
 
 	@Override
+	void remove(long id) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	int getRecordCount() {
 		return relocTable.getRecordCount();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV4.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV4.java
@@ -65,6 +65,11 @@ public class RelocationDBAdapterV4 extends RelocationDBAdapter {
 	}
 
 	@Override
+	void remove(long id) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	int getRecordCount() {
 		return relocTable.getRecordCount();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV5.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV5.java
@@ -66,6 +66,11 @@ public class RelocationDBAdapterV5 extends RelocationDBAdapter {
 	}
 
 	@Override
+	void remove(long id) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	int getRecordCount() {
 		return relocTable.getRecordCount();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV6.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationDBAdapterV6.java
@@ -91,6 +91,11 @@ public class RelocationDBAdapterV6 extends RelocationDBAdapter {
 	}
 
 	@Override
+	void remove(long id) throws IOException {
+		relocTable.deleteRecord(id);
+	}
+
+	@Override
 	int getRecordCount() {
 		return relocTable.getRecordCount();
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/reloc/RelocationManager.java
@@ -147,9 +147,10 @@ public class RelocationManager implements RelocationTable, ManagerDB {
 		try {
 			byte flags = RelocationDBAdapter.getFlags(status, 0);
 			adapter.add(addr, flags, type, values, bytes, symbolName);
-			return new Relocation(addr, status, type, values,
+			Relocation relocation = new Relocation(addr, status, type, values,
 				getOriginalBytes(addr, status, bytes, 0),
 				symbolName);
+			relocationAdded(relocation);
 		}
 		catch (IOException e) {
 			program.dbError(e);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/reloc/Relocation.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/reloc/Relocation.java
@@ -15,6 +15,9 @@
  */
 package ghidra.program.model.reloc;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import ghidra.program.model.address.Address;
 
 /**
@@ -191,5 +194,25 @@ public class Relocation {
 	 */
 	public String getSymbolName() {
 		return symbolName;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(addr, status, type, symbolName) ^ Arrays.hashCode(values) ^ Arrays.hashCode(bytes);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Relocation)) {
+			return false;
+		}
+
+		Relocation other = (Relocation) o;
+		return Objects.equals(addr, other.addr) && Objects.equals(status, other.status) &&
+				type == other.type && Arrays.equals(values, other.values) &&
+				Arrays.equals(bytes, other.bytes) && Objects.equals(symbolName, other.symbolName);
 	}
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/reloc/RelocationTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/reloc/RelocationTable.java
@@ -69,6 +69,12 @@ public interface RelocationTable {
 			String symbolName);
 
 	/**
+	 * Removes a relocation from the relocation table.
+	 * @param relocation the relocation to remove
+	 */
+	public void remove(Relocation relocation);
+
+	/**
 	 * Returns the ordered list of relocations which have been defined for the specified address.
 	 * In most cases there will be one or none, but in some cases multiple relocations may be
 	 * applied to a single address. 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/ChangeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/ChangeManager.java
@@ -725,6 +725,22 @@ public interface ChangeManager {
 	public static final int DOCR_USER_DATA_CHANGED = 201;
 
 	////////////////////////////////////////////////////////////////////////////
+	//
+	//                              RELOCATIONS
+	//
+	////////////////////////////////////////////////////////////////////////////
+
+	/**
+	 * A symbol was created.
+	 */
+	public static final int DOCR_RELOCATION_ADDED = 210;
+
+	/**
+	 * A symbol was removed.
+	 */
+	public static final int DOCR_RELOCATION_REMOVED = 211;
+
+	////////////////////////////////////////////////////////////////////////////
 	/**
 	 * Mark the state of a Program as having changed and generate
 	 * the event of the specified type.  Any or all parameters may be null.


### PR DESCRIPTION
As part of https://github.com/NationalSecurityAgency/ghidra/discussions/4922, I need the ability to add/modify/remove relocations from the relocation table. Just like in #4938, I don't know what's eligible or not for upstreaming, so I went with the smallest set of changes I can get away with (namely, removing one relocation in the table). I've also wired up relocation events so that the relocation table panel display is refreshed and added the ability to remove relocations from the clear plugin.

While this works for my own purposes, I haven't really worked on the GUI/event side of Ghidra before, so I probably got things wrong in there. Furthermore, given that the only source of relocations currently available within Ghidra is the initial import, maybe the `Edit > Clear With Options...` dialog shouldn't default to clearing out relocations?

It's fairly obvious the current core relocation table code in Ghidra was only designed to display the initial set of relocations from the imported files ; it's not really geared for on-the-fly modifications or integrated with the rest of the program model. Maybe my wacky idea of resynthesizing relocations to unlink program back into relocatable object files (https://github.com/boricj/ghidra/tree/feature/elfrelocatebleobjectexporter) warrants an overhaul of the relocation table design to better fit my own use-case, but I'm not going down _that_ rabbit hole just to make my prototype work.