### PR TITLE
Fix wrong type for TID_ATTRIBUTE_NAME in LldbModelTargetThreadImpl.java

### DIFF
--- a/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/model/impl/LldbModelTargetThreadImpl.java
+++ b/Ghidra/Debug/Debugger-agent-lldb/src/main/java/agent/lldb/model/impl/LldbModelTargetThreadImpl.java
@@ -94,7 +94,7 @@ public class LldbModelTargetThreadImpl extends LldbModelTargetObjectImpl
 			ACCESSIBLE_ATTRIBUTE_NAME, accessible = false, //
 			DISPLAY_ATTRIBUTE_NAME, getDisplay(), //
 			STATE_ATTRIBUTE_NAME, TargetExecutionState.ALIVE, //
-			TID_ATTRIBUTE_NAME, thread.GetThreadID().intValue(), //
+			TID_ATTRIBUTE_NAME, thread.GetThreadID().longValue(), //
 			SUPPORTED_STEP_KINDS_ATTRIBUTE_NAME, SUPPORTED_KINDS //
 		), "Initialized");
 


### PR DESCRIPTION
The `tid` attribute (`TID_ATTRIBUTE_NAME`) in `ghidra.dbg.target.TargetThread` is `java.lang.Long`, but the implementation was passing an `int`/`Integer` and failing to assign the attribute when calling `changeAttributes()`.