### PR TITLE
OMF format: Skip fixup for Comdat records

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
@@ -351,8 +351,10 @@ public class OmfFileHeader extends OmfRecord {
 				header.groups.add(group);
 			}
 			else if (record instanceof OmfFixupRecord fixuprec) {
-				fixuprec.setDataBlock(lastDataBlock);
-				header.fixup.add(fixuprec);
+				if(lastDataBlock != null) {
+					fixuprec.setDataBlock(lastDataBlock);
+					header.fixup.add(fixuprec);
+				}
 			}
 			else if (record instanceof OmfEnumeratedData enumheader) {
 				header.addEnumeratedBlock(enumheader);
@@ -368,6 +370,9 @@ public class OmfFileHeader extends OmfRecord {
 				lastDataBlock = iterheader;
 			}
 			else if (record instanceof OmfUnsupportedRecord) {
+				if (record.getRecordType() == COMDAT) {
+					lastDataBlock = null;
+				}
 				logRecord("Unsupported OMF record", record, log);
 			}
 			else if (record instanceof OmfObsoleteRecord) {


### PR DESCRIPTION
The unsupported record type COMDAT may have fixup records attached.

The data are only seen in object oriented libraries, where it contains static initialized classes and virtual tables.
The virtual tables are the ones requiring fixup.

I have tried to do a proper implementation as the data may be of interest for class support in Ghidra, to do something similar to FID but for static classes and virtual tables.
But it turns out to be a bit problematic to do a good implementation, which doesn't require a large amount of rewrite.

So in order to prevent those fixup to be applied to another datablock, I done this minor fix.
It could be acceptable to skip the test for COMDAT record, and set to null always, but this is the safe way.