### PR TITLE
Decompiler: Add `printRaw` implementation for ambiguous `TypeOp`s

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.cc
@@ -951,6 +951,16 @@ TypeOpIntSless::TypeOpIntSless(TypeFactory *t)
   behave = new OpBehaviorIntSless();
 }
 
+void TypeOpIntSless::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " s< ";
+  Varnode::printRaw(s,op->getIn(1));
+}
+
 Datatype *TypeOpIntSless::getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const
 
 {
@@ -975,6 +985,16 @@ TypeOpIntSlessEqual::TypeOpIntSlessEqual(TypeFactory *t)
   opflags = PcodeOp::binary | PcodeOp::booloutput;
   addlflags = inherits_sign;
   behave = new OpBehaviorIntSlessEqual();
+}
+
+void TypeOpIntSlessEqual::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " s<= ";
+  Varnode::printRaw(s,op->getIn(1));
 }
 
 Datatype *TypeOpIntSlessEqual::getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const
@@ -1586,6 +1606,16 @@ Datatype *TypeOpIntSdiv::getInputCast(const PcodeOp *op,int4 slot,const CastStra
   return castStrategy->castStandard(reqtype,curtype,true,true);
 }
 
+void TypeOpIntSdiv::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " s/ ";
+  Varnode::printRaw(s,op->getIn(1));
+}
+
 TypeOpIntRem::TypeOpIntRem(TypeFactory *t)
   : TypeOpBinary(t,CPUI_INT_REM,"%",TYPE_UINT,TYPE_UINT)
 {
@@ -1612,6 +1642,16 @@ TypeOpIntSrem::TypeOpIntSrem(TypeFactory *t)
   opflags = PcodeOp::binary;
   addlflags = inherits_sign | inherits_sign_zero;
   behave = new OpBehaviorIntSrem();
+}
+
+void TypeOpIntSrem::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " s% ";
+  Varnode::printRaw(s,op->getIn(1));
 }
 
 Datatype *TypeOpIntSrem::getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const
@@ -1661,11 +1701,31 @@ TypeOpFloatEqual::TypeOpFloatEqual(TypeFactory *t,const Translate *trans)
   behave = new OpBehaviorFloatEqual(trans);
 }
 
+void TypeOpFloatEqual::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f== ";
+  Varnode::printRaw(s,op->getIn(1));
+}
+
 TypeOpFloatNotEqual::TypeOpFloatNotEqual(TypeFactory *t,const Translate *trans)
   : TypeOpBinary(t,CPUI_FLOAT_NOTEQUAL,"!=",TYPE_BOOL,TYPE_FLOAT)
 {
   opflags = PcodeOp::binary | PcodeOp::booloutput | PcodeOp::commutative;
   behave = new OpBehaviorFloatNotEqual(trans);
+}
+
+void TypeOpFloatNotEqual::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f!= ";
+  Varnode::printRaw(s,op->getIn(1));
 }
 
 TypeOpFloatLess::TypeOpFloatLess(TypeFactory *t,const Translate *trans)
@@ -1675,11 +1735,31 @@ TypeOpFloatLess::TypeOpFloatLess(TypeFactory *t,const Translate *trans)
   behave = new OpBehaviorFloatLess(trans);
 }
 
+void TypeOpFloatLess::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f< ";
+  Varnode::printRaw(s,op->getIn(1));
+}
+
 TypeOpFloatLessEqual::TypeOpFloatLessEqual(TypeFactory *t,const Translate *trans)
   : TypeOpBinary(t,CPUI_FLOAT_LESSEQUAL,"<=",TYPE_BOOL,TYPE_FLOAT)
 {
   opflags = PcodeOp::binary | PcodeOp::booloutput;
   behave = new OpBehaviorFloatLessEqual(trans);
+}
+
+void TypeOpFloatLessEqual::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f<= ";
+  Varnode::printRaw(s,op->getIn(1));
 }
 
 TypeOpFloatNan::TypeOpFloatNan(TypeFactory *t,const Translate *trans)
@@ -1696,11 +1776,31 @@ TypeOpFloatAdd::TypeOpFloatAdd(TypeFactory *t,const Translate *trans)
   behave = new OpBehaviorFloatAdd(trans);
 }
 
+void TypeOpFloatAdd::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f+ ";
+  Varnode::printRaw(s,op->getIn(1));
+}
+
 TypeOpFloatDiv::TypeOpFloatDiv(TypeFactory *t,const Translate *trans)
   : TypeOpBinary(t,CPUI_FLOAT_DIV,"/",TYPE_FLOAT,TYPE_FLOAT)
 {
   opflags = PcodeOp::binary;
   behave = new OpBehaviorFloatDiv(trans);
+}
+
+void TypeOpFloatDiv::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f/ ";
+  Varnode::printRaw(s,op->getIn(1));
 }
 
 TypeOpFloatMult::TypeOpFloatMult(TypeFactory *t,const Translate *trans)
@@ -1710,6 +1810,16 @@ TypeOpFloatMult::TypeOpFloatMult(TypeFactory *t,const Translate *trans)
   behave = new OpBehaviorFloatMult(trans);
 }
 
+void TypeOpFloatMult::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f* ";
+  Varnode::printRaw(s,op->getIn(1));
+}
+
 TypeOpFloatSub::TypeOpFloatSub(TypeFactory *t,const Translate *trans)
   : TypeOpBinary(t,CPUI_FLOAT_SUB,"-",TYPE_FLOAT,TYPE_FLOAT)
 {
@@ -1717,11 +1827,29 @@ TypeOpFloatSub::TypeOpFloatSub(TypeFactory *t,const Translate *trans)
   behave = new OpBehaviorFloatSub(trans);
 }
 
+void TypeOpFloatSub::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = ";
+  Varnode::printRaw(s,op->getIn(0));
+  s << " f- ";
+  Varnode::printRaw(s,op->getIn(1));
+}
+
 TypeOpFloatNeg::TypeOpFloatNeg(TypeFactory *t,const Translate *trans)
   : TypeOpUnary(t,CPUI_FLOAT_NEG,"-",TYPE_FLOAT,TYPE_FLOAT)
 {
   opflags = PcodeOp::unary;
   behave = new OpBehaviorFloatNeg(trans);
+}
+
+void TypeOpFloatNeg::printRaw(ostream &s,const PcodeOp *op)
+
+{
+  Varnode::printRaw(s,op->getOut());
+  s << " = f- ";
+  Varnode::printRaw(s,op->getIn(0));
 }
 
 TypeOpFloatAbs::TypeOpFloatAbs(TypeFactory *t,const Translate *trans)

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.hh
@@ -340,6 +340,7 @@ public:
 class TypeOpIntSless : public TypeOpBinary {
 public:
   TypeOpIntSless(TypeFactory *t);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual Datatype *getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const;
   virtual Datatype *propagateType(Datatype *alttype,PcodeOp *op,Varnode *invn,Varnode *outvn,
 				  int4 inslot,int4 outslot);
@@ -350,6 +351,7 @@ public:
 class TypeOpIntSlessEqual : public TypeOpBinary {
 public:
   TypeOpIntSlessEqual(TypeFactory *t);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual Datatype *getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const;
   virtual Datatype *propagateType(Datatype *alttype,PcodeOp *op,Varnode *invn,Varnode *outvn,
 				  int4 inslot,int4 outslot);
@@ -534,6 +536,7 @@ public:
 class TypeOpIntSdiv : public TypeOpBinary {
 public:
   TypeOpIntSdiv(TypeFactory *t);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opIntSdiv(op); }
   virtual Datatype *getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const;
 };
@@ -550,6 +553,7 @@ public:
 class TypeOpIntSrem : public TypeOpBinary {
 public:
   TypeOpIntSrem(TypeFactory *t);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opIntSrem(op); }
   virtual Datatype *getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const;
 };
@@ -586,6 +590,7 @@ public:
 class TypeOpFloatEqual : public TypeOpBinary {
 public:
   TypeOpFloatEqual(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatEqual(op); }
 };
   
@@ -593,6 +598,7 @@ public:
 class TypeOpFloatNotEqual : public TypeOpBinary {
 public:
   TypeOpFloatNotEqual(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatNotEqual(op); }
 };
   
@@ -600,6 +606,7 @@ public:
 class TypeOpFloatLess : public TypeOpBinary {
 public:
   TypeOpFloatLess(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatLess(op); }
 };
   
@@ -607,6 +614,7 @@ public:
 class TypeOpFloatLessEqual : public TypeOpBinary {
 public:
   TypeOpFloatLessEqual(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatLessEqual(op); }
 };
   
@@ -621,6 +629,7 @@ public:
 class TypeOpFloatAdd : public TypeOpBinary {
 public:
   TypeOpFloatAdd(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatAdd(op); }
 };
   
@@ -628,6 +637,7 @@ public:
 class TypeOpFloatDiv : public TypeOpBinary {
 public:
   TypeOpFloatDiv(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatDiv(op); }
 };
 
@@ -635,6 +645,7 @@ public:
 class TypeOpFloatMult : public TypeOpBinary {
 public:
   TypeOpFloatMult(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatMult(op); }
 };
   
@@ -642,6 +653,7 @@ public:
 class TypeOpFloatSub : public TypeOpBinary {
 public:
   TypeOpFloatSub(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatSub(op); }
 };
   
@@ -649,6 +661,7 @@ public:
 class TypeOpFloatNeg : public TypeOpUnary {
 public:
   TypeOpFloatNeg(TypeFactory *t,const Translate *trans);			///< Constructor
+  virtual void printRaw(ostream &s,const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opFloatNeg(op); }
 };
 


### PR DESCRIPTION
Fixes #4951.

This adds a `printRaw` implementation to 13 `TypeOp`s, similar in implementation to `TypeOpIntSright::printRaw`. This change makes it possible to uniquely identify the `TypeOp` that produced a given `printRaw` output. The new operators used also correspond to the sleigh syntax for the `TypeOp`s. The changed operators are also shown in the table below.

`TypeOp` class name | Old operator | New operator
--- | --- | ---
`TypeOpIntSless` | `<` | `s<`
`TypeOpIntSlessEqual` | `<=` | `s<=`
`TypeOpIntSdiv` | `/` | `s/`
`TypeOpIntSrem` | `%` | `s%`
`TypeOpFloatEqual` | `==` | `f==`
`TypeOpFloatNotEqual` | `!=` | `f!=`
`TypeOpFloatLess` | `<` | `f<`
`TypeOpFloatLessEqual` | `<=` | `f<=`
`TypeOpFloatAdd` | `+` | `f+`
`TypeOpFloatDiv` | `/` | `f/`
`TypeOpFloatMult` | `*` | `f*`
`TypeOpFloatSub` | `-` | `f-`
`TypeOpFloatNeg` (unary) | `-` | `f-`