### PR TITLE
Fix crash in find field references

### DIFF
--- a/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/extension/datatype/finder/DecompilerVariable.java
+++ b/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/extension/datatype/finder/DecompilerVariable.java
@@ -106,7 +106,7 @@ public abstract class DecompilerVariable {
 		}
 
 		Varnode[] inputs = op.getInputs();
-		if (inputs.length == 2) {
+		if (inputs.length == 2 && inputs[0].getHigh() != null) {
 			return inputs[0].getHigh().getDataType();
 		}
 


### PR DESCRIPTION
This PR fix JAVA exception with getting data type to find field references. When this exception caused - find process is beaked, so you may see empty or not all references. This PR fixes it.