### PR TITLE
OMF format: Fix for comdat and fixup records

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/OmfFileHeader.java
@@ -351,10 +351,8 @@ public class OmfFileHeader extends OmfRecord {
 				header.groups.add(group);
 			}
 			else if (record instanceof OmfFixupRecord fixuprec) {
-				if (lastDataBlock != null) {
-					fixuprec.setDataBlock(lastDataBlock);
-					header.fixup.add(fixuprec);
-				}
+				fixuprec.setDataBlock(lastDataBlock);
+				header.fixup.add(fixuprec);
 			}
 			else if (record instanceof OmfEnumeratedData enumheader) {
 				header.addEnumeratedBlock(enumheader);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/OmfLoader.java
@@ -198,6 +198,9 @@ public class OmfLoader extends AbstractProgramWrapperLoader {
 					int method, index, locationType = -1;
 					locAddress = null;
 
+					if(fixup.getDataBlock() == null) {
+						continue;	// If no data block don't try to fixup
+					}
 					try {
 						if (subrec.isTargetThread()) {
 							Subrecord rec = targetThreads[subrec.getFixThreadNum()];


### PR DESCRIPTION
In order to make sure that thread records are created, even if actual fixups need to be skipped, all fixup records must be processed.
But if no datablock to apply fix to is found, actual fixup are skipped.

Importing a C++ OMF file will give lots of "Unsupported record COMDAT" and the occasional "Unhandled relocation" which most likely is a reference to a comdat block, that can't be resolved.