### PR TITLE
Fix two typos

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeOp.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeOp.java
@@ -120,7 +120,7 @@ public class PcodeOp {
 	// translation.
 	public static final int MULTIEQUAL = 60;  // Output equal to one of inputs, depending on execution
 	public static final int INDIRECT = 61;    // Output probably equals input, but may be indirectly affected
-	public static final int PIECE = 62;       // Output is constructed from multiple peices
+	public static final int PIECE = 62;       // Output is constructed from multiple pieces
 	public static final int SUBPIECE = 63;    // Output is a subpiece of input0, input1=offset into input0
 
 	public static final int CAST = 64;        // Cast from one type to another

--- a/GhidraDocs/languages/html/sleigh_constructors.html
+++ b/GhidraDocs/languages/html/sleigh_constructors.html
@@ -1617,7 +1617,7 @@ must match the size of the destination space.
 <p>
 In some cases, the semantics of an instruction may require
 branching <span class="emphasis"><em>within</em></span> the semantics of a single
-instruction, so specifying a destination address is too course. In
+instruction, so specifying a destination address is too coarse. In
 this case, SLEIGH is capable of <span class="emphasis"><em>p-code relative</em></span>
 branching. Individual p-code operations can be identified by
 a <span class="emphasis"><em>label</em></span>, and this label can be used as the


### PR DESCRIPTION
This PR fixes two typos: One in a comment in the sleigh documentation (`sleigh_constructors.html`), and one in a comment in `PcodeOp.java`.