### PR TITLE
Fix a few issues with PEF relocation and loading

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/LoaderRelocationHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/LoaderRelocationHeader.java
@@ -42,7 +42,7 @@ public class LoaderRelocationHeader implements StructConverter {
 	private int   relocCount;
 	private int   firstRelocOffset;
 
-	private List<Relocation> _relocations = new ArrayList<Relocation>();
+	private ArrayList<Relocation> _relocations = new ArrayList<Relocation>();
 
 	LoaderRelocationHeader(BinaryReader reader, LoaderInfoHeader loader) throws IOException {
 		sectionIndex     = reader.readNextShort();
@@ -99,7 +99,7 @@ public class LoaderRelocationHeader implements StructConverter {
 		return firstRelocOffset;
 	}
 
-	public List<Relocation> getRelocations() {
+	public ArrayList<Relocation> getRelocations() {
 		return _relocations;
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/RelocLgRepeat.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/RelocLgRepeat.java
@@ -33,7 +33,7 @@ public class RelocLgRepeat extends Relocation {
 		int value = reader.readNextShort() & 0xffff;
 
 		opcode       =  (value & 0xfc00) >> 10;
-		chunkCount   =  (value & 0x0330) >>  6;
+		chunkCount   =  (value & 0x03c0) >>  6;
 		repeatCount  =  (value & 0x003f) << 16;
 		repeatCount |=  reader.readNextShort() & 0xffff;
 	}
@@ -48,18 +48,19 @@ public class RelocLgRepeat extends Relocation {
 		return 4;
 	}
 
-	public int getChunkCount() {
+	@Override
+	public int getRepeatChunks() {
 		return chunkCount + 1;
 	}
 
+	@Override
 	public int getRepeatCount() {
-		return repeatCount + 1;
+		return repeatCount;
 	}
 
 	@Override
 	public void apply(ImportStateCache importState, RelocationState relocState, 
 			ContainerHeader header, Program program, MessageLog log, TaskMonitor monitor) {
-		
-		throw new RuntimeException("Unhandled relocation: RelocLgRepeat");
+		/* nothing to do */
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/RelocLgSetOrBySection.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/RelocLgSetOrBySection.java
@@ -18,6 +18,8 @@ package ghidra.app.util.bin.format.pef;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.symbol.*;
 import ghidra.util.task.TaskMonitor;
 
 import java.io.IOException;
@@ -26,6 +28,27 @@ import java.io.IOException;
  * See Apple's -- PEFBinaryFormat.h
  */
 public class RelocLgSetOrBySection extends Relocation {
+	/**
+	 * This instruction adds the address of the instantiated
+	 * section specified by <code>index</code> to the word
+	 * pointed to by <code>relocAddress</code>. After
+	 * execution, <code>relocAddress</code> points to just
+	 * past the modified word.
+	 */
+	public final static int kPEFRelocLgBySection = 0;
+	/**
+	 * This instruction sets the variable <code>sectionC</code>
+	 * to the memory address of the instantiated section
+	 * specified by <code>index</code>.
+	 */
+	public final static int kPEFRelocLgSetSectC = 1;
+	/**
+	 * This instruction sets the variable <code>sectionD</code>
+	 * to the memory adddress of the instantiated section
+	 * specified by <code>index</code>.
+	 */
+	public final static int kPEFRelocLgSetSectD = 2;
+
 	private int subopcode;
 	private int index;
 
@@ -33,7 +56,7 @@ public class RelocLgSetOrBySection extends Relocation {
 		int value = reader.readNextShort() & 0xffff;
 
 		opcode    =  (value & 0xfc00) >> 10;
-		subopcode =  (value & 0x0330) >> 6;
+		subopcode =  (value & 0x03c0) >> 6;
 		index     =  (value & 0x003f) << 16;
 		index    |=  reader.readNextShort() & 0xffff;
 	}
@@ -56,10 +79,44 @@ public class RelocLgSetOrBySection extends Relocation {
 		return index;
 	}
 
+        @Override
+	public String toString() {
+		switch (subopcode) {
+			case kPEFRelocLgBySection: return "RelocLgBySection";
+			case kPEFRelocLgSetSectC:  return "RelocLgSetSectC";
+			case kPEFRelocLgSetSectD:  return "RelocLgSetSectD";
+		}
+		return super.toString();
+	}
+
 	@Override
 	public void apply(ImportStateCache importState, RelocationState relocState, 
 			ContainerHeader header, Program program, MessageLog log, TaskMonitor monitor) {
 
-		throw new RuntimeException("Unhandled relocation: RelocLgSetOrBySection");
+		switch (subopcode) {
+			case kPEFRelocLgBySection: {
+				SectionHeader sect = header.getSections().get(index);
+				MemoryBlock block = importState.getMemoryBlockForSection(sect);
+				relocState.relocateMemoryAt(relocState.getRelocationAddress(),
+											(int)block.getStart().getOffset(), log);
+				break;
+			}
+			case kPEFRelocLgSetSectC: {
+				SectionHeader sectC = header.getSections().get(index);
+				MemoryBlock blockC = importState.getMemoryBlockForSection(sectC);
+				relocState.setSectionC(blockC.getStart());
+				break;
+			}
+			case kPEFRelocLgSetSectD: {
+				SectionHeader sectD = header.getSections().get(index);
+				MemoryBlock blockD = importState.getMemoryBlockForSection(sectD);
+				relocState.setSectionD(blockD.getStart());
+				break;
+			}
+			default: {
+				log.appendMsg("Unsupported RelocLgSetOrBySection subopcode: " + subopcode);
+				break;
+			}
+                }
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/RelocSmRepeat.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/RelocSmRepeat.java
@@ -42,10 +42,12 @@ public class RelocSmRepeat extends Relocation {
 		return opcode == 0x9;
 	}
 
-	public int getChunks() {
+	@Override
+	public int getRepeatChunks() {
 		return chunks + 1;
 	}
 
+	@Override
 	public int getRepeatCount() {
 		return repeatCount + 1;
 	}
@@ -53,7 +55,6 @@ public class RelocSmRepeat extends Relocation {
 	@Override
 	public void apply(ImportStateCache importState, RelocationState relocState, 
 			ContainerHeader header, Program program, MessageLog log, TaskMonitor monitor) {
-
-		throw new RuntimeException("Unhandled relocation: RelocSmRepeat");
+		/* nothing to do */
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/Relocation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/Relocation.java
@@ -63,6 +63,14 @@ public abstract class Relocation implements StructConverter {
 		return 2;
 	}
 
+	public int getRepeatCount() {
+		return 0;
+	}
+
+	public int getRepeatChunks() {
+		return 0;
+	}
+
 	public DataType toDataType() throws DuplicateNameException, IOException {
 		DataType dt = getSizeInBytes() == 2 ? WORD : DWORD;
 		return new TypedefDataType(toString(), dt);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/SectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pef/SectionHeader.java
@@ -153,7 +153,7 @@ public class SectionHeader implements StructConverter {
 						throw new IllegalStateException(
 							"Unable to read enough bytes for " + opcode);
 					}
-					for (int i = 0; i < repeatCount - 1; ++i) {
+					for (int i = 0; i < repeatCount + 1; ++i) {
 						System.arraycopy(rawData, 0, data, index, rawData.length);
 						index += rawData.length;
 					}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PefLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PefLoader.java
@@ -320,7 +320,7 @@ public class PefLoader extends AbstractProgramWrapperLoader {
 	}
 
 	private void processRelocations(ContainerHeader header, Program program,
-			ImportStateCache importState, MessageLog log, TaskMonitor monitor) {
+			ImportStateCache importState, MessageLog log, TaskMonitor monitor) throws IOException {
 		List<LoaderRelocationHeader> relocationHeaders = header.getLoader().getRelocations();
 		for (LoaderRelocationHeader relocationHeader : relocationHeaders) {
 			if (monitor.isCancelled()) {
@@ -328,9 +328,11 @@ public class PefLoader extends AbstractProgramWrapperLoader {
 			}
 			RelocationState state =
 				new RelocationState(header, relocationHeader, program, importState);
-			List<Relocation> relocations = relocationHeader.getRelocations();
+			ArrayList<Relocation> relocations = relocationHeader.getRelocations();
 			int relocationIndex = 0;
-			for (Relocation relocation : relocations) {
+			int numRepeats = 0;
+			int jumpToIdx = -1;
+			while (relocationIndex < relocations.size()) {
 				if (monitor.isCancelled()) {
 					return;
 				}
@@ -338,9 +340,40 @@ public class PefLoader extends AbstractProgramWrapperLoader {
 					monitor.setMessage(
 						"Processing relocation " + relocationIndex + " of " + relocations.size());
 				}
-				++relocationIndex;
 
+				Relocation relocation = relocations.get(relocationIndex);
 				relocation.apply(importState, state, header, program, log, monitor);
+
+				if (relocation.getRepeatCount() != 0) {
+					numRepeats++;
+
+					if (numRepeats < relocation.getRepeatCount()) {
+						if (jumpToIdx != -1) {
+							relocationIndex = jumpToIdx;
+							continue;
+						}
+
+						int blocksBack = 0;
+						jumpToIdx = relocationIndex;
+						while (blocksBack < relocation.getRepeatChunks()) {
+							jumpToIdx--;
+							blocksBack += relocations.get(jumpToIdx).getSizeInBytes() / 2;
+						}
+
+						if (blocksBack != relocation.getRepeatChunks()) {
+							throw new IOException("specified number of repeat chunks does not point to the start of a relocation command!");
+						}
+
+						continue;
+
+					} else {
+						/* done looping */
+						numRepeats = 0;
+						jumpToIdx = -1;
+					}
+				}
+
+				++relocationIndex;
 			}
 			state.dispose();
 		}


### PR DESCRIPTION
- Fix a bug where the repeatCount for the repeated block unpacking opcode is decremented by one rather than incremented by one. See Mac OS Runtime Architectures page 8-13 for how this is supposed to work.

- Implement the RelocSmRepeat and RelocLgRepeat relocation opcodes. The basic approach is to go back over the preceding blocks the specified number of times and insert new Relocation instances for each iteration. This approach may not scale the best for large numbers of repeats, but for real-world scenarios it seems to work OK.

- Implement the RelocLgSetOrBySection relocation opcode in the same manner as the RelocByIndexGroup opcode.

- Fix a couple of incorrect masks for the large opcodes.