### PR TITLE
Adjust plate comment word-wrap to take account of the plate wrapping space.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/PlateFieldFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/PlateFieldFactory.java
@@ -246,7 +246,11 @@ public class PlateFieldFactory extends FieldFactory {
 			commentsList.add(CommentUtils.parseTextForAnnotations(c, p, prototype, row++));
 		}
 		if (isWordWrap) {
-			commentsList = FieldUtils.wordWrapList(new CompositeFieldElement(commentsList), width);
+			int charWidth = getMetrics().charWidth(' ');
+			int paddingWidth = CONTENT_PADDING * charWidth;
+			commentsList = FieldUtils.wordWrapList(
+				new CompositeFieldElement(commentsList),
+				Math.max(width - paddingWidth, charWidth));
 		}
 		boolean isClipped = addSideBorders(commentsList);
 		elements.addAll(commentsList);


### PR DESCRIPTION
This is a pull request associated with #5297.

In short, word-wrapping of plate comments currently does not work well as it wraps to the width of the plate, including padding, and then truncates to the width of the plate, excluding padding.

This PR attempts to fix that.

I have tried to make the padding width calculation consistent with `addSideBorder`, while making this a minimal change to the code. If you would prefer it implemented another way, I would be happy to modify it.