### PR TITLE
Add annotation selection replacement for comments

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/comments/CommentsDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/comments/CommentsDialog.java
@@ -269,9 +269,13 @@ public class CommentsDialog extends ReusableDialogComponentProvider implements K
 			JTextArea currentTextArea = getSelectedTextArea();
 			AnnotationAdapterWrapper aaw =
 				(AnnotationAdapterWrapper) annotationsComboBox.getSelectedItem();
-			currentTextArea.insert(aaw.getPrototypeString(),
-				currentTextArea.getCaretPosition());
-			currentTextArea.setCaretPosition(currentTextArea.getCaretPosition() - 1);
+			if (currentTextArea.getSelectedText() != null && !currentTextArea.getSelectedText().isEmpty()) {
+				currentTextArea.replaceSelection(aaw.getPrototypeString(currentTextArea.getSelectedText()));
+			} else {
+				currentTextArea.insert(aaw.getPrototypeString(),
+						currentTextArea.getCaretPosition());
+				currentTextArea.setCaretPosition(currentTextArea.getCaretPosition() - 1);
+			}
 		});
 		JPanel annoPanel = new JPanel();
 		annoPanel.add(addAnnotationButton);
@@ -525,6 +529,10 @@ public class CommentsDialog extends ReusableDialogComponentProvider implements K
 
 		public String getPrototypeString() {
 			return handler.getPrototypeString();
+		}
+		
+		public String getPrototypeString(String contained) {
+			return handler.getPrototypeString(contained);
 		}
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/comments/CommentsDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/comments/CommentsDialog.java
@@ -25,6 +25,8 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 
+import org.apache.commons.lang3.StringUtils;
+
 import docking.*;
 import docking.widgets.OptionDialog;
 import docking.widgets.checkbox.GCheckBox;
@@ -266,15 +268,14 @@ public class CommentsDialog extends ReusableDialogComponentProvider implements K
 		GComboBox<AnnotationAdapterWrapper> annotationsComboBox = new GComboBox<>(annotations);
 		JButton addAnnotationButton = new JButton("Add Annotation");
 		addAnnotationButton.addActionListener(e -> {
-			JTextArea currentTextArea = getSelectedTextArea();
+			JTextArea textArea = getSelectedTextArea();
 			AnnotationAdapterWrapper aaw =
 				(AnnotationAdapterWrapper) annotationsComboBox.getSelectedItem();
-			if (currentTextArea.getSelectedText() != null && !currentTextArea.getSelectedText().isEmpty()) {
-				currentTextArea.replaceSelection(aaw.getPrototypeString(currentTextArea.getSelectedText()));
+			String selectedText = textArea.getSelectedText();
+			if (!StringUtils.isBlank(selectedText)) {
+				textArea.replaceSelection(aaw.getPrototypeString(selectedText));
 			} else {
-				currentTextArea.insert(aaw.getPrototypeString(),
-						currentTextArea.getCaretPosition());
-				currentTextArea.setCaretPosition(currentTextArea.getCaretPosition() - 1);
+				insertAnnotation(textArea, aaw);
 			}
 		});
 		JPanel annoPanel = new JPanel();
@@ -363,9 +364,7 @@ public class CommentsDialog extends ReusableDialogComponentProvider implements K
 			JTextArea currentTextArea = getSelectedTextArea();
 			for (AnnotationAdapterWrapper annotation : annotations) {
 				if (annotation.toString().equals(e.getActionCommand())) {
-					currentTextArea.insert(annotation.getPrototypeString(),
-						currentTextArea.getCaretPosition());
-					currentTextArea.setCaretPosition(currentTextArea.getCaretPosition() - 1);
+					insertAnnotation(currentTextArea, annotation);
 				}
 			}
 		};
@@ -385,6 +384,12 @@ public class CommentsDialog extends ReusableDialogComponentProvider implements K
 		repeatableField.addMouseListener(new PopupListener());
 
 		return panel;
+	}
+	
+	private void insertAnnotation(JTextArea textArea, AnnotationAdapterWrapper annotation) {
+		textArea.insert(annotation.getPrototypeString(),
+				textArea.getCaretPosition());
+		textArea.setCaretPosition(textArea.getCaretPosition() - 1);
 	}
 
 	private void installUndoRedo(JTextComponent textComponent) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AddressAnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AddressAnnotatedStringHandler.java
@@ -111,4 +111,9 @@ public class AddressAnnotatedStringHandler implements AnnotatedStringHandler {
 		return "{@address 0x00}";
 	}
 
+	@Override
+	public String getPrototypeString(String contained) {
+		return "{@address 0x" + contained.trim() + "}";
+	}
+
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AnnotatedStringHandler.java
@@ -95,4 +95,11 @@ public interface AnnotatedStringHandler extends ExtensionPoint {
 	 * @return the example of how this is used.
 	 */
 	public String getPrototypeString();
+	
+	/**
+	 * Returns an example string of how the annotation is used
+	 * @param contained The text that may be wrapped
+	 * @return the example of how this is used.
+	 */
+	public String getPrototypeString(String contained);
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AnnotatedStringHandler.java
@@ -98,8 +98,10 @@ public interface AnnotatedStringHandler extends ExtensionPoint {
 	
 	/**
 	 * Returns an example string of how the annotation is used
-	 * @param contained The text that may be wrapped
+	 * @param displayText The text that may be wrapped, cannot be null
 	 * @return the example of how this is used.
 	 */
-	public String getPrototypeString(String contained);
+	public default String getPrototypeString(String displayText) {
+		return getPrototypeString();
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/ExecutableTaskStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/ExecutableTaskStringHandler.java
@@ -196,4 +196,9 @@ public class ExecutableTaskStringHandler implements AnnotatedStringHandler {
 			return buffer.toString();
 		}
 	}
+
+	@Override
+	public String getPrototypeString(String contained) {
+		return "{@execute " + contained.trim() + "}";
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/InvalidAnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/InvalidAnnotatedStringHandler.java
@@ -63,4 +63,9 @@ public class InvalidAnnotatedStringHandler implements AnnotatedStringHandler {
 	public String getPrototypeString() {
 		return "";
 	}
+	
+	@Override
+	public String getPrototypeString(String contained) {
+		return this.getPrototypeString();
+	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/ProgramAnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/ProgramAnnotatedStringHandler.java
@@ -277,5 +277,10 @@ public class ProgramAnnotatedStringHandler implements AnnotatedStringHandler {
 	public String getPrototypeString() {
 		return "{@program program_name.exe@symbol_name}";
 	}
+	
+	@Override
+	public String getPrototypeString(String contained) {
+		return "{@program " + contained.trim() + "}";
+	}
 
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/SymbolAnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/SymbolAnnotatedStringHandler.java
@@ -173,5 +173,10 @@ public class SymbolAnnotatedStringHandler implements AnnotatedStringHandler {
 	public String getPrototypeString() {
 		return "{@symbol symbol_address}";
 	}
+	
+	@Override
+	public String getPrototypeString(String contained) {
+		return "{@symbol " + contained.trim() + "}";
+	}
 
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/URLAnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/URLAnnotatedStringHandler.java
@@ -118,5 +118,10 @@ public class URLAnnotatedStringHandler implements AnnotatedStringHandler {
 	public String getPrototypeString() {
 		return "{@url http://www.example.com}";
 	}
+	
+	@Override
+	public String getPrototypeString(String contained) {
+		return "{@url " + contained.trim() + "}";
+	}
 
 }


### PR DESCRIPTION
This pull request adds a feature where selecting what you want to annotate, then clicking the annotate button, encapsulates the selected item with an annotation. I found this helpful when trying to add address annotations, which means I don't need to type out the address twice if I didn't do this at the start.
I am a beginner, but have been seeking ways to contribute to Ghidra. If I'm wrong, please let me know.