### PR TITLE
Fix 68k trunc into a bigger size

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -2244,7 +2244,7 @@ fdivrnd: "d"                   is fopmode=0x64        {}
 :fgetman.^fprec	e2d, fdst	is op=15 & $(FP_COP) & op68=0 & $(MEM_ALTER_ADDR_MODES); frm=1 & f1515=0 & f1313=0 & fdst & $(FPREC_D) & fopmode=0x1f; e2d  [ savmod2=savmod1; regtsan=regtfan; ] unimpl
 :fgetman			fsrc, fdst	is op=15 & $(FP_COP) & op68=0 & mode=0 & regan=0; frm=0 & f1515=0 & f1313=0 & fsrc & fdst & fopmode=0x1f		    unimpl
 
-:fint.^fprec	e2l, fdst	is op=15 & $(FP_COP) & op68=0 & $(DAT_ALTER_ADDR_MODES); frm=1 & f1515=0 & f1313=0 & fdst & $(FPREC_BWLS) & fopmode=0x01; e2l  [ savmod2=savmod1; regtsan=regtfan; ] { tmp:8 = trunc(e2l); fdst = int2float(tmp); }
+:fint.^fprec	e2l, fdst	is op=15 & $(FP_COP) & op68=0 & $(DAT_ALTER_ADDR_MODES); frm=1 & f1515=0 & f1313=0 & fdst & $(FPREC_BWLS) & fopmode=0x01; e2l  [ savmod2=savmod1; regtsan=regtfan; ] { tmp:8 = sext(e2l); fdst = int2float(tmp); }
 :fint.^fprec	e2x, fdst	is op=15 & $(FP_COP) & op68=0 & $(MEM_ALTER_ADDR_MODES); frm=1 & f1515=0 & f1313=0 & fdst & $(FPREC_XP) & fopmode=0x01; e2x  [ savmod2=savmod1; regtsan=regtfan; ] { tmp:8 = trunc(e2x); fdst = int2float(tmp); }
 :fint.^fprec	e2d, fdst	is op=15 & $(FP_COP) & op68=0 & $(MEM_ALTER_ADDR_MODES); frm=1 & f1515=0 & f1313=0 & fdst & $(FPREC_D) & fopmode=0x01; e2d  [ savmod2=savmod1; regtsan=regtfan; ] { tmp:8 = trunc(e2d); fdst = int2float(tmp); }
 :fint			fsrc, fdst	is op=15 & $(FP_COP) & op68=0 & mode=0 & regan=0; frm=0 & f1515=0 & f1313=0 & fsrc & fdst & fopmode=0x01		    { tmp:8 = trunc(fsrc); fdst = int2float(tmp); }


### PR DESCRIPTION
The table `e2l` exports a 4 bytes value, the result value should be 8 bytes, truncation (`trunc`) should not be possible, only extension (`sext`).