### PR TITLE
Fix test for ghidra root path in cpp decompiler console

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/filemanage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/filemanage.cc
@@ -307,36 +307,15 @@ string FileManage::buildPath(const vector<string> &pathels,int level)
   return s.str();
 }
 
-bool FileManage::testDevelopmentPath(const vector<string> &pathels,int level,string &root)
-
-{ // Given pathels[level] is "Ghidra", determine if this is a Ghidra development layout
-  if (level + 2 >= pathels.size()) return false;
-  string parent = pathels[level + 1];
-  if (parent.size() < 11) return false;
-  string piecestr = parent.substr(0,7);
-  if (piecestr != "ghidra.") return false;
-  piecestr = parent.substr(parent.size() - 4);
-  if (piecestr != ".git") return false;
-  root = buildPath(pathels,level+2);
-  vector<string> testpaths1;
-  vector<string> testpaths2;
-  scanDirectoryRecursive(testpaths1,"ghidra.git",root,1);
-  if (testpaths1.size() != 1) return false;
-  scanDirectoryRecursive(testpaths2,"Ghidra",testpaths1[0],1);
-  return (testpaths2.size() == 1);
-}
-
-bool FileManage::testInstallPath(const vector<string> &pathels,int level,string &root)
+bool FileManage::testGhidraPath(const vector<string> &pathels,int level,string &root)
 
 {
   if (level + 1 >= pathels.size()) return false;
   root = buildPath(pathels,level+1);
+  string ghidraPath = buildPath(pathels,level);
   vector<string> testpaths1;
-  vector<string> testpaths2;
-  scanDirectoryRecursive(testpaths1,"server",root,1);
-  if (testpaths1.size() != 1) return false;
-  scanDirectoryRecursive(testpaths2,"server.conf",testpaths1[0],1);
-  return (testpaths2.size() == 1);
+  scanDirectoryRecursive(testpaths1,"Processors",ghidraPath,1);
+  return (testpaths1.size() == 1);
 }
 
 string FileManage::discoverGhidraRoot(const char *argv0)
@@ -350,6 +329,7 @@ string FileManage::discoverGhidraRoot(const char *argv0)
 
   for(;;) {
     int sizebefore = cur.size();
+    if (sizebefore == 0) break;
     splitPath(cur,cur,base);
     if (cur.size() == sizebefore) break;
     if (base == ".")
@@ -376,9 +356,7 @@ string FileManage::discoverGhidraRoot(const char *argv0)
   for(int i=0;i<pathels.size();++i) {
     if (pathels[i] != "Ghidra") continue;
     string root;
-    if (testDevelopmentPath(pathels,i,root))
-      return root;
-    if (testInstallPath(pathels,i,root))
+    if (testGhidraPath(pathels,i,root))
       return root;
   }
   return "";

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/filemanage.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/filemanage.hh
@@ -35,8 +35,7 @@ class FileManage {
   vector<string> pathlist;	// List of paths to search for files
   static char separator;
   static string buildPath(const vector<string> &pathels,int level);
-  static bool testDevelopmentPath(const vector<string> &pathels,int level,string &root);
-  static bool testInstallPath(const vector<string> &pathels,int level,string &root);
+  static bool testGhidraPath(const vector<string> &pathels,int level,string &root);
 public:
   void addDir2Path(const string &path);
   void addCurrentDir(void);


### PR DESCRIPTION
- `FileManage::discoverGhidraRoot` is only used by `consolemain.cc` to find ghidra root given the executable path (`argv[0]`). It only uses this path to discover all of the repository's sleigh language definitions (`SleighArchitecture::scanForSleighDirectories(root)`). It uses the following two tests to verify that path:
- `FileManage::testDevelopmentPath` is only used by `discoverGhidraRoot` to find the ghidra root in a "development" environment. It moves up the directory hierarchy looking for a "Ghidra" directory that has a parent with some weird requirements (ends in ".git", starts with "ghidra." and is more than 10 characters). This obviously doesn't work and I don't quite understand what exactly those rules were intended for.
- `FileManage::testInstallationPath` looks for the "Ghidra" directory and checks that it contains a "server" subdirectory with a "server.conf". This is reasonable for an installation environment, but `scanDirectoryRecursive` only looks for directories and not regular files, so this doesn't work on my machine (linux) either.

Instead I replaced those two tests with a single test that simply looks for the first Ghidra directory relative to the executable that contains a Processor subdirectory, which is a more direct test for `discoverGhidraRoot`'s intended use (to find language definitions). This works in both development and installed environments. I added a check for if `FileManage::discoverGhidraRoot` is passing an empty string to `splitPath` because this was also causing errors if the executable is called as a relative path

Resolves #5309