### PR TITLE
Fix ASAN static initialization order fiasco

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/test.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/test.cc
@@ -18,8 +18,6 @@
 
 namespace ghidra {
 
-vector<UnitTest *> UnitTest::tests;
-
 /// Run all the tests unless a non-empty set of names is passed in.
 /// In which case, only the named tests in the set are run.
 /// \param testNames is the set of names
@@ -30,7 +28,7 @@ int UnitTest::run(set<string> &testNames)
   int total = 0;
   int passed = 0;
 
-  for(auto &t : UnitTest::tests) {
+  for(auto &t : UnitTest::tests()) {
     if (testNames.size() > 0 && testNames.find(t->name) == testNames.end()) {
       continue;
     }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/test.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/test.hh
@@ -53,7 +53,6 @@ typedef void (*testfunc_t)();	///< A unit-test function
 /// The static run() method calls all the function pointers of all instantiated
 /// objects.
 struct UnitTest {
-  static vector<UnitTest *> tests;		///< The collection of test objects
   string name;					///< Name of the test
   testfunc_t func;				///< Call-back function executing the test
 
@@ -64,7 +63,13 @@ struct UnitTest {
   UnitTest(const string &name,testfunc_t func) :
       name(name), func(func)
   {
-    tests.push_back(this);
+    tests().push_back(this);
+  }
+
+  /// \brief The collection of test objects
+  static vector<UnitTest *> & tests() {
+    static vector<UnitTest *> tests;
+    return tests;
   }
 
   static int run(set<string> &testNames);	///< Run all the instantiated tests


### PR DESCRIPTION
This fixes errors/warnings reported by Address Sanitizer (ASAN).

See here for more details
https://github.com/google/sanitizers/wiki/AddressSanitizerInitializationOrderFiasco

Use the "Construct On First Use" idiom from
https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Construct_On_First_Use

## Reproduce

First, prep the repo, if you haven't already. We need to build the sleigh files for tests:
```sh
gradle --parallel -I gradle/support/fetchDependencies.gradle init
gradle --parallel sleighCompile
cd Ghidra/Features/Decompiler/src/decompile/cpp
```

Modify the `CXX` variable in the `Makefile` to append `-fsanitize=address` for address sanitizer checks, then run the following:

```sh
export 'ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=1'
make test -j$(nproc)
```

We set ASAN options to detect more than what's enabled by default.

On `master` branch, I get the following result from address sanitizer.

```text
=================================================================
==71861==ERROR: AddressSanitizer: initialization-order-fiasco on address 0x0000011a1b28 at pc 0x000000ce6cc4 bp 0x7ffdffab72d0 sp 0x7ffdffab72c8
READ of size 8 at 0x0000011a1b28 thread T0
    #0 0xce6cc3 in void std::vector<ghidra::UnitTest*, std::allocator<ghidra::UnitTest*> >::emplace_back<ghidra::UnitTest*>(ghidra::UnitTest*&&) /usr/include/c++/13/bits/vector.tcc:114
    #1 0xce6675 in std::vector<ghidra::UnitTest*, std::allocator<ghidra::UnitTest*> >::push_back(ghidra::UnitTest*&&) /usr/include/c++/13/bits/stl_vector.h:1296
    #2 0xce6529 in ghidra::UnitTest::UnitTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (*)()) test.hh:67
    #3 0xcded26 in __static_initialization_and_destruction_0 ../unittests/testcirclerange.cc:376
    #4 0xce63f5 in _GLOBAL__sub_I__ZN6ghidra26CircleRangeTestEnvironmentC2Ev ../unittests/testcirclerange.cc:928
    #5 0x7f3f40a46283 in __libc_start_main_impl (/lib64/libc.so.6+0x28283) (BuildId: 7ea8d85df0e89b90c63ac7ed2b3578b2e7728756)
    #6 0x409564 in _start (/tmp/work/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_test_dbg+0x409564) (BuildId: c22e634277d596eda823e5a8424d70813a14b2bc)

0x0000011a1b28 is located 8 bytes inside of global variable 'tests' defined in 'test.cc:21:20' (0x11a1b20) of size 24
  registered at:
    #0 0x7f3f4103c1f8 in __asan_register_globals.part.0 (/lib64/libasan.so.8+0x3c1f8) (BuildId: 7fcb7759bc17ef47f9682414b6d99732d6a6ab0c)
    #1 0xcc6bce in _sub_I_00099_1 (/tmp/work/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_test_dbg+0xcc6bce) (BuildId: c22e634277d596eda823e5a8424d70813a14b2bc)
    #2 0x7f3f40a46283 in __libc_start_main_impl (/lib64/libc.so.6+0x28283) (BuildId: 7ea8d85df0e89b90c63ac7ed2b3578b2e7728756)
    #3 0x409564 in _start (/tmp/work/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_test_dbg+0x409564) (BuildId: c22e634277d596eda823e5a8424d70813a14b2bc)

SUMMARY: AddressSanitizer: initialization-order-fiasco /usr/include/c++/13/bits/vector.tcc:114 in void std::vector<ghidra::UnitTest*, std::allocator<ghidra::UnitTest*> >::emplace_back<ghidra::UnitTest*>(ghidra::UnitTest*&&)
Shadow bytes around the buggy address:
  0x0000011a1880: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x0000011a1900: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
  0x0000011a1980: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 00 00 00 00
  0x0000011a1a00: 00 00 00 00 00 00 00 00 f6 f6 f6 f6 f6 f6 f6 f6
  0x0000011a1a80: f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6 f6
=>0x0000011a1b00: 00 00 00 00 f6[f6]f6 f6 f6 f6 f6 f6 00 00 00 00
  0x0000011a1b80: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0000011a1c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x0000011a1c80: 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 f9 f9 f9
  0x0000011a1d00: f9 f9 f9 f9 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9
  0x0000011a1d80: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==71861==ABORTING
make: *** [Makefile:260: test] Error 1
```