### PR TITLE
Encode documentation html files as UTF-8

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerConcepts.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerConcepts.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler Concepts</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
@@ -182,7 +182,7 @@
       </p>
 <div class="informalexample">
       <div class="table">
-<a name="ops.htmltable"></a><p class="title"><b>Table . P-code Operations</b></p>
+<a name="ops.htmltable"></a><p class="title"><b>TableÂ .Â P-code Operations</b></p>
 <div class="table-contents"><table width="90%" frame="box" rules="all" id="ops.htmltable">
         
         <col width="40%">

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerIntro.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerIntro.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
@@ -64,7 +64,7 @@
 <li class="listitem" style="list-style-type: disc">
 	Press the <span class="guiicon">
 	<span class="inlinemediaobject"><img src="images/decompileFunction.gif" width="16" height="16"></span>
-	</span> icon
+	</span>Â icon
 	in the tool bar, <span class="emphasis"><em>or</em></span>
       </li>
 <li class="listitem" style="list-style-type: disc">

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerOptions.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerOptions.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler Options</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
@@ -40,12 +40,12 @@
 <li class="listitem" style="list-style-type: none">
 	  &#8195;<span class="guiicon">
 	    <span class="inlinemediaobject"><img src="images/document-properties.png" width="16" height="16"></span>
-	  </span> <span class="emphasis"><em>Analysis</em></span> - lists <a class="xref" href="DecompilerOptions.html#AnalysisOptions" title="Analysis Options">Analysis Options</a> that affect the Decompiler's transformation process.
+	  </span>Â <span class="emphasis"><em>Analysis</em></span> - lists <a class="xref" href="DecompilerOptions.html#AnalysisOptions" title="Analysis Options">Analysis Options</a> that affect the Decompiler's transformation process.
 	</li>
 <li class="listitem" style="list-style-type: none">
 	  &#8195;<span class="guiicon">
 	    <span class="inlinemediaobject"><img src="images/document-properties.png" width="16" height="16"></span>
-	  </span> <span class="emphasis"><em>Display</em></span> - lists <a class="xref" href="DecompilerOptions.html#DisplayOptions" title="Display Options">Display Options</a> that affect the final presentation of Decompiler output.
+	  </span>Â <span class="emphasis"><em>Display</em></span> - lists <a class="xref" href="DecompilerOptions.html#DisplayOptions" title="Display Options">Display Options</a> that affect the final presentation of Decompiler output.
 	</li>
 </ul></div>
     </div>

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerWindow.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerWindow.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler Window</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
@@ -18,7 +18,7 @@
     function in the Code Browser, then select the
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/decompileFunction.gif" width="16" height="16"></span>
-      </span> icon from the tool bar, or the
+      </span>Â icon from the tool bar, or the
     <span class="bold"><strong>Decompile</strong></span> option from the
     <span class="bold"><strong>Window</strong></span> menu in the tool.
   </p>
@@ -91,7 +91,7 @@
     Initially pressing
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/decompileFunction.gif" width="16" height="16"></span>
-      </span> or selecting
+      </span>Â or selecting
     <span class="bold"><strong>Decompile</strong></span> from the <span class="bold"><strong>Window</strong></span> menu in the tool
     brings up the <span class="emphasis"><em>main</em></span> window.  The main window always displays the function
     at the <span class="emphasis"><em>current address</em></span> within the Code Browser and follows as the user navigates
@@ -153,7 +153,7 @@
     Pressing the
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/camera-photo.png" width="16" height="16"></span>
-    </span> icon
+    </span>Â icon
     in any Decompiler window's toolbar causes a <span class="emphasis"><em>Snapshot</em></span> window
     to be created, which shows decompilation of the same function.
     Unlike the <span class="emphasis"><em>main</em></span> window however, the <span class="emphasis"><em>Snapshot</em></span> window
@@ -240,7 +240,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/page_edit.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Exports the decompiled result of the current function to a file. A file chooser
@@ -265,7 +265,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/camera-photo.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Creates a new <span class="emphasis"><em>Snapshot</em></span> window.  The <span class="emphasis"><em>Snapshot</em></span> window
@@ -282,7 +282,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/reload3.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Triggers a re-decompilation of the current function displayed in the window.
@@ -310,7 +310,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/page_white_copy.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Copies the currently selected text in the Decompiler window to the clipboard.

--- a/GhidraDocs/languages/html/additionalpcode.html
+++ b/GhidraDocs/languages/html/additionalpcode.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Additional P-CODE Operations</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
@@ -16,9 +16,9 @@
 <tr><th colspan="3" align="center">Additional P-CODE Operations</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="pseudo-ops.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="reference.html">Next</a>
+<a accesskey="p" href="pseudo-ops.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="reference.html">Next</a>
 </td>
 </tr>
 </table>
@@ -437,15 +437,15 @@ to SLEIGH <span class="bold"><strong>bitrange</strong></span> syntax such as out
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="pseudo-ops.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="reference.html">Next</a>
+<a accesskey="p" href="pseudo-ops.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="reference.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">Pseudo P-CODE Operations </td>
+<td width="40%" align="left" valign="top">Pseudo P-CODE OperationsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top"> Syntax Reference</td>
+<td width="40%" align="right" valign="top">Â Syntax Reference</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/pcodedescription.html
+++ b/GhidraDocs/languages/html/pcodedescription.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>P-Code Operation Reference</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
@@ -16,9 +16,9 @@
 <tr><th colspan="3" align="center">P-Code Operation Reference</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="pcoderef.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="pseudo-ops.html">Next</a>
+<a accesskey="p" href="pcoderef.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="pseudo-ops.html">Next</a>
 </td>
 </tr>
 </table>
@@ -3024,15 +3024,15 @@ Input0 and output can be different sizes.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="pcoderef.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="pseudo-ops.html">Next</a>
+<a accesskey="p" href="pcoderef.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="pseudo-ops.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">P-Code Reference Manual </td>
+<td width="40%" align="left" valign="top">P-Code Reference ManualÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top"> Pseudo P-CODE Operations</td>
+<td width="40%" align="right" valign="top">Â Pseudo P-CODE Operations</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/pcoderef.html
+++ b/GhidraDocs/languages/html/pcoderef.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>P-Code Reference Manual</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
@@ -13,9 +13,9 @@
 <table width="100%" summary="Navigation header">
 <tr><th colspan="3" align="center">P-Code Reference Manual</th></tr>
 <tr>
-<td width="20%" align="left"> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="pcodedescription.html">Next</a>
+<td width="20%" align="left">Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="pcodedescription.html">Next</a>
 </td>
 </tr>
 </table>
@@ -353,15 +353,15 @@ of the varnode inputs or output, not by the opcode.
 <hr>
 <table width="100%" summary="Navigation footer">
 <tr>
-<td width="40%" align="left"> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="pcodedescription.html">Next</a>
+<td width="40%" align="left">Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="pcodedescription.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top"> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right" valign="top"> P-Code Operation Reference</td>
+<td width="40%" align="left" valign="top">Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right" valign="top">Â P-Code Operation Reference</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/pseudo-ops.html
+++ b/GhidraDocs/languages/html/pseudo-ops.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Pseudo P-CODE Operations</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
@@ -16,9 +16,9 @@
 <tr><th colspan="3" align="center">Pseudo P-CODE Operations</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="pcodedescription.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="additionalpcode.html">Next</a>
+<a accesskey="p" href="pcodedescription.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="additionalpcode.html">Next</a>
 </td>
 </tr>
 </table>
@@ -225,15 +225,15 @@ not modeled in these cases, so the operator serves as a placeholder to allow ana
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="pcodedescription.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="additionalpcode.html">Next</a>
+<a accesskey="p" href="pcodedescription.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="additionalpcode.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">P-Code Operation Reference </td>
+<td width="40%" align="left" valign="top">P-Code Operation ReferenceÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top"> Additional P-CODE Operations</td>
+<td width="40%" align="right" valign="top">Â Additional P-CODE Operations</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/reference.html
+++ b/GhidraDocs/languages/html/reference.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Syntax Reference</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
@@ -15,9 +15,9 @@
 <tr><th colspan="3" align="center">Syntax Reference</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="additionalpcode.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> </td>
+<a accesskey="p" href="additionalpcode.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â </td>
 </tr>
 </table>
 <hr>
@@ -515,14 +515,14 @@
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="additionalpcode.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> </td>
+<a accesskey="p" href="additionalpcode.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">Additional P-CODE Operations </td>
+<td width="40%" align="left" valign="top">Additional P-CODE OperationsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top"> </td>
+<td width="40%" align="right" valign="top">Â </td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh.html
+++ b/GhidraDocs/languages/html/sleigh.html
@@ -1,21 +1,21 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>SLEIGH</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
-<link rel="next" href="sleigh_layout.html" title="2. Basic Specification Layout">
+<link rel="next" href="sleigh_layout.html" title="2.Â Basic Specification Layout">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
 <tr><th colspan="3" align="center">SLEIGH</th></tr>
 <tr>
-<td width="20%" align="left"> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_layout.html">Next</a>
+<td width="20%" align="left">Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_layout.html">Next</a>
 </td>
 </tr>
 </table>
@@ -162,13 +162,13 @@ Italics are used when defining terms and for named entities. Bold is used for SL
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_introduction"></a>1. Introduction to P-Code</h2></div></div></div>
+<a name="sleigh_introduction"></a>1.Â Introduction to P-Code</h2></div></div></div>
 <p>
 Although p-code is a distinct language from SLEIGH, because a major
 purpose of SLEIGH is to specify the translation from machine code to
 p-code, this document serves as a primer for p-code. The key concepts
 and terminology are presented in this section, and more detail is
-given in <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7. The Semantic Section">Section 7.7, &#8220;The Semantic Section&#8221;</a>. There is also a complete set
+given in <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7.Â The Semantic Section">SectionÂ 7.7, &#8220;The Semantic Section&#8221;</a>. There is also a complete set
 of tables which list syntax and descriptions for p-code operations in
 the Appendix.
 </p>
@@ -221,7 +221,7 @@ respectively.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_address_spaces"></a>1.1. Address Spaces</h3></div></div></div>
+<a name="sleigh_address_spaces"></a>1.1.Â Address Spaces</h3></div></div></div>
 <p>
 An <span class="emphasis"><em>address</em></span> space for p-code is a generalization of
 the indexed memory (RAM) that a typical processor has access to, and
@@ -279,7 +279,7 @@ interpreted as constants.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_varnodes"></a>1.2. Varnodes</h3></div></div></div>
+<a name="sleigh_varnodes"></a>1.2.Â Varnodes</h3></div></div></div>
 <p>
 A <span class="emphasis"><em>varnode</em></span> is the unit of data manipulated by
 p-code. It is simply a contiguous sequence of bytes in some address
@@ -305,7 +305,7 @@ forces an interpretation on each varnode that it uses, as either an
 integer, a floating-point number, or a boolean value. In the case of
 an integer, the varnode is interpreted as having a big endian or
 little endian encoding, depending on the specification (see
-<a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1. Endianess Definition">Section 4.1, &#8220;Endianess Definition&#8221;</a>). Certain instructions
+<a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1.Â Endianess Definition">SectionÂ 4.1, &#8220;Endianess Definition&#8221;</a>). Certain instructions
 also distinguish between signed and unsigned interpretations. For a
 signed integer, the varnode is considered to have a standard twos
 complement encoding. For a boolean interpretation, the varnode must be
@@ -322,7 +322,7 @@ must be provided and enforced by the specification designer.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_operations"></a>1.3. Operations</h3></div></div></div>
+<a name="sleigh_operations"></a>1.3.Â Operations</h3></div></div></div>
 <p>
 P-code is intended to emulate a target processor by substituting a
 sequence of p-code operations for each machine instruction. Thus every
@@ -352,7 +352,7 @@ general purpose processor instruction sets. They break up into groups.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="ops.htmltable"></a><p class="title"><b>Table 1. P-code Operations</b></p>
+<a name="ops.htmltable"></a><p class="title"><b>TableÂ 1.Â P-code Operations</b></p>
 <div class="table-contents"><table xml:id="ops.htmltable" width="70%" frame="box" rules="all">
 <col width="40%">
 <col width="60%">
@@ -414,7 +414,7 @@ general purpose processor instruction sets. They break up into groups.
 <br class="table-break">
 </div>
 <p>
-We postpone a full discussion of the individual operations until <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7. The Semantic Section">Section 7.7, &#8220;The Semantic Section&#8221;</a>.
+We postpone a full discussion of the individual operations until <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7.Â The Semantic Section">SectionÂ 7.7, &#8220;The Semantic Section&#8221;</a>.
 </p>
 </div>
 </div>
@@ -423,15 +423,15 @@ We postpone a full discussion of the individual operations until <a class="xref"
 <hr>
 <table width="100%" summary="Navigation footer">
 <tr>
-<td width="40%" align="left"> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_layout.html">Next</a>
+<td width="40%" align="left">Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_layout.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top"> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right" valign="top"> 2. Basic Specification Layout</td>
+<td width="40%" align="left" valign="top">Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right" valign="top">Â 2.Â Basic Specification Layout</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_constructors.html
+++ b/GhidraDocs/languages/html/sleigh_constructors.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>7. Constructors</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>7.Â Constructors</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_tokens.html" title="6. Tokens and Fields">
-<link rel="next" href="sleigh_context.html" title="8. Using Context">
+<link rel="prev" href="sleigh_tokens.html" title="6.Â Tokens and Fields">
+<link rel="next" href="sleigh_context.html" title="8.Â Using Context">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">7. Constructors</th></tr>
+<tr><th colspan="3" align="center">7.Â Constructors</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_tokens.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_context.html">Next</a>
+<a accesskey="p" href="sleigh_tokens.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_context.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_constructors"></a>7. Constructors</h2></div></div></div>
+<a name="sleigh_constructors"></a>7.Â Constructors</h2></div></div></div>
 <p>
 Fields are the basic building block for family symbols. The mechanisms
 for building up from fields to the
@@ -56,11 +56,11 @@ to think of a constructor as a kind of table in and of itself. But it
 is only the table that has an actual family symbol identifier
 associated with it. Most of this chapter is devoted to describing how
 to define a single constructor. The issues involved in combining
-multiple constructors into a single table are addressed in <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8. Tables">Section 7.8, &#8220;Tables&#8221;</a>.
+multiple constructors into a single table are addressed in <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8.Â Tables">SectionÂ 7.8, &#8220;Tables&#8221;</a>.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_sections_constructor"></a>7.1. The Five Sections of a Constructor</h3></div></div></div>
+<a name="sleigh_sections_constructor"></a>7.1.Â The Five Sections of a Constructor</h3></div></div></div>
 <p>
 A single complex statement in the specification file describes a
 constructor. This statement is always made up of five distinct
@@ -92,7 +92,7 @@ in turn.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_table_header"></a>7.2. The Table Header</h3></div></div></div>
+<a name="sleigh_table_header"></a>7.2.Â The Table Header</h3></div></div></div>
 <p>
 Every constructor must be part of a table, which is the element with
 an actual family symbol identifier associated with it. So each
@@ -122,12 +122,12 @@ identifier.
 The identifier <span class="emphasis"><em>instruction</em></span> is actually reserved
 for the root table, but should not be used in the table header as the
 SLEIGH parser uses the blank identifier to help distinguish assembly
-mnemonics from operands (see <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1. Mnemonic">Section 7.3.1, &#8220;Mnemonic&#8221;</a>).
+mnemonics from operands (see <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1.Â Mnemonic">SectionÂ 7.3.1, &#8220;Mnemonic&#8221;</a>).
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_display_section"></a>7.3. The Display Section</h3></div></div></div>
+<a name="sleigh_display_section"></a>7.3.Â The Display Section</h3></div></div></div>
 <p>
 The <span class="emphasis"><em>display section</em></span> consists of all characters
 after the table header &#8216;:&#8217; up to the SLEIGH
@@ -198,7 +198,7 @@ but only their identifiers are established in the display section.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_mnemonic"></a>7.3.1. Mnemonic</h4></div></div></div>
+<a name="sleigh_mnemonic"></a>7.3.1.Â Mnemonic</h4></div></div></div>
 <p>
 If the constructor is part of the root instruction table, the first
 string of characters in the display section that does not contain
@@ -230,7 +230,7 @@ no such requirement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_caret"></a>7.3.2. The '^' character</h4></div></div></div>
+<a name="sleigh_caret"></a>7.3.2.Â The '^' character</h4></div></div></div>
 <p>
 The &#8216;^&#8217; character in the display section is used to separate
 identifiers from other characters where there shouldn&#8217;t be white space
@@ -256,7 +256,7 @@ and <span class="emphasis"><em>op2</em></span>.
 If the &#8216;^&#8217; is used as the first (non-whitespace) character in the
 display section of a base constructor, this inhibits the first
 identifier in the display from being considered the mnemonic, as
-described in <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1. Mnemonic">Section 7.3.1, &#8220;Mnemonic&#8221;</a>. This allows
+described in <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1.Â Mnemonic">SectionÂ 7.3.1, &#8220;Mnemonic&#8221;</a>. This allows
 specification of less common situations, where the first part of the
 mnemonic, rather than perhaps a later part, needs to be considered as
 an operand. An initial &#8216;^&#8217; character can also facilitate certain
@@ -266,7 +266,7 @@ recursive constructions.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_bit_pattern"></a>7.4. The Bit Pattern Section</h3></div></div></div>
+<a name="sleigh_bit_pattern"></a>7.4.Â The Bit Pattern Section</h3></div></div></div>
 <p>
 Syntactically, this section comes between the
 keyword <span class="bold"><strong>is</strong></span> and the delimiter for the
@@ -278,14 +278,14 @@ to <span class="emphasis"><em>match</em></span> the constructor being defined.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_constraints"></a>7.4.1. Constraints</h4></div></div></div>
+<a name="sleigh_constraints"></a>7.4.1.Â Constraints</h4></div></div></div>
 <p>
 The patterns required for processor specifications can almost always
 be described as a mask and value pair. Given a specific instruction
 encoding, we can decide if the encoding matches our pattern by looking
 at just the bits specified by the <span class="emphasis"><em>mask</em></span> and seeing
 if they match a specific <span class="emphasis"><em>value</em></span>. The fields, as
-defined in <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1. Defining Tokens and Fields">Section 6.1, &#8220;Defining Tokens and Fields&#8221;</a>, typically give us
+defined in <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1.Â Defining Tokens and Fields">SectionÂ 6.1, &#8220;Defining Tokens and Fields&#8221;</a>, typically give us
 our masks. So to construct a pattern, we can simply require that the
 field take on a specific value, as in the example below.
 </p>
@@ -311,7 +311,7 @@ field.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_ampandor"></a>7.4.2. The '&amp;' and '|' Operators</h4></div></div></div>
+<a name="sleigh_ampandor"></a>7.4.2.Â The '&amp;' and '|' Operators</h4></div></div></div>
 <p>
 More complicated patterns are built out of logical operators. The
 meaning of these are fairly straightforward. We can force two or more
@@ -337,7 +337,7 @@ requires two or more mask/value style checks to correctly implement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_defining_operands"></a>7.4.3. Defining Operands and Invoking Subtables</h4></div></div></div>
+<a name="sleigh_defining_operands"></a>7.4.3.Â Defining Operands and Invoking Subtables</h4></div></div></div>
 <p>
 The principle way of defining a constructor operand, left undefined
 from the display section, is done in the bit pattern section. If an
@@ -396,7 +396,7 @@ statement of the grouping of old symbols into the new constructor.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_variable_length"></a>7.4.4. Variable Length Instructions</h4></div></div></div>
+<a name="sleigh_variable_length"></a>7.4.4.Â Variable Length Instructions</h4></div></div></div>
 <p>
 There are some additional complexities to designing a specification
 for a processor with variable length instructions. Some initial
@@ -419,7 +419,7 @@ designer control over how tokens fit together.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_semicolon"></a>7.4.4.1. The ';' Operator</h5></div></div></div>
+<a name="sleigh_semicolon"></a>7.4.4.1.Â The ';' Operator</h5></div></div></div>
 <p>
 The most important operator for patterns defining variable length
 instructions is the concatenation operator &#8216;;&#8217;. When building a
@@ -481,7 +481,7 @@ operator, so parentheses may be necessary to get the intended meaning.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_ellipsis"></a>7.4.4.2. The '...' Operator</h5></div></div></div>
+<a name="sleigh_ellipsis"></a>7.4.4.2.Â The '...' Operator</h5></div></div></div>
 <p>
 The ellipsis operator &#8216;...&#8217; is used to satisfy the token matching
 requirements of the &#8216;&amp;&#8217; and &#8216;|&#8217; operators (described in the previous
@@ -538,7 +538,7 @@ constraints on a single byte in the final encoding.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_invisible_operands"></a>7.4.5. Invisible Operands</h4></div></div></div>
+<a name="sleigh_invisible_operands"></a>7.4.5.Â Invisible Operands</h4></div></div></div>
 <p>
 It is not necessary for a global symbol, which is needed by a
 constructor, to appear in the display section of the definition. If
@@ -549,7 +549,7 @@ operand</em></span>. Such an operand behaves and is parsed exactly like
 any other operand but there is absolutely no visible indication of the
 operand in the final display of the assembly instruction. The one
 common type of instruction that uses this is the relative branch (see
-<a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1. Relative Branches">Section 7.5.1, &#8220;Relative Branches&#8221;</a>) but it is otherwise needed
+<a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1.Â Relative Branches">SectionÂ 7.5.1, &#8220;Relative Branches&#8221;</a>) but it is otherwise needed
 only in more esoteric instructions. It is useful in situations where
 you need to break up the parsing of an instruction along lines that
 don&#8217;t quite match the assembly.
@@ -557,7 +557,7 @@ don&#8217;t quite match the assembly.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_empty_patterns"></a>7.4.6. Empty Patterns</h4></div></div></div>
+<a name="sleigh_empty_patterns"></a>7.4.6.Â Empty Patterns</h4></div></div></div>
 <p>
 Occasionally there is a need for an empty pattern when building
 tables. An empty pattern matches everything. There is a predefined
@@ -567,7 +567,7 @@ to indicate an empty pattern.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_advanced_constraints"></a>7.4.7. Advanced Constraints</h4></div></div></div>
+<a name="sleigh_advanced_constraints"></a>7.4.7.Â Advanced Constraints</h4></div></div></div>
 <p>
 A constraint does not have to be of the form &#8220;field = constant&#8221;,
 although this is almost always what is needed. In certain situations,
@@ -584,7 +584,7 @@ of parsing states for a single constraint.
 A constraint can actually be built out of arbitrary
 expressions. These <span class="emphasis"><em>pattern expressions</em></span> are more
 commonly used in disassembly actions and are defined in
-<a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2. General Actions and Pattern Expressions">Section 7.5.2, &#8220;General Actions and Pattern Expressions&#8221;</a>, but they can also be used in
+<a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2.Â General Actions and Pattern Expressions">SectionÂ 7.5.2, &#8220;General Actions and Pattern Expressions&#8221;</a>, but they can also be used in
 constraints. So in general, a constraint is any equation where the
 left-hand side is a single family symbol, the right-hand side is an
 arbitrary pattern expression, and the constraint operator is one of
@@ -592,7 +592,7 @@ the following:
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="constraints.htmltable"></a><p class="title"><b>Table 3. Constraint Operators</b></p>
+<a name="constraints.htmltable"></a><p class="title"><b>TableÂ 3.Â Constraint Operators</b></p>
 <div class="table-contents"><table xml:id="constraints.htmltable" width="50%" frame="box" rules="all">
 <col width="50%">
 <col width="50%">
@@ -655,7 +655,7 @@ registers. But the specification itself, at least, remains compact.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_disassembly_actions"></a>7.5. Disassembly Actions Section</h3></div></div></div>
+<a name="sleigh_disassembly_actions"></a>7.5.Â Disassembly Actions Section</h3></div></div></div>
 <p>
 After the bit pattern section, there can optionally be a section for
 doing dynamic calculations, which must be between square brackets. For
@@ -671,7 +671,7 @@ time, usually for part of the disassembly display.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_relative_branches"></a>7.5.1. Relative Branches</h4></div></div></div>
+<a name="sleigh_relative_branches"></a>7.5.1.Â Relative Branches</h4></div></div></div>
 <p>
 The canonical example of an action at disassembly time is a branch
 relocation. A jump instruction encodes the address of where it jumps
@@ -698,7 +698,7 @@ defined in the action section as the integer obtained by adding a
 multiple of <span class="emphasis"><em>simm8</em></span>
 to <span class="emphasis"><em>inst_next</em></span>, a symbol predefined to be equal to
 the address of the following instruction (see
-<a class="xref" href="sleigh_symbols.html#sleigh_predefined_symbols" title="5.2. Predefined Symbols">Section 5.2, &#8220;Predefined Symbols&#8221;</a>). Now <span class="emphasis"><em>reloc</em></span>
+<a class="xref" href="sleigh_symbols.html#sleigh_predefined_symbols" title="5.2.Â Predefined Symbols">SectionÂ 5.2, &#8220;Predefined Symbols&#8221;</a>). Now <span class="emphasis"><em>reloc</em></span>
 is a specific symbol with both semantic and display meaning equal to
 the desired absolute address. This address is calculated separately,
 at disassembly time, for every instruction that this constructor
@@ -707,7 +707,7 @@ matches.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_general_actions"></a>7.5.2. General Actions and Pattern Expressions</h4></div></div></div>
+<a name="sleigh_general_actions"></a>7.5.2.Â General Actions and Pattern Expressions</h4></div></div></div>
 <p>
 In general, the disassembly actions are encoded as a sequence of
 assignments separated by semicolons. The left-hand side of each
@@ -719,7 +719,7 @@ is built up out of the following typical operators:
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="patexp.htmltable"></a><p class="title"><b>Table 4. Pattern Expression Operators</b></p>
+<a name="patexp.htmltable"></a><p class="title"><b>TableÂ 4.Â Pattern Expression Operators</b></p>
 <div class="table-contents"><table xml:id="patexp.htmltable" width="50%" frame="box" rules="all">
 <col width="50%">
 <col width="50%">
@@ -816,7 +816,7 @@ local identifier before it can be used.
 </p>
 <p>
 The left-hand side of an assignment statement can be a context
-variable (see <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4. Context Variables">Section 6.4, &#8220;Context Variables&#8221;</a>). An
+variable (see <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4.Â Context Variables">SectionÂ 6.4, &#8220;Context Variables&#8221;</a>). An
 assignment to such a variable changes the context in which the current
 instruction is being disassembled and can potentially have a drastic
 effect on how the rest of the instruction is disassembled. An
@@ -828,9 +828,9 @@ more <span class="bold"><strong>globalset</strong></span> directives, which
 cause changes to context variables to become more permanent. This
 directive is distinct from the operators in a pattern expression and
 must be invoked as a separate statement. See
-<a class="xref" href="sleigh_context.html" title="8. Using Context">Section 8, &#8220;Using Context&#8221;</a>, for a discussion of how to
+<a class="xref" href="sleigh_context.html" title="8.Â Using Context">SectionÂ 8, &#8220;Using Context&#8221;</a>, for a discussion of how to
 effectively use context variables and
-<a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3. Global Context Change">Section 8.3, &#8220;Global Context Change&#8221;</a>, for details of
+<a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3.Â Global Context Change">SectionÂ 8.3, &#8220;Global Context Change&#8221;</a>, for details of
 the <span class="bold"><strong>globalset</strong></span> directive.
 </p>
 <p>
@@ -839,7 +839,7 @@ pattern expression. When an expression is used as part of a
 constraint, the &#8220;$and&#8221; and &#8220;$or&#8221; forms of the operators must be used
 in order to distinguish the bitwise operators from the special pattern
 combining operators, &#8216;&amp;&#8217; and &#8216;|&#8217; (as described in
-<a class="xref" href="sleigh_constructors.html#sleigh_ampandor" title="7.4.2. The '&amp;' and '|' Operators">Section 7.4.2, &#8220;The '&amp;' and '|' Operators&#8221;</a>). However inside the square braces
+<a class="xref" href="sleigh_constructors.html#sleigh_ampandor" title="7.4.2.Â The '&amp;' and '|' Operators">SectionÂ 7.4.2, &#8220;The '&amp;' and '|' Operators&#8221;</a>). However inside the square braces
 of the disassembly action section, &#8216;&amp;&#8217; and &#8216;|&#8217; are interpreted as
 the usual logical operators.
 </p>
@@ -847,7 +847,7 @@ the usual logical operators.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_with_block"></a>7.6. The With Block</h3></div></div></div>
+<a name="sleigh_with_block"></a>7.6.Â The With Block</h3></div></div></div>
 <p>
 To avoid tedious repetition and to ease the maintenance of specifications
 already having many, many constructors and tables, the <span class="emphasis"><em>with
@@ -867,9 +867,9 @@ with op1 : mode=1 [ mode=2; ] {
 In the example, both constructors are added to the table identified by
 <span class="emphasis"><em>op1</em></span>. Both require the context field
 <span class="emphasis"><em>mode</em></span> to be equal to 1. The listed constraints take the
-form described in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4. The Bit Pattern Section">Section 7.4, &#8220;The Bit Pattern Section&#8221;</a>, and they are joined to
+form described in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4.Â The Bit Pattern Section">SectionÂ 7.4, &#8220;The Bit Pattern Section&#8221;</a>, and they are joined to
 those given in the constructor statement as if prepended using &#8216;&amp;&#8217;. Similarly,
-the actions take the form described in <a class="xref" href="sleigh_constructors.html#sleigh_disassembly_actions" title="7.5. Disassembly Actions Section">Section 7.5, &#8220;Disassembly Actions Section&#8221;</a>
+the actions take the form described in <a class="xref" href="sleigh_constructors.html#sleigh_disassembly_actions" title="7.5.Â Disassembly Actions Section">SectionÂ 7.5, &#8220;Disassembly Actions Section&#8221;</a>
 and are prepended to the actions given in the constructor statement. Prepending
 the actions allows the statement to override actions in the with block. Both
 technically occur, but only the last one has a noticeable effect. The above
@@ -894,12 +894,12 @@ yet exist, the table is created immediately. Inside a with block that has a
 table header, a nested with block may specify the <span class="emphasis"><em>instruction</em></span>
 table by name, as in "with instruction : {<span class="weak">...</span>}".
 Inside such a block, the rule regarding mnemonic literals is restored (see
-<a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1. Mnemonic">Section 7.3.1, &#8220;Mnemonic&#8221;</a>).
+<a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1.Â Mnemonic">SectionÂ 7.3.1, &#8220;Mnemonic&#8221;</a>).
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_semantic_section"></a>7.7. The Semantic Section</h3></div></div></div>
+<a name="sleigh_semantic_section"></a>7.7.Â The Semantic Section</h3></div></div></div>
 <p>
 The final section of a constructor definition is the <span class="emphasis"><em>semantic
 section</em></span>. This is a description of how the processor would manipulate
@@ -939,22 +939,22 @@ varnode is <span class="emphasis"><em>r1</em></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_expressions"></a>7.7.1. Expressions</h4></div></div></div>
+<a name="sleigh_expressions"></a>7.7.1.Â Expressions</h4></div></div></div>
 <p>
 Expressions are built out of symbols and the binary and unary
-operators listed in <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table 5. Semantic Expression Operators and Syntax">Table 5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
+operators listed in <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="TableÂ 5.Â Semantic Expression Operators and Syntax">TableÂ 5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
 Appendix. All expressions evaluate to an integer, floating point, or
 boolean value, depending on the final operation of the expression. The
 value is then used depending on the kind of statement. Most of the
 operators require that their input and output varnodes all be the same
-size (see <a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, &#8220;Varnode Sizes&#8221;</a>). The operators all
+size (see <a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.Â Varnode Sizes">SectionÂ 7.7.3, &#8220;Varnode Sizes&#8221;</a>). The operators all
 have a precedence, which is used by the SLEIGH compiler to determine
 the ordering of the final p-code operations. Parentheses can be used
 within expressions to affect this order.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_arithmetic_logical"></a>7.7.1.1. Arithmetic, Logical and Boolean Operators</h5></div></div></div>
+<a name="sleigh_arithmetic_logical"></a>7.7.1.1.Â Arithmetic, Logical and Boolean Operators</h5></div></div></div>
 <p>
 For the most part these operators should be familiar to software
 developers. The only real differences arise from the fact that
@@ -974,7 +974,7 @@ some people in this form (see the descriptions in the Appendix).
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_star_operator"></a>7.7.1.2. The '*' Operator</h5></div></div></div>
+<a name="sleigh_star_operator"></a>7.7.1.2.Â The '*' Operator</h5></div></div></div>
 <p>
 The dereference operator, which generates <span class="emphasis"><em>LOAD</em></span>
 operations (and <span class="emphasis"><em>STORE</em></span> operations), has slightly
@@ -996,7 +996,7 @@ It is also frequently not clear what the size of the dereferenced data
 is because the pointer variable is typeless. The SLEIGH compiler can
 frequently deduce what the size must be by looking at the operation in
 the context of the entire statement (see
-<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, &#8220;Varnode Sizes&#8221;</a>). But in some situations, this
+<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.Â Varnode Sizes">SectionÂ 7.7.3, &#8220;Varnode Sizes&#8221;</a>). But in some situations, this
 may not be possible, so there is a way to specify the size
 explicitly. The operator can be followed by a colon &#8216;:&#8217; and an integer
 indicating the number of bytes being dereferenced. This can be used
@@ -1017,7 +1017,7 @@ set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_extension"></a>7.7.1.3. Extension</h5></div></div></div>
+<a name="sleigh_extension"></a>7.7.1.3.Â Extension</h5></div></div></div>
 <p>
 Most processors have instructions that extend small values into big
 values, and many instructions do these minor data manipulations
@@ -1039,7 +1039,7 @@ the <span class="bold"><strong>sext</strong></span> operator.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_truncation"></a>7.7.1.4. Truncation</h5></div></div></div>
+<a name="sleigh_truncation"></a>7.7.1.4.Â Truncation</h5></div></div></div>
 <p>
 There are two forms of syntax indicating a truncation of the input
 varnode. In one the varnode is followed by a colon &#8216;:&#8217; and an integer
@@ -1067,7 +1067,7 @@ half and <span class="emphasis"><em>hi</em></span> receives the most significant
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_bitrange_operator"></a>7.7.1.5. Bit Range Operator</h5></div></div></div>
+<a name="sleigh_bitrange_operator"></a>7.7.1.5.Â Bit Range Operator</h5></div></div></div>
 <p>
 A specific subrange of bits within a varnode can be explicitly
 referenced. Depending on the range, this may amount to just a
@@ -1119,12 +1119,12 @@ these are automatically set to zero.
 </p>
 <p>
 This operator can also be used on the left-hand side of assignments
-with similar behavior and caveats (see <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_assign" title="7.7.2.8. Bit Range Assignments">Section 7.7.2.8, &#8220;Bit Range Assignments&#8221;</a>).
+with similar behavior and caveats (see <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_assign" title="7.7.2.8.Â Bit Range Assignments">SectionÂ 7.7.2.8, &#8220;Bit Range Assignments&#8221;</a>).
 </p>
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_addressof"></a>7.7.1.6. Address-of Operator</h5></div></div></div>
+<a name="sleigh_addressof"></a>7.7.1.6.Â Address-of Operator</h5></div></div></div>
 <p>
 There is an <span class="emphasis"><em>address-of</em></span> operator for generating
 the address offset of a selected varnode as an integer value for use
@@ -1169,7 +1169,7 @@ the offset portion of the address, and to copy the desired value, the
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_managed_code"></a>7.7.1.7. Managed Code Operations</h5></div></div></div>
+<a name="sleigh_managed_code"></a>7.7.1.7.Â Managed Code Operations</h5></div></div></div>
 <p>
 SLEIGH provides basic support for instructions where encoding and context
 don't provide a complete description of the semantics. This is the case
@@ -1210,7 +1210,7 @@ of objects to allocate. It returns a pointer to the allocated object.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_userdef_op"></a>7.7.1.8. User-Defined Operations</h5></div></div></div>
+<a name="sleigh_userdef_op"></a>7.7.1.8.Â User-Defined Operations</h5></div></div></div>
 <p>
 Any identifier that has been defined as a new p-code operation, using
 the <span class="bold"><strong>define pcodeop</strong></span> statement, can be
@@ -1231,13 +1231,13 @@ define pcodeop arctan;
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_statements"></a>7.7.2. Statements</h4></div></div></div>
+<a name="sleigh_statements"></a>7.7.2.Â Statements</h4></div></div></div>
 <p>
 We describe the types of semantic statements that are allowed in SLEIGH.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_assign_statements"></a>7.7.2.1. Assignment Statements and Temporary Variables</h5></div></div></div>
+<a name="sleigh_assign_statements"></a>7.7.2.1.Â Assignment Statements and Temporary Variables</h5></div></div></div>
 <p>
 Of course SLEIGH allows assignment statements with the &#8216;=&#8217; operator,
 where the right-hand side is an arbitrary expression and the left-hand
@@ -1256,7 +1256,7 @@ result of the expression. The new symbol becomes part of the local
 scope of the constructor, and can be referred to in the following
 semantic statements. The size of the new varnode is calculated by
 examining the statement in context (see
-<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, &#8220;Varnode Sizes&#8221;</a>). It is also possible to
+<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.Â Varnode Sizes">SectionÂ 7.7.3, &#8220;Varnode Sizes&#8221;</a>). It is also possible to
 explicitly indicate the size by using the colon &#8216;:&#8217; operator followed
 by an integer size in bytes. The following examples demonstrate the
 temporary variable <span class="emphasis"><em>tmp</em></span> being defined using both
@@ -1305,7 +1305,7 @@ and may be enforced in future compiler versions.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_storage_statements"></a>7.7.2.2. Storage Statements</h5></div></div></div>
+<a name="sleigh_storage_statements"></a>7.7.2.2.Â Storage Statements</h5></div></div></div>
 <p>
 SLEIGH supports fairly standard <span class="emphasis"><em>storage statement</em></span>
 syntax to complement the load operator. The left-hand side of an
@@ -1326,7 +1326,7 @@ statement.
 The same size and address space considerations that apply to the &#8216;*&#8217;
 operator when it is used as a load operator also apply when it is used
 as a store operator, see
-<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, &#8220;The '*' Operator&#8221;</a>. Unless explicit modifiers are
+<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.Â The '*' Operator">SectionÂ 7.7.1.2, &#8220;The '*' Operator&#8221;</a>. Unless explicit modifiers are
 given, the default address space is assumed as the storage
 destination, and the size of the data being stored is calculated from
 context. Keep in mind that the address represented by the pointer is
@@ -1336,7 +1336,7 @@ attribute is set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_exports"></a>7.7.2.3. Exports</h5></div></div></div>
+<a name="sleigh_exports"></a>7.7.2.3.Â Exports</h5></div></div></div>
 <p>
 The semantic section doesn&#8217;t just specify how to generate p-code for a
 constructor. Except for those constructors in the root table, this
@@ -1382,19 +1382,19 @@ an <span class="bold"><strong>export</strong></span> statement, any expression
 must appear in an earlier statement. However, a single &#8216;&amp;&#8217;
 operator is allowed as part of the statement and it behaves as it
 would in a normal expression (see
-<a class="xref" href="sleigh_constructors.html#sleigh_addressof" title="7.7.1.6. Address-of Operator">Section 7.7.1.6, &#8220;Address-of Operator&#8221;</a>). It causes the address of the
+<a class="xref" href="sleigh_constructors.html#sleigh_addressof" title="7.7.1.6.Â Address-of Operator">SectionÂ 7.7.1.6, &#8220;Address-of Operator&#8221;</a>). It causes the address of the
 varnode being modified to be exported as an integer constant.
 </p>
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_dynamic_references"></a>7.7.2.4. Dynamic References</h5></div></div></div>
+<a name="sleigh_dynamic_references"></a>7.7.2.4.Â Dynamic References</h5></div></div></div>
 <p>
 The only other operator allowed as part of
 an <span class="bold"><strong>export</strong></span> statement, is the &#8216;*&#8217;
 operator. The semantic meaning of this operator is the same as if it
 were used in an expression (see
-<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, &#8220;The '*' Operator&#8221;</a>), but it is worth examining the
+<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.Â The '*' Operator">SectionÂ 7.7.1.2, &#8220;The '*' Operator&#8221;</a>), but it is worth examining the
 effects of this form of export in detail. Bearing in mind that
 an <span class="bold"><strong>export</strong></span> statement exports
 a <span class="emphasis"><em>reference</em></span>, using the &#8216;*&#8217; operator in the
@@ -1434,7 +1434,7 @@ portion of an address into the <span class="emphasis"><em>ram</em></span> addres
 space. The constant <span class="emphasis"><em>reloc</em></span> is calculated at
 disassembly time from the instruction
 field <span class="emphasis"><em>abs</em></span>. This is a very common construction for
-jump destinations (see <a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1. Relative Branches">Section 7.5.1, &#8220;Relative Branches&#8221;</a>) but
+jump destinations (see <a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1.Â Relative Branches">SectionÂ 7.5.1, &#8220;Relative Branches&#8221;</a>) but
 can be used in general. This particular combination of a disassembly
 time action and a dynamic export is a very general way to construct a
 family of varnodes.
@@ -1447,10 +1447,10 @@ levels.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_branching_statements"></a>7.7.2.5. Branching Statements</h5></div></div></div>
+<a name="sleigh_branching_statements"></a>7.7.2.5.Â Branching Statements</h5></div></div></div>
 <p>
 This section discusses statements that generate p-code branching
-operations. These are listed in <a class="xref" href="sleigh_ref.html#branchref.htmltable" title="Table 7. Branching Statements">Table 7, &#8220;Branching Statements&#8221;</a>, in the Appendix.
+operations. These are listed in <a class="xref" href="sleigh_ref.html#branchref.htmltable" title="TableÂ 7.Â Branching Statements">TableÂ 7, &#8220;Branching Statements&#8221;</a>, in the Appendix.
 </p>
 <p>
 There are six forms covering the gamut of typical assembly language
@@ -1492,7 +1492,7 @@ destination is the first p-code operation for the (translated) machine
 instruction at that address. For most cases, this is the only kind of
 branching needed. The rarer case of <span class="emphasis"><em>p-code
 relative</em></span> branching is discussed in the following section
-(<a class="xref" href="sleigh_constructors.html#sleigh_pcode_relative" title="7.7.2.6. P-code Relative Branching">Section 7.7.2.6, &#8220;P-code Relative Branching&#8221;</a>), but for the remainder of
+(<a class="xref" href="sleigh_constructors.html#sleigh_pcode_relative" title="7.7.2.6.Â P-code Relative Branching">SectionÂ 7.7.2.6, &#8220;P-code Relative Branching&#8221;</a>), but for the remainder of
 this section, we assume the destination is ultimately given as an
 address.
 </p>
@@ -1613,7 +1613,7 @@ must match the size of the destination space.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_pcode_relative"></a>7.7.2.6. P-code Relative Branching</h5></div></div></div>
+<a name="sleigh_pcode_relative"></a>7.7.2.6.Â P-code Relative Branching</h5></div></div></div>
 <p>
 In some cases, the semantics of an instruction may require
 branching <span class="emphasis"><em>within</em></span> the semantics of a single
@@ -1677,7 +1677,7 @@ or <span class="emphasis"><em>CALL</em></span> operation.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_skip_instruction_branching"></a>7.7.2.7. Skip Instruction Branching</h5></div></div></div>
+<a name="sleigh_skip_instruction_branching"></a>7.7.2.7.Â Skip Instruction Branching</h5></div></div></div>
 <p>
 Many processors have a conditional-skip-instruction which must branch over the next instruction
 based upon some condition.  The <span class="emphasis"><em>inst_next2</em></span> symbol has been provided for
@@ -1698,7 +1698,7 @@ instruction when the condition is satisfied.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_bitrange_assign"></a>7.7.2.8. Bit Range Assignments</h5></div></div></div>
+<a name="sleigh_bitrange_assign"></a>7.7.2.8.Â Bit Range Assignments</h5></div></div></div>
 <p>
 The bit range operator can appear on the left-hand side of an
 assignment. But as with the &#8216;*&#8217; operator, its meaning is slightly
@@ -1706,7 +1706,7 @@ different when used on this side. The bit range is specified in square
 brackets, as before, by giving the integer specifying the least
 significant bit of the range, followed by the number of bits in the
 range. In contrast with its use on the right however (see
-<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5. Bit Range Operator">Section 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>), the indicated bit range
+<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5.Â Bit Range Operator">SectionÂ 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>), the indicated bit range
 is filled rather than extracted. Bits obtained from evaluating the
 expression on the right are extracted and spliced into the result at
 the indicated bit offset.
@@ -1729,7 +1729,7 @@ In terms of the rest of the assignment expression, the bit range
 operator is again assumed to have a size equal to the minimum number
 of bytes needed to hold the bit range. In particular, in order to
 satisfy size restrictions (see
-<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, &#8220;Varnode Sizes&#8221;</a>), the right-hand side must
+<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.Â Varnode Sizes">SectionÂ 7.7.3, &#8220;Varnode Sizes&#8221;</a>), the right-hand side must
 match this size. Furthermore, it is assumed that any extra bits in the
 right-hand side expression are already set to zero.
 </p>
@@ -1737,7 +1737,7 @@ right-hand side expression are already set to zero.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_varnode_sizes"></a>7.7.3. Varnode Sizes</h4></div></div></div>
+<a name="sleigh_varnode_sizes"></a>7.7.3.Â Varnode Sizes</h4></div></div></div>
 <p>
 All statements within the semantic section must be specified up to the
 point where the sizes of all varnodes are unambiguously
@@ -1760,7 +1760,7 @@ The SLEIGH compiler does not make assumptions about the size of a
 constant variable based on the constant value itself. This is true of
 values occurring explicitly in the specification and of values that
 are calculated dynamically in a disassembly action. As described in
-<a class="xref" href="sleigh_constructors.html#sleigh_assign_statements" title="7.7.2.1. Assignment Statements and Temporary Variables">Section 7.7.2.1, &#8220;Assignment Statements and Temporary Variables&#8221;</a>, temporary variables do not
+<a class="xref" href="sleigh_constructors.html#sleigh_assign_statements" title="7.7.2.1.Â Assignment Statements and Temporary Variables">SectionÂ 7.7.2.1, &#8220;Assignment Statements and Temporary Variables&#8221;</a>, temporary variables do not
 need to have their size given explicitly.
 </p>
 <p>
@@ -1768,7 +1768,7 @@ The SLEIGH compiler can usually fill in the required size by examining
 these situations in the context of the entire semantic section. Most
 p-code operations have size restrictions on their inputs and outputs,
 which when put together can uniquely determine the unspecified
-sizes. Referring to <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table 5. Semantic Expression Operators and Syntax">Table 5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
+sizes. Referring to <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="TableÂ 5.Â Semantic Expression Operators and Syntax">TableÂ 5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
 Appendix, all arithmetic and logical operations, both integer and
 floating point, must have inputs and outputs all of the same size. The
 only exceptions are as follows. The overflow
@@ -1784,7 +1784,7 @@ a size of 1 byte.
 <p>
 The operators without a size constraint are the load and store
 operators, the extension and truncation operators, and the conversion
-operators. As discussed in <a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, &#8220;The '*' Operator&#8221;</a>, the
+operators. As discussed in <a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.Â The '*' Operator">SectionÂ 7.7.1.2, &#8220;The '*' Operator&#8221;</a>, the
 &#8216;*&#8217; operator cannot get size information for the dynamic (pointed-to)
 object from the pointer itself. The other operators by definition
 involve a change of size from input to output.
@@ -1823,7 +1823,7 @@ each followed by a variation which corrects the error.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_unimplemented_semantics"></a>7.7.4. Unimplemented Semantics</h4></div></div></div>
+<a name="sleigh_unimplemented_semantics"></a>7.7.4.Â Unimplemented Semantics</h4></div></div></div>
 <p>
 The semantic section must be present for every constructor in the
 specification. But the designer can leave the semantics explicitly
@@ -1849,7 +1849,7 @@ nothing.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_tables"></a>7.8. Tables</h3></div></div></div>
+<a name="sleigh_tables"></a>7.8.Â Tables</h3></div></div></div>
 <p>
 A single constructor does not form a new specific
 symbol. The <span class="emphasis"><em>table</em></span> that the constructor is
@@ -1874,7 +1874,7 @@ exploit the similarity to produce an extremely concise description.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_matching"></a>7.8.1. Matching</h4></div></div></div>
+<a name="sleigh_matching"></a>7.8.1.Â Matching</h4></div></div></div>
 <p>
 If a table contains exactly one constructor, the meaning of the table
 as a specific symbol is straightforward. The display meaning of the
@@ -1983,7 +1983,7 @@ should generally be avoided.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_specific_symbol_trees"></a>7.8.2. Specific Symbol Trees</h4></div></div></div>
+<a name="sleigh_specific_symbol_trees"></a>7.8.2.Â Specific Symbol Trees</h4></div></div></div>
 <p>
 When the SLEIGH parser analyzes an instruction, it starts with the
 root symbol <span class="emphasis"><em>instruction</em></span>, and decides which of the
@@ -1993,7 +1993,7 @@ parsing process recurses at this point.  Each of the unresolved family
 symbols is analyzed in the same way to find the matching specific
 symbol. The matching is accomplished either with a table lookup, as
 with a field with attached registers, or with the matching algorithm
-described in <a class="xref" href="sleigh_constructors.html#sleigh_matching" title="7.8.1. Matching">Section 7.8.1, &#8220;Matching&#8221;</a>. By the end of the
+described in <a class="xref" href="sleigh_constructors.html#sleigh_matching" title="7.8.1.Â Matching">SectionÂ 7.8.1, &#8220;Matching&#8221;</a>. By the end of the
 parsing process, we have a tree of specific symbols representing the
 parsed instruction. We present a small but complete SLEIGH
 specification to illustrate this hierarchy.
@@ -2049,10 +2049,10 @@ constructor is resolved in turn.
 </p>
 <div class="figure">
 <a name="sleigh_encoding_image"></a><div class="figure-contents"><div class="mediaobject" align="center"><table border="0" summary="manufactured viewport for HTML img" style="cellpadding: 0; cellspacing: 0;" width="100%"><tr><td align="center"><img src="Diagram1.png" align="middle" width="540" height="225" alt="Two Encodings and the Resulting Specific Symbol Trees"></td></tr></table></div></div>
-<p class="title"><b>Figure 1. Two Encodings and the Resulting Specific Symbol Trees</b></p>
+<p class="title"><b>FigureÂ 1.Â Two Encodings and the Resulting Specific Symbol Trees</b></p>
 </div>
 <br class="figure-break"><p>
-In <a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="Figure 1. Two Encodings and the Resulting Specific Symbol Trees">Figure 1, &#8220;Two Encodings and the Resulting Specific Symbol Trees&#8221;</a>, we can see the break down
+In <a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="FigureÂ 1.Â Two Encodings and the Resulting Specific Symbol Trees">FigureÂ 1, &#8220;Two Encodings and the Resulting Specific Symbol Trees&#8221;</a>, we can see the break down
 of two typical instructions in the example instruction set. For each
 instruction, we see the how the encodings split into the relevant
 fields and the resulting tree of specific symbols. Each node in the
@@ -2066,7 +2066,7 @@ and p-code for these encodings by walking the trees.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_disassembly_trees"></a>7.8.2.1. Disassembly Trees</h5></div></div></div>
+<a name="sleigh_disassembly_trees"></a>7.8.2.1.Â Disassembly Trees</h5></div></div></div>
 <p>
 If the nodes of each tree are replaced with the display information of
 the corresponding specific symbol, we see how the disassembly
@@ -2074,12 +2074,12 @@ statement is built.
 </p>
 <div class="figure">
 <a name="sleigh_disassembly_image"></a><div class="figure-contents"><div class="mediaobject" align="center"><table border="0" summary="manufactured viewport for HTML img" style="cellpadding: 0; cellspacing: 0;" width="100%"><tr><td align="center"><img src="Diagram2.png" align="middle" width="310" height="151" alt="Two Disassembly Trees"></td></tr></table></div></div>
-<p class="title"><b>Figure 2. Two Disassembly Trees</b></p>
+<p class="title"><b>FigureÂ 2.Â Two Disassembly Trees</b></p>
 </div>
 <br class="figure-break"><p>
-<a class="xref" href="sleigh_constructors.html#sleigh_disassembly_image" title="Figure 2. Two Disassembly Trees">Figure 2, &#8220;Two Disassembly Trees&#8221;</a>, shows the resulting
+<a class="xref" href="sleigh_constructors.html#sleigh_disassembly_image" title="FigureÂ 2.Â Two Disassembly Trees">FigureÂ 2, &#8220;Two Disassembly Trees&#8221;</a>, shows the resulting
 disassembly trees corresponding to the specific symbol trees in
-<a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="Figure 1. Two Encodings and the Resulting Specific Symbol Trees">Figure 1, &#8220;Two Encodings and the Resulting Specific Symbol Trees&#8221;</a>. The display information comes
+<a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="FigureÂ 1.Â Two Encodings and the Resulting Specific Symbol Trees">FigureÂ 1, &#8220;Two Encodings and the Resulting Specific Symbol Trees&#8221;</a>. The display information comes
 from constructor display sections, the names of attached registers, or
 the integer interpretation of fields. The identifiers in a constructor
 display section serves as placeholders for the subtrees below them. By
@@ -2089,7 +2089,7 @@ statements corresponding to the original instruction encodings.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_pcode_trees"></a>7.8.2.2. P-code Trees</h5></div></div></div>
+<a name="sleigh_pcode_trees"></a>7.8.2.2.Â P-code Trees</h5></div></div></div>
 <p>
 A similar procedure produces the resulting p-code translation of the
 instruction. If each node in the specific symbol tree is replaced with
@@ -2097,10 +2097,10 @@ the corresponding p-code, we see how the final translation is built.
 </p>
 <div class="figure">
 <a name="sleigh_pcode_image"></a><div class="figure-contents"><div class="mediaobject" align="center"><table border="0" summary="manufactured viewport for HTML img" style="cellpadding: 0; cellspacing: 0;" width="100%"><tr><td align="center"><img src="Diagram3.png" align="middle" width="405" height="149" alt="Two P-code Trees"></td></tr></table></div></div>
-<p class="title"><b>Figure 3. Two P-code Trees</b></p>
+<p class="title"><b>FigureÂ 3.Â Two P-code Trees</b></p>
 </div>
 <br class="figure-break"><p>
-<a class="xref" href="sleigh_constructors.html#sleigh_pcode_image" title="Figure 3. Two P-code Trees">Figure 3, &#8220;Two P-code Trees&#8221;</a> lists the final p-code
+<a class="xref" href="sleigh_constructors.html#sleigh_pcode_image" title="FigureÂ 3.Â Two P-code Trees">FigureÂ 3, &#8220;Two P-code Trees&#8221;</a> lists the final p-code
 translation for our example instructions and shows the trees from
 which the translation is derived. Symbol names within the p-code for a
 particular node, as with the disassembly tree, are placeholders for
@@ -2108,7 +2108,7 @@ the subtree below them. The final translation is put together by
 concatenating the p-code from each node, traversing the nodes in a
 depth-first order. Thus the p-code of a child tends to come before the
 p-code of the parent node (but see
-<a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9. P-code Macros">Section 7.9, &#8220;P-code Macros&#8221;</a>). Placeholders are filled in with the
+<a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9.Â P-code Macros">SectionÂ 7.9, &#8220;P-code Macros&#8221;</a>). Placeholders are filled in with the
 appropriate varnode, as determined by the export statement of the root
 of the corresponding subtree.
 </p>
@@ -2117,7 +2117,7 @@ of the corresponding subtree.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_macros"></a>7.9. P-code Macros</h3></div></div></div>
+<a name="sleigh_macros"></a>7.9.Â P-code Macros</h3></div></div></div>
 <p>
 SLEIGH supports a macro facility for encapsulating semantic
 actions. The syntax, in effect, allows the designer to define p-code
@@ -2168,7 +2168,7 @@ directive however should not be used in a macro.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_build_directives"></a>7.10. Build Directives</h3></div></div></div>
+<a name="sleigh_build_directives"></a>7.10.Â Build Directives</h3></div></div></div>
 <p>
 Because the nodes of a specific symbol tree are traversed in a
 depth-first order, the p-code for a child node in general comes before
@@ -2223,7 +2223,7 @@ normal action of the instruction.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_delayslot_directives"></a>7.11. Delay Slot Directives</h3></div></div></div>
+<a name="sleigh_delayslot_directives"></a>7.11.Â Delay Slot Directives</h3></div></div></div>
 <p>
 For processors with a pipe-lined architecture, multiple instructions
 are typically executing simultaneously. This can lead to processor
@@ -2289,15 +2289,15 @@ when computing the value of <span class="emphasis"><em>inst_next2</em></span>.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_tokens.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_context.html">Next</a>
+<a accesskey="p" href="sleigh_tokens.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_context.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">6. Tokens and Fields </td>
+<td width="40%" align="left" valign="top">6.Â Tokens and FieldsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 8. Using Context</td>
+<td width="40%" align="right" valign="top">Â 8.Â Using Context</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_context.html
+++ b/GhidraDocs/languages/html/sleigh_context.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>8. Using Context</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>8.Â Using Context</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_constructors.html" title="7. Constructors">
-<link rel="next" href="sleigh_ref.html" title="9. P-code Tables">
+<link rel="prev" href="sleigh_constructors.html" title="7.Â Constructors">
+<link rel="next" href="sleigh_ref.html" title="9.Â P-code Tables">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">8. Using Context</th></tr>
+<tr><th colspan="3" align="center">8.Â Using Context</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_constructors.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_ref.html">Next</a>
+<a accesskey="p" href="sleigh_constructors.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_ref.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_context"></a>8. Using Context</h2></div></div></div>
+<a name="sleigh_context"></a>8.Â Using Context</h2></div></div></div>
 <p>
 For most practical specifications, the disassembly and semantic
 meaning of an instruction can be determined by looking only at the
@@ -77,7 +77,7 @@ necessary.
 <p>
 SLEIGH solves these problems by introducing <span class="emphasis"><em>context
 variables</em></span>. The syntax for defining these symbols was
-described in <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4. Context Variables">Section 6.4, &#8220;Context Variables&#8221;</a>. As mentioned
+described in <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4.Â Context Variables">SectionÂ 6.4, &#8220;Context Variables&#8221;</a>. As mentioned
 there, the easiest and most common way to use a context variable is as
 just another field to use in our bit patterns. It gives us the extra
 information we need to distinguish between different instructions
@@ -85,7 +85,7 @@ whose encodings are otherwise the same.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_context_basic"></a>8.1. Basic Use of Context Variables</h3></div></div></div>
+<a name="sleigh_context_basic"></a>8.1.Â Basic Use of Context Variables</h3></div></div></div>
 <p>
 Suppose a processor supports the use of two different sets of
 registers in its main addressing mode, based on the setting of a
@@ -149,12 +149,12 @@ although see the following sections.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_local_change"></a>8.2. Local Context Change</h3></div></div></div>
+<a name="sleigh_local_change"></a>8.2.Â Local Context Change</h3></div></div></div>
 <p>
 SLEIGH can make direct modifications to context variables through
 statements in the disassembly action section of a constructor. The
 left-hand side of an assignment statement in this section can be a context variable,
-see <a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2. General Actions and Pattern Expressions">Section 7.5.2, &#8220;General Actions and Pattern Expressions&#8221;</a>. Because the result of this
+see <a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2.Â General Actions and Pattern Expressions">SectionÂ 7.5.2, &#8220;General Actions and Pattern Expressions&#8221;</a>. Because the result of this
 assignment is calculated in the middle of the instruction disassembly,
 the change in value of the context variable can potentially affect any
 remaining parsing for that instruction. A modal variable is being
@@ -193,7 +193,7 @@ use <span class="emphasis"><em>mode</em></span>, its value will have reverted to
 original global state. The same holds for any context variable
 modified with this syntax. If an instruction needs to permanently
 modify the state of a context variable, the designer must use
-constructions described in <a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3. Global Context Change">Section 8.3, &#8220;Global Context Change&#8221;</a>.
+constructions described in <a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3.Â Global Context Change">SectionÂ 8.3, &#8220;Global Context Change&#8221;</a>.
 </p>
 <p>
 Clearly, the behavior of the above example could be easily replicated
@@ -219,7 +219,7 @@ by <span class="bold"><strong>build</strong></span> directives.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_global_change"></a>8.3. Global Context Change</h3></div></div></div>
+<a name="sleigh_global_change"></a>8.3.Â Global Context Change</h3></div></div></div>
 <p>
 It is possible for an instruction to attempt a permanent change to a
 context variable, which would then affect the parsing of other
@@ -261,7 +261,7 @@ select <span class="emphasis"><em>r</em></span> registers
 via <span class="emphasis"><em>rreg1</em></span>, and <span class="emphasis"><em>smode</em></span>
 sets <span class="emphasis"><em>mode</em></span> to 1 in order to
 select <span class="emphasis"><em>s</em></span> registers. As is described in
-<a class="xref" href="sleigh_context.html#sleigh_local_change" title="8.2. Local Context Change">Section 8.2, &#8220;Local Context Change&#8221;</a>, these assignments by themselves
+<a class="xref" href="sleigh_context.html#sleigh_local_change" title="8.2.Â Local Context Change">SectionÂ 8.2, &#8220;Local Context Change&#8221;</a>, these assignments by themselves
 cause only a local context change.  However, the
 subsequent <span class="bold"><strong>globalset</strong></span> directives make
 the change persist outside of the the instructions
@@ -276,7 +276,7 @@ of <span class="emphasis"><em>mode</em></span> begins at the next address.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_contextflow"></a>8.3.1. Context Flow</h4></div></div></div>
+<a name="sleigh_contextflow"></a>8.3.1.Â Context Flow</h4></div></div></div>
 <p>
 A global change to context that affects instruction decoding is typically
 open-ended. I.e. once the mode switching instruction is executed, a permanent change
@@ -290,7 +290,7 @@ is encountered.
 </p>
 <p>
 Flow following behavior can be overridden by adding the <span class="bold"><strong>noflow</strong></span>
-attribute to the definition of the context field. (See <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4. Context Variables">Section 6.4, &#8220;Context Variables&#8221;</a>)
+attribute to the definition of the context field. (See <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4.Â Context Variables">SectionÂ 6.4, &#8220;Context Variables&#8221;</a>)
 In this case, a <span class="bold"><strong>globalset</strong></span> directive only affects the context
 of a single instruction at the specified address. Subsequent instructions
 retain their original context. This can be useful in a variety of situations but is typically
@@ -348,15 +348,15 @@ end and what to do if there are conflicts.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_constructors.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_ref.html">Next</a>
+<a accesskey="p" href="sleigh_constructors.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_ref.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">7. Constructors </td>
+<td width="40%" align="left" valign="top">7.Â ConstructorsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 9. P-code Tables</td>
+<td width="40%" align="right" valign="top">Â 9.Â P-code Tables</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_definitions.html
+++ b/GhidraDocs/languages/html/sleigh_definitions.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>4. Basic Definitions</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>4.Â Basic Definitions</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_preprocessing.html" title="3. Preprocessing">
-<link rel="next" href="sleigh_symbols.html" title="5. Introduction to Symbols">
+<link rel="prev" href="sleigh_preprocessing.html" title="3.Â Preprocessing">
+<link rel="next" href="sleigh_symbols.html" title="5.Â Introduction to Symbols">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">4. Basic Definitions</th></tr>
+<tr><th colspan="3" align="center">4.Â Basic Definitions</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_preprocessing.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_symbols.html">Next</a>
+<a accesskey="p" href="sleigh_preprocessing.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_symbols.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_definitions"></a>4. Basic Definitions</h2></div></div></div>
+<a name="sleigh_definitions"></a>4.Â Basic Definitions</h2></div></div></div>
 <p>
 SLEIGH files must start with all the definitions needed by the rest of
 the specification. All definition statements start with the keyword
@@ -34,7 +34,7 @@ the specification. All definition statements start with the keyword
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_endianess_definition"></a>4.1. Endianess Definition</h3></div></div></div>
+<a name="sleigh_endianess_definition"></a>4.1.Â Endianess Definition</h3></div></div></div>
 <p>
 The first definition in any SLEIGH specification must be for endianess. Either
 </p>
@@ -46,7 +46,7 @@ define endian=little;
 This defines how the processor interprets contiguous sequences of
 bytes as integers or other values and globally affects values across
 all address spaces. It also affects how integer fields
-within an instruction are interpreted, (see <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1. Defining Tokens and Fields">Section 6.1, &#8220;Defining Tokens and Fields&#8221;</a>),
+within an instruction are interpreted, (see <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1.Â Defining Tokens and Fields">SectionÂ 6.1, &#8220;Defining Tokens and Fields&#8221;</a>),
 although it is possible to override this setting in the rare case that endianess is
 different for data versus instruction encoding.
 The specification designer generally only needs to worry about
@@ -56,7 +56,7 @@ otherwise the specification language hides endianess issues.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_alignment_definition"></a>4.2. Alignment Definition</h3></div></div></div>
+<a name="sleigh_alignment_definition"></a>4.2.Â Alignment Definition</h3></div></div></div>
 <p>
 An alignment definition looks like
 </p>
@@ -73,7 +73,7 @@ instruction as an error.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_space_definitions"></a>4.3. Space Definitions</h3></div></div></div>
+<a name="sleigh_space_definitions"></a>4.3.Â Space Definitions</h3></div></div></div>
 <p>
 The definition of an address space looks like
 </p>
@@ -158,7 +158,7 @@ the <span class="bold"><strong>default</strong></span> attribute. This should be
 the space that the processor accesses with its main address bus. In
 terms of the rest of the specification file, this sets the default
 space referred to by the &#8216;*&#8217; operator (see
-<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, &#8220;The '*' Operator&#8221;</a>). It also has meaning to
+<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.Â The '*' Operator">SectionÂ 7.7.1.2, &#8220;The '*' Operator&#8221;</a>). It also has meaning to
 GHIDRA.
 </p>
 <p>
@@ -184,7 +184,7 @@ bits).
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_naming_registers"></a>4.4. Naming Registers</h3></div></div></div>
+<a name="sleigh_naming_registers"></a>4.4.Â Naming Registers</h3></div></div></div>
 <p>
 The general purpose registers of the processors can be named with the
 following define syntax:
@@ -228,7 +228,7 @@ define register offset=0 size=1
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_bitrange_registers"></a>4.5. Bit Range Registers</h3></div></div></div>
+<a name="sleigh_bitrange_registers"></a>4.5.Â Bit Range Registers</h3></div></div></div>
 <p>
 Many processors define registers that either consist of a single bit
 or otherwise don't use an integral number of bytes. A recurring
@@ -245,7 +245,7 @@ models because the smallest object they can manipulate directly is a
 byte. In order to manipulate single bits, p-code must use a
 combination of bitwise logical, extension, and truncation
 operations. So a register defined as a bit range is not really a
-varnode as described in <a class="xref" href="sleigh.html#sleigh_varnodes" title="1.2. Varnodes">Section 1.2, &#8220;Varnodes&#8221;</a>, but is
+varnode as described in <a class="xref" href="sleigh.html#sleigh_varnodes" title="1.2.Â Varnodes">SectionÂ 1.2, &#8220;Varnodes&#8221;</a>, but is
 really just a signal to the SLEIGH compiler to fill in the proper
 operators to simulate the bit manipulation. Using this feature may
 greatly increase the complexity of the compiled specification with
@@ -282,11 +282,11 @@ bit of <span class="emphasis"><em>statusreg</em></span> respectively.
 <p>
 The syntax for defining a new bit register is consistent with the
 pseudo bit range operator, described in
-<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5. Bit Range Operator">Section 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>, and the resulting symbol
+<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5.Â Bit Range Operator">SectionÂ 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>, and the resulting symbol
 is really just a placeholder for this operator. Whenever SLEIGH sees
 this symbol it generates p-code precisely as if the designer had used
 the bit range operator
-instead. <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5. Bit Range Operator">Section 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>, provides some
+instead. <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5.Â Bit Range Operator">SectionÂ 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>, provides some
 additional details about how p-code is generated, which apply to the
 use of bit range registers.
 </p>
@@ -299,14 +299,14 @@ used as an alternate syntax for defining overlapping registers.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_userdefined_operations"></a>4.6. User-Defined Operations</h3></div></div></div>
+<a name="sleigh_userdefined_operations"></a>4.6.Â User-Defined Operations</h3></div></div></div>
 <p>
 The specification designer can define new p-code operations using
 a <span class="bold"><strong>define pcodeop</strong></span> statement.  This
 statement automatically reserves an internal form for the new p-code
 operation and associates an identifier with it. This identifier can
 then be used in semantic expressions (see
-<a class="xref" href="sleigh_constructors.html#sleigh_userdef_op" title="7.7.1.8. User-Defined Operations">Section 7.7.1.8, &#8220;User-Defined Operations&#8221;</a>).  The following example defines a
+<a class="xref" href="sleigh_constructors.html#sleigh_userdef_op" title="7.7.1.8.Â User-Defined Operations">SectionÂ 7.7.1.8, &#8220;User-Defined Operations&#8221;</a>).  The following example defines a
 new p-code operation <span class="emphasis"><em>arctan</em></span>.
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -338,15 +338,15 @@ actions that are too esoteric or too complicated to implement.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_preprocessing.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_symbols.html">Next</a>
+<a accesskey="p" href="sleigh_preprocessing.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_symbols.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">3. Preprocessing </td>
+<td width="40%" align="left" valign="top">3.Â PreprocessingÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 5. Introduction to Symbols</td>
+<td width="40%" align="right" valign="top">Â 5.Â Introduction to Symbols</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_layout.html
+++ b/GhidraDocs/languages/html/sleigh_layout.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>2. Basic Specification Layout</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>2.Â Basic Specification Layout</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh.html" title="SLEIGH">
-<link rel="next" href="sleigh_preprocessing.html" title="3. Preprocessing">
+<link rel="next" href="sleigh_preprocessing.html" title="3.Â Preprocessing">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">2. Basic Specification Layout</th></tr>
+<tr><th colspan="3" align="center">2.Â Basic Specification Layout</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_preprocessing.html">Next</a>
+<a accesskey="p" href="sleigh.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_preprocessing.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,27 +26,27 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_layout"></a>2. Basic Specification Layout</h2></div></div></div>
+<a name="sleigh_layout"></a>2.Â Basic Specification Layout</h2></div></div></div>
 <p>
 A SLEIGH specification is typically contained in a single file,
-although see <a class="xref" href="sleigh_preprocessing.html#sleigh_including_files" title="3.1. Including Files">Section 3.1, &#8220;Including Files&#8221;</a>.  The file must
+although see <a class="xref" href="sleigh_preprocessing.html#sleigh_including_files" title="3.1.Â Including Files">SectionÂ 3.1, &#8220;Including Files&#8221;</a>.  The file must
 follow a specific format as parsed by the SLEIGH compiler. In this
 section, we list the basic formatting rules for this file as enforced
 by the compiler.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_comments"></a>2.1. Comments</h3></div></div></div>
+<a name="sleigh_comments"></a>2.1.Â Comments</h3></div></div></div>
 <p>
 Comments start with the &#8216;#&#8217; character and continue to the end of the
 line. Comments can appear anywhere except the <span class="emphasis"><em>display section</em></span> of a
-constructor (see <a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3. The Display Section">Section 7.3, &#8220;The Display Section&#8221;</a>) where the &#8216;#&#8217; character will be
+constructor (see <a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3.Â The Display Section">SectionÂ 7.3, &#8220;The Display Section&#8221;</a>) where the &#8216;#&#8217; character will be
 interpreted as something that should be printed in disassembly.
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_identifiers"></a>2.2. Identifiers</h3></div></div></div>
+<a name="sleigh_identifiers"></a>2.2.Â Identifiers</h3></div></div></div>
 <p>
 Identifiers are made up of letters a-z, capitals A-Z, digits 0-9 and
 the characters &#8216;.&#8217; and &#8216;_&#8217;. An identifier can use these characters in
@@ -55,7 +55,7 @@ any order and for any length, but it must not start with a digit.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_strings"></a>2.3. Strings</h3></div></div></div>
+<a name="sleigh_strings"></a>2.3.Â Strings</h3></div></div></div>
 <p>
 String literals can be used, when specifying names and when specifying
 how disassembly should be printed, so that special characters are
@@ -66,7 +66,7 @@ meaning.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_integers"></a>2.4. Integers</h3></div></div></div>
+<a name="sleigh_integers"></a>2.4.Â Integers</h3></div></div></div>
 <p>
 Integers are specified either in a decimal format or in a standard
 <span class="emphasis"><em>C-style</em></span> hexadecimal format by prepending the
@@ -82,17 +82,17 @@ can be given by prepending the string of '0' and '1' characters with "0b".
 <p>
 Numbers are treated as unsigned
 except when used in patterns where they are treated as signed (see
-<a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4. The Bit Pattern Section">Section 7.4, &#8220;The Bit Pattern Section&#8221;</a>). The number of bytes used to
+<a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4.Â The Bit Pattern Section">SectionÂ 7.4, &#8220;The Bit Pattern Section&#8221;</a>). The number of bytes used to
 encode the integer when specifying the semantics of an instruction is
 inferred from other parts of the syntax (see
-<a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3. The Display Section">Section 7.3, &#8220;The Display Section&#8221;</a>). Otherwise, integers should
+<a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3.Â The Display Section">SectionÂ 7.3, &#8220;The Display Section&#8221;</a>). Otherwise, integers should
 be thought of as having arbitrary precision. Currently, SLEIGH stores
 integers internally with 64 bits of precision.
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_white_space"></a>2.5. White Space</h3></div></div></div>
+<a name="sleigh_white_space"></a>2.5.Â White Space</h3></div></div></div>
 <p>
 White space characters include space, tab, line-feed, vertical
 line-feed, and carriage-return (&#8216; &#8216;, &#8216;\t&#8217;, &#8216;\r&#8217;, &#8216;\v&#8217;,
@@ -106,15 +106,15 @@ except in string literals.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_preprocessing.html">Next</a>
+<a accesskey="p" href="sleigh.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_preprocessing.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">SLEIGH </td>
+<td width="40%" align="left" valign="top">SLEIGHÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 3. Preprocessing</td>
+<td width="40%" align="right" valign="top">Â 3.Â Preprocessing</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_preprocessing.html
+++ b/GhidraDocs/languages/html/sleigh_preprocessing.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>3. Preprocessing</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>3.Â Preprocessing</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_layout.html" title="2. Basic Specification Layout">
-<link rel="next" href="sleigh_definitions.html" title="4. Basic Definitions">
+<link rel="prev" href="sleigh_layout.html" title="2.Â Basic Specification Layout">
+<link rel="next" href="sleigh_definitions.html" title="4.Â Basic Definitions">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">3. Preprocessing</th></tr>
+<tr><th colspan="3" align="center">3.Â Preprocessing</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_layout.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_definitions.html">Next</a>
+<a accesskey="p" href="sleigh_layout.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_definitions.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_preprocessing"></a>3. Preprocessing</h2></div></div></div>
+<a name="sleigh_preprocessing"></a>3.Â Preprocessing</h2></div></div></div>
 <p>
 SLEIGH provides support for simple file inclusion, macros, and other
 basic preprocessing functions.  These are all invoked with directives
@@ -35,7 +35,7 @@ in the line.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_including_files"></a>3.1. Including Files</h3></div></div></div>
+<a name="sleigh_including_files"></a>3.1.Â Including Files</h3></div></div></div>
 <p>
 In general a single SLEIGH specification is contained in a single
 file, and the compiler is invoked on one file at a time. Multiple
@@ -54,7 +54,7 @@ own <span class="bold"><strong>@include</strong></span> directives.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_preprocessor_macros"></a>3.2. Preprocessor Macros</h3></div></div></div>
+<a name="sleigh_preprocessor_macros"></a>3.2.Â Preprocessor Macros</h3></div></div></div>
 <p>
 SLEIGH allows simple (unparameterized) macro definitions and
 expansions. A macro definition occurs on one line and starts with
@@ -85,7 +85,7 @@ definition of a macro from that point on in the file.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_conditional_compilation"></a>3.3. Conditional Compilation</h3></div></div></div>
+<a name="sleigh_conditional_compilation"></a>3.3.Â Conditional Compilation</h3></div></div></div>
 <p>
 SLEIGH supports several directives that allow conditional inclusion of
 parts of a specification, based on the existence of a macro, or its
@@ -103,7 +103,7 @@ and <span class="bold"><strong>@endif</strong></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_ifdef"></a>3.3.1. @ifdef and @ifndef</h4></div></div></div>
+<a name="sleigh_ifdef"></a>3.3.1.Â @ifdef and @ifndef</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@ifdef</strong></span> directive is followed by a
 macro identifier and evaluates to true if the macro is defined.
@@ -129,7 +129,7 @@ or <span class="bold"><strong>@elif</strong></span> directive (See below).
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_if"></a>3.3.2. @if</h4></div></div></div>
+<a name="sleigh_if"></a>3.3.2.Â @if</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@if</strong></span> directive is followed by a
 boolean expression with macros as the variables and strings as the
@@ -158,7 +158,7 @@ is defined.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_else"></a>3.3.3. @else and @elif</h4></div></div></div>
+<a name="sleigh_else"></a>3.3.3.Â @else and @elif</h4></div></div></div>
 <p>
 An <span class="bold"><strong>@else</strong></span> directive splits the lines
 bounded by an <span class="bold"><strong>@if</strong></span> directive and
@@ -198,15 +198,15 @@ the <span class="bold"><strong>@elif</strong></span> directives.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_layout.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_definitions.html">Next</a>
+<a accesskey="p" href="sleigh_layout.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_definitions.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">2. Basic Specification Layout </td>
+<td width="40%" align="left" valign="top">2.Â Basic Specification LayoutÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 4. Basic Definitions</td>
+<td width="40%" align="right" valign="top">Â 4.Â Basic Definitions</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_ref.html
+++ b/GhidraDocs/languages/html/sleigh_ref.html
@@ -1,34 +1,34 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>9. P-code Tables</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>9.Â P-code Tables</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_context.html" title="8. Using Context">
+<link rel="prev" href="sleigh_context.html" title="8.Â Using Context">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">9. P-code Tables</th></tr>
+<tr><th colspan="3" align="center">9.Â P-code Tables</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_context.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> </td>
+<a accesskey="p" href="sleigh_context.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â </td>
 </tr>
 </table>
 <hr>
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_ref"></a>9. P-code Tables</h2></div></div></div>
+<a name="sleigh_ref"></a>9.Â P-code Tables</h2></div></div></div>
 <p>
 We list all the p-code operations by name along with the syntax for
 invoking them within the semantic section of a constructor definition
-(see <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7. The Semantic Section">Section 7.7, &#8220;The Semantic Section&#8221;</a>), and with a
+(see <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7.Â The Semantic Section">SectionÂ 7.7, &#8220;The Semantic Section&#8221;</a>), and with a
 description of the operator. The terms <span class="emphasis"><em>v0</em></span>
 and <span class="emphasis"><em>v1</em></span> represent identifiers of individual input
 varnodes to the operation. In terms of syntax, <span class="emphasis"><em>v0</em></span>
@@ -46,7 +46,7 @@ to lowest.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="syntaxref.htmltable"></a><p class="title"><b>Table 5. Semantic Expression Operators and Syntax</b></p>
+<a name="syntaxref.htmltable"></a><p class="title"><b>TableÂ 5.Â Semantic Expression Operators and Syntax</b></p>
 <div class="table-contents"><table xml:id="syntaxref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
@@ -459,7 +459,7 @@ The following table lists the basic forms of a semantic statement.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="statementref.htmltable"></a><p class="title"><b>Table 6. Basic Statements and Associated Operators</b></p>
+<a name="statementref.htmltable"></a><p class="title"><b>TableÂ 6.Â Basic Statements and Associated Operators</b></p>
 <div class="table-contents"><table xml:id="statementref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
@@ -538,7 +538,7 @@ The following table lists the branching operations and the statements which invo
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="branchref.htmltable"></a><p class="title"><b>Table 7. Branching Statements</b></p>
+<a name="branchref.htmltable"></a><p class="title"><b>TableÂ 7.Â Branching Statements</b></p>
 <div class="table-contents"><table xml:id="branchref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
@@ -592,14 +592,14 @@ The following table lists the branching operations and the statements which invo
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_context.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> </td>
+<a accesskey="p" href="sleigh_context.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">8. Using Context </td>
+<td width="40%" align="left" valign="top">8.Â Using ContextÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> </td>
+<td width="40%" align="right" valign="top">Â </td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_symbols.html
+++ b/GhidraDocs/languages/html/sleigh_symbols.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>5. Introduction to Symbols</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>5.Â Introduction to Symbols</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_definitions.html" title="4. Basic Definitions">
-<link rel="next" href="sleigh_tokens.html" title="6. Tokens and Fields">
+<link rel="prev" href="sleigh_definitions.html" title="4.Â Basic Definitions">
+<link rel="next" href="sleigh_tokens.html" title="6.Â Tokens and Fields">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">5. Introduction to Symbols</th></tr>
+<tr><th colspan="3" align="center">5.Â Introduction to Symbols</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_definitions.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_tokens.html">Next</a>
+<a accesskey="p" href="sleigh_definitions.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_tokens.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_symbols"></a>5. Introduction to Symbols</h2></div></div></div>
+<a name="sleigh_symbols"></a>5.Â Introduction to Symbols</h2></div></div></div>
 <p>
 After the definition section, we are prepared to start writing the
 body of the specification. This part of the specification shows how
@@ -61,7 +61,7 @@ Formally a <span class="emphasis"><em>Specific Symbol</em></span> is defined as 
 <p>
 The named registers that we defined earlier are the simplest examples
 of specific symbols (see
-<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4. Naming Registers">Section 4.4, &#8220;Naming Registers&#8221;</a>). The symbol identifier
+<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4.Â Naming Registers">SectionÂ 4.4, &#8220;Naming Registers&#8221;</a>). The symbol identifier
 itself is the string that will get printed in disassembly and the
 varnode associated with the symbol is the one constructed by the
 define statement.
@@ -79,7 +79,7 @@ instructions to specific symbols.
 <p>
 The set of instruction encodings that map to a single specific symbol
 is called an <span class="emphasis"><em>instruction pattern</em></span> and is described
-more fully in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4. The Bit Pattern Section">Section 7.4, &#8220;The Bit Pattern Section&#8221;</a>. In most cases, this
+more fully in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4.Â The Bit Pattern Section">SectionÂ 7.4, &#8220;The Bit Pattern Section&#8221;</a>. In most cases, this
 can be thought of as a mask on the bits of the instruction and a value
 that the remaining unmasked bits must match. At any rate, the family
 symbol identifier, when taken out of context, represents the entire
@@ -98,14 +98,14 @@ that simulate the instruction.
 <p>
 The symbol responsible for combining smaller family symbols is called
 a <span class="emphasis"><em>table</em></span>, which is fully described in
-<a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8. Tables">Section 7.8, &#8220;Tables&#8221;</a>. Any <span class="emphasis"><em>table</em></span> symbol
+<a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8.Â Tables">SectionÂ 7.8, &#8220;Tables&#8221;</a>. Any <span class="emphasis"><em>table</em></span> symbol
 can be used in the definition of other <span class="emphasis"><em>table</em></span>
 symbols until the root symbol is fully described. The root symbol has
 the predefined identifier <span class="emphasis"><em>instruction</em></span>.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_notes_namespaces"></a>5.1. Notes on Namespaces</h3></div></div></div>
+<a name="sleigh_notes_namespaces"></a>5.1.Â Notes on Namespaces</h3></div></div></div>
 <p>
 Almost all identifiers live in the same global "scope". The global scope includes
 </p>
@@ -126,15 +126,15 @@ Almost all identifiers live in the same global "scope". The global scope include
   Names of registers
   </li>
 <li class="listitem" style="list-style-type: disc">
-  Names of macros (see <a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9. P-code Macros">Section 7.9, &#8220;P-code Macros&#8221;</a>)
+  Names of macros (see <a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9.Â P-code Macros">SectionÂ 7.9, &#8220;P-code Macros&#8221;</a>)
   </li>
 <li class="listitem" style="list-style-type: disc">
-  Names of tables (see <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8. Tables">Section 7.8, &#8220;Tables&#8221;</a>)
+  Names of tables (see <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8.Â Tables">SectionÂ 7.8, &#8220;Tables&#8221;</a>)
   </li>
 </ul></div></div>
 <p>
 All of the names in this scope must be unique. Each
-individual <span class="emphasis"><em>constructor</em></span> (defined in <a class="xref" href="sleigh_constructors.html" title="7. Constructors">Section 7, &#8220;Constructors&#8221;</a>)
+individual <span class="emphasis"><em>constructor</em></span> (defined in <a class="xref" href="sleigh_constructors.html" title="7.Â Constructors">SectionÂ 7, &#8220;Constructors&#8221;</a>)
 defines a local scope for operand names. As with most languages, a
 local symbol with the same name as a global
 symbol <span class="emphasis"><em>hides</em></span> the global symbol while that scope
@@ -143,13 +143,13 @@ is in effect.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_predefined_symbols"></a>5.2. Predefined Symbols</h3></div></div></div>
+<a name="sleigh_predefined_symbols"></a>5.2.Â Predefined Symbols</h3></div></div></div>
 <p>
 We list all of the symbols that are predefined by SLEIGH.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="predefine.htmltable"></a><p class="title"><b>Table 2. Predefined Symbols</b></p>
+<a name="predefine.htmltable"></a><p class="title"><b>TableÂ 2.Â Predefined Symbols</b></p>
 <div class="table-contents"><table xml:id="predefine.htmltable" width="80%" frame="box" rules="all">
 <col width="30%">
 <col width="70%">
@@ -213,15 +213,15 @@ is the root instruction table.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_definitions.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_tokens.html">Next</a>
+<a accesskey="p" href="sleigh_definitions.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_tokens.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">4. Basic Definitions </td>
+<td width="40%" align="left" valign="top">4.Â Basic DefinitionsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 6. Tokens and Fields</td>
+<td width="40%" align="right" valign="top">Â 6.Â Tokens and Fields</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_tokens.html
+++ b/GhidraDocs/languages/html/sleigh_tokens.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>6. Tokens and Fields</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>6.Â Tokens and Fields</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_symbols.html" title="5. Introduction to Symbols">
-<link rel="next" href="sleigh_constructors.html" title="7. Constructors">
+<link rel="prev" href="sleigh_symbols.html" title="5.Â Introduction to Symbols">
+<link rel="next" href="sleigh_constructors.html" title="7.Â Constructors">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">6. Tokens and Fields</th></tr>
+<tr><th colspan="3" align="center">6.Â Tokens and Fields</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_symbols.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_constructors.html">Next</a>
+<a accesskey="p" href="sleigh_symbols.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_constructors.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,10 +26,10 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_tokens"></a>6. Tokens and Fields</h2></div></div></div>
+<a name="sleigh_tokens"></a>6.Â Tokens and Fields</h2></div></div></div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_defining_tokens"></a>6.1. Defining Tokens and Fields</h3></div></div></div>
+<a name="sleigh_defining_tokens"></a>6.1.Â Defining Tokens and Fields</h3></div></div></div>
 <p>
 A <span class="emphasis"><em>token</em></span> is one of the byte-sized pieces that make
 up the machine code instructions being modeled.
@@ -57,7 +57,7 @@ field and the range of bits within the token making up the field. The
 size of a field does <span class="emphasis"><em>not</em></span> need to be a multiple of
 8. The range is inclusive where the least significant bit in the token
 is labeled 0. When defining tokens that are bigger than 1 byte, the
-global endianess setting (See <a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1. Endianess Definition">Section 4.1, &#8220;Endianess Definition&#8221;</a>)
+global endianess setting (See <a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1.Â Endianess Definition">SectionÂ 4.1, &#8220;Endianess Definition&#8221;</a>)
 will affect this labeling. Although it is rarely required, it is possible to override
 the global endianess setting for a specific token by appending either the qualifier
 <span class="bold"><strong>endian=little</strong></span> or <span class="bold"><strong>endian=big</strong></span>
@@ -88,7 +88,7 @@ different names.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_fields_family"></a>6.2. Fields as Family Symbols</h3></div></div></div>
+<a name="sleigh_fields_family"></a>6.2.Â Fields as Family Symbols</h3></div></div></div>
 <p>
 Fields are the most basic form of family symbol; they define a natural
 map from instruction bits to a specific symbol as follows. We take the
@@ -113,7 +113,7 @@ the <span class="bold"><strong>dec</strong></span> attribute is not supported]
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_alternate_meanings"></a>6.3. Attaching Alternate Meanings to Fields</h3></div></div></div>
+<a name="sleigh_alternate_meanings"></a>6.3.Â Attaching Alternate Meanings to Fields</h3></div></div></div>
 <p>
 The default interpretation of a field is probably the most natural but
 of course processors interpret fields within an instruction in a wide
@@ -124,7 +124,7 @@ interpretations must be built up out of tables.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_attaching_registers"></a>6.3.1. Attaching Registers</h4></div></div></div>
+<a name="sleigh_attaching_registers"></a>6.3.1.Â Attaching Registers</h4></div></div></div>
 <p>
 Probably <span class="emphasis"><em>the</em></span> most common processor interpretation
 of a field is as an encoding of a particular register. In SLEIGH this
@@ -140,7 +140,7 @@ space separated list of field identifiers surrounded by square
 brackets. A <span class="emphasis"><em>registerlist</em></span> must be a square bracket
 surrounded and space separated list of register identifiers as created
 with <span class="bold"><strong>define</strong></span> statements (see Section
-<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4. Naming Registers">Section 4.4, &#8220;Naming Registers&#8221;</a>). For each field in
+<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4.Â Naming Registers">SectionÂ 4.4, &#8220;Naming Registers&#8221;</a>). For each field in
 the <span class="emphasis"><em>fieldlist</em></span>, instead of having the display and
 semantic meaning of an integer, the field becomes a look-up table for
 the given list of registers. The original integer interpretation is
@@ -163,7 +163,7 @@ of the instruction.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_attaching_integers"></a>6.3.2. Attaching Other Integers</h4></div></div></div>
+<a name="sleigh_attaching_integers"></a>6.3.2.Â Attaching Other Integers</h4></div></div></div>
 <p>
 Sometimes a processor interprets a field as an integer but not the
 integer given by the default interpretation. A different integer
@@ -185,7 +185,7 @@ unspecified positions in the list using a &#8216;_&#8217;]
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_attaching_names"></a>6.3.3. Attaching Names</h4></div></div></div>
+<a name="sleigh_attaching_names"></a>6.3.3.Â Attaching Names</h4></div></div></div>
 <p>
 It is possible to just modify the display characteristics of a field
 without changing the semantic meaning. The need for this is rare, but
@@ -196,7 +196,7 @@ appropriate to define overlapping fields, one of which is defined to
 have no semantic meaning. The most convenient way to break down the
 required disassembly may not be the most convenient way to break down
 the semantics. It is also possible to have symbols with semantic
-meaning but no display meaning (see <a class="xref" href="sleigh_constructors.html#sleigh_invisible_operands" title="7.4.5. Invisible Operands">Section 7.4.5, &#8220;Invisible Operands&#8221;</a>).
+meaning but no display meaning (see <a class="xref" href="sleigh_constructors.html#sleigh_invisible_operands" title="7.4.5.Â Invisible Operands">SectionÂ 7.4.5, &#8220;Invisible Operands&#8221;</a>).
 </p>
 <p>
 At any rate we can list the display interpretation of a field directly
@@ -218,7 +218,7 @@ encodings.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_context_variables"></a>6.4. Context Variables</h3></div></div></div>
+<a name="sleigh_context_variables"></a>6.4.Â Context Variables</h3></div></div></div>
 <p>
 SLEIGH supports the concept of <span class="emphasis"><em>context
 variables</em></span>. For the most part processor instructions can be
@@ -254,12 +254,12 @@ By default, globally setting a context variable affects instruction decoding
 from the point of the change, forward,
 following the flow of the instructions, but if the variable is labeled as
 <span class="bold"><strong>noflow</strong></span>, any change is limited to a
-single instruction. (See <a class="xref" href="sleigh_context.html#sleigh_contextflow" title="8.3.1. Context Flow">Section 8.3.1, &#8220;Context Flow&#8221;</a>)
+single instruction. (See <a class="xref" href="sleigh_context.html#sleigh_contextflow" title="8.3.1.Â Context Flow">SectionÂ 8.3.1, &#8220;Context Flow&#8221;</a>)
 </p>
 <p>
 Once the context variable is defined, in terms of the specification
 syntax, it can be treated as if it were just another field. See
-<a class="xref" href="sleigh_context.html" title="8. Using Context">Section 8, &#8220;Using Context&#8221;</a>, for a complete discussion of how to
+<a class="xref" href="sleigh_context.html" title="8.Â Using Context">SectionÂ 8, &#8220;Using Context&#8221;</a>, for a complete discussion of how to
 use context variables.
 </p>
 </div>
@@ -269,15 +269,15 @@ use context variables.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_symbols.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_constructors.html">Next</a>
+<a accesskey="p" href="sleigh_symbols.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_constructors.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">5. Introduction to Symbols </td>
+<td width="40%" align="left" valign="top">5.Â Introduction to SymbolsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 7. Constructors</td>
+<td width="40%" align="right" valign="top">Â 7.Â Constructors</td>
 </tr>
 </table>
 </div>


### PR DESCRIPTION
This makes the diffs generated by git as part of future changes (for example typo fixes) to these files easier to read. This PR only includes html files whose contents would change when encoding them as utf-8. These encoding differences are caused by the "non-breaking space" character (U+00A0 / 0xA0 in ISO-8859-1), which is included in these html files. Github renders them as a normal space, so the diff looks a bit weird.