### PR TITLE
[doc]: fix semantic statement for pcode CALL

### DIFF
--- a/GhidraDocs/languages/html/pcodedescription.html
+++ b/GhidraDocs/languages/html/pcodedescription.html
@@ -396,7 +396,7 @@ relative branching is not possible with <span class="bold"><strong>BRANCHIND</st
 </tr>
 <tr>
   <td></td>
-  <td colspan="2"><code class="code">call [input0];</code></td>
+  <td colspan="2"><code class="code">call input0;</code></td>
 </tr>
 </tfoot>
 </table>


### PR DESCRIPTION
The original semantic statement of CALL is   
```
call [input0]
```
It is **incorrect** because the input0 is a varnode which contains the direct address instead of indirect.

So I change it to 
```
call input0
```
to fix it.

The modified version will correct it and differentiate from the CALLIND whose input0 is an indirect address, which should use "[]"
