### PR TITLE
OMF format: Fix for record name and libmod name

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfCommentRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfCommentRecord.java
@@ -36,12 +36,17 @@ public class OmfCommentRecord extends OmfRecord {
 		readRecordHeader(reader);
 		commentType = reader.readNextByte();
 		commentClass = reader.readNextByte();
-		byte[] bytes = reader.readNextByteArray(
-			getRecordLength() - 3 /* 3 = sizeof(commentType+commentClass+trailing_crcbyte*/);
 
-		if (commentClass == COMMENT_CLASS_TRANSLATOR || commentClass == COMMENT_CLASS_LIBMOD ||
-			commentClass == COMMENT_CLASS_DEFAULT_LIBRARY) {
+		switch(commentClass) {
+		case COMMENT_CLASS_TRANSLATOR:
+		case COMMENT_CLASS_DEFAULT_LIBRARY:
+			byte[] bytes = reader.readNextByteArray(
+				getRecordLength() - 3 /* 3 = sizeof(commentType+commentClass+trailing_crcbyte*/);
 			value = new String(bytes, StandardCharsets.US_ASCII); // assuming ASCII
+			break;
+		case COMMENT_CLASS_LIBMOD:
+			value = readString(reader);
+			break;
 		}
 		readCheckSumByte(reader);
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfRecord.java
@@ -246,6 +246,6 @@ public abstract class OmfRecord {
 	@Override
 	public String toString() {
 		return String.format("name: %s, type: 0x%x, offset: 0x%x, length: 0x%x",
-			getRecordName(recordType), recordType, recordOffset, recordLength);
+			getRecordName(recordType & 0xfe), recordType, recordOffset, recordLength);
 	}
 }


### PR DESCRIPTION
When printing the record name the lowest bit should be removed for 32 bit record type, otherwise they will be shown as unknown.
A string based on the low bit could be added to show that it is a 32 bit record.

The comment class COMMENT_CLASS_LIB is stored as count, string as documented in the OMF manual on page 19.
Tested with Borland C++ 4, Microsoft C++ 7 and SoundBlaster libraries which all match that format.

Been unable to find files with either COMMENT_CLASS_TRANSLATOR or COMMENT_CLASS_DEFAULT_LIBRARY, so it is unknown whether these are in the same format. Looked in Borland C++ 2 to 4, Microsoft C++ 7, SoundBlaster and OpenWatcom libraries.

Final update: According to the Watcom dump omf utility this should be correct now.