### PR TITLE
Add support for R_AARCH64_MOVW_UABS_G* relocations

### DIFF
--- a/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/util/bin/format/elf/relocation/AARCH64_ElfRelocationHandler.java
+++ b/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/util/bin/format/elf/relocation/AARCH64_ElfRelocationHandler.java
@@ -71,6 +71,8 @@ public class AARCH64_ElfRelocationHandler extends ElfRelocationHandler {
 
 		boolean is64bit = true;
 		
+		boolean overflowCheck = true; // *_NC type relocations specify "no overflow check"
+
 		Address symbolAddr = elfRelocationContext.getSymbolAddress(sym);
 		long symbolValue = elfRelocationContext.getSymbolValue(sym);
 		long newValue = 0;
@@ -134,6 +136,87 @@ public class AARCH64_ElfRelocationHandler extends ElfRelocationHandler {
 				newValue -= (offset); // PC relative
 				memory.setShort(relocationAddress, (short) (newValue & 0xffff));
 				byteLength = 2;
+				break;
+			}
+
+			// MOV[ZK]:   ((S+A) >>  0) & 0xffff
+			case AARCH64_ElfRelocationConstants.R_AARCH64_MOVW_UABS_G0_NC: {
+				overflowCheck = false;
+				// fall-through
+			}
+			case AARCH64_ElfRelocationConstants.R_AARCH64_MOVW_UABS_G0: {
+				int oldValue = memory.getInt(relocationAddress, isBigEndianInstructions);
+				long imm = (symbolValue + addend) >> 0;
+
+				oldValue &= ~(0xffff << 5);
+				newValue = oldValue | ((imm & 0xffff) << 5);
+
+				memory.setInt(relocationAddress, (int) newValue, isBigEndianInstructions);
+
+				if (overflowCheck && imm > 0xffffL) {
+					// relocation already applied; report overflow condition
+					markAsError(program, relocationAddress, "R_AARCH64_MOVW_UABS_G0", symbolName,
+						"Failed overflow check for R_AARCH64_MOVW_UABS_G0 immediate value",
+						elfRelocationContext.getLog());
+				}
+				break;
+			}
+
+			// MOV[ZK]:   ((S+A) >>  16) & 0xffff
+			case AARCH64_ElfRelocationConstants.R_AARCH64_MOVW_UABS_G1_NC: {
+				overflowCheck = false;
+				// fall-through
+			}
+			case AARCH64_ElfRelocationConstants.R_AARCH64_MOVW_UABS_G1: {
+				int oldValue = memory.getInt(relocationAddress, isBigEndianInstructions);
+				long imm = (symbolValue + addend) >> 16;
+
+				oldValue &= ~(0xffff << 5);
+				newValue = oldValue | ((imm & 0xffff) << 5);
+
+				memory.setInt(relocationAddress, (int) newValue, isBigEndianInstructions);
+
+				if (overflowCheck && imm > 0xffffL) {
+					// relocation already applied; report overflow condition
+					markAsError(program, relocationAddress, "R_AARCH64_MOVW_UABS_G0", symbolName,
+						"Failed overflow check for R_AARCH64_MOVW_UABS_G0 immediate value",
+						elfRelocationContext.getLog());
+				}
+				break;
+			}
+
+			// MOV[ZK]:   ((S+A) >>  32) & 0xffff
+			case AARCH64_ElfRelocationConstants.R_AARCH64_MOVW_UABS_G2_NC: {
+				overflowCheck = false;
+				// fall-through
+			}
+			case AARCH64_ElfRelocationConstants.R_AARCH64_MOVW_UABS_G2: {
+				int oldValue = memory.getInt(relocationAddress, isBigEndianInstructions);
+				long imm = (symbolValue + addend) >> 32;
+
+				oldValue &= ~(0xffff << 5);
+				newValue = oldValue | ((imm & 0xffff) << 5);
+
+				memory.setInt(relocationAddress, (int) newValue, isBigEndianInstructions);
+
+				if (overflowCheck && imm > 0xffffL) {
+					// relocation already applied; report overflow condition
+					markAsError(program, relocationAddress, "R_AARCH64_MOVW_UABS_G0", symbolName,
+						"Failed overflow check for R_AARCH64_MOVW_UABS_G0 immediate value",
+						elfRelocationContext.getLog());
+				}
+				break;
+			}
+
+			// MOV[ZK]:   ((S+A) >>  48) & 0xffff
+			case AARCH64_ElfRelocationConstants.R_AARCH64_MOVW_UABS_G3: {
+				int oldValue = memory.getInt(relocationAddress, isBigEndianInstructions);
+				long imm = (symbolValue + addend) >> 48;
+
+				oldValue &= ~(0xffff << 5);
+				newValue = oldValue | ((imm & 0xffff) << 5);
+
+				memory.setInt(relocationAddress, (int) newValue, isBigEndianInstructions);
 				break;
 			}
 


### PR DESCRIPTION
Adding support to the `AARCH64` processor module for handling ELF relocations of types `R_AARCH64_MOVW_UABS_G*`. This pull request addresses the concerns mentioned in #3546 and fixes issue #3545

This patch has been successfully tested for the above broken relocation types on several large `AARCH64` kernel modules which use these relocation types excessively.