### PR TITLE
SPARC: Add recognition for PC relative addressing

### DIFF
--- a/Ghidra/Processors/Sparc/data/languages/SparcV9_32.cspec
+++ b/Ghidra/Processors/Sparc/data/languages/SparcV9_32.cspec
@@ -100,4 +100,13 @@
       </localrange>
     </prototype>
   </default_proto>
+  <callfixup name="get_pc_thunk">
+    <target name="__sparc_get_pc_thunk"/>
+    <pcode>
+      <body><![CDATA[
+      l7 = inst_start + l7;
+      ]]>
+      </body>
+    </pcode>
+  </callfixup>
 </compiler_spec>

--- a/Ghidra/Processors/Sparc/data/languages/SparcV9_64.cspec
+++ b/Ghidra/Processors/Sparc/data/languages/SparcV9_64.cspec
@@ -187,4 +187,13 @@
         <range space="stack" first="0x0" last="0x8ae"/>   <!-- Stack bias of 7FF + 0xb0 window size -->
       </localrange>
     </prototype>
+  <callfixup name="get_pc_thunk">
+    <target name="__sparc_get_pc_thunk"/>
+    <pcode>
+      <body><![CDATA[
+      l7 = inst_start + l7;
+      ]]>
+      </body>
+    </pcode>
+  </callfixup>
 </compiler_spec>

--- a/Ghidra/Processors/Sparc/data/patterns/SPARC_patterns.xml
+++ b/Ghidra/Processors/Sparc/data/patterns/SPARC_patterns.xml
@@ -32,4 +32,9 @@
       <funcstart/>
     </postpatterns>
   </patternpairs>
+  <pattern>
+    <!-- retl; add o7, l7, l7 -->
++   <data>0x81 0xc3 0xe0 0x08 0xae 0x03 0xc0 0x17</data>
++   <funcstart label="__sparc_get_pc_thunk" validcode="function"/>
++  </pattern>
  </patternlist>


### PR DESCRIPTION
This change adds recognition for the GCC-inserted `__sparc_get_pc_thunk` function so that cross-references in binaries that call this function are resolved correctly.
