### PR TITLE
Fix warning "error: unmappable character (0xE2) for encoding US-ASCII"

### DIFF
--- a/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/model/impl/LldbModelTargetProcessLaunchWithOptionsConnectorImpl.java
+++ b/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/model/impl/LldbModelTargetProcessLaunchWithOptionsConnectorImpl.java
@@ -122,7 +122,7 @@ public class LldbModelTargetProcessLaunchWithOptionsConnectorImpl extends LldbMo
 		ParameterDescription<Boolean> pF8 =
 			ParameterDescription.create(Boolean.class, "ExitRace", false,
 				false, "Suppress race on exit",
-				"set this flag so lldb & the handee don’t race to set its exit status");
+				"set this flag so lldb & the handee don't race to set its exit status");
 		map.put("ExitRace", pF8);
 		ParameterDescription<Boolean> pF9 = ParameterDescription.create(Boolean.class, "Detach",
 			false,


### PR DESCRIPTION
> Task :Debugger-agent-lldb:compileJava
/tmp/ghidra/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/model/impl/LldbModelTargetProcessLaunchWithOptionsConnectorImpl.java:125: error: unmappable character (0xE2) for encoding US-ASCII
                                "set this flag so lldb & the handee don???t race to set its exit status");
                                                                       ^
/tmp/ghidra/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/model/impl/LldbModelTargetProcessLaunchWithOptionsConnectorImpl.java:125: error: unmappable character (0x80) for encoding US-ASCII
                                "set this flag so lldb & the handee don???t race to set its exit status");
                                                                        ^
/tmp/ghidra/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/model/impl/LldbModelTargetProcessLaunchWithOptionsConnectorImpl.java:125: error: unmappable character (0x99) for encoding US-ASCII
                                "set this flag so lldb & the handee don???t race to set its exit status");