### PR TITLE
CopySpecial Action: fn + Offset

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
@@ -318,19 +318,22 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 	}
 
 	private Transferable copySymbolString() {
+		Listing listing = currentProgram.getListing();
 		CodeUnitIterator codeUnits =
-			currentProgram.getListing().getCodeUnits(getSelectedAddresses(), true);
+			listing.getCodeUnits(getSelectedAddresses(), true);
 		StringBuilder builder = new StringBuilder();
 		while (codeUnits.hasNext()) {
-			// TODO: Can we improve this by caching the function?
+			// TODO: Can we improve this for the usual case where all the address(es)
+			// are in the same function?
 			CodeUnit cu = codeUnits.next();
 			Address addr = cu.getAddress();
-			Function foo = currentProgram.getListing().getFunctionContaining(addr);
+			Function foo = listing.getFunctionContaining(addr);
 			boolean insideFunction = foo != null;
 			String addrStr;
 			if (insideFunction) {
 				addrStr = String.format("%s + %#x\n", foo, addr.subtract(foo.getEntryPoint()));
 			} else {
+				// TODO: Probably better to have a second version for addresses of instructions
 				addrStr = String.format("%s\n", addr);
 			}
 			builder.append(addrStr);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
@@ -328,10 +328,19 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 			CodeUnit cu = codeUnits.next();
 			Address addr = cu.getAddress();
 			Function foo = listing.getFunctionContaining(addr);
+			Address entry = foo.getEntryPoint();
 			boolean insideFunction = foo != null;
+			int delta = addr.compareTo(entry);
 			String addrStr;
 			if (insideFunction) {
-				addrStr = String.format("%s + %#x\n", foo, addr.subtract(foo.getEntryPoint()));
+				if (delta > 0) {
+					addrStr = String.format("%s + %#x\n", foo, addr.subtract(entry));					
+				}
+				else if (delta == 0) {
+					addrStr = String.format("%s\n", foo);
+				} else {
+					addrStr = String.format("%s - %#x\n", foo, entry.subtract(addr));
+				}
 			} else {
 				// TODO: Probably better to have a second version for addresses of instructions
 				addrStr = String.format("%s\n", addr);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
@@ -328,11 +328,11 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 			CodeUnit cu = codeUnits.next();
 			Address addr = cu.getAddress();
 			Function foo = listing.getFunctionContaining(addr);
-			Address entry = foo.getEntryPoint();
 			boolean insideFunction = foo != null;
-			int delta = addr.compareTo(entry);
 			String addrStr;
 			if (insideFunction) {
+				Address entry = foo.getEntryPoint();			
+				int delta = addr.compareTo(entry);
 				if (delta > 0) {
 					addrStr = String.format("%s + %#x\n", foo, addr.subtract(entry));					
 				}


### PR DESCRIPTION
This P/R adds an extra option to the "Copy Special" action in the listing which adds to the clipboard strings of the form:

```
main + 0x64
main + 0x69
main + 0x6e
main + 0x75
main + 0x78
main + 0x7d
main + 0x82
```

which should be more useful when interacting with debuggers (instead of repeatedly rebasing)