### PR TITLE
Fix srvAdmin compatibility with BSD systems

### DIFF
--- a/Ghidra/RuntimeScripts/Linux/server/svrAdmin
+++ b/Ghidra/RuntimeScripts/Linux/server/svrAdmin
@@ -42,7 +42,7 @@ else
 fi
 
 # Identify server process owner if set within server.conf
-OWNER="$(grep '^wrapper.app.account=' "${CONFIG}" | sed -e 's/^.*=\(.*\)\s*.*$/\1/')"
+OWNER="$(grep '^wrapper.app.account=' "${CONFIG}" | cut -d '=' -f 2)"
 
 if [ -z "${OWNER}" -o "${OWNER}" = "$(whoami)" ]; then
 	VMARGS="-DUserAdmin.invocation=$(basename "${SCRIPT_FILE}")"


### PR DESCRIPTION
The version of `sed` that comes with some BSD systems such as FreeBSD does not support escape sequence `\s` and fails with the following error:

```
sed: 1: "s/^.*=\(.*\)\s*.*$/\1/
```

Using `cut` to obtain the username should be more compatible.