### PR TITLE
Fix stack overflow in decompiler for very large functions

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
@@ -582,7 +582,7 @@ void AliasChecker::gatherInternal(void) const
 
   gatherAdditiveBase(spacebase,addBase);
   for(vector<AddBase>::iterator iter=addBase.begin();iter!=addBase.end();++iter) {
-    uintb offset = gatherOffset((*iter).base);
+    uintb offset = gatherOffset((*iter).base, &calculatedOffsets);
     offset = AddrSpace::addressToByte(offset,space->getWordSize()); // Convert to byte offset
     alias.push_back(offset);
     if (direction == 1) {
@@ -612,6 +612,7 @@ void AliasChecker::gather(const Funcdata *f,AddrSpace *spc,bool defer)
   calculated = false;		// Defer calculation
   addBase.clear();
   alias.clear();
+  calculatedOffsets.clear();
   direction = space->stackGrowsNegative() ? 1 : -1;		// direction == 1 for normal negative stack growth
   deriveBoundaries(fd->getFuncProto());
   if (!defer)
@@ -729,7 +730,7 @@ void AliasChecker::gatherAdditiveBase(Varnode *startvn,vector<AddBase> &addbase)
 /// the syntax tree rooted at \b vn, backwards, only through additive operations.
 /// \param vn is the given Varnode to gather off of
 /// \return the resulting sub-sum
-uintb AliasChecker::gatherOffset(Varnode *vn)
+uintb AliasChecker::gatherOffset(Varnode *vn, unordered_map<uint4, uintb> *offsets)
 
 {
   uintb retval;
@@ -738,35 +739,42 @@ uintb AliasChecker::gatherOffset(Varnode *vn)
   if (vn->isConstant()) return vn->getOffset();
   PcodeOp *def = vn->getDef();
   if (def == (PcodeOp *)0) return 0;
+
+  unordered_map<uint4, uintb>::const_iterator iter = offsets->find(vn->getCreateIndex());
+  if (iter != offsets->end()) {
+    return iter->second;
+  }
   switch(def->code()) {
   case CPUI_COPY:
-    retval = gatherOffset(def->getIn(0));
+    retval = gatherOffset(def->getIn(0), offsets);
     break;
   case CPUI_PTRSUB:
   case CPUI_INT_ADD:
-    retval = gatherOffset(def->getIn(0));
-    retval += gatherOffset(def->getIn(1));
+    retval = gatherOffset(def->getIn(0), offsets);
+    retval += gatherOffset(def->getIn(1), offsets);
     break;
   case CPUI_INT_SUB:
-    retval = gatherOffset(def->getIn(0));
-    retval -= gatherOffset(def->getIn(1));
+    retval = gatherOffset(def->getIn(0), offsets);
+    retval -= gatherOffset(def->getIn(1), offsets);
     break;
   case CPUI_PTRADD:
     othervn = def->getIn(2);
-    retval = gatherOffset(def->getIn(0));
+    retval = gatherOffset(def->getIn(0), offsets);
     // We need to treat PTRADD exactly as if it were encoded as an ADD and MULT
     // Because a plain MULT truncates the ADD tree
     // We only follow getIn(1) if the PTRADD multiply is by 1
     if (othervn->isConstant() && (othervn->getOffset()==1))
-      retval = retval + gatherOffset(def->getIn(1));
+      retval = retval + gatherOffset(def->getIn(1), offsets);
     break;
   case CPUI_SEGMENTOP:
-    retval = gatherOffset(def->getIn(2));
+    retval = gatherOffset(def->getIn(2), offsets);
     break;
   default:
     retval = 0;
   }
-  return retval & calc_mask(vn->getSize());
+  retval &= calc_mask(vn->getSize());
+  offsets->insert({vn->getCreateIndex(), retval});
+  return retval;
 }
 
 /// \param spc is the address space being analyzed

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
@@ -20,6 +20,7 @@
 #define __VARMAP_HH__
 
 #include "database.hh"
+#include <unordered_map>
 
 namespace ghidra {
 
@@ -140,6 +141,7 @@ private:
   AddrSpace *space;		///< AddressSpace in which to search
   mutable vector<AddBase> addBase; ///< Collection of pointers into the AddressSpace
   mutable vector<uintb> alias;	///< List of aliased addresses (as offsets)
+  mutable unordered_map<uint4, uintb> calculatedOffsets; ///< Map of offsets of already visited Varnodes so the recursive algorithm doesn't blow the stack
   mutable bool calculated;	///< Have aliases been calculated
   uintb localExtreme;		///< Largest possible offset for a local variable
   uintb localBoundary;		///< Boundary offset separating locals and parameters
@@ -155,7 +157,7 @@ public:
   const vector<AddBase> &getAddBase(void) const { return addBase; }	///< Get the collection of pointer Varnodes
   const vector<uintb> &getAlias(void) const { return alias; }		///< Get the list of alias starting offsets
   static void gatherAdditiveBase(Varnode *startvn,vector<AddBase> &addbase);
-  static uintb gatherOffset(Varnode *vn);
+  static uintb gatherOffset(Varnode *vn, unordered_map<uint4, uintb> *offsets);
 };
 
 /// \brief A container for hints about the data-type layout of an address space


### PR DESCRIPTION
The AliasChecker has a recursive function for calculating offsets and on sufficiently large functions will encounter a stack overflow. Added a map of offsets already calculated with a lookup key of the varnode create index with the assumption that a previously calculated offset will be found before stack overflows.

[stack_overflow.zip](https://github.com/NationalSecurityAgency/ghidra/files/12041058/stack_overflow.zip)
decompiler debug output for function which encountered this issue.