### PR TITLE
Fix Debugger exercise termmines parse_int function

### DIFF
--- a/GhidraDocs/GhidraClass/ExerciseFiles/Debugger/termmines.c
+++ b/GhidraDocs/GhidraClass/ExerciseFiles/Debugger/termmines.c
@@ -189,6 +189,7 @@ unsigned long parse_int(char *a, char *name,
 				name, a, min, max);
 		exit(-1);
 	}
+    return val;
 }
 
 void parse_width(char *arg) {


### PR DESCRIPTION
Going through the new Debugger documentation I noticed the example code did not work as expected.
The parse_int() function always returned zero.
With this small patch it works.