### PR TITLE
Documentation: Ensure HTML files are UTF-8 encoded

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/cspec_html.xsl
@@ -29,4 +29,6 @@
 
 <xsl:param name="chunker.output.indent" select="'yes'"/>  <!-- Do proper indenting of html -->
 
+<xsl:param name="chunker.output.encoding" select="'UTF-8'"/>  <!-- Encode the chunks as UTF-8 files -->
+
 </xsl:stylesheet>

--- a/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/decompileplugin_html.xsl
@@ -54,6 +54,8 @@
 
 <xsl:param name="chunker.output.indent" select="'yes'"/>   <!-- Do proper indenting of html -->
 
+<xsl:param name="chunker.output.encoding" select="'UTF-8'"/>  <!-- Encode the chunks as UTF-8 files -->
+
 <xsl:param name="admon.graphics" select="1"/>  <!-- Turn on graphic icon for important/note tags -->
 
 <xsl:param name="admon.textlabel" select="0"/>  <!-- Don't display title for important/note tags -->

--- a/Ghidra/Features/Decompiler/src/main/doc/pcoderef_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/pcoderef_html.xsl
@@ -12,4 +12,6 @@
 
 <xsl:param name="chunker.output.indent" select="'yes'"/>   <!-- Do proper indenting of html -->
 
+<xsl:param name="chunker.output.encoding" select="'UTF-8'"/>  <!-- Encode the chunks as UTF-8 files -->
+
 </xsl:stylesheet>

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh_html.xsl
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh_html.xsl
@@ -12,4 +12,6 @@
 
 <xsl:param name="chunker.output.indent" select="'yes'"/>   <!-- Do proper indenting of html -->
 
+<xsl:param name="chunker.output.encoding" select="'UTF-8'"/>  <!-- Encode the chunks as UTF-8 files -->
+
 </xsl:stylesheet>

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerAnnotations.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerAnnotations.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Program Annotations Affecting the Decompiler</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="Decompiler.html" title="Decompiler">
 <link rel="up" href="Decompiler.html" title="Decompiler">
 <link rel="prev" href="DecompilerConcepts.html" title="Decompiler Concepts">

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerConcepts.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerConcepts.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler Concepts</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="Decompiler.html" title="Decompiler">
 <link rel="up" href="Decompiler.html" title="Decompiler">
 <link rel="prev" href="DecompilerIntro.html" title="Decompiler">
@@ -182,7 +182,7 @@
       </p>
 <div class="informalexample">
       <div class="table">
-<a name="ops.htmltable"></a><p class="title"><b>Table . P-code Operations</b></p>
+<a name="ops.htmltable"></a><p class="title"><b>TableÂ .Â P-code Operations</b></p>
 <div class="table-contents"><table width="90%" frame="box" rules="all" id="ops.htmltable">
         
         <col width="40%">

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerIntro.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerIntro.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="Decompiler.html" title="Decompiler">
 <link rel="up" href="Decompiler.html" title="Decompiler">
 <link rel="prev" href="Decompiler.html" title="Decompiler">
@@ -64,7 +64,7 @@
 <li class="listitem" style="list-style-type: disc">
 	Press the <span class="guiicon">
 	<span class="inlinemediaobject"><img src="images/decompileFunction.gif" width="16" height="16"></span>
-	</span> icon
+	</span>Â icon
 	in the tool bar, <span class="emphasis"><em>or</em></span>
       </li>
 <li class="listitem" style="list-style-type: disc">

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerOptions.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerOptions.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler Options</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="Decompiler.html" title="Decompiler">
 <link rel="up" href="Decompiler.html" title="Decompiler">
 <link rel="prev" href="DecompilerAnnotations.html" title="Program Annotations Affecting the Decompiler">
@@ -38,14 +38,14 @@
 	  </span><span class="emphasis"><em>Decompiler</em></span> - lists <a class="xref" href="DecompilerOptions.html#GeneralOptions" title="General Options">General Options</a> that affect the engine behavior.
 	</li>
 <li class="listitem" style="list-style-type: none">
-	  &#8195;<span class="guiicon">
+	   <span class="guiicon">
 	    <span class="inlinemediaobject"><img src="images/document-properties.png" width="16" height="16"></span>
-	  </span>�<span class="emphasis"><em>Analysis</em></span> - lists <a class="xref" href="DecompilerOptions.html#AnalysisOptions" title="Analysis Options">Analysis Options</a> that affect the Decompiler's transformation process.
+	  </span> <span class="emphasis"><em>Analysis</em></span> - lists <a class="xref" href="DecompilerOptions.html#AnalysisOptions" title="Analysis Options">Analysis Options</a> that affect the Decompiler's transformation process.
 	</li>
 <li class="listitem" style="list-style-type: none">
-	  &#8195;<span class="guiicon">
+	   <span class="guiicon">
 	    <span class="inlinemediaobject"><img src="images/document-properties.png" width="16" height="16"></span>
-	  </span>�<span class="emphasis"><em>Display</em></span> - lists <a class="xref" href="DecompilerOptions.html#DisplayOptions" title="Display Options">Display Options</a> that affect the final presentation of Decompiler output.
+	  </span> <span class="emphasis"><em>Display</em></span> - lists <a class="xref" href="DecompilerOptions.html#DisplayOptions" title="Display Options">Display Options</a> that affect the final presentation of Decompiler output.
 	</li>
 </ul></div>
     </div>

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerWindow.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerWindow.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Decompiler Window</title>
 <link rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="../../shared/languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="Decompiler.html" title="Decompiler">
 <link rel="up" href="Decompiler.html" title="Decompiler">
 <link rel="prev" href="DecompilerOptions.html" title="Decompiler Options">
@@ -18,7 +18,7 @@
     function in the Code Browser, then select the
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/decompileFunction.gif" width="16" height="16"></span>
-      </span> icon from the tool bar, or the
+      </span>Â icon from the tool bar, or the
     <span class="bold"><strong>Decompile</strong></span> option from the
     <span class="bold"><strong>Window</strong></span> menu in the tool.
   </p>
@@ -91,7 +91,7 @@
     Initially pressing
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/decompileFunction.gif" width="16" height="16"></span>
-      </span> or selecting
+      </span>Â or selecting
     <span class="bold"><strong>Decompile</strong></span> from the <span class="bold"><strong>Window</strong></span> menu in the tool
     brings up the <span class="emphasis"><em>main</em></span> window.  The main window always displays the function
     at the <span class="emphasis"><em>current address</em></span> within the Code Browser and follows as the user navigates
@@ -153,7 +153,7 @@
     Pressing the
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/camera-photo.png" width="16" height="16"></span>
-    </span> icon
+    </span>Â icon
     in any Decompiler window's toolbar causes a <span class="emphasis"><em>Snapshot</em></span> window
     to be created, which shows decompilation of the same function.
     Unlike the <span class="emphasis"><em>main</em></span> window however, the <span class="emphasis"><em>Snapshot</em></span> window
@@ -240,7 +240,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/page_edit.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Exports the decompiled result of the current function to a file. A file chooser
@@ -265,7 +265,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/camera-photo.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Creates a new <span class="emphasis"><em>Snapshot</em></span> window.  The <span class="emphasis"><em>Snapshot</em></span> window
@@ -282,7 +282,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/reload3.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Triggers a re-decompilation of the current function displayed in the window.
@@ -310,7 +310,7 @@
   <p>
     <span class="guiicon">
       <span class="inlinemediaobject"><img src="images/page_white_copy.png" width="16" height="16"></span>
-      </span> - button
+      </span>Â - button
   </p>
   <p>
     Copies the currently selected text in the Decompiler window to the clipboard.

--- a/GhidraDocs/languages/html/additionalpcode.html
+++ b/GhidraDocs/languages/html/additionalpcode.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Additional P-CODE Operations</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="pseudo-ops.html" title="Pseudo P-CODE Operations">
@@ -16,9 +16,9 @@
 <tr><th colspan="3" align="center">Additional P-CODE Operations</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="pseudo-ops.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="reference.html">Next</a>
+<a accesskey="p" href="pseudo-ops.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="reference.html">Next</a>
 </td>
 </tr>
 </table>
@@ -437,15 +437,15 @@ to SLEIGH <span class="bold"><strong>bitrange</strong></span> syntax such as out
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="pseudo-ops.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="reference.html">Next</a>
+<a accesskey="p" href="pseudo-ops.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="reference.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">Pseudo P-CODE Operations </td>
+<td width="40%" align="left" valign="top">Pseudo P-CODE OperationsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top"> Syntax Reference</td>
+<td width="40%" align="right" valign="top">Â Syntax Reference</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/pcodedescription.html
+++ b/GhidraDocs/languages/html/pcodedescription.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>P-Code Operation Reference</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="pcoderef.html" title="P-Code Reference Manual">
@@ -16,9 +16,9 @@
 <tr><th colspan="3" align="center">P-Code Operation Reference</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="pcoderef.html">Prev</a>�</td>
-<th width="60%" align="center">�</th>
-<td width="20%" align="right">�<a accesskey="n" href="pseudo-ops.html">Next</a>
+<a accesskey="p" href="pcoderef.html">Prev</a> </td>
+<th width="60%" align="center"> </th>
+<td width="20%" align="right"> <a accesskey="n" href="pseudo-ops.html">Next</a>
 </td>
 </tr>
 </table>
@@ -121,7 +121,7 @@ input0 and output must be the same.
 </div></div>
 <p>
 This instruction loads data from a dynamic location into the output
-variable by dereferencing a pointer. The &#8220;pointer&#8221; comes in two
+variable by dereferencing a pointer. The “pointer” comes in two
 pieces. One piece, input1, is a normal variable containing the offset
 of the object being pointed at. The other piece, input0, is a constant
 indicating the space into which the offset applies. The data in input1
@@ -133,7 +133,7 @@ loaded by this instruction is determined by the size of the output
 variable.  It is easy to confuse the address space of the output and
 input1 variables and the Address Space represented by the ID, which
 could all be different. Unlike many programming models, there are
-multiple spaces that a &#8220;pointer&#8221; can refer to, and so an extra ID is
+multiple spaces that a “pointer” can refer to, and so an extra ID is
 required.
 </p>
 <p>
@@ -194,7 +194,7 @@ correct byte offset into the space.
 This instruction is the complement
 of <span class="bold"><strong>LOAD</strong></span>.  The data in the variable
 input2 is stored at a dynamic location by dereferencing a pointer. As
-with <span class="bold"><strong>LOAD</strong></span>, the &#8220;pointer&#8221; comes in two
+with <span class="bold"><strong>LOAD</strong></span>, the “pointer” comes in two
 pieces: a space ID part, and an offset variable. The size of input1
 must match the address space specified by the ID, and the amount of
 data stored is determined by the size of input2.
@@ -264,7 +264,7 @@ of the current machine instruction. This allows branching within the
 operations forming a single instruction. For example, if
 the <span class="bold"><strong>BRANCH</strong></span> occurs as the pcode
 operation with index 5 for the instruction, it can branch to operation
-with index 8 by specifying a constant destination &#8220;address&#8221; of
+with index 8 by specifying a constant destination “address” of
 3. Negative constants can be used for backward branches.
 </p>
 </div>
@@ -1821,7 +1821,7 @@ sign-extended to the desired size.
 This is an unsigned integer division operation. Divide input0 by
 input1, truncating the result to the nearest integer, and store the
 result in output. Both inputs and output must be the same size. There
-is no handling of division by zero. To simulate a processor&#8217;s handling
+is no handling of division by zero. To simulate a processor’s handling
 of a division-by-zero trap, other operations must be used before
 the <span class="bold"><strong>INT_DIV</strong></span>.
 </p>
@@ -1923,7 +1923,7 @@ This is a signed integer division operation. The resulting integer is
 the one closest to the rational value input0/input1 but which is still
 smaller in absolute value. Both inputs and output must be the same
 size. There is no handling of division by zero. To simulate a
-processor&#8217;s handling of a division-by-zero trap, other operations must
+processor’s handling of a division-by-zero trap, other operations must
 be used before the <span class="bold"><strong>INT_SDIV</strong></span>.
 </p>
 </div>
@@ -3024,15 +3024,15 @@ Input0 and output can be different sizes.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="pcoderef.html">Prev</a>�</td>
-<td width="20%" align="center">�</td>
-<td width="40%" align="right">�<a accesskey="n" href="pseudo-ops.html">Next</a>
+<a accesskey="p" href="pcoderef.html">Prev</a> </td>
+<td width="20%" align="center"> </td>
+<td width="40%" align="right"> <a accesskey="n" href="pseudo-ops.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">P-Code Reference Manual�</td>
+<td width="40%" align="left" valign="top">P-Code Reference Manual </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top">�Pseudo P-CODE Operations</td>
+<td width="40%" align="right" valign="top"> Pseudo P-CODE Operations</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/pcoderef.html
+++ b/GhidraDocs/languages/html/pcoderef.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>P-Code Reference Manual</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="next" href="pcodedescription.html" title="P-Code Operation Reference">
 </head>
@@ -13,9 +13,9 @@
 <table width="100%" summary="Navigation header">
 <tr><th colspan="3" align="center">P-Code Reference Manual</th></tr>
 <tr>
-<td width="20%" align="left">�</td>
-<th width="60%" align="center">�</th>
-<td width="20%" align="right">�<a accesskey="n" href="pcodedescription.html">Next</a>
+<td width="20%" align="left"> </td>
+<th width="60%" align="center"> </th>
+<td width="20%" align="right"> <a accesskey="n" href="pcodedescription.html">Next</a>
 </td>
 </tr>
 </table>
@@ -195,7 +195,7 @@ to as <span class="bold"><strong>raw p-code</strong></span>. Raw p-code can be u
 instruction execution and generally follows the same control-flow,
 although it may add some of its own internal control-flow. The subset of
 opcodes that can occur in raw p-code is described in
-<a class="xref" href="pcodedescription.html" title="P-Code Operation Reference">the section called &#8220;P-Code Operation Reference&#8221;</a> and in <a class="xref" href="pseudo-ops.html" title="Pseudo P-CODE Operations">the section called &#8220;Pseudo P-CODE Operations&#8221;</a>, making up
+<a class="xref" href="pcodedescription.html" title="P-Code Operation Reference">the section called “P-Code Operation Reference”</a> and in <a class="xref" href="pseudo-ops.html" title="Pseudo P-CODE Operations">the section called “Pseudo P-CODE Operations”</a>, making up
 the bulk of this document. 
 </p>
 <p>
@@ -209,7 +209,7 @@ opcodes. Two of these,
 <span class="bold"><strong>MULTIEQUAL</strong></span> and <span class="bold"><strong>INDIRECT</strong></span>,
 are specific to the graph construction process, but other opcodes can be introduced during
 subsequent analysis and transformation of a graph and help hold recovered data-type relationships.
-All of the new opcodes are described in <a class="xref" href="additionalpcode.html" title="Additional P-CODE Operations">the section called &#8220;Additional P-CODE Operations&#8221;</a>, none of which can occur
+All of the new opcodes are described in <a class="xref" href="additionalpcode.html" title="Additional P-CODE Operations">the section called “Additional P-CODE Operations”</a>, none of which can occur
 in the original raw p-code translation. Finally, a few of the p-code operators,
 <span class="bold"><strong>CALL</strong></span>,
 <span class="bold"><strong>CALLIND</strong></span>, and <span class="bold"><strong>RETURN</strong></span>,
@@ -319,7 +319,7 @@ its <span class="bold"><strong>opcode</strong></span>.
 For almost all p-code operations, only the output varnode can have its
 value modified; there are no indirect effects of the operation.
 The only possible exceptions are <span class="emphasis"><em>pseudo</em></span> operations,
-see <a class="xref" href="pseudo-ops.html" title="Pseudo P-CODE Operations">the section called &#8220;Pseudo P-CODE Operations&#8221;</a>, which are sometimes necessary when there
+see <a class="xref" href="pseudo-ops.html" title="Pseudo P-CODE Operations">the section called “Pseudo P-CODE Operations”</a>, which are sometimes necessary when there
 is incomplete knowledge of an instruction's behavior.
 </p>
 <p>
@@ -342,7 +342,7 @@ The list of possible
 opcodes are similar to many RISC based instruction sets. The effect of
 each opcode is described in detail in the following sections,
 and a reference table is given
-in <a class="xref" href="reference.html" title="Syntax Reference">the section called &#8220;Syntax Reference&#8221;</a>. In general, the size or
+in <a class="xref" href="reference.html" title="Syntax Reference">the section called “Syntax Reference”</a>. In general, the size or
 precision of a particular p-code operation is determined by the size
 of the varnode inputs or output, not by the opcode.
 </p>
@@ -353,15 +353,15 @@ of the varnode inputs or output, not by the opcode.
 <hr>
 <table width="100%" summary="Navigation footer">
 <tr>
-<td width="40%" align="left">�</td>
-<td width="20%" align="center">�</td>
-<td width="40%" align="right">�<a accesskey="n" href="pcodedescription.html">Next</a>
+<td width="40%" align="left"> </td>
+<td width="20%" align="center"> </td>
+<td width="40%" align="right"> <a accesskey="n" href="pcodedescription.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">�</td>
-<td width="20%" align="center">�</td>
-<td width="40%" align="right" valign="top">�P-Code Operation Reference</td>
+<td width="40%" align="left" valign="top"> </td>
+<td width="20%" align="center"> </td>
+<td width="40%" align="right" valign="top"> P-Code Operation Reference</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/pseudo-ops.html
+++ b/GhidraDocs/languages/html/pseudo-ops.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Pseudo P-CODE Operations</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="pcodedescription.html" title="P-Code Operation Reference">
@@ -16,9 +16,9 @@
 <tr><th colspan="3" align="center">Pseudo P-CODE Operations</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="pcodedescription.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="additionalpcode.html">Next</a>
+<a accesskey="p" href="pcodedescription.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="additionalpcode.html">Next</a>
 </td>
 </tr>
 </table>
@@ -104,7 +104,7 @@ parameter. Exact details are processor and specification dependent.
 Ideally, the output parameter is determined by the input
 parameters, and no variable is affected except the output
 parameter. But this is no longer a strict requirement, side-effects are possible.
-Analysis should generally treat these instructions as a &#8220;black-box&#8221; which
+Analysis should generally treat these instructions as a â€œblack-boxâ€ which
 still have normal data-flow and can be manipulated symbolically.
 </p>
 </div>
@@ -225,15 +225,15 @@ not modeled in these cases, so the operator serves as a placeholder to allow ana
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="pcodedescription.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="additionalpcode.html">Next</a>
+<a accesskey="p" href="pcodedescription.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="additionalpcode.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">P-Code Operation Reference </td>
+<td width="40%" align="left" valign="top">P-Code Operation ReferenceÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top"> Additional P-CODE Operations</td>
+<td width="40%" align="right" valign="top">Â Additional P-CODE Operations</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/reference.html
+++ b/GhidraDocs/languages/html/reference.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Syntax Reference</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="up" href="pcoderef.html" title="P-Code Reference Manual">
 <link rel="prev" href="additionalpcode.html" title="Additional P-CODE Operations">
@@ -15,9 +15,9 @@
 <tr><th colspan="3" align="center">Syntax Reference</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="additionalpcode.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> </td>
+<a accesskey="p" href="additionalpcode.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â </td>
 </tr>
 </table>
 <hr>
@@ -515,14 +515,14 @@
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="additionalpcode.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> </td>
+<a accesskey="p" href="additionalpcode.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">Additional P-CODE Operations </td>
+<td width="40%" align="left" valign="top">Additional P-CODE OperationsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="pcoderef.html">Home</a></td>
-<td width="40%" align="right" valign="top"> </td>
+<td width="40%" align="right" valign="top">Â </td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh.html
+++ b/GhidraDocs/languages/html/sleigh.html
@@ -1,21 +1,21 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>SLEIGH</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
-<link rel="next" href="sleigh_layout.html" title="2. Basic Specification Layout">
+<link rel="next" href="sleigh_layout.html" title="2.Â Basic Specification Layout">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
 <tr><th colspan="3" align="center">SLEIGH</th></tr>
 <tr>
-<td width="20%" align="left"> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_layout.html">Next</a>
+<td width="20%" align="left">Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_layout.html">Next</a>
 </td>
 </tr>
 </table>
@@ -108,7 +108,7 @@
   project. The language that is now called SLEIGH has undergone
   several redesign iterations, but it can still trace its heritage
   from the language SLED, from whom its name is derived. SLED, the
-  &#8220;Specification Language for Encoding and Decoding&#8221;, was defined by
+  â€œSpecification Language for Encoding and Decodingâ€, was defined by
   Norman Ramsey and Mary F. Fernandez as a concise way to define the
   translation, in both directions, between machine instructions and
   their corresponding assembly statements. This facilitated the
@@ -162,13 +162,13 @@ Italics are used when defining terms and for named entities. Bold is used for SL
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_introduction"></a>1. Introduction to P-Code</h2></div></div></div>
+<a name="sleigh_introduction"></a>1.Â Introduction to P-Code</h2></div></div></div>
 <p>
 Although p-code is a distinct language from SLEIGH, because a major
 purpose of SLEIGH is to specify the translation from machine code to
 p-code, this document serves as a primer for p-code. The key concepts
 and terminology are presented in this section, and more detail is
-given in <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7. The Semantic Section">Section 7.7, &#8220;The Semantic Section&#8221;</a>. There is also a complete set
+given in <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7.Â The Semantic Section">SectionÂ 7.7, â€œThe Semantic Sectionâ€</a>. There is also a complete set
 of tables which list syntax and descriptions for p-code operations in
 the Appendix.
 </p>
@@ -179,9 +179,9 @@ general purpose processor. Code for different processors can be
 translated in a straightforward manner into p-code, and then a single
 suite of analysis software can be used to do data-flow analysis and
 decompilation. In this way, the analysis software
-becomes <span class="emphasis"><em>retargetable</em></span>, and it isn&#8217;t necessary to
+becomes <span class="emphasis"><em>retargetable</em></span>, and it isnâ€™t necessary to
 redesign it for each new processor being analyzed. It is only
-necessary to specify the translation of the processor&#8217;s instruction
+necessary to specify the translation of the processorâ€™s instruction
 set into p-code.
 </p>
 <p>
@@ -221,7 +221,7 @@ respectively.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_address_spaces"></a>1.1. Address Spaces</h3></div></div></div>
+<a name="sleigh_address_spaces"></a>1.1.Â Address Spaces</h3></div></div></div>
 <p>
 An <span class="emphasis"><em>address</em></span> space for p-code is a generalization of
 the indexed memory (RAM) that a typical processor has access to, and
@@ -261,7 +261,7 @@ Typically, a processor can be modeled with only two spaces,
 a <span class="emphasis"><em>ram</em></span> address space that represents the main
 memory accessible to the processor via its data-bus, and
 a <span class="emphasis"><em>register</em></span> address space that is used to
-implement the processor&#8217;s registers. However, the specification
+implement the processorâ€™s registers. However, the specification
 designer can define as many address spaces as needed.
 </p>
 <p>
@@ -272,14 +272,14 @@ semantics into individual p-code operations. It is called
 the <span class="emphasis"><em>unique</em></span> space. There is also a special address
 space, called the <span class="emphasis"><em>const</em></span> space, used as a
 placeholder for constant operands of p-code instructions. For the most
-part, a SLEIGH specification doesn&#8217;t need to be aware of this space,
+part, a SLEIGH specification doesnâ€™t need to be aware of this space,
 but it can be used in certain situations to force values to be
 interpreted as constants.
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_varnodes"></a>1.2. Varnodes</h3></div></div></div>
+<a name="sleigh_varnodes"></a>1.2.Â Varnodes</h3></div></div></div>
 <p>
 A <span class="emphasis"><em>varnode</em></span> is the unit of data manipulated by
 p-code. It is simply a contiguous sequence of bytes in some address
@@ -305,7 +305,7 @@ forces an interpretation on each varnode that it uses, as either an
 integer, a floating-point number, or a boolean value. In the case of
 an integer, the varnode is interpreted as having a big endian or
 little endian encoding, depending on the specification (see
-<a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1. Endianess Definition">Section 4.1, &#8220;Endianess Definition&#8221;</a>). Certain instructions
+<a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1.Â Endianess Definition">SectionÂ 4.1, â€œEndianess Definitionâ€</a>). Certain instructions
 also distinguish between signed and unsigned interpretations. For a
 signed integer, the varnode is considered to have a standard twos
 complement encoding. For a boolean interpretation, the varnode must be
@@ -322,7 +322,7 @@ must be provided and enforced by the specification designer.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_operations"></a>1.3. Operations</h3></div></div></div>
+<a name="sleigh_operations"></a>1.3.Â Operations</h3></div></div></div>
 <p>
 P-code is intended to emulate a target processor by substituting a
 sequence of p-code operations for each machine instruction. Thus every
@@ -352,7 +352,7 @@ general purpose processor instruction sets. They break up into groups.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="ops.htmltable"></a><p class="title"><b>Table 1. P-code Operations</b></p>
+<a name="ops.htmltable"></a><p class="title"><b>TableÂ 1.Â P-code Operations</b></p>
 <div class="table-contents"><table xml:id="ops.htmltable" width="70%" frame="box" rules="all">
 <col width="40%">
 <col width="60%">
@@ -414,7 +414,7 @@ general purpose processor instruction sets. They break up into groups.
 <br class="table-break">
 </div>
 <p>
-We postpone a full discussion of the individual operations until <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7. The Semantic Section">Section 7.7, &#8220;The Semantic Section&#8221;</a>.
+We postpone a full discussion of the individual operations until <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7.Â The Semantic Section">SectionÂ 7.7, â€œThe Semantic Sectionâ€</a>.
 </p>
 </div>
 </div>
@@ -423,15 +423,15 @@ We postpone a full discussion of the individual operations until <a class="xref"
 <hr>
 <table width="100%" summary="Navigation footer">
 <tr>
-<td width="40%" align="left"> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_layout.html">Next</a>
+<td width="40%" align="left">Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_layout.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top"> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right" valign="top"> 2. Basic Specification Layout</td>
+<td width="40%" align="left" valign="top">Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right" valign="top">Â 2.Â Basic Specification Layout</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_constructors.html
+++ b/GhidraDocs/languages/html/sleigh_constructors.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>7.�Constructors</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>7. Constructors</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_tokens.html" title="6.�Tokens and Fields">
-<link rel="next" href="sleigh_context.html" title="8.�Using Context">
+<link rel="prev" href="sleigh_tokens.html" title="6. Tokens and Fields">
+<link rel="next" href="sleigh_context.html" title="8. Using Context">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">7.�Constructors</th></tr>
+<tr><th colspan="3" align="center">7. Constructors</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_tokens.html">Prev</a>�</td>
-<th width="60%" align="center">�</th>
-<td width="20%" align="right">�<a accesskey="n" href="sleigh_context.html">Next</a>
+<a accesskey="p" href="sleigh_tokens.html">Prev</a> </td>
+<th width="60%" align="center"> </th>
+<td width="20%" align="right"> <a accesskey="n" href="sleigh_context.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_constructors"></a>7.�Constructors</h2></div></div></div>
+<a name="sleigh_constructors"></a>7. Constructors</h2></div></div></div>
 <p>
 Fields are the basic building block for family symbols. The mechanisms
 for building up from fields to the
@@ -56,11 +56,11 @@ to think of a constructor as a kind of table in and of itself. But it
 is only the table that has an actual family symbol identifier
 associated with it. Most of this chapter is devoted to describing how
 to define a single constructor. The issues involved in combining
-multiple constructors into a single table are addressed in <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8.�Tables">Section�7.8, &#8220;Tables&#8221;</a>.
+multiple constructors into a single table are addressed in <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8. Tables">Section 7.8, “Tables”</a>.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_sections_constructor"></a>7.1.�The Five Sections of a Constructor</h3></div></div></div>
+<a name="sleigh_sections_constructor"></a>7.1. The Five Sections of a Constructor</h3></div></div></div>
 <p>
 A single complex statement in the specification file describes a
 constructor. This statement is always made up of five distinct
@@ -92,12 +92,12 @@ in turn.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_table_header"></a>7.2.�The Table Header</h3></div></div></div>
+<a name="sleigh_table_header"></a>7.2. The Table Header</h3></div></div></div>
 <p>
 Every constructor must be part of a table, which is the element with
 an actual family symbol identifier associated with it. So each
 constructor starts with the identifier of the table it belongs to
-followed by a colon &#8216;:&#8217;.
+followed by a colon ‘:’.
 </p>
 <div class="informalexample"><pre class="programlisting">
 mode1:           <span class="weak">...</span>
@@ -122,18 +122,18 @@ identifier.
 The identifier <span class="emphasis"><em>instruction</em></span> is actually reserved
 for the root table, but should not be used in the table header as the
 SLEIGH parser uses the blank identifier to help distinguish assembly
-mnemonics from operands (see <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1.�Mnemonic">Section�7.3.1, &#8220;Mnemonic&#8221;</a>).
+mnemonics from operands (see <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1. Mnemonic">Section 7.3.1, “Mnemonic”</a>).
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_display_section"></a>7.3.�The Display Section</h3></div></div></div>
+<a name="sleigh_display_section"></a>7.3. The Display Section</h3></div></div></div>
 <p>
 The <span class="emphasis"><em>display section</em></span> consists of all characters
-after the table header &#8216;:&#8217; up to the SLEIGH
-keyword <span class="bold"><strong>is</strong></span>. The section&#8217;s primary
+after the table header ‘:’ up to the SLEIGH
+keyword <span class="bold"><strong>is</strong></span>. The section’s primary
 purpose is to assign disassembly display meaning to the
-constructor. The section&#8217;s secondary purpose is to define local
+constructor. The section’s secondary purpose is to define local
 identifiers for the pieces out of which the constructor is being
 built. Characters in the display section are treated as literals with
 the following exceptions.
@@ -151,7 +151,7 @@ the following exceptions.
 </ol></div>
 </li>
 <li class="listitem" style="list-style-type: disc">
-    The character &#8216;^&#8217; has special meaning.
+    The character ‘^’ has special meaning.
   </li>
 <li class="listitem" style="list-style-type: disc">
     White space is trimmed from the beginning and end of the section.
@@ -163,13 +163,13 @@ the following exceptions.
 <p>
 </p>
 <p>
-In particular, all punctuation except &#8216;^&#8217; loses its special
+In particular, all punctuation except ‘^’ loses its special
 meaning. Those identifiers that are not treated as literals are
 considered to be new, initially undefined, family symbols. We refer to
 these new symbols as the <span class="emphasis"><em>operands</em></span> of the constructor. And for root
 constructors, these operands frequently correspond to the natural
 assembly operands. Thinking of it as a family symbol, the
-constructor&#8217;s display meaning becomes the string of literals itself,
+constructor’s display meaning becomes the string of literals itself,
 with each identifier replaced with the display meaning of the symbol
 corresponding to that identifier.
 </p>
@@ -182,11 +182,11 @@ mode1: ( op1 ),op2 is          <span class="weak">...</span>
 In the above example, a constructor for
 table <span class="emphasis"><em>mode1</em></span> is being built out of two pieces,
 symbol <span class="emphasis"><em>op1</em></span> and
-symbol <span class="emphasis"><em>op2</em></span>. The characters &#8216;(&#8216;, &#8217;)&#8217;, and &#8216;,&#8217;
+symbol <span class="emphasis"><em>op2</em></span>. The characters ‘(‘, ’)’, and ‘,’
 become literal parts of the disassembly display for symbol
 mode1. After the display strings for <span class="emphasis"><em>op1</em></span>
 and <span class="emphasis"><em>op2</em></span> are found, they are inserted into the
-string of literals, forming the constructor&#8217;s display string. The
+string of literals, forming the constructor’s display string. The
 white space characters surrounding the <span class="emphasis"><em>op1</em></span>
 identifier are preserved as part of this string.
 </p>
@@ -198,7 +198,7 @@ but only their identifiers are established in the display section.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_mnemonic"></a>7.3.1.�Mnemonic</h4></div></div></div>
+<a name="sleigh_mnemonic"></a>7.3.1. Mnemonic</h4></div></div></div>
 <p>
 If the constructor is part of the root instruction table, the first
 string of characters in the display section that does not contain
@@ -212,8 +212,8 @@ if it is legal.
 <p>
 </p>
 <p>
-In the above example, the string &#8220;var1&#8221; is treated as a symbol
-identifier, but the string &#8220;and&#8221; is considered to be the mnemonic of
+In the above example, the string “var1” is treated as a symbol
+identifier, but the string “and” is considered to be the mnemonic of
 the instruction.
 </p>
 <p>
@@ -230,10 +230,10 @@ no such requirement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_caret"></a>7.3.2.�The '^' character</h4></div></div></div>
+<a name="sleigh_caret"></a>7.3.2. The '^' character</h4></div></div></div>
 <p>
-The &#8216;^&#8217; character in the display section is used to separate
-identifiers from other characters where there shouldn&#8217;t be white space
+The ‘^’ character in the display section is used to separate
+identifiers from other characters where there shouldn’t be white space
 in the disassembly display. This can be used in any manner but is
 usually used to attach display characters from a local symbol to the
 literal characters of the mnemonic.
@@ -244,7 +244,7 @@ literal characters of the mnemonic.
 <p>
 </p>
 <p>
-In the above example, &#8220;bra&#8221; is treated as literal characters in the
+In the above example, “bra” is treated as literal characters in the
 resulting display string followed immediately, with no intervening
 spaces, by the display string of the local
 symbol <span class="emphasis"><em>cc</em></span>. Thus the whole constructor actually
@@ -253,39 +253,39 @@ identifiers <span class="emphasis"><em>cc</em></span>, <span class="emphasis"><e
 and <span class="emphasis"><em>op2</em></span>.
 </p>
 <p>
-If the &#8216;^&#8217; is used as the first (non-whitespace) character in the
+If the ‘^’ is used as the first (non-whitespace) character in the
 display section of a base constructor, this inhibits the first
 identifier in the display from being considered the mnemonic, as
-described in <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1.�Mnemonic">Section�7.3.1, &#8220;Mnemonic&#8221;</a>. This allows
+described in <a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1. Mnemonic">Section 7.3.1, “Mnemonic”</a>. This allows
 specification of less common situations, where the first part of the
 mnemonic, rather than perhaps a later part, needs to be considered as
-an operand. An initial &#8216;^&#8217; character can also facilitate certain
+an operand. An initial ‘^’ character can also facilitate certain
 recursive constructions.
 </p>
 </div>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_bit_pattern"></a>7.4.�The Bit Pattern Section</h3></div></div></div>
+<a name="sleigh_bit_pattern"></a>7.4. The Bit Pattern Section</h3></div></div></div>
 <p>
 Syntactically, this section comes between the
 keyword <span class="bold"><strong>is</strong></span> and the delimiter for the
-following section, either an &#8216;{&#8216; or an &#8216;[&#8216;. The <span class="emphasis"><em>bit pattern
+following section, either an ‘{‘ or an ‘[‘. The <span class="emphasis"><em>bit pattern
 section</em></span> describes a
-constructor&#8217;s <span class="emphasis"><em>pattern</em></span>, the subset of possible
+constructor’s <span class="emphasis"><em>pattern</em></span>, the subset of possible
 instruction encodings that the designer wants
 to <span class="emphasis"><em>match</em></span> the constructor being defined.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_constraints"></a>7.4.1.�Constraints</h4></div></div></div>
+<a name="sleigh_constraints"></a>7.4.1. Constraints</h4></div></div></div>
 <p>
 The patterns required for processor specifications can almost always
 be described as a mask and value pair. Given a specific instruction
 encoding, we can decide if the encoding matches our pattern by looking
 at just the bits specified by the <span class="emphasis"><em>mask</em></span> and seeing
 if they match a specific <span class="emphasis"><em>value</em></span>. The fields, as
-defined in <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1.�Defining Tokens and Fields">Section�6.1, &#8220;Defining Tokens and Fields&#8221;</a>, typically give us
+defined in <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1. Defining Tokens and Fields">Section 6.1, “Defining Tokens and Fields”</a>, typically give us
 our masks. So to construct a pattern, we can simply require that the
 field take on a specific value, as in the example below.
 </p>
@@ -294,9 +294,9 @@ field take on a specific value, as in the example below.
 </pre></div>
 <p>
 Assuming the symbol <span class="emphasis"><em>opcode</em></span> was defined as a field, this says that a
-root constructor with mnemonic &#8220;halt&#8221; matches any instruction where
+root constructor with mnemonic “halt” matches any instruction where
 the bits defining this field have the value 0x15. The equation
-&#8220;opcode=0x15&#8221; is called a <span class="emphasis"><em>constraint</em></span>.
+“opcode=0x15” is called a <span class="emphasis"><em>constraint</em></span>.
 </p>
 <p>
 The standard bit encoding of the integer is used when restricting the
@@ -311,13 +311,13 @@ field.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_ampandor"></a>7.4.2.�The '&amp;' and '|' Operators</h4></div></div></div>
+<a name="sleigh_ampandor"></a>7.4.2. The '&amp;' and '|' Operators</h4></div></div></div>
 <p>
 More complicated patterns are built out of logical operators. The
 meaning of these are fairly straightforward. We can force two or more
 constraints to be true at the same time, a <span class="emphasis"><em>logical
-and</em></span> &#8216;&amp;&#8217;, or we can require that either one constraint or
-another must be true, a <span class="emphasis"><em>logical or</em></span> &#8216;|&#8217;. By using these with
+and</em></span> ‘&amp;’, or we can require that either one constraint or
+another must be true, a <span class="emphasis"><em>logical or</em></span> ‘|’. By using these with
 constraints and parentheses for grouping, arbitrarily complicated
 patterns can be constructed.
 </p>
@@ -337,11 +337,11 @@ requires two or more mask/value style checks to correctly implement.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_defining_operands"></a>7.4.3.�Defining Operands and Invoking Subtables</h4></div></div></div>
+<a name="sleigh_defining_operands"></a>7.4.3. Defining Operands and Invoking Subtables</h4></div></div></div>
 <p>
 The principle way of defining a constructor operand, left undefined
 from the display section, is done in the bit pattern section. If an
-operand&#8217;s identifier is used by itself, not as part of a constraint,
+operand’s identifier is used by itself, not as part of a constraint,
 then the operand takes on both the display and semantic definition of
 the global symbol with the same identifier. The syntax is slightly
 confusing at first. The identifier must appear in the pattern as if it
@@ -390,13 +390,13 @@ parsers, a SLEIGH specification is in part a grammar
 specification. The terminal symbols, or tokens, are the bits of an
 instruction, and the constructors and tables are the non-terminating
 symbols. These all build up to the root instruction table, the
-grammar&#8217;s start symbol. So this link from local to global is simply a
+grammar’s start symbol. So this link from local to global is simply a
 statement of the grouping of old symbols into the new constructor.
 </p>
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_variable_length"></a>7.4.4.�Variable Length Instructions</h4></div></div></div>
+<a name="sleigh_variable_length"></a>7.4.4. Variable Length Instructions</h4></div></div></div>
 <p>
 There are some additional complexities to designing a specification
 for a processor with variable length instructions. Some initial
@@ -419,14 +419,14 @@ designer control over how tokens fit together.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_semicolon"></a>7.4.4.1.�The ';' Operator</h5></div></div></div>
+<a name="sleigh_semicolon"></a>7.4.4.1. The ';' Operator</h5></div></div></div>
 <p>
 The most important operator for patterns defining variable length
-instructions is the concatenation operator &#8216;;&#8217;. When building a
+instructions is the concatenation operator ‘;’. When building a
 constructor with fields from two or more tokens, the pattern must
 explicitly define the order of the tokens. In terms of the logic of
-the pattern expressions themselves, the &#8216;;&#8217; operator has the same
-meaning as the &#8216;&amp;&#8217; operator. The combined expression matches only if
+the pattern expressions themselves, the ‘;’ operator has the same
+meaning as the ‘&amp;’ operator. The combined expression matches only if
 both subexpressions are true. However, it also requires that the
 subexpressions involve multiple tokens and explicitly indicates an
 order for them.
@@ -456,7 +456,7 @@ corresponding encoding. The second
 instruction, <span class="emphasis"><em>add</em></span>, uses
 fields <span class="emphasis"><em>op</em></span> and <span class="emphasis"><em>reg</em></span>, but it
 also uses field <span class="emphasis"><em>imm16</em></span> contained
-in <span class="emphasis"><em>immtoken</em></span>. The &#8216;;&#8217; operator indicates that
+in <span class="emphasis"><em>immtoken</em></span>. The ‘;’ operator indicates that
 token <span class="emphasis"><em>base</em></span> (via its fields) comes first in the
 encoding, followed by <span class="emphasis"><em>immtoken</em></span>. The constraints
 on <span class="emphasis"><em>base</em></span> will therefore correspond to constraints
@@ -466,25 +466,25 @@ bytes. The length of the final encoding for <span class="emphasis"><em>add</em><
 will be 3 bytes, the sum of the lengths of the two tokens.
 </p>
 <p>
-If two pattern expressions are combined with the &#8216;&amp;&#8217; or &#8216;|&#8217; operator,
-where the concatenation operator &#8216;;&#8217; is also being used, the designer
+If two pattern expressions are combined with the ‘&amp;’ or ‘|’ operator,
+where the concatenation operator ‘;’ is also being used, the designer
 must make sure that the tokens underlying each expression are the same
 and come in the same order. In the example <span class="emphasis"><em>add</em></span>
-instruction for instance, the &#8216;&amp;&#8217; operator combines the &#8220;op=3&#8221; and
-&#8220;reg&#8221; expressions. Both of these expressions involve only the
+instruction for instance, the ‘&amp;’ operator combines the “op=3” and
+“reg” expressions. Both of these expressions involve only the
 token <span class="emphasis"><em>base</em></span>, so the matching requirement is
-satisfied. The &#8216;&amp;&#8217; and &#8216;|&#8217; operators can combine expressions built out
+satisfied. The ‘&amp;’ and ‘|’ operators can combine expressions built out
 of more than one token, but the tokens must come in the same
-order. Also these operators have higher precedence than the &#8216;;&#8217;
+order. Also these operators have higher precedence than the ‘;’
 operator, so parentheses may be necessary to get the intended meaning.
 </p>
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_ellipsis"></a>7.4.4.2.�The '...' Operator</h5></div></div></div>
+<a name="sleigh_ellipsis"></a>7.4.4.2. The '...' Operator</h5></div></div></div>
 <p>
-The ellipsis operator &#8216;...&#8217; is used to satisfy the token matching
-requirements of the &#8216;&amp;&#8217; and &#8216;|&#8217; operators (described in the previous
+The ellipsis operator ‘...’ is used to satisfy the token matching
+requirements of the ‘&amp;’ and ‘|’ operators (described in the previous
 section), when the operands are of different lengths. The ellipsis is
 a unary operator applied to a pattern expression that extends its
 token length before it is combined with another expression. Depending
@@ -496,7 +496,7 @@ extension.
 addrmode: reg is reg &amp; mode=0    {     <span class="weak">...</span>
 addrmode: #imm16 is mode=1; imm16    {  <span class="weak">...</span>
 
-:xor &#8220;A&#8221;,addrmode is op=4 ... &amp; addrmode {	<span class="weak">...</span>
+:xor “A”,addrmode is op=4 ... &amp; addrmode {	<span class="weak">...</span>
 </pre></div>
 <p>
 </p>
@@ -527,7 +527,7 @@ whatever the length of <span class="emphasis"><em>addrmode</em></span> turns out
 <p>
 Since the <span class="emphasis"><em>op</em></span> constraint occurs to the left of the
 ellipsis, it is considered left justified, and the matching
-requirement for &#8216;&amp;&#8217; will insist that <span class="emphasis"><em>base</em></span> is the
+requirement for ‘&amp;’ will insist that <span class="emphasis"><em>base</em></span> is the
 first token in all forms of <span class="emphasis"><em>addrmode</em></span>. This allows
 the <span class="emphasis"><em>xor</em></span> instruction's constraint
 on <span class="emphasis"><em>op</em></span> and the <span class="emphasis"><em>addrmode</em></span>
@@ -538,7 +538,7 @@ constraints on a single byte in the final encoding.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_invisible_operands"></a>7.4.5.�Invisible Operands</h4></div></div></div>
+<a name="sleigh_invisible_operands"></a>7.4.5. Invisible Operands</h4></div></div></div>
 <p>
 It is not necessary for a global symbol, which is needed by a
 constructor, to appear in the display section of the definition. If
@@ -549,15 +549,15 @@ operand</em></span>. Such an operand behaves and is parsed exactly like
 any other operand but there is absolutely no visible indication of the
 operand in the final display of the assembly instruction. The one
 common type of instruction that uses this is the relative branch (see
-<a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1.�Relative Branches">Section�7.5.1, &#8220;Relative Branches&#8221;</a>) but it is otherwise needed
+<a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1. Relative Branches">Section 7.5.1, “Relative Branches”</a>) but it is otherwise needed
 only in more esoteric instructions. It is useful in situations where
 you need to break up the parsing of an instruction along lines that
-don&#8217;t quite match the assembly.
+don’t quite match the assembly.
 </p>
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_empty_patterns"></a>7.4.6.�Empty Patterns</h4></div></div></div>
+<a name="sleigh_empty_patterns"></a>7.4.6. Empty Patterns</h4></div></div></div>
 <p>
 Occasionally there is a need for an empty pattern when building
 tables. An empty pattern matches everything. There is a predefined
@@ -567,9 +567,9 @@ to indicate an empty pattern.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_advanced_constraints"></a>7.4.7.�Advanced Constraints</h4></div></div></div>
+<a name="sleigh_advanced_constraints"></a>7.4.7. Advanced Constraints</h4></div></div></div>
 <p>
-A constraint does not have to be of the form &#8220;field = constant&#8221;,
+A constraint does not have to be of the form “field = constant”,
 although this is almost always what is needed. In certain situations,
 it may be more convenient to use a different kind of
 constraint. Special care should be taken when designing these
@@ -584,7 +584,7 @@ of parsing states for a single constraint.
 A constraint can actually be built out of arbitrary
 expressions. These <span class="emphasis"><em>pattern expressions</em></span> are more
 commonly used in disassembly actions and are defined in
-<a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2.�General Actions and Pattern Expressions">Section�7.5.2, &#8220;General Actions and Pattern Expressions&#8221;</a>, but they can also be used in
+<a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2. General Actions and Pattern Expressions">Section 7.5.2, “General Actions and Pattern Expressions”</a>, but they can also be used in
 constraints. So in general, a constraint is any equation where the
 left-hand side is a single family symbol, the right-hand side is an
 arbitrary pattern expression, and the constraint operator is one of
@@ -592,7 +592,7 @@ the following:
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="constraints.htmltable"></a><p class="title"><b>Table�3.�Constraint Operators</b></p>
+<a name="constraints.htmltable"></a><p class="title"><b>Table 3. Constraint Operators</b></p>
 <div class="table-contents"><table xml:id="constraints.htmltable" width="50%" frame="box" rules="all">
 <col width="50%">
 <col width="50%">
@@ -645,7 +645,7 @@ feature of <span class="emphasis"><em>clr</em></span> from <span class="emphasis
 that the two fields, specifying the two register inputs
 to <span class="emphasis"><em>xor</em></span>, are equal. The easiest way to specify
 this special case is with the general constraint,
-&#8220;<span class="emphasis"><em>r2</em></span> = <span class="emphasis"><em>r1</em></span>&#8221;, as in the second
+“<span class="emphasis"><em>r2</em></span> = <span class="emphasis"><em>r1</em></span>”, as in the second
 line of the example. The SLEIGH compiler will implement this by
 enumerating all the cases where <span class="emphasis"><em>r2</em></span>
 equals <span class="emphasis"><em>r1</em></span>, creating as many states as there are
@@ -655,7 +655,7 @@ registers. But the specification itself, at least, remains compact.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_disassembly_actions"></a>7.5.�Disassembly Actions Section</h3></div></div></div>
+<a name="sleigh_disassembly_actions"></a>7.5. Disassembly Actions Section</h3></div></div></div>
 <p>
 After the bit pattern section, there can optionally be a section for
 doing dynamic calculations, which must be between square brackets. For
@@ -671,11 +671,11 @@ time, usually for part of the disassembly display.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_relative_branches"></a>7.5.1.�Relative Branches</h4></div></div></div>
+<a name="sleigh_relative_branches"></a>7.5.1. Relative Branches</h4></div></div></div>
 <p>
 The canonical example of an action at disassembly time is a branch
 relocation. A jump instruction encodes the address of where it jumps
-to as a relative offset to the instruction&#8217;s address, for
+to as a relative offset to the instruction’s address, for
 instance. But when we display the assembly, we want to show the
 absolute address of the jump destination. The correct way to specify
 this is to reserve an identifier in the display section which
@@ -698,7 +698,7 @@ defined in the action section as the integer obtained by adding a
 multiple of <span class="emphasis"><em>simm8</em></span>
 to <span class="emphasis"><em>inst_next</em></span>, a symbol predefined to be equal to
 the address of the following instruction (see
-<a class="xref" href="sleigh_symbols.html#sleigh_predefined_symbols" title="5.2.�Predefined Symbols">Section�5.2, &#8220;Predefined Symbols&#8221;</a>). Now <span class="emphasis"><em>reloc</em></span>
+<a class="xref" href="sleigh_symbols.html#sleigh_predefined_symbols" title="5.2. Predefined Symbols">Section 5.2, “Predefined Symbols”</a>). Now <span class="emphasis"><em>reloc</em></span>
 is a specific symbol with both semantic and display meaning equal to
 the desired absolute address. This address is calculated separately,
 at disassembly time, for every instruction that this constructor
@@ -707,7 +707,7 @@ matches.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_general_actions"></a>7.5.2.�General Actions and Pattern Expressions</h4></div></div></div>
+<a name="sleigh_general_actions"></a>7.5.2. General Actions and Pattern Expressions</h4></div></div></div>
 <p>
 In general, the disassembly actions are encoded as a sequence of
 assignments separated by semicolons. The left-hand side of each
@@ -719,7 +719,7 @@ is built up out of the following typical operators:
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="patexp.htmltable"></a><p class="title"><b>Table�4.�Pattern Expression Operators</b></p>
+<a name="patexp.htmltable"></a><p class="title"><b>Table 4. Pattern Expression Operators</b></p>
 <div class="table-contents"><table xml:id="patexp.htmltable" width="50%" frame="box" rules="all">
 <col width="50%">
 <col width="50%">
@@ -816,7 +816,7 @@ local identifier before it can be used.
 </p>
 <p>
 The left-hand side of an assignment statement can be a context
-variable (see <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4.�Context Variables">Section�6.4, &#8220;Context Variables&#8221;</a>). An
+variable (see <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4. Context Variables">Section 6.4, “Context Variables”</a>). An
 assignment to such a variable changes the context in which the current
 instruction is being disassembled and can potentially have a drastic
 effect on how the rest of the instruction is disassembled. An
@@ -828,26 +828,26 @@ more <span class="bold"><strong>globalset</strong></span> directives, which
 cause changes to context variables to become more permanent. This
 directive is distinct from the operators in a pattern expression and
 must be invoked as a separate statement. See
-<a class="xref" href="sleigh_context.html" title="8.�Using Context">Section�8, &#8220;Using Context&#8221;</a>, for a discussion of how to
+<a class="xref" href="sleigh_context.html" title="8. Using Context">Section 8, “Using Context”</a>, for a discussion of how to
 effectively use context variables and
-<a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3.�Global Context Change">Section�8.3, &#8220;Global Context Change&#8221;</a>, for details of
+<a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3. Global Context Change">Section 8.3, “Global Context Change”</a>, for details of
 the <span class="bold"><strong>globalset</strong></span> directive.
 </p>
 <p>
 Note that there are two syntax forms for the logical operators in a
 pattern expression. When an expression is used as part of a
-constraint, the &#8220;$and&#8221; and &#8220;$or&#8221; forms of the operators must be used
+constraint, the “$and” and “$or” forms of the operators must be used
 in order to distinguish the bitwise operators from the special pattern
-combining operators, &#8216;&amp;&#8217; and &#8216;|&#8217; (as described in
-<a class="xref" href="sleigh_constructors.html#sleigh_ampandor" title="7.4.2.�The '&amp;' and '|' Operators">Section�7.4.2, &#8220;The '&amp;' and '|' Operators&#8221;</a>). However inside the square braces
-of the disassembly action section, &#8216;&amp;&#8217; and &#8216;|&#8217; are interpreted as
+combining operators, ‘&amp;’ and ‘|’ (as described in
+<a class="xref" href="sleigh_constructors.html#sleigh_ampandor" title="7.4.2. The '&amp;' and '|' Operators">Section 7.4.2, “The '&amp;' and '|' Operators”</a>). However inside the square braces
+of the disassembly action section, ‘&amp;’ and ‘|’ are interpreted as
 the usual logical operators.
 </p>
 </div>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_with_block"></a>7.6.�The With Block</h3></div></div></div>
+<a name="sleigh_with_block"></a>7.6. The With Block</h3></div></div></div>
 <p>
 To avoid tedious repetition and to ease the maintenance of specifications
 already having many, many constructors and tables, the <span class="emphasis"><em>with
@@ -867,9 +867,9 @@ with op1 : mode=1 [ mode=2; ] {
 In the example, both constructors are added to the table identified by
 <span class="emphasis"><em>op1</em></span>. Both require the context field
 <span class="emphasis"><em>mode</em></span> to be equal to 1. The listed constraints take the
-form described in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4.�The Bit Pattern Section">Section�7.4, &#8220;The Bit Pattern Section&#8221;</a>, and they are joined to
-those given in the constructor statement as if prepended using &#8216;&amp;&#8217;. Similarly,
-the actions take the form described in <a class="xref" href="sleigh_constructors.html#sleigh_disassembly_actions" title="7.5.�Disassembly Actions Section">Section�7.5, &#8220;Disassembly Actions Section&#8221;</a>
+form described in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4. The Bit Pattern Section">Section 7.4, “The Bit Pattern Section”</a>, and they are joined to
+those given in the constructor statement as if prepended using ‘&amp;’. Similarly,
+the actions take the form described in <a class="xref" href="sleigh_constructors.html#sleigh_disassembly_actions" title="7.5. Disassembly Actions Section">Section 7.5, “Disassembly Actions Section”</a>
 and are prepended to the actions given in the constructor statement. Prepending
 the actions allows the statement to override actions in the with block. Both
 technically occur, but only the last one has a noticeable effect. The above
@@ -894,12 +894,12 @@ yet exist, the table is created immediately. Inside a with block that has a
 table header, a nested with block may specify the <span class="emphasis"><em>instruction</em></span>
 table by name, as in "with instruction : {<span class="weak">...</span>}".
 Inside such a block, the rule regarding mnemonic literals is restored (see
-<a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1.�Mnemonic">Section�7.3.1, &#8220;Mnemonic&#8221;</a>).
+<a class="xref" href="sleigh_constructors.html#sleigh_mnemonic" title="7.3.1. Mnemonic">Section 7.3.1, “Mnemonic”</a>).
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_semantic_section"></a>7.7.�The Semantic Section</h3></div></div></div>
+<a name="sleigh_semantic_section"></a>7.7. The Semantic Section</h3></div></div></div>
 <p>
 The final section of a constructor definition is the <span class="emphasis"><em>semantic
 section</em></span>. This is a description of how the processor would manipulate
@@ -916,8 +916,8 @@ were varnodes.
 </p>
 <p>
 The semantic section for one constructor is surrounded by curly braces
-&#8216;{&#8216; and &#8216;}&#8217; and consists of zero or more statements separated by
-semicolons &#8216;;&#8217;. Most statements are built up out of C-like syntax,
+‘{‘ and ‘}’ and consists of zero or more statements separated by
+semicolons ‘;’. Most statements are built up out of C-like syntax,
 where the variables are the symbols visible to the constructor. There
 is a direct correspondence between each type of operator used in the
 statements and a p-code operation. The SLEIGH compiler generates
@@ -939,29 +939,29 @@ varnode is <span class="emphasis"><em>r1</em></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_expressions"></a>7.7.1.�Expressions</h4></div></div></div>
+<a name="sleigh_expressions"></a>7.7.1. Expressions</h4></div></div></div>
 <p>
 Expressions are built out of symbols and the binary and unary
-operators listed in <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table�5.�Semantic Expression Operators and Syntax">Table�5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
+operators listed in <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table 5. Semantic Expression Operators and Syntax">Table 5, “Semantic Expression Operators and Syntax”</a> in the
 Appendix. All expressions evaluate to an integer, floating point, or
 boolean value, depending on the final operation of the expression. The
 value is then used depending on the kind of statement. Most of the
 operators require that their input and output varnodes all be the same
-size (see <a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.�Varnode Sizes">Section�7.7.3, &#8220;Varnode Sizes&#8221;</a>). The operators all
+size (see <a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, “Varnode Sizes”</a>). The operators all
 have a precedence, which is used by the SLEIGH compiler to determine
 the ordering of the final p-code operations. Parentheses can be used
 within expressions to affect this order.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_arithmetic_logical"></a>7.7.1.1.�Arithmetic, Logical and Boolean Operators</h5></div></div></div>
+<a name="sleigh_arithmetic_logical"></a>7.7.1.1. Arithmetic, Logical and Boolean Operators</h5></div></div></div>
 <p>
 For the most part these operators should be familiar to software
 developers. The only real differences arise from the fact that
 varnodes are typeless. So for instance, there has to be separate
-operators to distinguish between dividing unsigned numbers &#8216;/&#8217;,
-dividing signed numbers &#8216;s/&#8217;, and dividing floating point numbers
-&#8216;f/&#8217;.
+operators to distinguish between dividing unsigned numbers ‘/’,
+dividing signed numbers ‘s/’, and dividing floating point numbers
+‘f/’.
 </p>
 <p>
 Carry, borrow, and overflow calculations are implemented with separate
@@ -974,11 +974,11 @@ some people in this form (see the descriptions in the Appendix).
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_star_operator"></a>7.7.1.2.�The '*' Operator</h5></div></div></div>
+<a name="sleigh_star_operator"></a>7.7.1.2. The '*' Operator</h5></div></div></div>
 <p>
 The dereference operator, which generates <span class="emphasis"><em>LOAD</em></span>
 operations (and <span class="emphasis"><em>STORE</em></span> operations), has slightly
-unfamiliar syntax. The &#8216;*&#8217; operator, as is usual in many programming
+unfamiliar syntax. The ‘*’ operator, as is usual in many programming
 languages, indicates that the affected variable is a pointer and that
 the expression is <span class="emphasis"><em>dereferencing</em></span> the data being
 pointed to. Unlike most languages, in SLEIGH, it is not immediately
@@ -989,16 +989,16 @@ the <span class="emphasis"><em>default</em></span> space, as labeled in the defi
 of one of the address spaces with
 the <span class="bold"><strong>default</strong></span> attribute. If that is not
 the space desired, the default can be overridden by putting the
-identifier for the space in square brackets immediately after the &#8216;*&#8217;.
+identifier for the space in square brackets immediately after the ‘*’.
 </p>
 <p>
 It is also frequently not clear what the size of the dereferenced data
 is because the pointer variable is typeless. The SLEIGH compiler can
 frequently deduce what the size must be by looking at the operation in
 the context of the entire statement (see
-<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.�Varnode Sizes">Section�7.7.3, &#8220;Varnode Sizes&#8221;</a>). But in some situations, this
+<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, “Varnode Sizes”</a>). But in some situations, this
 may not be possible, so there is a way to specify the size
-explicitly. The operator can be followed by a colon &#8216;:&#8217; and an integer
+explicitly. The operator can be followed by a colon ‘:’ and an integer
 indicating the number of bytes being dereferenced. This can be used
 with or without the address space override. We give an example of each
 kind of override in the example below.
@@ -1017,7 +1017,7 @@ set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_extension"></a>7.7.1.3.�Extension</h5></div></div></div>
+<a name="sleigh_extension"></a>7.7.1.3. Extension</h5></div></div></div>
 <p>
 Most processors have instructions that extend small values into big
 values, and many instructions do these minor data manipulations
@@ -1039,15 +1039,15 @@ the <span class="bold"><strong>sext</strong></span> operator.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_truncation"></a>7.7.1.4.�Truncation</h5></div></div></div>
+<a name="sleigh_truncation"></a>7.7.1.4. Truncation</h5></div></div></div>
 <p>
 There are two forms of syntax indicating a truncation of the input
-varnode. In one the varnode is followed by a colon &#8216;:&#8217; and an integer
+varnode. In one the varnode is followed by a colon ‘:’ and an integer
 indicating the number of bytes to copy into the output, starting with
 the least significant byte. In the second form, the varnode is
 followed by an integer, surrounded by parentheses, indicating the
 number of least significant bytes to truncate from the input. This
-second form doesn&#8217;t directly specify the size of the output, which
+second form doesn’t directly specify the size of the output, which
 must be inferred from context.
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -1067,7 +1067,7 @@ half and <span class="emphasis"><em>hi</em></span> receives the most significant
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_bitrange_operator"></a>7.7.1.5.�Bit Range Operator</h5></div></div></div>
+<a name="sleigh_bitrange_operator"></a>7.7.1.5. Bit Range Operator</h5></div></div></div>
 <p>
 A specific subrange of bits within a varnode can be explicitly
 referenced. Depending on the range, this may amount to just a
@@ -1082,7 +1082,7 @@ restricted to byte alignment.
 </p>
 <p>
 A varnode, <span class="emphasis"><em>r2</em></span> in this example, is immediately
-followed by square brackets &#8216;[&#8217; and &#8216;]&#8217; indicating a bit range, and
+followed by square brackets ‘[’ and ‘]’ indicating a bit range, and
 within the brackets, there are two parameters separated by a
 comma. The first parameter is an integer indicating the least
 significant bit of the resulting bit range. The bits of the varnode
@@ -1101,7 +1101,7 @@ with memory down to byte resolution. The bit range operator will
 generate some combination
 of <span class="emphasis"><em>INT_RIGHT</em></span>, <span class="emphasis"><em>INT_AND</em></span>,
 and <span class="emphasis"><em>SUBPIECE</em></span> to simulate the extraction of
-smaller or unaligned pieces. The &#8220;r2[3,1]&#8221; from the example generates
+smaller or unaligned pieces. The “r2[3,1]” from the example generates
 the following p-code, for instance.
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -1119,12 +1119,12 @@ these are automatically set to zero.
 </p>
 <p>
 This operator can also be used on the left-hand side of assignments
-with similar behavior and caveats (see <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_assign" title="7.7.2.8.�Bit Range Assignments">Section�7.7.2.8, &#8220;Bit Range Assignments&#8221;</a>).
+with similar behavior and caveats (see <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_assign" title="7.7.2.8. Bit Range Assignments">Section 7.7.2.8, “Bit Range Assignments”</a>).
 </p>
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_addressof"></a>7.7.1.6.�Address-of Operator</h5></div></div></div>
+<a name="sleigh_addressof"></a>7.7.1.6. Address-of Operator</h5></div></div></div>
 <p>
 There is an <span class="emphasis"><em>address-of</em></span> operator for generating
 the address offset of a selected varnode as an integer value for use
@@ -1143,8 +1143,8 @@ specification may produce unexpected results.
 </p>
 </div>
 <p>
-There &#8216;&amp;&#8217; operator in front of a symbol invokes this function. The
-ampersand can also be followed by a colon &#8216;:&#8217; and an integer
+There ‘&amp;’ operator in front of a symbol invokes this function. The
+ampersand can also be followed by a colon ‘:’ and an integer
 explicitly indicating the size of the resulting constant as a varnode.
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -1164,12 +1164,12 @@ following <span class="emphasis"><em>r1</em></span> is copied
 into <span class="emphasis"><em>r1</em></span>, even though it is not mentioned directly
 in the instruction. Notice that the address-of operator only produces
 the offset portion of the address, and to copy the desired value, the
-&#8216;*&#8217; operator must have a <span class="emphasis"><em>register</em></span> space override.
+‘*’ operator must have a <span class="emphasis"><em>register</em></span> space override.
 </p>
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_managed_code"></a>7.7.1.7.�Managed Code Operations</h5></div></div></div>
+<a name="sleigh_managed_code"></a>7.7.1.7. Managed Code Operations</h5></div></div></div>
 <p>
 SLEIGH provides basic support for instructions where encoding and context
 don't provide a complete description of the semantics. This is the case
@@ -1210,7 +1210,7 @@ of objects to allocate. It returns a pointer to the allocated object.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_userdef_op"></a>7.7.1.8.�User-Defined Operations</h5></div></div></div>
+<a name="sleigh_userdef_op"></a>7.7.1.8. User-Defined Operations</h5></div></div></div>
 <p>
 Any identifier that has been defined as a new p-code operation, using
 the <span class="bold"><strong>define pcodeop</strong></span> statement, can be
@@ -1231,15 +1231,15 @@ define pcodeop arctan;
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_statements"></a>7.7.2.�Statements</h4></div></div></div>
+<a name="sleigh_statements"></a>7.7.2. Statements</h4></div></div></div>
 <p>
 We describe the types of semantic statements that are allowed in SLEIGH.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_assign_statements"></a>7.7.2.1.�Assignment Statements and Temporary Variables</h5></div></div></div>
+<a name="sleigh_assign_statements"></a>7.7.2.1. Assignment Statements and Temporary Variables</h5></div></div></div>
 <p>
-Of course SLEIGH allows assignment statements with the &#8216;=&#8217; operator,
+Of course SLEIGH allows assignment statements with the ‘=’ operator,
 where the right-hand side is an arbitrary expression and the left-hand
 side is the varnode being assigned. The assigned varnode can be any
 specific symbol in the scope of the constructor, either a global
@@ -1256,8 +1256,8 @@ result of the expression. The new symbol becomes part of the local
 scope of the constructor, and can be referred to in the following
 semantic statements. The size of the new varnode is calculated by
 examining the statement in context (see
-<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.�Varnode Sizes">Section�7.7.3, &#8220;Varnode Sizes&#8221;</a>). It is also possible to
-explicitly indicate the size by using the colon &#8216;:&#8217; operator followed
+<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, “Varnode Sizes”</a>). It is also possible to
+explicitly indicate the size by using the colon ‘:’ operator followed
 by an integer size in bytes. The following examples demonstrate the
 temporary variable <span class="emphasis"><em>tmp</em></span> being defined using both
 forms.
@@ -1305,11 +1305,11 @@ and may be enforced in future compiler versions.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_storage_statements"></a>7.7.2.2.�Storage Statements</h5></div></div></div>
+<a name="sleigh_storage_statements"></a>7.7.2.2. Storage Statements</h5></div></div></div>
 <p>
 SLEIGH supports fairly standard <span class="emphasis"><em>storage statement</em></span>
 syntax to complement the load operator. The left-hand side of an
-assignment statement uses the &#8216;*&#8217; operator to indicate a dynamic
+assignment statement uses the ‘*’ operator to indicate a dynamic
 storage location, followed by an arbitrary expression to calculate the
 location. This syntax of course generates the
 p-code <span class="emphasis"><em>STORE</em></span> operator as the final step of the
@@ -1323,10 +1323,10 @@ statement.
 <p>
 </p>
 <p>
-The same size and address space considerations that apply to the &#8216;*&#8217;
+The same size and address space considerations that apply to the ‘*’
 operator when it is used as a load operator also apply when it is used
 as a store operator, see
-<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.�The '*' Operator">Section�7.7.1.2, &#8220;The '*' Operator&#8221;</a>. Unless explicit modifiers are
+<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, “The '*' Operator”</a>. Unless explicit modifiers are
 given, the default address space is assumed as the storage
 destination, and the size of the data being stored is calculated from
 context. Keep in mind that the address represented by the pointer is
@@ -1336,9 +1336,9 @@ attribute is set to something other than one.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_exports"></a>7.7.2.3.�Exports</h5></div></div></div>
+<a name="sleigh_exports"></a>7.7.2.3. Exports</h5></div></div></div>
 <p>
-The semantic section doesn&#8217;t just specify how to generate p-code for a
+The semantic section doesn’t just specify how to generate p-code for a
 constructor. Except for those constructors in the root table, this
 section also associates a semantic meaning to the table symbol the
 constructor is part of, allowing the table to be used as an operand in
@@ -1374,32 +1374,32 @@ a <span class="emphasis"><em>reference</em></span> to the varnode being exported
 copy of the value. If the table symbol is written to, as the left-hand
 side of an assignment statement, in some other constructor, the
 exported varnode is affected. A constant can be exported if its size
-as a varnode is given explicitly with the &#8216;:&#8217; operator.
+as a varnode is given explicitly with the ‘:’ operator.
 </p>
 <p>
 It is not legal to put a full expression in
 an <span class="bold"><strong>export</strong></span> statement, any expression
-must appear in an earlier statement. However, a single &#8216;&amp;&#8217;
+must appear in an earlier statement. However, a single ‘&amp;’
 operator is allowed as part of the statement and it behaves as it
 would in a normal expression (see
-<a class="xref" href="sleigh_constructors.html#sleigh_addressof" title="7.7.1.6.�Address-of Operator">Section�7.7.1.6, &#8220;Address-of Operator&#8221;</a>). It causes the address of the
+<a class="xref" href="sleigh_constructors.html#sleigh_addressof" title="7.7.1.6. Address-of Operator">Section 7.7.1.6, “Address-of Operator”</a>). It causes the address of the
 varnode being modified to be exported as an integer constant.
 </p>
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_dynamic_references"></a>7.7.2.4.�Dynamic References</h5></div></div></div>
+<a name="sleigh_dynamic_references"></a>7.7.2.4. Dynamic References</h5></div></div></div>
 <p>
 The only other operator allowed as part of
-an <span class="bold"><strong>export</strong></span> statement, is the &#8216;*&#8217;
+an <span class="bold"><strong>export</strong></span> statement, is the ‘*’
 operator. The semantic meaning of this operator is the same as if it
 were used in an expression (see
-<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.�The '*' Operator">Section�7.7.1.2, &#8220;The '*' Operator&#8221;</a>), but it is worth examining the
+<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, “The '*' Operator”</a>), but it is worth examining the
 effects of this form of export in detail. Bearing in mind that
 an <span class="bold"><strong>export</strong></span> statement exports
-a <span class="emphasis"><em>reference</em></span>, using the &#8216;*&#8217; operator in the
+a <span class="emphasis"><em>reference</em></span>, using the ‘*’ operator in the
 statement exports a <span class="emphasis"><em>dynamic reference</em></span>. The
-varnode being modified by the &#8216;*&#8217; is interpreted as a pointer to
+varnode being modified by the ‘*’ is interpreted as a pointer to
 another varnode. It is this varnode being pointed to which is
 exported, even though the address may be dynamic and cannot be
 determined at disassembly time. This is not the same as dereferencing
@@ -1427,14 +1427,14 @@ calculated from a register <span class="emphasis"><em>reg</em></span> and a fiel
 instruction <span class="emphasis"><em>off</em></span>. The constructor does not export
 the resulting pointer <span class="emphasis"><em>ea</em></span>, it exports the location
 being pointed to by <span class="emphasis"><em>ea</em></span>. Notice the size of this
-location (4) is given explicitly with the &#8216;:&#8217; modifier. The &#8216;*&#8217;
+location (4) is given explicitly with the ‘:’ modifier. The ‘*’
 operator can also be used on constant pointers. In the second example,
 the constant operand <span class="emphasis"><em>reloc</em></span> is used as the offset
 portion of an address into the <span class="emphasis"><em>ram</em></span> address
 space. The constant <span class="emphasis"><em>reloc</em></span> is calculated at
 disassembly time from the instruction
 field <span class="emphasis"><em>abs</em></span>. This is a very common construction for
-jump destinations (see <a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1.�Relative Branches">Section�7.5.1, &#8220;Relative Branches&#8221;</a>) but
+jump destinations (see <a class="xref" href="sleigh_constructors.html#sleigh_relative_branches" title="7.5.1. Relative Branches">Section 7.5.1, “Relative Branches”</a>) but
 can be used in general. This particular combination of a disassembly
 time action and a dynamic export is a very general way to construct a
 family of varnodes.
@@ -1447,10 +1447,10 @@ levels.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_branching_statements"></a>7.7.2.5.�Branching Statements</h5></div></div></div>
+<a name="sleigh_branching_statements"></a>7.7.2.5. Branching Statements</h5></div></div></div>
 <p>
 This section discusses statements that generate p-code branching
-operations. These are listed in <a class="xref" href="sleigh_ref.html#branchref.htmltable" title="Table�7.�Branching Statements">Table�7, &#8220;Branching Statements&#8221;</a>, in the Appendix.
+operations. These are listed in <a class="xref" href="sleigh_ref.html#branchref.htmltable" title="Table 7. Branching Statements">Table 7, “Branching Statements”</a>, in the Appendix.
 </p>
 <p>
 There are six forms covering the gamut of typical assembly language
@@ -1492,12 +1492,12 @@ destination is the first p-code operation for the (translated) machine
 instruction at that address. For most cases, this is the only kind of
 branching needed. The rarer case of <span class="emphasis"><em>p-code
 relative</em></span> branching is discussed in the following section
-(<a class="xref" href="sleigh_constructors.html#sleigh_pcode_relative" title="7.7.2.6.�P-code Relative Branching">Section�7.7.2.6, &#8220;P-code Relative Branching&#8221;</a>), but for the remainder of
+(<a class="xref" href="sleigh_constructors.html#sleigh_pcode_relative" title="7.7.2.6. P-code Relative Branching">Section 7.7.2.6, “P-code Relative Branching”</a>), but for the remainder of
 this section, we assume the destination is ultimately given as an
 address.
 </p>
 <p>
-There are two ways to specify a branching operation&#8217;s destination
+There are two ways to specify a branching operation’s destination
 address; directly and indirectly. Where a direct address is needed, as
 for the <span class="emphasis"><em>BRANCH</em></span>, <span class="emphasis"><em>CBRANCH</em></span>,
 and <span class="emphasis"><em>CALL</em></span> instructions, The specification can give
@@ -1613,7 +1613,7 @@ must match the size of the destination space.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_pcode_relative"></a>7.7.2.6.�P-code Relative Branching</h5></div></div></div>
+<a name="sleigh_pcode_relative"></a>7.7.2.6. P-code Relative Branching</h5></div></div></div>
 <p>
 In some cases, the semantics of an instruction may require
 branching <span class="emphasis"><em>within</em></span> the semantics of a single
@@ -1623,7 +1623,7 @@ branching. Individual p-code operations can be identified by
 a <span class="emphasis"><em>label</em></span>, and this label can be used as the
 destination specifier, after the <span class="bold"><strong>goto</strong></span>
 keyword. A <span class="emphasis"><em>label</em></span>, within the semantic section, is
-any identifier surrounded by the &#8216;&lt;&#8217; and &#8216;&gt;&#8217; characters. If this
+any identifier surrounded by the ‘&lt;’ and ‘&gt;’ characters. If this
 construction occurs at the beginning of a statement, we say the label
 is <span class="emphasis"><em>defined</em></span>, and that identifier is now associated
 with the first p-code operation corresponding to the following
@@ -1649,7 +1649,7 @@ defined. Multiple references to the same label are allowed.
 <p>
 </p>
 <p>
-In the example above, the string &#8220;loopstart&#8221; is the label identifier
+In the example above, the string “loopstart” is the label identifier
 which appears twice; once at the point where the label is defined at
 the top of the loop, after the initialization, and once as a reference
 where the conditional branch is made for the loop.
@@ -1665,10 +1665,10 @@ instruction is not possible.
 </p>
 <p>
 Internally, branches to labels are encoded as a relative index. Each
-p-code operation is assigned an index corresponding to the operation&#8217;s
+p-code operation is assigned an index corresponding to the operation’s
 position within the entire translation of the instruction. Then the
 branch can be expressed as a relative offset between the branch
-operation&#8217;s index and the destination operation&#8217;s index. The SLEIGH
+operation’s index and the destination operation’s index. The SLEIGH
 compiler encodes this offset as a constant varnode that is used as
 input to
 the <span class="emphasis"><em>BRANCH</em></span>, <span class="emphasis"><em>CBRANCH</em></span>,
@@ -1677,7 +1677,7 @@ or <span class="emphasis"><em>CALL</em></span> operation.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_skip_instruction_branching"></a>7.7.2.7.�Skip Instruction Branching</h5></div></div></div>
+<a name="sleigh_skip_instruction_branching"></a>7.7.2.7. Skip Instruction Branching</h5></div></div></div>
 <p>
 Many processors have a conditional-skip-instruction which must branch over the next instruction
 based upon some condition.  The <span class="emphasis"><em>inst_next2</em></span> symbol has been provided for
@@ -1698,15 +1698,15 @@ instruction when the condition is satisfied.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_bitrange_assign"></a>7.7.2.8.�Bit Range Assignments</h5></div></div></div>
+<a name="sleigh_bitrange_assign"></a>7.7.2.8. Bit Range Assignments</h5></div></div></div>
 <p>
 The bit range operator can appear on the left-hand side of an
-assignment. But as with the &#8216;*&#8217; operator, its meaning is slightly
+assignment. But as with the ‘*’ operator, its meaning is slightly
 different when used on this side. The bit range is specified in square
 brackets, as before, by giving the integer specifying the least
 significant bit of the range, followed by the number of bits in the
 range. In contrast with its use on the right however (see
-<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5.�Bit Range Operator">Section�7.7.1.5, &#8220;Bit Range Operator&#8221;</a>), the indicated bit range
+<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5. Bit Range Operator">Section 7.7.1.5, “Bit Range Operator”</a>), the indicated bit range
 is filled rather than extracted. Bits obtained from evaluating the
 expression on the right are extracted and spliced into the result at
 the indicated bit offset.
@@ -1729,7 +1729,7 @@ In terms of the rest of the assignment expression, the bit range
 operator is again assumed to have a size equal to the minimum number
 of bytes needed to hold the bit range. In particular, in order to
 satisfy size restrictions (see
-<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3.�Varnode Sizes">Section�7.7.3, &#8220;Varnode Sizes&#8221;</a>), the right-hand side must
+<a class="xref" href="sleigh_constructors.html#sleigh_varnode_sizes" title="7.7.3. Varnode Sizes">Section 7.7.3, “Varnode Sizes”</a>), the right-hand side must
 match this size. Furthermore, it is assumed that any extra bits in the
 right-hand side expression are already set to zero.
 </p>
@@ -1737,7 +1737,7 @@ right-hand side expression are already set to zero.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_varnode_sizes"></a>7.7.3.�Varnode Sizes</h4></div></div></div>
+<a name="sleigh_varnode_sizes"></a>7.7.3. Varnode Sizes</h4></div></div></div>
 <p>
 All statements within the semantic section must be specified up to the
 point where the sizes of all varnodes are unambiguously
@@ -1760,7 +1760,7 @@ The SLEIGH compiler does not make assumptions about the size of a
 constant variable based on the constant value itself. This is true of
 values occurring explicitly in the specification and of values that
 are calculated dynamically in a disassembly action. As described in
-<a class="xref" href="sleigh_constructors.html#sleigh_assign_statements" title="7.7.2.1.�Assignment Statements and Temporary Variables">Section�7.7.2.1, &#8220;Assignment Statements and Temporary Variables&#8221;</a>, temporary variables do not
+<a class="xref" href="sleigh_constructors.html#sleigh_assign_statements" title="7.7.2.1. Assignment Statements and Temporary Variables">Section 7.7.2.1, “Assignment Statements and Temporary Variables”</a>, temporary variables do not
 need to have their size given explicitly.
 </p>
 <p>
@@ -1768,7 +1768,7 @@ The SLEIGH compiler can usually fill in the required size by examining
 these situations in the context of the entire semantic section. Most
 p-code operations have size restrictions on their inputs and outputs,
 which when put together can uniquely determine the unspecified
-sizes. Referring to <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table�5.�Semantic Expression Operators and Syntax">Table�5, &#8220;Semantic Expression Operators and Syntax&#8221;</a> in the
+sizes. Referring to <a class="xref" href="sleigh_ref.html#syntaxref.htmltable" title="Table 5. Semantic Expression Operators and Syntax">Table 5, “Semantic Expression Operators and Syntax”</a> in the
 Appendix, all arithmetic and logical operations, both integer and
 floating point, must have inputs and outputs all of the same size. The
 only exceptions are as follows. The overflow
@@ -1784,8 +1784,8 @@ a size of 1 byte.
 <p>
 The operators without a size constraint are the load and store
 operators, the extension and truncation operators, and the conversion
-operators. As discussed in <a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.�The '*' Operator">Section�7.7.1.2, &#8220;The '*' Operator&#8221;</a>, the
-&#8216;*&#8217; operator cannot get size information for the dynamic (pointed-to)
+operators. As discussed in <a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, “The '*' Operator”</a>, the
+‘*’ operator cannot get size information for the dynamic (pointed-to)
 object from the pointer itself. The other operators by definition
 involve a change of size from input to output.
 </p>
@@ -1793,7 +1793,7 @@ involve a change of size from input to output.
 If the SLEIGH compiler cannot discover the sizes of constants and
 temporaries, it will report an error stating that it could not resolve
 variable sizes for that constructor. This can usually be fixed rapidly
-by appending the size &#8216;:&#8217; modifier to either the &#8216;*&#8217; operator, the
+by appending the size ‘:’ modifier to either the ‘*’ operator, the
 temporary variable definition, or to an explicit integer. Here are
 three examples of statements that generate a size resolution error,
 each followed by a variation which corrects the error.
@@ -1823,7 +1823,7 @@ each followed by a variation which corrects the error.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_unimplemented_semantics"></a>7.7.4.�Unimplemented Semantics</h4></div></div></div>
+<a name="sleigh_unimplemented_semantics"></a>7.7.4. Unimplemented Semantics</h4></div></div></div>
 <p>
 The semantic section must be present for every constructor in the
 specification. But the designer can leave the semantics explicitly
@@ -1849,7 +1849,7 @@ nothing.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_tables"></a>7.8.�Tables</h3></div></div></div>
+<a name="sleigh_tables"></a>7.8. Tables</h3></div></div></div>
 <p>
 A single constructor does not form a new specific
 symbol. The <span class="emphasis"><em>table</em></span> that the constructor is
@@ -1874,13 +1874,13 @@ exploit the similarity to produce an extremely concise description.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_matching"></a>7.8.1.�Matching</h4></div></div></div>
+<a name="sleigh_matching"></a>7.8.1. Matching</h4></div></div></div>
 <p>
 If a table contains exactly one constructor, the meaning of the table
 as a specific symbol is straightforward. The display meaning of the
 symbol comes from the <span class="emphasis"><em>display section</em></span> of the
-constructor, and the symbol&#8217;s semantic meaning comes from the
-constructor&#8217;s <span class="emphasis"><em>semantic section</em></span>.
+constructor, and the symbol’s semantic meaning comes from the
+constructor’s <span class="emphasis"><em>semantic section</em></span>.
 </p>
 <div class="informalexample"><pre class="programlisting">
 mode1: (r1) is addrmode=1 &amp; r1 { export r1; }
@@ -1890,8 +1890,8 @@ mode1: (r1) is addrmode=1 &amp; r1 { export r1; }
 <p>
 The table symbol in this example
 is <span class="emphasis"><em>mode1</em></span>. Assuming this is the only constructor,
-the display meaning of the symbol are the literal characters &#8216;(&#8216;, and
-&#8216;)&#8217; concatenated with the display meaning of <span class="emphasis"><em>r1</em></span>,
+the display meaning of the symbol are the literal characters ‘(‘, and
+‘)’ concatenated with the display meaning of <span class="emphasis"><em>r1</em></span>,
 presumably a register name that has been attached. The semantic
 meaning of <span class="emphasis"><em>mode1</em></span>, because of the export
 statement, becomes whatever register is matched by
@@ -1938,7 +1938,7 @@ symbol.
 </p>
 <div class="informalexample"><pre class="programlisting">
 zA: r1  is addrmode=3 &amp; r1   { export r1; }
-zA: &#8220;0&#8221; is addrmode=3 &amp; r1=0 { export 0:4; } # Special case
+zA: “0” is addrmode=3 &amp; r1=0 { export 0:4; } # Special case
 </pre></div>
 <p>
 </p>
@@ -1983,7 +1983,7 @@ should generally be avoided.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_specific_symbol_trees"></a>7.8.2.�Specific Symbol Trees</h4></div></div></div>
+<a name="sleigh_specific_symbol_trees"></a>7.8.2. Specific Symbol Trees</h4></div></div></div>
 <p>
 When the SLEIGH parser analyzes an instruction, it starts with the
 root symbol <span class="emphasis"><em>instruction</em></span>, and decides which of the
@@ -1993,7 +1993,7 @@ parsing process recurses at this point.  Each of the unresolved family
 symbols is analyzed in the same way to find the matching specific
 symbol. The matching is accomplished either with a table lookup, as
 with a field with attached registers, or with the matching algorithm
-described in <a class="xref" href="sleigh_constructors.html#sleigh_matching" title="7.8.1.�Matching">Section�7.8.1, &#8220;Matching&#8221;</a>. By the end of the
+described in <a class="xref" href="sleigh_constructors.html#sleigh_matching" title="7.8.1. Matching">Section 7.8.1, “Matching”</a>. By the end of the
 parsing process, we have a tree of specific symbols representing the
 parsed instruction. We present a small but complete SLEIGH
 specification to illustrate this hierarchy.
@@ -2049,10 +2049,10 @@ constructor is resolved in turn.
 </p>
 <div class="figure">
 <a name="sleigh_encoding_image"></a><div class="figure-contents"><div class="mediaobject" align="center"><table border="0" summary="manufactured viewport for HTML img" style="cellpadding: 0; cellspacing: 0;" width="100%"><tr><td align="center"><img src="Diagram1.png" align="middle" width="540" height="225" alt="Two Encodings and the Resulting Specific Symbol Trees"></td></tr></table></div></div>
-<p class="title"><b>Figure�1.�Two Encodings and the Resulting Specific Symbol Trees</b></p>
+<p class="title"><b>Figure 1. Two Encodings and the Resulting Specific Symbol Trees</b></p>
 </div>
 <br class="figure-break"><p>
-In <a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="Figure�1.�Two Encodings and the Resulting Specific Symbol Trees">Figure�1, &#8220;Two Encodings and the Resulting Specific Symbol Trees&#8221;</a>, we can see the break down
+In <a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="Figure 1. Two Encodings and the Resulting Specific Symbol Trees">Figure 1, “Two Encodings and the Resulting Specific Symbol Trees”</a>, we can see the break down
 of two typical instructions in the example instruction set. For each
 instruction, we see the how the encodings split into the relevant
 fields and the resulting tree of specific symbols. Each node in the
@@ -2066,7 +2066,7 @@ and p-code for these encodings by walking the trees.
 </p>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_disassembly_trees"></a>7.8.2.1.�Disassembly Trees</h5></div></div></div>
+<a name="sleigh_disassembly_trees"></a>7.8.2.1. Disassembly Trees</h5></div></div></div>
 <p>
 If the nodes of each tree are replaced with the display information of
 the corresponding specific symbol, we see how the disassembly
@@ -2074,12 +2074,12 @@ statement is built.
 </p>
 <div class="figure">
 <a name="sleigh_disassembly_image"></a><div class="figure-contents"><div class="mediaobject" align="center"><table border="0" summary="manufactured viewport for HTML img" style="cellpadding: 0; cellspacing: 0;" width="100%"><tr><td align="center"><img src="Diagram2.png" align="middle" width="310" height="151" alt="Two Disassembly Trees"></td></tr></table></div></div>
-<p class="title"><b>Figure�2.�Two Disassembly Trees</b></p>
+<p class="title"><b>Figure 2. Two Disassembly Trees</b></p>
 </div>
 <br class="figure-break"><p>
-<a class="xref" href="sleigh_constructors.html#sleigh_disassembly_image" title="Figure�2.�Two Disassembly Trees">Figure�2, &#8220;Two Disassembly Trees&#8221;</a>, shows the resulting
+<a class="xref" href="sleigh_constructors.html#sleigh_disassembly_image" title="Figure 2. Two Disassembly Trees">Figure 2, “Two Disassembly Trees”</a>, shows the resulting
 disassembly trees corresponding to the specific symbol trees in
-<a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="Figure�1.�Two Encodings and the Resulting Specific Symbol Trees">Figure�1, &#8220;Two Encodings and the Resulting Specific Symbol Trees&#8221;</a>. The display information comes
+<a class="xref" href="sleigh_constructors.html#sleigh_encoding_image" title="Figure 1. Two Encodings and the Resulting Specific Symbol Trees">Figure 1, “Two Encodings and the Resulting Specific Symbol Trees”</a>. The display information comes
 from constructor display sections, the names of attached registers, or
 the integer interpretation of fields. The identifiers in a constructor
 display section serves as placeholders for the subtrees below them. By
@@ -2089,7 +2089,7 @@ statements corresponding to the original instruction encodings.
 </div>
 <div class="sect4">
 <div class="titlepage"><div><div><h5 class="title">
-<a name="sleigh_pcode_trees"></a>7.8.2.2.�P-code Trees</h5></div></div></div>
+<a name="sleigh_pcode_trees"></a>7.8.2.2. P-code Trees</h5></div></div></div>
 <p>
 A similar procedure produces the resulting p-code translation of the
 instruction. If each node in the specific symbol tree is replaced with
@@ -2097,10 +2097,10 @@ the corresponding p-code, we see how the final translation is built.
 </p>
 <div class="figure">
 <a name="sleigh_pcode_image"></a><div class="figure-contents"><div class="mediaobject" align="center"><table border="0" summary="manufactured viewport for HTML img" style="cellpadding: 0; cellspacing: 0;" width="100%"><tr><td align="center"><img src="Diagram3.png" align="middle" width="405" height="149" alt="Two P-code Trees"></td></tr></table></div></div>
-<p class="title"><b>Figure�3.�Two P-code Trees</b></p>
+<p class="title"><b>Figure 3. Two P-code Trees</b></p>
 </div>
 <br class="figure-break"><p>
-<a class="xref" href="sleigh_constructors.html#sleigh_pcode_image" title="Figure�3.�Two P-code Trees">Figure�3, &#8220;Two P-code Trees&#8221;</a> lists the final p-code
+<a class="xref" href="sleigh_constructors.html#sleigh_pcode_image" title="Figure 3. Two P-code Trees">Figure 3, “Two P-code Trees”</a> lists the final p-code
 translation for our example instructions and shows the trees from
 which the translation is derived. Symbol names within the p-code for a
 particular node, as with the disassembly tree, are placeholders for
@@ -2108,7 +2108,7 @@ the subtree below them. The final translation is put together by
 concatenating the p-code from each node, traversing the nodes in a
 depth-first order. Thus the p-code of a child tends to come before the
 p-code of the parent node (but see
-<a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9.�P-code Macros">Section�7.9, &#8220;P-code Macros&#8221;</a>). Placeholders are filled in with the
+<a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9. P-code Macros">Section 7.9, “P-code Macros”</a>). Placeholders are filled in with the
 appropriate varnode, as determined by the export statement of the root
 of the corresponding subtree.
 </p>
@@ -2117,11 +2117,11 @@ of the corresponding subtree.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_macros"></a>7.9.�P-code Macros</h3></div></div></div>
+<a name="sleigh_macros"></a>7.9. P-code Macros</h3></div></div></div>
 <p>
 SLEIGH supports a macro facility for encapsulating semantic
 actions. The syntax, in effect, allows the designer to define p-code
-subroutines which can be invoked as part of a constructor&#8217;s semantic
+subroutines which can be invoked as part of a constructor’s semantic
 action. The subroutine is expanded automatically at compile time.
 </p>
 <p>
@@ -2131,8 +2131,8 @@ anywhere in the file before its first use. This is followed by the
 global identifier for the new macro and a parameter list, comma
 separated and in parentheses. The body of the definition comes next,
 surrounded by curly braces.  The body is a sequence of semantic
-statements with the same syntax as a constructor&#8217;s semantic
-section. The identifiers in the macro&#8217;s parameter list are local in
+statements with the same syntax as a constructor’s semantic
+section. The identifiers in the macro’s parameter list are local in
 scope. The macro can refer to these and any global specific symbol.
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -2168,7 +2168,7 @@ directive however should not be used in a macro.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_build_directives"></a>7.10.�Build Directives</h3></div></div></div>
+<a name="sleigh_build_directives"></a>7.10. Build Directives</h3></div></div></div>
 <p>
 Because the nodes of a specific symbol tree are traversed in a
 depth-first order, the p-code for a child node in general comes before
@@ -2180,10 +2180,10 @@ used to affect these issues in the rare cases where it is
 necessary. The <span class="bold"><strong>build</strong></span> directive occurs
 as another form of statement in the semantic section of a
 constructor. The keyword <span class="bold"><strong>build</strong></span> is
-followed by one of the constructor&#8217;s operand identifiers. Then,
-instead of filling in the operand&#8217;s associated p-code based on an
+followed by one of the constructor’s operand identifiers. Then,
+instead of filling in the operand’s associated p-code based on an
 arbitrary traversal of the symbol tree, the directive specifies that
-the operand&#8217;s p-code must occur at that point in the p-code for the
+the operand’s p-code must occur at that point in the p-code for the
 parent constructor.
 </p>
 <p>
@@ -2199,7 +2199,7 @@ efficient to treat the condition bit which distinguishes the variants
 as a special operand.
 </p>
 <div class="informalexample"><pre class="programlisting">
-cc: &#8220;c&#8221; is condition=1 { if (flag==1) goto inst_next; }
+cc: “c” is condition=1 { if (flag==1) goto inst_next; }
 cc:     is condition=0 { }
 
 :and^cc  r1,r2 is opcode=0x67 &amp; cc &amp; r1 &amp; r2 {
@@ -2210,7 +2210,7 @@ cc:     is condition=0 { }
 <p>
 </p>
 <p>
-In this example, the conditional variant is distinguished by a &#8216;c&#8217;
+In this example, the conditional variant is distinguished by a ‘c’
 appended to the assembly mnemonic. The <span class="emphasis"><em>cc</em></span> operand
 performs the conditional side-effect, checking a flag in one case, or
 doing nothing in the other. The two forms of the instruction can now
@@ -2223,7 +2223,7 @@ normal action of the instruction.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_delayslot_directives"></a>7.11.�Delay Slot Directives</h3></div></div></div>
+<a name="sleigh_delayslot_directives"></a>7.11. Delay Slot Directives</h3></div></div></div>
 <p>
 For processors with a pipe-lined architecture, multiple instructions
 are typically executing simultaneously. This can lead to processor
@@ -2268,7 +2268,7 @@ Because the <span class="bold"><strong>delayslot</strong></span> directive
 combines two or more instructions into one, the meaning of the
 symbols <span class="emphasis"><em>inst_next</em></span> and <span class="emphasis"><em>inst_next2</em></span> 
 become ambiguous. It is not
-clear anymore what exactly the &#8220;next instruction&#8221; is. SLEIGH uses the
+clear anymore what exactly the “next instruction” is. SLEIGH uses the
 following conventions for interpreting
 an <span class="emphasis"><em>inst_next</em></span> symbol. If it is used in the
 semantic section, the symbol refers to the address of the instruction
@@ -2289,15 +2289,15 @@ when computing the value of <span class="emphasis"><em>inst_next2</em></span>.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_tokens.html">Prev</a>�</td>
-<td width="20%" align="center">�</td>
-<td width="40%" align="right">�<a accesskey="n" href="sleigh_context.html">Next</a>
+<a accesskey="p" href="sleigh_tokens.html">Prev</a> </td>
+<td width="20%" align="center"> </td>
+<td width="40%" align="right"> <a accesskey="n" href="sleigh_context.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">6.�Tokens and Fields�</td>
+<td width="40%" align="left" valign="top">6. Tokens and Fields </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top">�8.�Using Context</td>
+<td width="40%" align="right" valign="top"> 8. Using Context</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_context.html
+++ b/GhidraDocs/languages/html/sleigh_context.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>8. Using Context</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>8.Â Using Context</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_constructors.html" title="7. Constructors">
-<link rel="next" href="sleigh_ref.html" title="9. P-code Tables">
+<link rel="prev" href="sleigh_constructors.html" title="7.Â Constructors">
+<link rel="next" href="sleigh_ref.html" title="9.Â P-code Tables">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">8. Using Context</th></tr>
+<tr><th colspan="3" align="center">8.Â Using Context</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_constructors.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_ref.html">Next</a>
+<a accesskey="p" href="sleigh_constructors.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_ref.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_context"></a>8. Using Context</h2></div></div></div>
+<a name="sleigh_context"></a>8.Â Using Context</h2></div></div></div>
 <p>
 For most practical specifications, the disassembly and semantic
 meaning of an instruction can be determined by looking only at the
@@ -77,7 +77,7 @@ necessary.
 <p>
 SLEIGH solves these problems by introducing <span class="emphasis"><em>context
 variables</em></span>. The syntax for defining these symbols was
-described in <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4. Context Variables">Section 6.4, &#8220;Context Variables&#8221;</a>. As mentioned
+described in <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4.Â Context Variables">SectionÂ 6.4, â€œContext Variablesâ€</a>. As mentioned
 there, the easiest and most common way to use a context variable is as
 just another field to use in our bit patterns. It gives us the extra
 information we need to distinguish between different instructions
@@ -85,7 +85,7 @@ whose encodings are otherwise the same.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_context_basic"></a>8.1. Basic Use of Context Variables</h3></div></div></div>
+<a name="sleigh_context_basic"></a>8.1.Â Basic Use of Context Variables</h3></div></div></div>
 <p>
 Suppose a processor supports the use of two different sets of
 registers in its main addressing mode, based on the setting of a
@@ -149,12 +149,12 @@ although see the following sections.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_local_change"></a>8.2. Local Context Change</h3></div></div></div>
+<a name="sleigh_local_change"></a>8.2.Â Local Context Change</h3></div></div></div>
 <p>
 SLEIGH can make direct modifications to context variables through
 statements in the disassembly action section of a constructor. The
 left-hand side of an assignment statement in this section can be a context variable,
-see <a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2. General Actions and Pattern Expressions">Section 7.5.2, &#8220;General Actions and Pattern Expressions&#8221;</a>. Because the result of this
+see <a class="xref" href="sleigh_constructors.html#sleigh_general_actions" title="7.5.2.Â General Actions and Pattern Expressions">SectionÂ 7.5.2, â€œGeneral Actions and Pattern Expressionsâ€</a>. Because the result of this
 assignment is calculated in the middle of the instruction disassembly,
 the change in value of the context variable can potentially affect any
 remaining parsing for that instruction. A modal variable is being
@@ -193,7 +193,7 @@ use <span class="emphasis"><em>mode</em></span>, its value will have reverted to
 original global state. The same holds for any context variable
 modified with this syntax. If an instruction needs to permanently
 modify the state of a context variable, the designer must use
-constructions described in <a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3. Global Context Change">Section 8.3, &#8220;Global Context Change&#8221;</a>.
+constructions described in <a class="xref" href="sleigh_context.html#sleigh_global_change" title="8.3.Â Global Context Change">SectionÂ 8.3, â€œGlobal Context Changeâ€</a>.
 </p>
 <p>
 Clearly, the behavior of the above example could be easily replicated
@@ -219,7 +219,7 @@ by <span class="bold"><strong>build</strong></span> directives.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_global_change"></a>8.3. Global Context Change</h3></div></div></div>
+<a name="sleigh_global_change"></a>8.3.Â Global Context Change</h3></div></div></div>
 <p>
 It is possible for an instruction to attempt a permanent change to a
 context variable, which would then affect the parsing of other
@@ -261,7 +261,7 @@ select <span class="emphasis"><em>r</em></span> registers
 via <span class="emphasis"><em>rreg1</em></span>, and <span class="emphasis"><em>smode</em></span>
 sets <span class="emphasis"><em>mode</em></span> to 1 in order to
 select <span class="emphasis"><em>s</em></span> registers. As is described in
-<a class="xref" href="sleigh_context.html#sleigh_local_change" title="8.2. Local Context Change">Section 8.2, &#8220;Local Context Change&#8221;</a>, these assignments by themselves
+<a class="xref" href="sleigh_context.html#sleigh_local_change" title="8.2.Â Local Context Change">SectionÂ 8.2, â€œLocal Context Changeâ€</a>, these assignments by themselves
 cause only a local context change.  However, the
 subsequent <span class="bold"><strong>globalset</strong></span> directives make
 the change persist outside of the the instructions
@@ -276,7 +276,7 @@ of <span class="emphasis"><em>mode</em></span> begins at the next address.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_contextflow"></a>8.3.1. Context Flow</h4></div></div></div>
+<a name="sleigh_contextflow"></a>8.3.1.Â Context Flow</h4></div></div></div>
 <p>
 A global change to context that affects instruction decoding is typically
 open-ended. I.e. once the mode switching instruction is executed, a permanent change
@@ -290,7 +290,7 @@ is encountered.
 </p>
 <p>
 Flow following behavior can be overridden by adding the <span class="bold"><strong>noflow</strong></span>
-attribute to the definition of the context field. (See <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4. Context Variables">Section 6.4, &#8220;Context Variables&#8221;</a>)
+attribute to the definition of the context field. (See <a class="xref" href="sleigh_tokens.html#sleigh_context_variables" title="6.4.Â Context Variables">SectionÂ 6.4, â€œContext Variablesâ€</a>)
 In this case, a <span class="bold"><strong>globalset</strong></span> directive only affects the context
 of a single instruction at the specified address. Subsequent instructions
 retain their original context. This can be useful in a variety of situations but is typically
@@ -348,15 +348,15 @@ end and what to do if there are conflicts.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_constructors.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_ref.html">Next</a>
+<a accesskey="p" href="sleigh_constructors.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_ref.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">7. Constructors </td>
+<td width="40%" align="left" valign="top">7.Â ConstructorsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 9. P-code Tables</td>
+<td width="40%" align="right" valign="top">Â 9.Â P-code Tables</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_definitions.html
+++ b/GhidraDocs/languages/html/sleigh_definitions.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>4. Basic Definitions</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>4.Â Basic Definitions</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_preprocessing.html" title="3. Preprocessing">
-<link rel="next" href="sleigh_symbols.html" title="5. Introduction to Symbols">
+<link rel="prev" href="sleigh_preprocessing.html" title="3.Â Preprocessing">
+<link rel="next" href="sleigh_symbols.html" title="5.Â Introduction to Symbols">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">4. Basic Definitions</th></tr>
+<tr><th colspan="3" align="center">4.Â Basic Definitions</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_preprocessing.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_symbols.html">Next</a>
+<a accesskey="p" href="sleigh_preprocessing.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_symbols.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,15 +26,15 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_definitions"></a>4. Basic Definitions</h2></div></div></div>
+<a name="sleigh_definitions"></a>4.Â Basic Definitions</h2></div></div></div>
 <p>
 SLEIGH files must start with all the definitions needed by the rest of
 the specification. All definition statements start with the keyword
-<span class="bold"><strong>define</strong></span> and end with a semicolon &#8216;;&#8217;.
+<span class="bold"><strong>define</strong></span> and end with a semicolon â€˜;â€™.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_endianess_definition"></a>4.1. Endianess Definition</h3></div></div></div>
+<a name="sleigh_endianess_definition"></a>4.1.Â Endianess Definition</h3></div></div></div>
 <p>
 The first definition in any SLEIGH specification must be for endianess. Either
 </p>
@@ -46,7 +46,7 @@ define endian=little;
 This defines how the processor interprets contiguous sequences of
 bytes as integers or other values and globally affects values across
 all address spaces. It also affects how integer fields
-within an instruction are interpreted, (see <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1. Defining Tokens and Fields">Section 6.1, &#8220;Defining Tokens and Fields&#8221;</a>),
+within an instruction are interpreted, (see <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1.Â Defining Tokens and Fields">SectionÂ 6.1, â€œDefining Tokens and Fieldsâ€</a>),
 although it is possible to override this setting in the rare case that endianess is
 different for data versus instruction encoding.
 The specification designer generally only needs to worry about
@@ -56,7 +56,7 @@ otherwise the specification language hides endianess issues.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_alignment_definition"></a>4.2. Alignment Definition</h3></div></div></div>
+<a name="sleigh_alignment_definition"></a>4.2.Â Alignment Definition</h3></div></div></div>
 <p>
 An alignment definition looks like
 </p>
@@ -73,7 +73,7 @@ instruction as an error.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_space_definitions"></a>4.3. Space Definitions</h3></div></div></div>
+<a name="sleigh_space_definitions"></a>4.3.Â Space Definitions</h3></div></div></div>
 <p>
 The definition of an address space looks like
 </p>
@@ -115,7 +115,7 @@ and store from dynamic pointers into the space.
 </p>
 <p>
 A space of type <span class="bold"><strong>register_space</strong></span> is
-intended to model the processor&#8217;s general-purpose registers. In terms
+intended to model the processorâ€™s general-purpose registers. In terms
 of accessing and manipulating data within the space, SLEIGH and p-code
 make no distinction between the
 type <span class="bold"><strong>ram_space</strong></span> or the
@@ -157,8 +157,8 @@ At least one space needs to be labeled with
 the <span class="bold"><strong>default</strong></span> attribute. This should be
 the space that the processor accesses with its main address bus. In
 terms of the rest of the specification file, this sets the default
-space referred to by the &#8216;*&#8217; operator (see
-<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2. The '*' Operator">Section 7.7.1.2, &#8220;The '*' Operator&#8221;</a>). It also has meaning to
+space referred to by the â€˜*â€™ operator (see
+<a class="xref" href="sleigh_constructors.html#sleigh_star_operator" title="7.7.1.2.Â The '*' Operator">SectionÂ 7.7.1.2, â€œThe '*' Operatorâ€</a>). It also has meaning to
 GHIDRA.
 </p>
 <p>
@@ -184,7 +184,7 @@ bits).
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_naming_registers"></a>4.4. Naming Registers</h3></div></div></div>
+<a name="sleigh_naming_registers"></a>4.4.Â Naming Registers</h3></div></div></div>
 <p>
 The general purpose registers of the processors can be named with the
 following define syntax:
@@ -194,8 +194,8 @@ define <span class="bold"><strong>spacename</strong></span> offset=<span class="
 </pre></div>
 <p>
 A <span class="emphasis"><em>stringlist</em></span> is either a single string or a white
-space separated list of strings in square brackets &#8216;[&#8217; and &#8216;]&#8217;. A
-string of just &#8220;_&#8221; indicates a skip in the sequence for that
+space separated list of strings in square brackets â€˜[â€™ and â€˜]â€™. A
+string of just â€œ_â€ indicates a skip in the sequence for that
 definition. The offset corresponding to that position in the list of
 names will not have a varnode defined at it.
 </p>
@@ -228,7 +228,7 @@ define register offset=0 size=1
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_bitrange_registers"></a>4.5. Bit Range Registers</h3></div></div></div>
+<a name="sleigh_bitrange_registers"></a>4.5.Â Bit Range Registers</h3></div></div></div>
 <p>
 Many processors define registers that either consist of a single bit
 or otherwise don't use an integral number of bytes. A recurring
@@ -245,7 +245,7 @@ models because the smallest object they can manipulate directly is a
 byte. In order to manipulate single bits, p-code must use a
 combination of bitwise logical, extension, and truncation
 operations. So a register defined as a bit range is not really a
-varnode as described in <a class="xref" href="sleigh.html#sleigh_varnodes" title="1.2. Varnodes">Section 1.2, &#8220;Varnodes&#8221;</a>, but is
+varnode as described in <a class="xref" href="sleigh.html#sleigh_varnodes" title="1.2.Â Varnodes">SectionÂ 1.2, â€œVarnodesâ€</a>, but is
 really just a signal to the SLEIGH compiler to fill in the proper
 operators to simulate the bit manipulation. Using this feature may
 greatly increase the complexity of the compiled specification with
@@ -265,7 +265,7 @@ register. In this example, <span class="emphasis"><em>statusreg</em></span> is d
 first as a 4 byte register, and the bit registers themselves are built
 by the following <span class="bold"><strong>define bitrange</strong></span>
 statement. A single bit register definition consists of an identifier
-for the register, followed by &#8216;=&#8217;, then the name of the register
+for the register, followed by â€˜=â€™, then the name of the register
 containing the bits, and finally a pair of numbers in square
 brackets. The first number indicates the lowest significant bit in the
 containing register of the bit range, where bit 0 is the least
@@ -282,11 +282,11 @@ bit of <span class="emphasis"><em>statusreg</em></span> respectively.
 <p>
 The syntax for defining a new bit register is consistent with the
 pseudo bit range operator, described in
-<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5. Bit Range Operator">Section 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>, and the resulting symbol
+<a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5.Â Bit Range Operator">SectionÂ 7.7.1.5, â€œBit Range Operatorâ€</a>, and the resulting symbol
 is really just a placeholder for this operator. Whenever SLEIGH sees
 this symbol it generates p-code precisely as if the designer had used
 the bit range operator
-instead. <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5. Bit Range Operator">Section 7.7.1.5, &#8220;Bit Range Operator&#8221;</a>, provides some
+instead. <a class="xref" href="sleigh_constructors.html#sleigh_bitrange_operator" title="7.7.1.5.Â Bit Range Operator">SectionÂ 7.7.1.5, â€œBit Range Operatorâ€</a>, provides some
 additional details about how p-code is generated, which apply to the
 use of bit range registers.
 </p>
@@ -299,14 +299,14 @@ used as an alternate syntax for defining overlapping registers.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_userdefined_operations"></a>4.6. User-Defined Operations</h3></div></div></div>
+<a name="sleigh_userdefined_operations"></a>4.6.Â User-Defined Operations</h3></div></div></div>
 <p>
 The specification designer can define new p-code operations using
 a <span class="bold"><strong>define pcodeop</strong></span> statement.  This
 statement automatically reserves an internal form for the new p-code
 operation and associates an identifier with it. This identifier can
 then be used in semantic expressions (see
-<a class="xref" href="sleigh_constructors.html#sleigh_userdef_op" title="7.7.1.8. User-Defined Operations">Section 7.7.1.8, &#8220;User-Defined Operations&#8221;</a>).  The following example defines a
+<a class="xref" href="sleigh_constructors.html#sleigh_userdef_op" title="7.7.1.8.Â User-Defined Operations">SectionÂ 7.7.1.8, â€œUser-Defined Operationsâ€</a>).  The following example defines a
 new p-code operation <span class="emphasis"><em>arctan</em></span>.
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -338,15 +338,15 @@ actions that are too esoteric or too complicated to implement.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_preprocessing.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_symbols.html">Next</a>
+<a accesskey="p" href="sleigh_preprocessing.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_symbols.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">3. Preprocessing </td>
+<td width="40%" align="left" valign="top">3.Â PreprocessingÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 5. Introduction to Symbols</td>
+<td width="40%" align="right" valign="top">Â 5.Â Introduction to Symbols</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_layout.html
+++ b/GhidraDocs/languages/html/sleigh_layout.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>2.�Basic Specification Layout</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>2. Basic Specification Layout</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
 <link rel="prev" href="sleigh.html" title="SLEIGH">
-<link rel="next" href="sleigh_preprocessing.html" title="3.�Preprocessing">
+<link rel="next" href="sleigh_preprocessing.html" title="3. Preprocessing">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">2.�Basic Specification Layout</th></tr>
+<tr><th colspan="3" align="center">2. Basic Specification Layout</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh.html">Prev</a>�</td>
-<th width="60%" align="center">�</th>
-<td width="20%" align="right">�<a accesskey="n" href="sleigh_preprocessing.html">Next</a>
+<a accesskey="p" href="sleigh.html">Prev</a> </td>
+<th width="60%" align="center"> </th>
+<td width="20%" align="right"> <a accesskey="n" href="sleigh_preprocessing.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,51 +26,51 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_layout"></a>2.�Basic Specification Layout</h2></div></div></div>
+<a name="sleigh_layout"></a>2. Basic Specification Layout</h2></div></div></div>
 <p>
 A SLEIGH specification is typically contained in a single file,
-although see <a class="xref" href="sleigh_preprocessing.html#sleigh_including_files" title="3.1.�Including Files">Section�3.1, &#8220;Including Files&#8221;</a>.  The file must
+although see <a class="xref" href="sleigh_preprocessing.html#sleigh_including_files" title="3.1. Including Files">Section 3.1, “Including Files”</a>.  The file must
 follow a specific format as parsed by the SLEIGH compiler. In this
 section, we list the basic formatting rules for this file as enforced
 by the compiler.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_comments"></a>2.1.�Comments</h3></div></div></div>
+<a name="sleigh_comments"></a>2.1. Comments</h3></div></div></div>
 <p>
-Comments start with the &#8216;#&#8217; character and continue to the end of the
+Comments start with the ‘#’ character and continue to the end of the
 line. Comments can appear anywhere except the <span class="emphasis"><em>display section</em></span> of a
-constructor (see <a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3.�The Display Section">Section�7.3, &#8220;The Display Section&#8221;</a>) where the &#8216;#&#8217; character will be
+constructor (see <a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3. The Display Section">Section 7.3, “The Display Section”</a>) where the ‘#’ character will be
 interpreted as something that should be printed in disassembly.
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_identifiers"></a>2.2.�Identifiers</h3></div></div></div>
+<a name="sleigh_identifiers"></a>2.2. Identifiers</h3></div></div></div>
 <p>
 Identifiers are made up of letters a-z, capitals A-Z, digits 0-9 and
-the characters &#8216;.&#8217; and &#8216;_&#8217;. An identifier can use these characters in
+the characters ‘.’ and ‘_’. An identifier can use these characters in
 any order and for any length, but it must not start with a digit.
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_strings"></a>2.3.�Strings</h3></div></div></div>
+<a name="sleigh_strings"></a>2.3. Strings</h3></div></div></div>
 <p>
 String literals can be used, when specifying names and when specifying
 how disassembly should be printed, so that special characters are
 treated as literals. Strings are surrounded by the double quote
-character &#8216;&#8221;&#8217; and all characters in between lose their special
+character ‘”’ and all characters in between lose their special
 meaning.
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_integers"></a>2.4.�Integers</h3></div></div></div>
+<a name="sleigh_integers"></a>2.4. Integers</h3></div></div></div>
 <p>
 Integers are specified either in a decimal format or in a standard
 <span class="emphasis"><em>C-style</em></span> hexadecimal format by prepending the
-number with &#8220;0x&#8221;. Alternately, a binary representation of an integer
+number with “0x”. Alternately, a binary representation of an integer
 can be given by prepending the string of '0' and '1' characters with "0b".
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -82,21 +82,21 @@ can be given by prepending the string of '0' and '1' characters with "0b".
 <p>
 Numbers are treated as unsigned
 except when used in patterns where they are treated as signed (see
-<a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4.�The Bit Pattern Section">Section�7.4, &#8220;The Bit Pattern Section&#8221;</a>). The number of bytes used to
+<a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4. The Bit Pattern Section">Section 7.4, “The Bit Pattern Section”</a>). The number of bytes used to
 encode the integer when specifying the semantics of an instruction is
 inferred from other parts of the syntax (see
-<a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3.�The Display Section">Section�7.3, &#8220;The Display Section&#8221;</a>). Otherwise, integers should
+<a class="xref" href="sleigh_constructors.html#sleigh_display_section" title="7.3. The Display Section">Section 7.3, “The Display Section”</a>). Otherwise, integers should
 be thought of as having arbitrary precision. Currently, SLEIGH stores
 integers internally with 64 bits of precision.
 </p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_white_space"></a>2.5.�White Space</h3></div></div></div>
+<a name="sleigh_white_space"></a>2.5. White Space</h3></div></div></div>
 <p>
 White space characters include space, tab, line-feed, vertical
-line-feed, and carriage-return (&#8216; &#8216;, &#8216;\t&#8217;, &#8216;\r&#8217;, &#8216;\v&#8217;,
-&#8216;\n&#8217;). Variations in spacing have no effect on the parsing of the file
+line-feed, and carriage-return (‘ ‘, ‘\t’, ‘\r’, ‘\v’,
+‘\n’). Variations in spacing have no effect on the parsing of the file
 except in string literals.
 </p>
 </div>
@@ -106,15 +106,15 @@ except in string literals.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh.html">Prev</a>�</td>
-<td width="20%" align="center">�</td>
-<td width="40%" align="right">�<a accesskey="n" href="sleigh_preprocessing.html">Next</a>
+<a accesskey="p" href="sleigh.html">Prev</a> </td>
+<td width="20%" align="center"> </td>
+<td width="40%" align="right"> <a accesskey="n" href="sleigh_preprocessing.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">SLEIGH�</td>
+<td width="40%" align="left" valign="top">SLEIGH </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top">�3.�Preprocessing</td>
+<td width="40%" align="right" valign="top"> 3. Preprocessing</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_preprocessing.html
+++ b/GhidraDocs/languages/html/sleigh_preprocessing.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>3.�Preprocessing</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>3. Preprocessing</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_layout.html" title="2.�Basic Specification Layout">
-<link rel="next" href="sleigh_definitions.html" title="4.�Basic Definitions">
+<link rel="prev" href="sleigh_layout.html" title="2. Basic Specification Layout">
+<link rel="next" href="sleigh_definitions.html" title="4. Basic Definitions">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">3.�Preprocessing</th></tr>
+<tr><th colspan="3" align="center">3. Preprocessing</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_layout.html">Prev</a>�</td>
-<th width="60%" align="center">�</th>
-<td width="20%" align="right">�<a accesskey="n" href="sleigh_definitions.html">Next</a>
+<a accesskey="p" href="sleigh_layout.html">Prev</a> </td>
+<th width="60%" align="center"> </th>
+<td width="20%" align="right"> <a accesskey="n" href="sleigh_definitions.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,16 +26,16 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_preprocessing"></a>3.�Preprocessing</h2></div></div></div>
+<a name="sleigh_preprocessing"></a>3. Preprocessing</h2></div></div></div>
 <p>
 SLEIGH provides support for simple file inclusion, macros, and other
 basic preprocessing functions.  These are all invoked with directives
-that start with the &#8216;@&#8217; character, which must be the first character
+that start with the ‘@’ character, which must be the first character
 in the line.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_including_files"></a>3.1.�Including Files</h3></div></div></div>
+<a name="sleigh_including_files"></a>3.1. Including Files</h3></div></div></div>
 <p>
 In general a single SLEIGH specification is contained in a single
 file, and the compiler is invoked on one file at a time. Multiple
@@ -54,7 +54,7 @@ own <span class="bold"><strong>@include</strong></span> directives.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_preprocessor_macros"></a>3.2.�Preprocessor Macros</h3></div></div></div>
+<a name="sleigh_preprocessor_macros"></a>3.2. Preprocessor Macros</h3></div></div></div>
 <p>
 SLEIGH allows simple (unparameterized) macro definitions and
 expansions. A macro definition occurs on one line and starts with
@@ -62,7 +62,7 @@ the <span class="bold"><strong>@define</strong></span> directive. This is
 followed by an identifier for the macro and then a string to which the
 macro should expand. The string must either be a proper identifier
 itself or surrounded with double quotes. The macro can then be
-expanded with typical &#8220;$(identifier)&#8221; syntax at any other point in the
+expanded with typical “$(identifier)” syntax at any other point in the
 specification following the definition.
 </p>
 <div class="informalexample"><pre class="programlisting">
@@ -72,9 +72,9 @@ define endian=$(ENDIAN);
 </pre></div>
 <p>
 This example defines a macro identified as <span class="emphasis"><em>ENDIAN</em></span>
-with the string &#8220;big&#8221;, and then expands the macro in a later SLEIGH
+with the string “big”, and then expands the macro in a later SLEIGH
 statement. Macro definitions can also be made from the command line
-and in the &#8220;.spec&#8221; file, allowing multiple specification variations to
+and in the “.spec” file, allowing multiple specification variations to
 be derived from one file. SLEIGH also has
 an <span class="bold"><strong>@undef</strong></span> directive which removes the
 definition of a macro from that point on in the file.
@@ -85,7 +85,7 @@ definition of a macro from that point on in the file.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_conditional_compilation"></a>3.3.�Conditional Compilation</h3></div></div></div>
+<a name="sleigh_conditional_compilation"></a>3.3. Conditional Compilation</h3></div></div></div>
 <p>
 SLEIGH supports several directives that allow conditional inclusion of
 parts of a specification, based on the existence of a macro, or its
@@ -103,7 +103,7 @@ and <span class="bold"><strong>@endif</strong></span>.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_ifdef"></a>3.3.1.�@ifdef and @ifndef</h4></div></div></div>
+<a name="sleigh_ifdef"></a>3.3.1. @ifdef and @ifndef</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@ifdef</strong></span> directive is followed by a
 macro identifier and evaluates to true if the macro is defined.
@@ -129,14 +129,14 @@ or <span class="bold"><strong>@elif</strong></span> directive (See below).
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_if"></a>3.3.2.�@if</h4></div></div></div>
+<a name="sleigh_if"></a>3.3.2. @if</h4></div></div></div>
 <p>
 The <span class="bold"><strong>@if</strong></span> directive is followed by a
 boolean expression with macros as the variables and strings as the
 constants. Comparisons between macros and strings are currently
 limited to string equality or inequality. But individual comparisons
 can be combined arbitrarily using parentheses and the boolean
-operators &#8216;&amp;&amp;&#8217;, &#8216;||&#8217;, and &#8216;^^&#8217;. These represent a <span class="emphasis"><em>logical
+operators ‘&amp;&amp;’, ‘||’, and ‘^^’. These represent a <span class="emphasis"><em>logical
 and</em></span>, a <span class="emphasis"><em>logical or</em></span>, and
 a <span class="emphasis"><em>logical exclusive-or</em></span> operation respectively. It
 is possible to test whether a particular macro is defined within the
@@ -158,7 +158,7 @@ is defined.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_else"></a>3.3.3.�@else and @elif</h4></div></div></div>
+<a name="sleigh_else"></a>3.3.3. @else and @elif</h4></div></div></div>
 <p>
 An <span class="bold"><strong>@else</strong></span> directive splits the lines
 bounded by an <span class="bold"><strong>@if</strong></span> directive and
@@ -180,12 +180,12 @@ one <span class="bold"><strong>@else</strong></span>, which must occur after all
 the <span class="bold"><strong>@elif</strong></span> directives.
 </p>
 <div class="informalexample"><pre class="programlisting">
-@if PROCESSOR == &#8220;mips&#8221;
-@ define ENDIAN &#8220;big&#8221;
-@elif ((PROCESSOR==&#8221;x86&#8221;)&amp;&amp;(OS!=&#8221;win&#8221;))
-@ define ENDIAN &#8220;little&#8221;
+@if PROCESSOR == “mips”
+@ define ENDIAN “big”
+@elif ((PROCESSOR==”x86”)&amp;&amp;(OS!=”win”))
+@ define ENDIAN “little”
 @else
-@ define ENDIAN &#8220;unknown&#8221;
+@ define ENDIAN “unknown”
 @endif
 </pre></div>
 <p>
@@ -198,15 +198,15 @@ the <span class="bold"><strong>@elif</strong></span> directives.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_layout.html">Prev</a>�</td>
-<td width="20%" align="center">�</td>
-<td width="40%" align="right">�<a accesskey="n" href="sleigh_definitions.html">Next</a>
+<a accesskey="p" href="sleigh_layout.html">Prev</a> </td>
+<td width="20%" align="center"> </td>
+<td width="40%" align="right"> <a accesskey="n" href="sleigh_definitions.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">2.�Basic Specification Layout�</td>
+<td width="40%" align="left" valign="top">2. Basic Specification Layout </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top">�4.�Basic Definitions</td>
+<td width="40%" align="right" valign="top"> 4. Basic Definitions</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_ref.html
+++ b/GhidraDocs/languages/html/sleigh_ref.html
@@ -1,34 +1,34 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>9. P-code Tables</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>9.Â P-code Tables</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_context.html" title="8. Using Context">
+<link rel="prev" href="sleigh_context.html" title="8.Â Using Context">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">9. P-code Tables</th></tr>
+<tr><th colspan="3" align="center">9.Â P-code Tables</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_context.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> </td>
+<a accesskey="p" href="sleigh_context.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â </td>
 </tr>
 </table>
 <hr>
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_ref"></a>9. P-code Tables</h2></div></div></div>
+<a name="sleigh_ref"></a>9.Â P-code Tables</h2></div></div></div>
 <p>
 We list all the p-code operations by name along with the syntax for
 invoking them within the semantic section of a constructor definition
-(see <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7. The Semantic Section">Section 7.7, &#8220;The Semantic Section&#8221;</a>), and with a
+(see <a class="xref" href="sleigh_constructors.html#sleigh_semantic_section" title="7.7.Â The Semantic Section">SectionÂ 7.7, â€œThe Semantic Sectionâ€</a>), and with a
 description of the operator. The terms <span class="emphasis"><em>v0</em></span>
 and <span class="emphasis"><em>v1</em></span> represent identifiers of individual input
 varnodes to the operation. In terms of syntax, <span class="emphasis"><em>v0</em></span>
@@ -46,7 +46,7 @@ to lowest.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="syntaxref.htmltable"></a><p class="title"><b>Table 5. Semantic Expression Operators and Syntax</b></p>
+<a name="syntaxref.htmltable"></a><p class="title"><b>TableÂ 5.Â Semantic Expression Operators and Syntax</b></p>
 <div class="table-contents"><table xml:id="syntaxref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
@@ -459,7 +459,7 @@ The following table lists the basic forms of a semantic statement.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="statementref.htmltable"></a><p class="title"><b>Table 6. Basic Statements and Associated Operators</b></p>
+<a name="statementref.htmltable"></a><p class="title"><b>TableÂ 6.Â Basic Statements and Associated Operators</b></p>
 <div class="table-contents"><table xml:id="statementref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
@@ -538,7 +538,7 @@ The following table lists the branching operations and the statements which invo
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="branchref.htmltable"></a><p class="title"><b>Table 7. Branching Statements</b></p>
+<a name="branchref.htmltable"></a><p class="title"><b>TableÂ 7.Â Branching Statements</b></p>
 <div class="table-contents"><table xml:id="branchref.htmltable" width="95%" frame="box" rules="all">
 <col width="25%">
 <col width="25%">
@@ -592,14 +592,14 @@ The following table lists the branching operations and the statements which invo
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_context.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> </td>
+<a accesskey="p" href="sleigh_context.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">8. Using Context </td>
+<td width="40%" align="left" valign="top">8.Â Using ContextÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> </td>
+<td width="40%" align="right" valign="top">Â </td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_symbols.html
+++ b/GhidraDocs/languages/html/sleigh_symbols.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>5. Introduction to Symbols</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>5.Â Introduction to Symbols</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_definitions.html" title="4. Basic Definitions">
-<link rel="next" href="sleigh_tokens.html" title="6. Tokens and Fields">
+<link rel="prev" href="sleigh_definitions.html" title="4.Â Basic Definitions">
+<link rel="next" href="sleigh_tokens.html" title="6.Â Tokens and Fields">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">5. Introduction to Symbols</th></tr>
+<tr><th colspan="3" align="center">5.Â Introduction to Symbols</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_definitions.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_tokens.html">Next</a>
+<a accesskey="p" href="sleigh_definitions.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_tokens.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,7 +26,7 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_symbols"></a>5. Introduction to Symbols</h2></div></div></div>
+<a name="sleigh_symbols"></a>5.Â Introduction to Symbols</h2></div></div></div>
 <p>
 After the definition section, we are prepared to start writing the
 body of the specification. This part of the specification shows how
@@ -61,7 +61,7 @@ Formally a <span class="emphasis"><em>Specific Symbol</em></span> is defined as 
 <p>
 The named registers that we defined earlier are the simplest examples
 of specific symbols (see
-<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4. Naming Registers">Section 4.4, &#8220;Naming Registers&#8221;</a>). The symbol identifier
+<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4.Â Naming Registers">SectionÂ 4.4, â€œNaming Registersâ€</a>). The symbol identifier
 itself is the string that will get printed in disassembly and the
 varnode associated with the symbol is the one constructed by the
 define statement.
@@ -79,7 +79,7 @@ instructions to specific symbols.
 <p>
 The set of instruction encodings that map to a single specific symbol
 is called an <span class="emphasis"><em>instruction pattern</em></span> and is described
-more fully in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4. The Bit Pattern Section">Section 7.4, &#8220;The Bit Pattern Section&#8221;</a>. In most cases, this
+more fully in <a class="xref" href="sleigh_constructors.html#sleigh_bit_pattern" title="7.4.Â The Bit Pattern Section">SectionÂ 7.4, â€œThe Bit Pattern Sectionâ€</a>. In most cases, this
 can be thought of as a mask on the bits of the instruction and a value
 that the remaining unmasked bits must match. At any rate, the family
 symbol identifier, when taken out of context, represents the entire
@@ -98,14 +98,14 @@ that simulate the instruction.
 <p>
 The symbol responsible for combining smaller family symbols is called
 a <span class="emphasis"><em>table</em></span>, which is fully described in
-<a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8. Tables">Section 7.8, &#8220;Tables&#8221;</a>. Any <span class="emphasis"><em>table</em></span> symbol
+<a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8.Â Tables">SectionÂ 7.8, â€œTablesâ€</a>. Any <span class="emphasis"><em>table</em></span> symbol
 can be used in the definition of other <span class="emphasis"><em>table</em></span>
 symbols until the root symbol is fully described. The root symbol has
 the predefined identifier <span class="emphasis"><em>instruction</em></span>.
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_notes_namespaces"></a>5.1. Notes on Namespaces</h3></div></div></div>
+<a name="sleigh_notes_namespaces"></a>5.1.Â Notes on Namespaces</h3></div></div></div>
 <p>
 Almost all identifiers live in the same global "scope". The global scope includes
 </p>
@@ -126,15 +126,15 @@ Almost all identifiers live in the same global "scope". The global scope include
   Names of registers
   </li>
 <li class="listitem" style="list-style-type: disc">
-  Names of macros (see <a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9. P-code Macros">Section 7.9, &#8220;P-code Macros&#8221;</a>)
+  Names of macros (see <a class="xref" href="sleigh_constructors.html#sleigh_macros" title="7.9.Â P-code Macros">SectionÂ 7.9, â€œP-code Macrosâ€</a>)
   </li>
 <li class="listitem" style="list-style-type: disc">
-  Names of tables (see <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8. Tables">Section 7.8, &#8220;Tables&#8221;</a>)
+  Names of tables (see <a class="xref" href="sleigh_constructors.html#sleigh_tables" title="7.8.Â Tables">SectionÂ 7.8, â€œTablesâ€</a>)
   </li>
 </ul></div></div>
 <p>
 All of the names in this scope must be unique. Each
-individual <span class="emphasis"><em>constructor</em></span> (defined in <a class="xref" href="sleigh_constructors.html" title="7. Constructors">Section 7, &#8220;Constructors&#8221;</a>)
+individual <span class="emphasis"><em>constructor</em></span> (defined in <a class="xref" href="sleigh_constructors.html" title="7.Â Constructors">SectionÂ 7, â€œConstructorsâ€</a>)
 defines a local scope for operand names. As with most languages, a
 local symbol with the same name as a global
 symbol <span class="emphasis"><em>hides</em></span> the global symbol while that scope
@@ -143,13 +143,13 @@ is in effect.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_predefined_symbols"></a>5.2. Predefined Symbols</h3></div></div></div>
+<a name="sleigh_predefined_symbols"></a>5.2.Â Predefined Symbols</h3></div></div></div>
 <p>
 We list all of the symbols that are predefined by SLEIGH.
 </p>
 <div class="informalexample">
 <div class="table">
-<a name="predefine.htmltable"></a><p class="title"><b>Table 2. Predefined Symbols</b></p>
+<a name="predefine.htmltable"></a><p class="title"><b>TableÂ 2.Â Predefined Symbols</b></p>
 <div class="table-contents"><table xml:id="predefine.htmltable" width="80%" frame="box" rules="all">
 <col width="30%">
 <col width="70%">
@@ -213,15 +213,15 @@ is the root instruction table.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_definitions.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_tokens.html">Next</a>
+<a accesskey="p" href="sleigh_definitions.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_tokens.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">4. Basic Definitions </td>
+<td width="40%" align="left" valign="top">4.Â Basic DefinitionsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 6. Tokens and Fields</td>
+<td width="40%" align="right" valign="top">Â 6.Â Tokens and Fields</td>
 </tr>
 </table>
 </div>

--- a/GhidraDocs/languages/html/sleigh_tokens.html
+++ b/GhidraDocs/languages/html/sleigh_tokens.html
@@ -1,24 +1,24 @@
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>6. Tokens and Fields</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>6.Â Tokens and Fields</title>
 <link rel="stylesheet" type="text/css" href="DefaultStyle.css">
 <link rel="stylesheet" type="text/css" href="languages.css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
+<meta name="generator" content="DocBook XSL Stylesheets Vsnapshot">
 <link rel="home" href="sleigh.html" title="SLEIGH">
 <link rel="up" href="sleigh.html" title="SLEIGH">
-<link rel="prev" href="sleigh_symbols.html" title="5. Introduction to Symbols">
-<link rel="next" href="sleigh_constructors.html" title="7. Constructors">
+<link rel="prev" href="sleigh_symbols.html" title="5.Â Introduction to Symbols">
+<link rel="next" href="sleigh_constructors.html" title="7.Â Constructors">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
 <div class="navheader">
 <table width="100%" summary="Navigation header">
-<tr><th colspan="3" align="center">6. Tokens and Fields</th></tr>
+<tr><th colspan="3" align="center">6.Â Tokens and Fields</th></tr>
 <tr>
 <td width="20%" align="left">
-<a accesskey="p" href="sleigh_symbols.html">Prev</a> </td>
-<th width="60%" align="center"> </th>
-<td width="20%" align="right"> <a accesskey="n" href="sleigh_constructors.html">Next</a>
+<a accesskey="p" href="sleigh_symbols.html">Prev</a>Â </td>
+<th width="60%" align="center">Â </th>
+<td width="20%" align="right">Â <a accesskey="n" href="sleigh_constructors.html">Next</a>
 </td>
 </tr>
 </table>
@@ -26,10 +26,10 @@
 </div>
 <div class="sect1">
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
-<a name="sleigh_tokens"></a>6. Tokens and Fields</h2></div></div></div>
+<a name="sleigh_tokens"></a>6.Â Tokens and Fields</h2></div></div></div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_defining_tokens"></a>6.1. Defining Tokens and Fields</h3></div></div></div>
+<a name="sleigh_defining_tokens"></a>6.1.Â Defining Tokens and Fields</h3></div></div></div>
 <p>
 A <span class="emphasis"><em>token</em></span> is one of the byte-sized pieces that make
 up the machine code instructions being modeled.
@@ -57,7 +57,7 @@ field and the range of bits within the token making up the field. The
 size of a field does <span class="emphasis"><em>not</em></span> need to be a multiple of
 8. The range is inclusive where the least significant bit in the token
 is labeled 0. When defining tokens that are bigger than 1 byte, the
-global endianess setting (See <a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1. Endianess Definition">Section 4.1, &#8220;Endianess Definition&#8221;</a>)
+global endianess setting (See <a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1.Â Endianess Definition">SectionÂ 4.1, â€œEndianess Definitionâ€</a>)
 will affect this labeling. Although it is rarely required, it is possible to override
 the global endianess setting for a specific token by appending either the qualifier
 <span class="bold"><strong>endian=little</strong></span> or <span class="bold"><strong>endian=big</strong></span>
@@ -88,11 +88,11 @@ different names.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_fields_family"></a>6.2. Fields as Family Symbols</h3></div></div></div>
+<a name="sleigh_fields_family"></a>6.2.Â Fields as Family Symbols</h3></div></div></div>
 <p>
 Fields are the most basic form of family symbol; they define a natural
 map from instruction bits to a specific symbol as follows. We take the
-set of bits within the instruction as given by the field&#8217;s defining
+set of bits within the instruction as given by the fieldâ€™s defining
 range and treat them as an integer encoding. The resulting integer is
 both the display portion and the semantic meaning of the specific
 symbol. The display string is obtained by converting the integer into
@@ -113,7 +113,7 @@ the <span class="bold"><strong>dec</strong></span> attribute is not supported]
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_alternate_meanings"></a>6.3. Attaching Alternate Meanings to Fields</h3></div></div></div>
+<a name="sleigh_alternate_meanings"></a>6.3.Â Attaching Alternate Meanings to Fields</h3></div></div></div>
 <p>
 The default interpretation of a field is probably the most natural but
 of course processors interpret fields within an instruction in a wide
@@ -124,7 +124,7 @@ interpretations must be built up out of tables.
 </p>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_attaching_registers"></a>6.3.1. Attaching Registers</h4></div></div></div>
+<a name="sleigh_attaching_registers"></a>6.3.1.Â Attaching Registers</h4></div></div></div>
 <p>
 Probably <span class="emphasis"><em>the</em></span> most common processor interpretation
 of a field is as an encoding of a particular register. In SLEIGH this
@@ -140,7 +140,7 @@ space separated list of field identifiers surrounded by square
 brackets. A <span class="emphasis"><em>registerlist</em></span> must be a square bracket
 surrounded and space separated list of register identifiers as created
 with <span class="bold"><strong>define</strong></span> statements (see Section
-<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4. Naming Registers">Section 4.4, &#8220;Naming Registers&#8221;</a>). For each field in
+<a class="xref" href="sleigh_definitions.html#sleigh_naming_registers" title="4.4.Â Naming Registers">SectionÂ 4.4, â€œNaming Registersâ€</a>). For each field in
 the <span class="emphasis"><em>fieldlist</em></span>, instead of having the display and
 semantic meaning of an integer, the field becomes a look-up table for
 the given list of registers. The original integer interpretation is
@@ -152,7 +152,7 @@ display and semantic meaning of the field are now taken from the new
 register.
 </p>
 <p>
-A particular integer can remain unspecified by putting a &#8216;_&#8217; character
+A particular integer can remain unspecified by putting a â€˜_â€™ character
 in the appropriate position of the register list or also if the length
 of the register list is less than the integer. A specific integer
 encoding of the field that is unspecified like this
@@ -163,7 +163,7 @@ of the instruction.
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_attaching_integers"></a>6.3.2. Attaching Other Integers</h4></div></div></div>
+<a name="sleigh_attaching_integers"></a>6.3.2.Â Attaching Other Integers</h4></div></div></div>
 <p>
 Sometimes a processor interprets a field as an integer but not the
 integer given by the default interpretation. A different integer
@@ -180,12 +180,12 @@ register interpretation is assigned to fields with
 an <span class="bold"><strong>attach variables</strong></span> statement, the
 integers in the list are assigned to each field specified in
 the <span class="emphasis"><em>fieldlist</em></span>. [Currently SLEIGH does not support
-unspecified positions in the list using a &#8216;_&#8217;]
+unspecified positions in the list using a â€˜_â€™]
 </p>
 </div>
 <div class="sect3">
 <div class="titlepage"><div><div><h4 class="title">
-<a name="sleigh_attaching_names"></a>6.3.3. Attaching Names</h4></div></div></div>
+<a name="sleigh_attaching_names"></a>6.3.3.Â Attaching Names</h4></div></div></div>
 <p>
 It is possible to just modify the display characteristics of a field
 without changing the semantic meaning. The need for this is rare, but
@@ -196,7 +196,7 @@ appropriate to define overlapping fields, one of which is defined to
 have no semantic meaning. The most convenient way to break down the
 required disassembly may not be the most convenient way to break down
 the semantics. It is also possible to have symbols with semantic
-meaning but no display meaning (see <a class="xref" href="sleigh_constructors.html#sleigh_invisible_operands" title="7.4.5. Invisible Operands">Section 7.4.5, &#8220;Invisible Operands&#8221;</a>).
+meaning but no display meaning (see <a class="xref" href="sleigh_constructors.html#sleigh_invisible_operands" title="7.4.5.Â Invisible Operands">SectionÂ 7.4.5, â€œInvisible Operandsâ€</a>).
 </p>
 <p>
 At any rate we can list the display interpretation of a field directly
@@ -218,7 +218,7 @@ encodings.
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_context_variables"></a>6.4. Context Variables</h3></div></div></div>
+<a name="sleigh_context_variables"></a>6.4.Â Context Variables</h3></div></div></div>
 <p>
 SLEIGH supports the concept of <span class="emphasis"><em>context
 variables</em></span>. For the most part processor instructions can be
@@ -254,12 +254,12 @@ By default, globally setting a context variable affects instruction decoding
 from the point of the change, forward,
 following the flow of the instructions, but if the variable is labeled as
 <span class="bold"><strong>noflow</strong></span>, any change is limited to a
-single instruction. (See <a class="xref" href="sleigh_context.html#sleigh_contextflow" title="8.3.1. Context Flow">Section 8.3.1, &#8220;Context Flow&#8221;</a>)
+single instruction. (See <a class="xref" href="sleigh_context.html#sleigh_contextflow" title="8.3.1.Â Context Flow">SectionÂ 8.3.1, â€œContext Flowâ€</a>)
 </p>
 <p>
 Once the context variable is defined, in terms of the specification
 syntax, it can be treated as if it were just another field. See
-<a class="xref" href="sleigh_context.html" title="8. Using Context">Section 8, &#8220;Using Context&#8221;</a>, for a complete discussion of how to
+<a class="xref" href="sleigh_context.html" title="8.Â Using Context">SectionÂ 8, â€œUsing Contextâ€</a>, for a complete discussion of how to
 use context variables.
 </p>
 </div>
@@ -269,15 +269,15 @@ use context variables.
 <table width="100%" summary="Navigation footer">
 <tr>
 <td width="40%" align="left">
-<a accesskey="p" href="sleigh_symbols.html">Prev</a> </td>
-<td width="20%" align="center"> </td>
-<td width="40%" align="right"> <a accesskey="n" href="sleigh_constructors.html">Next</a>
+<a accesskey="p" href="sleigh_symbols.html">Prev</a>Â </td>
+<td width="20%" align="center">Â </td>
+<td width="40%" align="right">Â <a accesskey="n" href="sleigh_constructors.html">Next</a>
 </td>
 </tr>
 <tr>
-<td width="40%" align="left" valign="top">5. Introduction to Symbols </td>
+<td width="40%" align="left" valign="top">5.Â Introduction to SymbolsÂ </td>
 <td width="20%" align="center"><a accesskey="h" href="sleigh.html">Home</a></td>
-<td width="40%" align="right" valign="top"> 7. Constructors</td>
+<td width="40%" align="right" valign="top">Â 7.Â Constructors</td>
 </tr>
 </table>
 </div>


### PR DESCRIPTION
This is a follow-up of #5462. Unlike that PR, this PR fixes the issue in the source files and regenerates the `.html` files. The cause of the issue turned out to be the chunking style defaulting to `ISO-8859-1` encoding. This PR changes the encoding to `UTF-8`, which makes the resulting files easier to edit and the diffs generated by github easier to read.