### PR TITLE
Enable build of decomp_dbg and sleigh_dbg

### DIFF
--- a/Ghidra/Features/Decompiler/buildNatives.gradle
+++ b/Ghidra/Features/Decompiler/buildNatives.gradle
@@ -22,20 +22,179 @@ if (findProject(':Generic') == null) {
 	apply from: "../../../GPL/nativeBuildProperties.gradle"
 }
 
-/**
+// Define the source files that are compiled and linked to become the decompiler.
+// The decompiler source is a bit weird in that all the cpp and headers all live in
+// the same directory with other files that are not used by the decompiler.
+// That is why we have to list every cpp file that makes up the decomplier.
+// NOTE: The bison/flex generated files are assumed to be up-to-date.
+//       The task `generateParsers` should be executed if needed.
+// builtBy lexSleigh
+
+def core_files = [
+	"address.cc",
+	"float.cc",
+	"globalcontext.cc",
+	"marshal.cc",
+	"opcodes.cc",
+	"pcoderaw.cc",
+	"space.cc",
+	"translate.cc",
+	"xml.cc"
+]
+
+def decompiler_files = [
+	"action.cc",
+	"architecture.cc",
+	"bitfield.cc",
+	"block.cc",
+	"blockaction.cc",
+	"capability.cc",
+	"cast.cc",
+	"comment.cc",
+	"condexe.cc",
+	"constseq.cc",
+	"coreaction.cc",
+	"cover.cc",
+	"cpool.cc",
+	"crc32.cc",
+	"database.cc",
+	"double.cc",
+	"dynamic.cc",
+	"emulate.cc",
+	"emulateutil.cc",
+	"expression.cc",
+	"flow.cc",
+	"fspec.cc",
+	"funcdata.cc",
+	"funcdata_block.cc",
+	"funcdata_op.cc",
+	"funcdata_varnode.cc",
+	"graph.cc",
+	"heritage.cc",
+	"jumptable.cc",
+	"loadimage.cc",
+	"memstate.cc",
+	"merge.cc",
+	"modelrules.cc",
+	"multiprecision.cc",
+	"op.cc",
+	"opbehavior.cc",
+	"options.cc",
+	"override.cc",
+	"paramid.cc",
+	"pcodeinject.cc",
+	"prefersplit.cc",
+	"prettyprint.cc",
+	"printc.cc",
+	"printjava.cc",
+	"printlanguage.cc",
+	"rangeutil.cc",
+	"ruleaction.cc",
+	"signature.cc",
+	"stringmanage.cc",
+	"subflow.cc",
+	"transform.cc",
+	"type.cc",
+	"typeop.cc",
+	"unionresolve.cc",
+	"userop.cc",
+	"variable.cc",
+	"varmap.cc",
+	"varnode.cc"
+]
+
+def decompiler_opt_files = [
+	"comment_ghidra.cc",
+	"cpool_ghidra.cc",
+	"database_ghidra.cc",
+	"ghidra_arch.cc",
+	"ghidra_context.cc",
+	"ghidra_process.cc",
+	"ghidra_translate.cc",
+	"inject_ghidra.cc",
+	"loadimage_ghidra.cc",
+	"signature_ghidra.cc",
+	"string_ghidra.cc",
+	"typegrp_ghidra.cc"
+]
+
+def decompiler_cli_files = [
+	"bfd_arch.cc",
+	"callgraph.cc",
+	"codedata.cc",
+	"consolemain.cc",
+	"grammar.cc",
+	"ifacedecomp.cc",
+	"ifaceterm.cc",
+	"inject_sleigh.cc",
+	"interface.cc",
+	"loadimage_bfd.cc",
+	"loadimage_xml.cc",
+	"libdecomp.cc",
+	"raw_arch.cc",
+	"rulecompile.cc",
+	"sleigh_arch.cc",
+	"testfunction.cc",
+	"unify.cc",
+	"xml_arch.cc"
+]
+
+def sleigh_common_files = [
+	"compression.cc",
+	"context.cc",
+	"filemanage.cc",
+	"pcodecompile.cc",
+	"pcodeparse.cc",
+	"semantics.cc",
+	"slaformat.cc",
+	"sleigh.cc",
+	"sleighbase.cc",
+	"slghpatexpress.cc",
+	"slghpattern.cc",
+	"slghsymbol.cc"
+]
+
+def sleigh_files = [
+	"slgh_compile.cc",
+	"slghparse.cc",
+	"slghscan.cc"
+]
+
+
+/*
+ * Try to find libbfd*.so or a static libbfd.a for linking decomp_dbg
+ */
+def linkBFDUnix = {
+	def fallback = '-lbfd -Wl,--no-whole-archive -liberty -lsframe -lz -lzstd'
+	def versionProc = 'ld.bfd -v'.execute()
+	def versionOut = versionProc.text
+	def matcher = versionOut =~ /([0-9].*)/
+	if (!matcher.find()) return fallback
+	def libName = "-lbfd-${matcher.group(1)}"
+	def checkProc = ["ld", "-shared", "-o", "/dev/null", libName].execute()
+	def checkErr = checkProc.err.text
+	checkProc.waitFor()
+	if (!checkErr.contains("cannot find")) {
+		return "${libName} -Wl,--no-whole-archive -liberty -lsframe -lz -lzstd"
+	}
+	return fallback
+}
+
+/*
  * Define the "native build model" for building the decompiler executables.
+ * Options:
+ * -Pcli	Build unoptimized debug interfaces with debug information (not for Windows)
+ * -Pdebug	Build with debug information (all systems)
+ * -Pgdb	Try to create a gdb backtrace to /tmp/ghidra_gdb_bt.log (not always possible in this form)
+ * -Pwait	Wait for debugger to set startDebug = true
+ * -Plto	Enable Link Time Optimization (not for debug interfaces (-Pcli), disable on Windows with -Pnolto)
+ * -Popt	Build optimized with GCC / Clang (disable on Windows with -Pnoopt)
+ * -PsysZlib	Build against system zlib (ignored for Windows)
  */
 model {
-	// Define the source files that are compiled and linked to become the decompiler.
-	// The decompiler source is a bit weird in that all the cpp and headers all live in
-	// the same directory with other files that are not used by the decompiler.
-	// That is why we have to list every cpp file that makes up the decomplier.
 	components {
-			
 		decompile(NativeExecutableSpec) {
-		
 			baseName "decompile"
-									
 			// these tell gradle for which platforms to build a decompiler executable.
 			targetPlatform "win_x86_64"
 			targetPlatform "win_arm_64"
@@ -49,105 +208,37 @@ model {
 			targetPlatform "openbsd_arm_64"
 			sources {
 				cpp {
-					// NOTE: The bison/flex generated files are assumed to be up-to-date.
-					//       The task `generateParsers` should be executed if needed.
-					// builtBy yaccDecompiler
-		            source {
-		                srcDir "src/decompile/cpp"
-		                
-		         	 	include "marshal.cc"
-		                include "space.cc"
-		                include "float.cc"
-		                include "address.cc"
-		                include "pcoderaw.cc"
-		                include "translate.cc"
-		                include "opcodes.cc"
-		                include "globalcontext.cc"
-		                include "capability.cc"
-		                include "architecture.cc"
-		                include "options.cc"
-		                include "graph.cc"
-		                include "cover.cc"
-		                include "block.cc"
-		                include "cast.cc"
-		                include "typeop.cc"
-		                include "database.cc"
-		                include "cpool.cc"
-		                include "comment.cc"
-						include "stringmanage.cc"
-						include "modelrules.cc"
-		                include "fspec.cc"
-		                include "action.cc"
-		                include "loadimage.cc"
-		                include "varnode.cc"
-		                include "op.cc"
-		                include "type.cc"
-		                include "variable.cc"
-		                include "varmap.cc"
-		                include "jumptable.cc"
-		                include "emulate.cc"
-		                include "emulateutil.cc"
-		                include "flow.cc"
-		                include "userop.cc"
-		                include "expression.cc"
-		                include "multiprecision.cc"
-		                include "funcdata.cc"
-		                include "funcdata_block.cc"
-		                include "funcdata_varnode.cc"
-		                include "unionresolve.cc"
-		                include "funcdata_op.cc"
-		                include "pcodeinject.cc"
-		                include "heritage.cc"
-		                include "prefersplit.cc"
-		                include "rangeutil.cc"
-		                include "ruleaction.cc"
-		                include "subflow.cc"
-		                include "transform.cc"
-		                include "blockaction.cc"
-		                include "merge.cc"
-		                include "double.cc"
-		                include "constseq.cc"
-		                include "bitfield.cc"
-		                include "coreaction.cc"
-		                include "condexe.cc"
-		                include "override.cc"
-		                include "dynamic.cc"
-		                include "crc32.cc"
-		                include "prettyprint.cc"
-		                include "printlanguage.cc"
-		                include "printc.cc"
-		                include "printjava.cc"
-		                include "memstate.cc"
-		                include "opbehavior.cc"
-		                include "paramid.cc"
-		                include "ghidra_arch.cc"
-		                include "inject_ghidra.cc"
-		                include "ghidra_translate.cc"
-		                include "loadimage_ghidra.cc"
-		                include "typegrp_ghidra.cc"
-		                include "database_ghidra.cc"
-		                include "ghidra_context.cc"
-		                include "cpool_ghidra.cc"
-		                include "ghidra_process.cc"
-		                include "comment_ghidra.cc"
-						include "string_ghidra.cc"
-						include "signature.cc"
-						include "signature_ghidra.cc"
-		         //       include "callgraph.cc"			// uncomment for debug
-		         //       include "ifacedecomp.cc"			// uncomment for debug
-		         //       include "ifaceterm.cc"			// uncomment for debug
-		         //       include "interface.cc"			// uncomment for debug
-		         
-		         		// generated source files
-		         		
-		         	 	include "xml.cc"
-		         // 	  include "grammar.cc"				// used by diagnostic console mode
-		            }
+					source {
+						srcDir "src/decompile/cpp"
+						include core_files
+						include decompiler_files
+						include decompiler_opt_files
+					}
 					exportedHeaders {
 						srcDir "src/decompile/cpp"
 					}
-				} // end cpp				
-			} // end sources
+				}
+			}
+			binaries.all { b ->
+				if (b.toolChain in Gcc || b.toolChain in Clang) {
+					if (project.hasProperty('debug')) {
+						b.cppCompiler.args "-g"
+					}
+					if (project.hasProperty('opt')) {
+						b.cppCompiler.args "-O2"
+					}
+					if (project.hasProperty('lto')) {
+						b.cppCompiler.args "-flto"
+						b.linker.args "-flto"
+					}
+					if (project.hasProperty('gdb')) {
+						b.cppCompiler.define "GDB_BT"
+					}
+					if (project.hasProperty('wait')) {
+						b.cppCompiler.define "WAIT_DEBUGGER"
+					}
+				}
+			}
 		} // end decompile
 		
 		sleigh(NativeExecutableSpec) {
@@ -163,89 +254,194 @@ model {
 			targetPlatform "openbsd_arm_64"
 			sources {
 				cpp {
-					// NOTE: The bison/flex generated files are assumed to be up-to-date.
-					//       The task `generateParsers` should be executed if needed.
-					// builtBy lexSleigh
 					source {
 						srcDir "src/decompile/cpp"
-						
-		         	 	include "marshal.cc"
-						include "space.cc"
-						include "float.cc"
-						include "address.cc"
-						include "pcoderaw.cc"
-						include "translate.cc"
-						include "opcodes.cc"
-						include "globalcontext.cc"
-						include "sleigh.cc"
-						include "pcodecompile.cc"
-						include "sleighbase.cc"
-						include "slghsymbol.cc"
-						include "slghpatexpress.cc"
-						include "slghpattern.cc"
-						include "semantics.cc"
-						include "context.cc"
-						include "slaformat.cc"
-						include "compression.cc"
-						include "filemanage.cc"
-						include "slgh_compile.cc"
-						
-						// generated source files
-						
-						include "xml.cc"
-						include "pcodeparse.cc"
-						include "slghparse.cc"
-						include "slghscan.cc"
+						include core_files
+						include sleigh_common_files
+						include sleigh_files
 					}
 					exportedHeaders {
 						srcDir "src/decompile/cpp"
 					}
-				} // end cpp
-				
-				c {
-					source {
-						srcDir "src/decompile/zlib"
-						include "*.c"
+				}
+				if (isCurrentWindows() || !project.hasProperty('sysZlib')) {
+					c {
+						source {
+							srcDir "src/decompile/zlib"
+							include "*.c"
+						}
 					}
 				}
-			} // end sources (sleigh)
-			
-			binaries {
-				all{ b ->
+			}
+			binaries.all { b ->
+				if (b.toolChain in Gcc || b.toolChain in Clang) {
+					if (project.hasProperty('debug')) {
+						b.cppCompiler.args "-g"
+						b.cCompiler.args "-g"
+					}
+					if (project.hasProperty('opt')) {
+						b.cppCompiler.args "-O2"
+						b.cCompiler.args "-O2"
+					}
+					if (project.hasProperty('sysZlib')) {
+						b.linker.args "-lz"
+					}
+					if (project.hasProperty('lto')) {
+						b.cppCompiler.args "-flto"
+						if (!project.hasProperty('sysZlib')) {
+							b.cCompiler.args "-flto"
+						}
+						b.linker.args "-flto"
+					}
+				}
+				if (isCurrentWindows() || !project.hasProperty('sysZlib')) {
 					b.cppCompiler.define "LOCAL_ZLIB"
 					b.cCompiler.define "NO_GZIP"
 				}
-			} // end binaries.all (sleigh)
+			}
 		} // end sleigh
-		
-	}  // end components
-	
+
+		if (project.hasProperty('cli')) {
+			decomp_dbg(NativeExecutableSpec) {
+				baseName "decomp_dbg"
+				targetPlatform "linux_x86_64"
+				targetPlatform "linux_arm_64"
+				targetPlatform "mac_x86_64"
+				targetPlatform "mac_arm_64"
+				targetPlatform "freebsd_x86_64"
+				targetPlatform "freebsd_arm_64"
+				targetPlatform "openbsd_x86_64"
+				targetPlatform "openbsd_arm_64"
+				sources {
+					cpp {
+						source {
+							srcDir "src/decompile/cpp"
+							include core_files
+							include decompiler_files
+							include decompiler_cli_files
+							include sleigh_common_files
+						}
+						exportedHeaders {
+							srcDir "src/decompile/cpp"
+						}
+					}
+					if (isCurrentWindows() || !project.hasProperty('sysZlib')) {
+						c {
+							source {
+								srcDir "src/decompile/zlib"
+								include "*.c"
+							}
+						}
+					}
+				}
+				binaries.all { b ->
+					if (b.toolChain in Gcc || b.toolChain in Clang) {
+						b.cppCompiler.args "-g"
+						b.linker.args linkBFDUnix().split(" ")
+					}
+					else if (b.toolChain in VisualCpp) {
+						b.cppCompiler.args "/Zi"
+						b.cppCompiler.args "/FS"
+						b.linker.args "/DEBUG"
+					}
+					b.cppCompiler.define "CPUI_DEBUG"
+					b.cppCompiler.define "__TERMINAL__"
+					if (isCurrentWindows() || !project.hasProperty('sysZlib')) {
+						b.cppCompiler.define "LOCAL_ZLIB"
+						b.cCompiler.define "NO_GZIP"
+					}
+				}
+			} // end decomp_dbg
+
+			sleigh_dbg(NativeExecutableSpec) {
+				targetPlatform "linux_x86_64"
+				targetPlatform "linux_arm_64"
+				targetPlatform "mac_x86_64"
+				targetPlatform "mac_arm_64"
+				targetPlatform "freebsd_x86_64"
+				targetPlatform "freebsd_arm_64"
+				targetPlatform "openbsd_x86_64"
+				targetPlatform "openbsd_arm_64"
+				sources {
+					cpp {
+						source {
+							srcDir "src/decompile/cpp"
+							include core_files
+							include sleigh_common_files
+							include sleigh_files
+						}
+						exportedHeaders {
+							srcDir "src/decompile/cpp"
+						}
+					}
+					if (isCurrentWindows() || !project.hasProperty('sysZlib')) {
+						c {
+							source {
+								srcDir "src/decompile/zlib"
+								include "*.c"
+							}
+						}
+					}
+				}
+				binaries.all { b ->
+					if (b.toolChain in Gcc || b.toolChain in Clang) {
+						b.cppCompiler.args "-g"
+						if (project.hasProperty('sysZlib')) {
+							b.linker.args "-lz"
+						}
+					}
+					else if (b.toolChain in VisualCpp) {
+						b.cppCompiler.args "/Zi"
+						b.cppCompiler.args "/FS"
+						b.linker.args "/DEBUG"
+					}
+					if (isCurrentWindows() || !project.hasProperty('sysZlib')) {
+						b.cppCompiler.define "LOCAL_ZLIB"
+						b.cCompiler.define "NO_GZIP"
+					}
+					b.cppCompiler.define "YYDEBUG"
+				}
+			} // end sleigh_dbg
+		} // end debug
+	} // end components
+
 	binaries {
-		all{ b ->
-			if (b.toolChain in Gcc) {
+		all { b ->
+			if (b.toolChain in Gcc || b.toolChain in Clang) {
 				b.cppCompiler.args "-std=c++11"
 				b.cppCompiler.args "-Wall"
-				b.cppCompiler.args "-O2"			// for DEBUG, comment this line out
-				// b.cppCompiler.args "-g"			// for DEBUG, uncomment	this line
 				b.cppCompiler.args "-Wno-sign-compare"
 				if (b.targetPlatform.operatingSystem.linux) {
-//					b.linker.args "-static"
 					b.cppCompiler.define "LINUX"
 					b.cppCompiler.define "_LINUX"
 				}
 			}
-		 	else if (b.toolChain in VisualCpp) {
-				b.cppCompiler.args "/EHsc"
+			else if (b.toolChain in VisualCpp) {
+				b.cppCompiler.args "/W3"
+				b.cCompiler.args "/W3"
+				if (project.hasProperty('debug')) {
+					b.cppCompiler.args "/Zi"
+					b.cppCompiler.args "/FS"
+					b.cCompiler.args "/Zi"
+					b.cCompiler.args "/FS"
+					b.linker.args "/DEBUG"
+				}
+				if (!project.hasProperty('noopt')) {
+					b.cppCompiler.args "/EHsc"
+					b.cppCompiler.args "/O2"
+					b.cppCompiler.args "/Oy"	// Omit frame pointer
+					b.cppCompiler.args "/GL"
+					b.cCompiler.args "/EHsc"
+					b.cCompiler.args "O2"
+					b.cCompiler.args "Oy"		// Omit frame pointer
+					b.cCompiler.args "GL"
+				}
+				if (!project.hasProperty('nolto')) {
+					b.linker.args "/LTCG"
+				}
 				b.cppCompiler.define "_SECURE_SCL=0"
 				b.cppCompiler.define "_HAS_ITERATOR_DEBUGGING=0"
-				b.cppCompiler.args "/W3"
-				b.cppCompiler.args "/O2"
-				b.cppCompiler.args "/Oy"			// Omit frame pointer
-				b.cppCompiler.args "/GL"
-				// b.cppCompiler.args "/Zi"		// for DEBUG, uncomment this line
-				// b.cppCompiler.args "/FS"		// for DEBUG, uncomment this line
-				// b.linker.args "/DEBUG"		// for DEBUG, uncomment this line
-				b.linker.args "/LTCG"
+				b.cppCompiler.define "_HAS_STD_BYTE=0"  // msvc has a byte typedef that conflicts with c++17 std::byte
 				if (b.targetPlatform.operatingSystem.windows) {
 					b.cppCompiler.define "WINDOWS"
 					b.cppCompiler.define "_WINDOWS"
@@ -256,25 +452,10 @@ model {
 						b.cppCompiler.define "_WIN64"
 					}	
 				}
-				b.cCompiler.args "/W3"
-				b.cCompiler.args "/O2"
-				b.cCompiler.args "/Oy"			// Omit frame pointer
-				b.cCompiler.args "/GL"
 				b.cCompiler.define "_CRT_SECURE_NO_DEPRECATE"
 				b.cCompiler.define "_CRT_NONSTDC_NO_DEPRECATE"
 				b.cCompiler.define "ZLIB_WINAPI"
 			}
-			else if (b.toolChain in Clang) {
-				b.cppCompiler.args "-std=c++11"
-				b.cppCompiler.args "-Wall"
-				b.cppCompiler.args "-O2"			// for DEBUG, comment this line out
-				// b.cppCompiler.args "-g"			// for DEBUG, uncomment	this line
-				b.cppCompiler.args "-Wno-sign-compare"
-				b.cppCompiler.args "-w"
-				if (b.targetPlatform.operatingSystem.linux) {
-//					b.linker.args "-static"
-				}
-			}
-		}
-	}
+		} // end all
+	} // end binaries
 } // end model

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_arch.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_arch.cc
@@ -23,6 +23,13 @@
 #include "cpool_ghidra.hh"
 #include "inject_ghidra.hh"
 
+#ifdef GDB_BT
+#include <execinfo.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#endif
+
 namespace ghidra {
 
 //AttributeId ATTRIB_BADDATA = AttributeId("baddata",145);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_process.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_process.cc
@@ -26,6 +26,21 @@
 #include "ifacedecomp.hh"
 #endif
 
+#if defined(GDB_BT) || defined(WAIT_DEBUGGER)
+#include <sys/prctl.h>
+#endif
+
+#ifdef WAIT_DEBUGGER
+#include <thread>
+#include <chrono>
+volatile bool startDebug = false;
+
+void wait_for_debugger() {
+  while (!startDebug)
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+#endif
+
 namespace ghidra {
 
 #ifdef __REMOTE_SOCKET__
@@ -503,6 +518,31 @@ void GhidraDecompCapability::initialize(void)
 static void segvHandler(int4 sig)
 
 {
+#ifdef GDB_BT
+  pid_t crashed_pid = getpid();
+  pid_t child = fork();
+  if (child == 0) {
+    int gdb_fd = open("/tmp/ghidra_gdb_bt.log", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (gdb_fd != -1) {
+      dup2(gdb_fd, STDOUT_FILENO);
+      dup2(gdb_fd, STDERR_FILENO);
+      close(gdb_fd);
+    }
+    char attach_cmd[32];
+    snprintf(attach_cmd, sizeof(attach_cmd), "attach %d", crashed_pid);
+    execlp("gdb", "gdb",
+      "--batch",
+      "-ex", attach_cmd,
+      "-ex", "thread apply all bt full",
+      "-ex", "detach",
+      "-ex", "quit",
+      NULL);
+    exit(1);   // prevents OS from popping-up a dialog
+  } else if (child > 0) {
+    int status;
+    waitpid(child, &status, 0);
+  }
+#endif
   _Exit(1);	// Don't do any cleanup, just die - prevents OS from popping-up a dialog
 }
 
@@ -512,6 +552,14 @@ int main(int argc,char **argv)
 
 {
   using namespace ghidra;
+
+#if defined(GDB_BT) || defined(WAIT_DEBUGGER)
+  // Allow user to attach to this process with debugger
+  prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
+#endif
+#ifdef WAIT_DEBUGGER
+  wait_for_debugger();
+#endif
 
   signal(SIGSEGV, &segvHandler);  // Exit on SEGV errors
 #ifdef _WINDOWS


### PR DESCRIPTION
Building decomp_dbg and sleigh_dbg can now easily enabled via 'gradle -Pdebug' switch.

Fixes: #5296