### PR TITLE
OMF format: Select 16/32 bit based on SEGHEAD (Closes #5081)

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfCommentRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfCommentRecord.java
@@ -27,6 +27,10 @@ public class OmfCommentRecord extends OmfRecord {
 	public static final byte COMMENT_CLASS_LIBMOD = (byte) 0xA3;
 	// Default library cmd
 	public static final byte COMMENT_CLASS_DEFAULT_LIBRARY = (byte) 0x9F;
+	// Watcom compile parameters
+	public static final byte COMMENT_CLASS_WATCOM_SETTINGS = (byte) 0x9b;
+	// Microsoft compile parameters
+	public static final byte COMMENT_CLASS_MICROSOFT_SETTINGS = (byte) 0x9d;
 
 	private byte commentType;
 	private byte commentClass;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
@@ -37,6 +37,7 @@ public class OmfFileHeader extends OmfRecord {
 	private ArrayList<OmfFixupRecord> fixup = new ArrayList<OmfFixupRecord>();
 	private ArrayList<OmfSegmentHeader> extraSeg = null;		// Holds implied segments that don't have official header record
 	//	private OmfModuleEnd endModule = null;
+	private boolean format16bit;
 
 	public OmfFileHeader(BinaryReader reader) throws IOException {
 		readRecordHeader(reader);
@@ -65,7 +66,7 @@ public class OmfFileHeader extends OmfRecord {
 	 * @return the string identifying the architecture this object was compiled for
 	 */
 	public String getMachineName() {
-		return "i386";			// This is the only possibility
+		return format16bit ? "16bit" : "32bit";
 	}
 
 	/**
@@ -250,13 +251,13 @@ public class OmfFileHeader extends OmfRecord {
 	 * Scan the object file, for the main header and comment records. Other records are parsed but not saved
 	 * @param reader is the byte stream
 	 * @param monitor is checked for cancellation
-	 * @param initialCommentsOnly  is true if we only want to scan the header and the initial comments,
+	 * @param fastscan is true if we only want to scan the header until first seghead,
 	 * @return the header record
 	 * @throws IOException for problems reading program data
 	 * @throws OmfException for malformed records
 	 */
 	public static OmfFileHeader scan(BinaryReader reader, TaskMonitor monitor,
-			boolean initialCommentsOnly) throws IOException, OmfException {
+			boolean fastscan) throws IOException, OmfException {
 		OmfRecord record = OmfRecord.readRecord(reader);
 		if (!(record instanceof OmfFileHeader)) {
 			throw new OmfException("Object file does not start with proper header");
@@ -274,16 +275,26 @@ public class OmfFileHeader extends OmfRecord {
 			}
 
 			if (record instanceof OmfCommentRecord comment) {
-				byte commentClass = comment.getCommentClass();
-				if (commentClass == OmfCommentRecord.COMMENT_CLASS_TRANSLATOR) {
+				switch(comment.getCommentClass()) {
+				case OmfCommentRecord.COMMENT_CLASS_TRANSLATOR:
 					header.translator = comment.getValue();
-				}
-				else if (commentClass == OmfCommentRecord.COMMENT_CLASS_LIBMOD) {
+					break;
+				case OmfCommentRecord.COMMENT_CLASS_LIBMOD:
 					header.libModuleName = comment.getValue();
+					break;
+				case OmfCommentRecord.COMMENT_CLASS_WATCOM_SETTINGS:
+					header.translator = "Watcom";
+					break;
+				case OmfCommentRecord.COMMENT_CLASS_MICROSOFT_SETTINGS:
+					header.translator = "Microsoft";
+					break;
 				}
 			}
-			else if (initialCommentsOnly) {
-				break;
+			else if (record instanceof OmfSegmentHeader head) {
+				header.format16bit = head.is16Bit();
+				if(fastscan) {
+					break;
+				}
 			}
 		}
 		return header;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfSegmentHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfSegmentHeader.java
@@ -207,6 +207,13 @@ public class OmfSegmentHeader extends OmfRecord {
 	}
 
 	/**
+	 * @return if 16 or 32 bit segments are used
+	 */
+	public boolean is16Bit() {
+		return (segAttr & 1) == 0;
+	}
+
+	/**
 	 * @return true if this block uses filler other than zero bytes
 	 */
 	public boolean hasNonZeroData() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
@@ -70,6 +70,12 @@ public class OmfLoader extends AbstractProgramWrapperLoader {
 		if (record.startsWith("CodeGear")) {
 			return "codegearcpp";
 		}
+		if (record.equals("MS C")) {
+			return "windows";
+		}
+		if(record.startsWith("Watcom")) {
+			return "watcom";
+		}
 		return null;
 	}
 

--- a/Ghidra/Processors/x86/data/languages/x86.opinion
+++ b/Ghidra/Processors/x86/data/languages/x86.opinion
@@ -65,17 +65,17 @@
     </constraint>
     <constraint loader="Relocatable Object Module Format (OMF)">
       <constraint compilerSpecID="windows">
-        <constraint primary="i386" processor="x86"          endian="little" size="32" />
+        <constraint primary="32bit" processor="x86"          endian="little" size="32" />
       </constraint>
       <constraint compilerSpecID="default">
-        <constraint primary="i386" processor="x86"          endian="little" size="16" />
+        <constraint primary="16bit" processor="x86"          endian="little" size="16" />
       </constraint>
       <constraint compilerSpecID="borlandcpp">
-        <constraint primary="i386" secondary="borlandcpp" processor="x86"        endian="little" size="32" />
-        <constraint primary="i386" secondary="codegearcpp" processor="x86"       endian="little" size="32" />
+        <constraint primary="32bit" secondary="borlandcpp" processor="x86"        endian="little" size="32" />
+        <constraint primary="32bit" secondary="codegearcpp" processor="x86"       endian="little" size="32" />
       </constraint>
       <constraint compilerSpecID="borlanddelphi">
-        <constraint primary="i386" secondary="borlanddelphi" processor="x86"     endian="little" size="32" />
+        <constraint primary="32bit" secondary="borlanddelphi" processor="x86"     endian="little" size="32" />
       </constraint>
     </constraint>
 </opinions>


### PR DESCRIPTION
This implement selection of 16/32 based on the SEGHEAD record flag for using 16 or 32 bit.
It also adds some translator names based on comment records types.
These comment records also contain additional info about the compile
    class 9bh WATCOM Compile parameters:
    Processor     : 80386
    Memory Model  : Flat
    Optimized     : Yes
    Floating point: Emulator calls

The "MS C" translator name is based on the file in ticket 4793.
Is this an acceptable mix of fixes?
Is it ok to add Watcom, even if I haven't added files for a watcom compile spec yet?