### PR TITLE
Check for negative length in `SemisparseByteArray.putData()`

### DIFF
--- a/Ghidra/Framework/Emulation/src/main/java/ghidra/generic/util/datastruct/SemisparseByteArray.java
+++ b/Ghidra/Framework/Emulation/src/main/java/ghidra/generic/util/datastruct/SemisparseByteArray.java
@@ -242,7 +242,9 @@ public class SemisparseByteArray {
 	 */
 	public synchronized void putData(final long loc, final byte[] data, final int offset,
 			final int length) {
-		if (length == 0) {
+		if (length < 0) {
+			throw new IllegalArgumentException("length: " + length);
+		} else if (length == 0) {
 			return;
 		}
 		defined.add(ULongSpan.extent(loc, length));


### PR DESCRIPTION
In `SemisparseByteArray.java` it is illegal to pass a negative `length` argument to `getData()` and to `putData()`.  The `getData()` method checks this requirement and throws a useful error message.  However, the `putData()` method does not.  This pull request makes the two methods consistent.