### PR TITLE
Add option to force Clang on Linux

### DIFF
--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -39,6 +39,13 @@ model {
 	// native Gradle plugin. 
 	toolChains {
 		if (isCurrentLinux()) {
+			if (project.hasProperty('clang')) {
+				clang(Clang) {
+					if (isCurrentArm_64()) {
+						target("linux_arm_64")
+					}
+				}
+			}
 			gcc(Gcc) {
 				if (isCurrentArm_64()) {
 					target("linux_arm_64")

--- a/Ghidra/Debug/Framework-Debugging/src/expCloneExec/c/expCloneExec.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expCloneExec/c/expCloneExec.c
@@ -15,6 +15,9 @@
  */
 #include <pthread.h>
 #include <stdio.h>
+#ifdef __unix__
+#include <unistd.h>
+#endif
 
 pthread_t thread;
 

--- a/Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expCloneExit/c/expCloneExit.c
@@ -15,6 +15,9 @@
  */
 #include <pthread.h>
 #include <stdio.h>
+#ifdef __unix__
+#include <unistd.h>
+#endif
 
 pthread_t thread;
 

--- a/Ghidra/Debug/Framework-Debugging/src/expFork/c/expFork.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expFork/c/expFork.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include <stdio.h>
+#ifdef __unix__
+#include <unistd.h>
+#endif
 
 int func(int id) {
     if (id) {

--- a/Ghidra/Debug/Framework-Debugging/src/expSpin/c/expSpin.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expSpin/c/expSpin.c
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef WIN32
-#include <Windows.h>
-#endif
 
 #ifdef WIN32
+#include <Windows.h>
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow) {
 	for (int i = 0; i < 10; i++) {
 		Sleep(1000);
 	}
 }
 #else
+#include <unistd.h>
 int main(int argc, char** argv) {
 	for (int i = 0; i < 10; i++) {
 		sleep(1);

--- a/Ghidra/Debug/Framework-Debugging/src/expTypes/c/expTypes.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expTypes/c/expTypes.c
@@ -38,7 +38,7 @@ typedef enum _myenum {
 typedef void (*myfunc_p)(int arg0, long arg1);
 typedef void (*myvargfunc_p)(int arg0, long arg1, ...);
 
-typedef myundef;
+typedef int myundef;
 
 int int_var;
 void* void_p_var;
@@ -83,8 +83,8 @@ myundef myundef_var;
 mylist_p mylist_p_var;
 
 int main(int argc, char** argv) {
-    printf("complex: %d\n", sizeof(complex_var));
-    printf("double complex: %d\n", sizeof(double_complex_var));
+    printf("complex: %lu\n", sizeof(complex_var));
+    printf("double complex: %lu\n", sizeof(double_complex_var));
     
     register mycomplex_p cparts = &complex_var;
     printf("single real: %f\n", cparts->real);


### PR DESCRIPTION
Currently Gcc is preferred (not to say forced) when both (Gcc and Clang) are available on the system. With this patch Clang can be forced via 'gradle -Pclang' switch.

Clang 16.0.4 then failed due to missing '#include <unistd.h>" and an undefined 'typedef myundef;'.