### PR TITLE
Add no high variable error handling while unwinding stack in SymPcodeExecutor

### DIFF
--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/stack/StackUnwindWarning.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/stack/StackUnwindWarning.java
@@ -25,6 +25,7 @@ import ghidra.program.model.data.DataType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.pcode.PcodeOp;
 import ghidra.program.model.pcode.PcodeOpAST;
+import ghidra.program.model.pcode.VarnodeAST;
 
 /**
  * A warning issued while unwinding a stack
@@ -183,6 +184,17 @@ public interface StackUnwindWarning {
 		@Override
 		public String getMessage() {
 			return "Indirect call target has unexpected type: " + type;
+		}
+	}
+
+	/**
+	 * While analyzing an indirect call, couldn't get the function signature because its input doesn't have a high variable.
+	 */
+	public record NoHighVariableFromTargetPointerTypeUnwindWarning(VarnodeAST vn)
+			implements StackUnwindWarning {
+		@Override
+		public String getMessage() {
+			return "Input of indirect call target has no high variable: " + vn;
 		}
 	}
 

--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/stack/SymPcodeExecutor.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/stack/SymPcodeExecutor.java
@@ -216,7 +216,14 @@ class SymPcodeExecutor extends PcodeExecutor<Sym> {
 	 */
 	protected FunctionSignature getSignatureFromTargetPointerType(PcodeOpAST op) {
 		VarnodeAST target = (VarnodeAST) op.getInput(0);
-		DataType dataType = target.getHigh().getDataType();
+		HighVariable high = target.getHigh();
+		
+		if (high == null) {
+			warnings.add(new NoHighVariableFromTargetPointerTypeUnwindWarning(target));
+			return null;
+		}
+
+		DataType dataType = high.getDataType();
 		if (!(dataType instanceof Pointer ptrType)) {
 			warnings.add(new UnexpectedTargetTypeStackUnwindWarning(dataType));
 			return null;


### PR DESCRIPTION
Apparently caused by unwinding external (imported) functions which are not loaded, solves #5332 