### PR TITLE
Close FileDataTypeManager in CompareGDTs.java

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/CompareGDTs.java
+++ b/Ghidra/Features/Base/ghidra_scripts/CompareGDTs.java
@@ -69,6 +69,7 @@ public class CompareGDTs extends GhidraScript {
 			popup(
 				"An architecture language error occured while opening archive (see log for details)\n" +
 					secondFile.getPath());
+			firstArchive.close();
 			return;
 		}
 
@@ -83,6 +84,8 @@ public class CompareGDTs extends GhidraScript {
 		}
 		finally {
 			printWriter.close();
+			firstArchive.close();
+			secondArchive.close();
 		}
 	}
 


### PR DESCRIPTION
`firstArchive` and `secondArchive` are not closed, which causes errors the next time you run this script with the same GDTs, because the two GDT files are still in use.