### PR TITLE
Catch exception when reading invalid dwarf abbrev code and continue

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
@@ -351,8 +351,19 @@ public class DWARFCompilationUnit {
 		DebugInfoEntry parent = null;
 		DebugInfoEntry die;
 		DebugInfoEntry unexpectedTerminator = null;
-		while ((br.getPointerIndex() < getEndOffset()) &&
-			(die = DebugInfoEntry.read(br, this, dwarfProgram.getAttributeFactory())) != null) {
+		while ((br.getPointerIndex() < getEndOffset())) {
+			try {
+				die = DebugInfoEntry.read(br, this, dwarfProgram.getAttributeFactory());
+			}
+			catch (IOException ioe) {
+				Msg.error(null,
+					"Failed to parse the DW_TAG_compile_unit DIE at the start of compilation unit " +
+						this.compUnitNumber + " at offset " + this.startOffset + " (0x" +
+						Long.toHexString(this.startOffset) + "), skipping entire compilation unit",
+					ioe);
+				br.setPointerIndex(this.getEndOffset());
+				continue;
+			}
 
 			monitor.checkCancelled();
 


### PR DESCRIPTION
`DebugInfoEntry.read` throws an exception if there is an invalid DIE entry. As is, if the dwarf parser encounters an invalid abbreviation code, it prevents the rest of the dwarf from getting parsed since the exception is uncaught.