### PR TITLE
Fixed incorrect parsing of the Erase In Line ANSI code.

### DIFF
--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/java/agent/gdb/pty/windows/AnsiBufferedInputStream.java
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/java/agent/gdb/pty/windows/AnsiBufferedInputStream.java
@@ -365,6 +365,9 @@ public class AnsiBufferedInputStream extends InputStream {
 
 	protected int parseNumericBuffer() {
 		String numeric = readAndClearEscBuf();
+		if (numeric.isEmpty()) {
+			return 0;
+		}
 		int result = Integer.parseInt(numeric);
 		return result;
 	}


### PR DESCRIPTION
All credits go to nsadeveloper789 for the patch. Fixes #3562 .