### PR TITLE
Fixed bug in fidb for getting data of a not initialized block

### DIFF
--- a/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidServiceLibraryIngest.java
+++ b/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidServiceLibraryIngest.java
@@ -624,6 +624,9 @@ class FidServiceLibraryIngest {
 		}
 		Address entryPoint = function.getEntryPoint();
 		MemoryBlock block = function.getProgram().getMemory().getBlock(entryPoint);
+		if(block == null){
+			return true;
+		}
 		if (!block.isInitialized()) {
 			return true;
 		}


### PR DESCRIPTION
When populating a database with Function ID, I got the following error:

![ghidra_fidb_populate_fail](https://github.com/NationalSecurityAgency/ghidra/assets/13707289/e8f1f6a4-7624-4a86-90b2-8cdb32a4b55f)

There is a check if a block is initialized. However the block is null, which generates the error. 
I added a check for this: if the block is null the function is external so we return true.