### PR TITLE
OMF format: Remove some logging messages

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
@@ -373,9 +373,7 @@ public class OmfLoader extends AbstractProgramWrapperLoader {
 			Address segmentAddr = segment.getAddress(language);
 
 			if (segmentSize == 0) {
-				// don't create a block...just log that we've seen the segment
-				block = program.getMemory().getBlock(segmentAddr);
-				log.appendMsg("Empty Segment: " + segment.getName());
+				// don't create a block
 			}
 			else if (segment.hasNonZeroData()) {
 				block = MemoryBlockUtils.createInitializedBlock(program, false, segment.getName(),
@@ -384,10 +382,7 @@ public class OmfLoader extends AbstractProgramWrapperLoader {
 						Long.toHexString(segmentSize),
 					null/*source*/, segment.isReadable(), segment.isWritable(),
 					segment.isExecutable(), log, monitor);
-				if (block != null) {
-					log.appendMsg(
-						"Created Initialized Block: " + segment.getName() + " @ " + segmentAddr);
-				}
+
 			}
 			else {
 				block = MemoryBlockUtils.createUninitializedBlock(program, false, segment.getName(),
@@ -396,10 +391,6 @@ public class OmfLoader extends AbstractProgramWrapperLoader {
 						Long.toHexString(segmentSize),
 					null/*source*/, segment.isReadable(), segment.isWritable(),
 					segment.isExecutable(), log);
-				if (block != null) {
-					log.appendMsg(
-						"Created Uninitialized Block: " + segment.getName() + " @ " + segmentAddr);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Removing 3 log message about memory block creating.

The first about empty memory block, triggers 3-5 times pr. module of which there may be several hundreds in a library.
The information itself, doesn't convey much useful information, as it seems the compilers like to put the same list in all modules, regardless of it being used or not.

The information from the 2 next about created initialized or uninitialized memory block, can be seen in the code debugger later.
So not much value in those message either.

While creating the loader this information may had some value, but not any longer.
So in my opinion they should simply be removed. 