### PR TITLE
Fix call_frame_cfa value for ppc

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/ppc.dwarf
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc.dwarf
@@ -15,5 +15,5 @@
 		<register_mapping dwarf="119" ghidra="DAR"/>
 		<!-- <register_mapping dwarf="1124" ghidra="v0" auto_count="32"/> **not implemented** --> <!-- v0...v31 -->
 	</register_mappings>
-	<call_frame_cfa value="31"/>
+	<call_frame_cfa value="0"/>
 </dwarf>


### PR DESCRIPTION
The current value of 31 doesn't make any sense and causes the dwarf expression evaluator to produce a bogus value https://github.com/NationalSecurityAgency/ghidra/blob/b3616a6831320daf71d299ab988a0bf13e052174/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/next/DWARFVariable.java#L355. When the `ParamSpillDWARFFunctionFixup` https://github.com/NationalSecurityAgency/ghidra/blob/b3616a6831320daf71d299ab988a0bf13e052174/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/funcfixup/ParamSpillDWARFFunctionFixup.java#L39 runs, it will fail the 
```C
			if (dfunc.isInLocalVarStorageArea(paramStackOffset) &&
				dfunc.getLocalVarByOffset(paramStackOffset) == null) {
```
check and cause an incorrect custom calling convention to get applied throughout the binary.

A value of 0 i think makes the most sense here but i'm open to alternative values as well. Other architectures have either 0, 4, or 8.