### PR TITLE
bugfix: pythonRun.bat ignored its arguments

### DIFF
--- a/Ghidra/RuntimeScripts/Windows/support/pythonRun.bat
+++ b/Ghidra/RuntimeScripts/Windows/support/pythonRun.bat
@@ -24,4 +24,4 @@ set DEBUG_ADDRESS=127.0.0.1:13002
 set VMARG_LIST=-XX:ParallelGCThreads=2
 set VMARG_LIST=%VMARG_LIST% -XX:CICompilerCount=2
 
-call "%~dp0launch.bat" %LAUNCH_MODE% jdk Ghidra-Python "%MAXMEM%" "%VMARG_LIST%" ghidra.python.PythonRun %params%
+call "%~dp0launch.bat" %LAUNCH_MODE% jdk Ghidra-Python "%MAXMEM%" "%VMARG_LIST%" ghidra.python.PythonRun %*


### PR DESCRIPTION
The last line of `pythonRun.bat` reads:
```
call "%~dp0launch.bat" %LAUNCH_MODE% jdk Ghidra-Python "%MAXMEM%" "%VMARG_LIST%" ghidra.python.PythonRun %params%
```

The `%params%` is incorrect because in this batch file no such variable is defined. As a result, none of the arguments passed to `pythonRun.bat` ever reach `Ghidra-Python`.

It was obviously copied from `analyzeHeadless.bat` where there is a block of code that builds that variable – but since that block of code is missing from the batch file, it does nothing. The obvious fix is to use `%*` instead, which is the standard Windows batch syntax for "all arguments" (equivalent to Unix `$*`), which is what most of the other Ghidra batch files do. It appears the reason for `%params%` in `analyzeHeadless.bat` is to workaround an issue where Windows doesn't do correct wildcard expansion of the `-import` argument, but I don't think that is relevant to `pythonRun.bat`, so just `%*` will do here.