### PR TITLE
Fixed instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ To create the latest development build for your platform from this source reposi
 ##### Download and extract the source:
 [Download from GitHub][master]
 ```
-$ unzip ghidra-master
-$ cd ghidra-master
+unzip ghidra-master
+cd ghidra-master
 ```
 **NOTE:** Instead of downloading the compressed source, you may instead want to clone the GitHub 
 repository: `git clone https://github.com/NationalSecurityAgency/ghidra.git`
 
 ##### Download additional build dependencies into source repository: 
 ```
-$ gradle -I gradle/support/fetchDependencies.gradle init
+gradle -I gradle/support/fetchDependencies.gradle init
 ```
 
 ##### Create development build: 
 ```
-$ gradle buildGhidra
+gradle buildGhidra
 ```
 The compressed development build will be located at `build/dist/`.
 
@@ -93,7 +93,7 @@ development process has been highly customized for.
 
 ##### Prepare the development environment:
 ``` 
-$ gradle prepdev eclipse buildNatives
+gradle prepdev eclipse buildNatives
 ```
 
 ##### Import Ghidra projects into Eclipse:


### PR DESCRIPTION
I tried following the build instructions in the README and encountered a baffling error.

![image](https://user-images.githubusercontent.com/46897303/235795623-7a9af413-fbb8-4472-8ae8-8bbdf0b37bb2.png)


Note: There is now a copy button on GitHub for copying the contents of a code block in markdown. The `$` was being included which is how I encountered this.