### PR TITLE
Throw exception on invalid address space element during decode

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
@@ -234,7 +234,7 @@ AddrSpace *AddrSpaceManager::decodeSpace(Decoder &decoder,const Translate *trans
   else if (elemId == ELEM_SPACE)
     res = new AddrSpace(this,trans,IPTR_PROCESSOR);
   else
-    throw LowLevelError("Invalid address space element. Internal element id: " + elemId);
+    throw LowlevelError("Invalid address space element. Internal element id: " + elemId);
 
   res->decode(decoder);
   return res;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
@@ -231,8 +231,10 @@ AddrSpace *AddrSpaceManager::decodeSpace(Decoder &decoder,const Translate *trans
     res = new OtherSpace(this,trans);
   else if (elemId == ELEM_SPACE_OVERLAY)
     res = new OverlaySpace(this,trans);
-  else
+  else if (elemId == ELEM_SPACE)
     res = new AddrSpace(this,trans,IPTR_PROCESSOR);
+  else
+    throw LowLevelError("Invalid address space element. Internal element id: " + elemId);
 
   res->decode(decoder);
   return res;


### PR DESCRIPTION
When decoding an address space, the translator will peek the next element from the decoder and select the appropriate address space based on the element id returned by the decoder. The translator currently assumes the address space must be a `<space>` element if it doesn't match any of the others. This change confirms that the address space is a `<space>` element and throws an exception if the element is not a valid address space.

This situation can also occur if the `ElementId::initialize()` function has not been called before decoding. In that case, the decoder will fail to recognize any address space element and will always return `ELEM_UNKNOWN`.

The exception includes the internal element id since that is all that's available in the translator. Additional information could be obtained if instead of peeking an arbitrary element, a separate decoding function peeking a set of valid elements was called instead. The decoder could then throw an exception naming the unexpected element.