### PR TITLE
Fix ability to set working directory and env for dbgeng debug processes

### DIFF
--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/impl/dbgeng/client/DebugClientImpl1.java
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/impl/dbgeng/client/DebugClientImpl1.java
@@ -199,11 +199,11 @@ public class DebugClientImpl1 implements DebugClientInternal {
 			BitmaskSet<DebugVerifierFlags> unusedVerifierFlags) {
 		ULONGLONG ullServer = new ULONGLONG(si.id);
 		ULONG ulFlags = new ULONG(createFlags.getBitmask());
-		if (unusedInitialDirectory != null) {
+		if (unusedInitialDirectory != null && unusedInitialDirectory.length() > 0) {
 			throw new UnsupportedOperationException(
 				"IDebugClient1 does not support 'initial directory'");
 		}
-		if (unusedEnvironment != null) {
+		if (unusedEnvironment != null && unusedEnvironment.length() > 0) {
 			throw new UnsupportedOperationException("IDebugClient1 does not support 'environment'");
 		}
 		COMUtils.checkRC(jnaClient.CreateProcess(ullServer, commandLine, ulFlags));

--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/impl/dbgeng/client/DebugClientImpl3.java
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/impl/dbgeng/client/DebugClientImpl3.java
@@ -42,11 +42,11 @@ public class DebugClientImpl3 extends DebugClientImpl2 {
 			BitmaskSet<DebugVerifierFlags> unusedVerifierFlags) {
 		ULONGLONG ullServer = new ULONGLONG(si.id);
 		ULONG ulFlags = new ULONG(createFlags.getBitmask());
-		if (unusedInitialDirectory != null) {
+		if (unusedInitialDirectory != null && unusedInitialDirectory.length() > 0) {
 			throw new UnsupportedOperationException(
 				"IDebugClient3 does not support 'initial directory'");
 		}
-		if (unusedEnvironment != null) {
+		if (unusedEnvironment != null && unusedEnvironment.length() > 0) {
 			throw new UnsupportedOperationException("IDebugClient3 does not support 'environment'");
 		}
 		COMUtils.checkRC(jnaClient.CreateProcessWide(ullServer, new WString(commandLine), ulFlags));

--- a/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/model/impl/DbgModelTargetProcessLaunchConnectorImpl.java
+++ b/Ghidra/Debug/Debugger-agent-dbgeng/src/main/java/agent/dbgeng/model/impl/DbgModelTargetProcessLaunchConnectorImpl.java
@@ -60,12 +60,12 @@ public class DbgModelTargetProcessLaunchConnectorImpl extends DbgModelTargetObje
 		HashMap<String, ParameterDescription<?>> map =
 			new HashMap<String, ParameterDescription<?>>();
 		ParameterDescription<String> param = ParameterDescription.create(String.class, "args", true,
-			null, "Cmd", "executable to be launched");
+			"", "Cmd", "executable to be launched");
 		ParameterDescription<String> initDir =
 			ParameterDescription.create(String.class, "dir", false,
-				null, "Dir", "initial directory");
+				"", "Dir", "initial directory");
 		ParameterDescription<String> env = ParameterDescription.create(String.class, "env", false,
-			null, "Env (sep=/0)", "environment block");
+			"", "Env (sep=/0)", "environment block");
 		ParameterDescription<Integer> cf = ParameterDescription.create(Integer.class, "cf", true,
 			1, "Create Flags", "creation flags");
 		ParameterDescription<Integer> ef = ParameterDescription.create(Integer.class, "ef", false,


### PR DESCRIPTION
Default value of null for dir and env parameters prevents them from actually being set to any non null value.