### PR TITLE
fix NPE LocalFileChooserModel

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/LocalFileChooserModel.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/LocalFileChooserModel.java
@@ -260,6 +260,9 @@ public class LocalFileChooserModel implements GhidraFileChooserModel {
 					}
 
 					Icon rootIcon = FS_VIEW.getSystemIcon(root); // possibly a slow call
+					if (rootIcon == null) {
+						rootIcon = PROBLEM_FILE_ICON;
+					}
 					iconMap.put(root, rootIcon);
 					callback.call();
 				}


### PR DESCRIPTION
On my Windows system, ghidra will throw an `Uncaught Exception` if I open `My Computer` page on `File Chooser`.
**It will only happen if there is a disconnected network drive.**
Like this
![image](https://github.com/NationalSecurityAgency/ghidra/assets/29306733/dded56dc-36f1-4dd0-ae3f-922866e4030f)
Exception Image:
![image](https://github.com/NationalSecurityAgency/ghidra/assets/29306733/b3bb65fb-ccbd-4e0d-a97a-6a613b390296)

```
java.lang.NullPointerException
	at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)
	at java.base/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)
	at docking.widgets.filechooser.LocalFileChooserModel$FileSystemRootInfo.asyncUpdateRootInfo(LocalFileChooserModel.java:263)
	at docking.widgets.filechooser.LocalFileChooserModel$FileSystemRootInfo.lambda$updateRootInfo$0(LocalFileChooserModel.java:229)
	at java.base/java.lang.Thread.run(Thread.java:1623)

```

The error message points to [this code ↗](https://github.com/NationalSecurityAgency/ghidra/blob/351e121268ad42975645caeeb67d4323e4472356/Ghidra/Framework/Docking/src/main/java/docking/widgets/filechooser/LocalFileChooserModel.java#L266C4-L266C4) as the root cause of the problem. After investigating, I determined that `getSystemIcon` could potentially return null, so I added some code to handle this scenario. After successfully recompiling the code, the NPE no longer occurs.

UPDATE: or perhaps we can remove this root path?