### PR TITLE
Fix hashcode for ParameterDB

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/function/ParameterDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/function/ParameterDB.java
@@ -90,4 +90,11 @@ class ParameterDB extends VariableDB implements Parameter {
 		return null;
 	}
 
+	@Override
+	public int hashCode() {
+		int hashcode = getVariableStorage().hashCode();
+		hashcode ^= function.hashCode();
+		return hashcode;
+	}
+
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/function/VariableDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/function/VariableDB.java
@@ -389,6 +389,9 @@ public abstract class VariableDB implements Variable {
 		// If we have a VariableImpl or either function is using custom variable storage
 		// then they are only equivalent if the storage is the same.
 		Function otherFunction = otherVar.getFunction();
+		if (function != null && !(function.equals(otherFunction))) {
+			return false;
+		}
 		boolean eitherHasCustomVariableStorage =
 			(function == null || function.hasCustomVariableStorage()) ||
 				(otherFunction == null || otherFunction.hasCustomVariableStorage());


### PR DESCRIPTION
This fixes #3340 : many parameters have the same hashcode, meaning scripts that rely on ``hashCode`` e.g. ``HashSet<Parameter> params`` will not work as intended.
