### PR TITLE
Fix Arm neon vqdmull invalid pattern

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -4821,7 +4821,7 @@ define pcodeop SignedSatQ;
 }
 
 :vqdmull.S^esize2021 Qd, Dn, Dm	is ( ( $(AMODE) & ARMcond=0 & cond=15 & c2327=5 & c2021<3 & c0811=0xD & Q6=0 & c0404=0 ) |
-                                      ( $(TMODE_E) & thv_c2327=0x1f & thv_c2324=1 & thv_c2021<3 & thv_c0811=0xD & thv_Q6=0 & thv_c0404=0 ) ) & esize2021 & Dm & Dn & Qd
+                                      ( $(TMODE_E) & thv_c2327=0x1f & thv_c2021<3 & thv_c0811=0xD & thv_Q6=0 & thv_c0404=0 ) ) & esize2021 & Dm & Dn & Qd
 
 {
 	Qd = VectorDoubleMultiplyLong(Dn,Dm,esize2021,0:1);
@@ -4829,7 +4829,7 @@ define pcodeop SignedSatQ;
 }
 
 :vqdmull.S^esize2021 Qd, Dn, vmlDmA	is ( ( $(AMODE) & ARMcond=0 & cond=15 & c2327=5 & c2021<3 & c0811=0xb & Q6=1 & c0404=0 ) |
-                                      ( $(TMODE_E) & thv_c2327=0x1e & thv_c2324=1 & thv_c2021<3 & thv_c0811=0xb & thv_Q6=1 & thv_c0404=0 ) ) & esize2021 & vmlDmA & Dn & Qd
+                                      ( $(TMODE_E) & thv_c2327=0x1f & thv_c2021<3 & thv_c0811=0xb & thv_Q6=1 & thv_c0404=0 ) ) & esize2021 & vmlDmA & Dn & Qd
 
 {
 	Qd = VectorDoubleMultiplyLong(Dn,vmlDmA,esize2021,0:1);


### PR DESCRIPTION
The pattern for `vqdmull` instruction in ARM-neon is invalid and impossible. Using the invalid value `0x1e` and the impossible condition `thv_c2327=0x1f & thv_c2324=1`.

With this bug, Ghidra is unable to disassemble instructions `vqdmull.*` in thumb mode. eg:
```
   0:	ef90 0b49 	vqdmull.s16	q0, d0, d1[1]
   4:	efa0 0d00 	vqdmull.s32	q0, d0, d0
```

This was found during the development of https://github.com/rbran/sleigh-rs. It was detected an impossible pattern matching with `thv_c2327=0x1f & thv_c2324=1` and `thv_c2327=0x1e & thv_c2324=1`, because both conditions require that `thv_c24` to have the bit value 0/1 at the same time.