### PR TITLE
Add 'Toggle Printing of Type Casts' decompiler pane menu item.

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/DecompilerProvider.java
@@ -980,6 +980,9 @@ public class DecompilerProvider extends NavigatableComponentProviderAdapter
 		String optionsGroup = "comment6 - Options Group";
 		subGroupPosition = 0; // reset for the next group
 
+		ToggleTypeCastsAction toggleTypeCastsAction = new ToggleTypeCastsAction(owner, tool);
+		setGroupInfo(toggleTypeCastsAction, optionsGroup, subGroupPosition++);
+
 		EditPropertiesAction propertiesAction = new EditPropertiesAction(owner, tool);
 		setGroupInfo(propertiesAction, optionsGroup, subGroupPosition++);
 
@@ -1037,6 +1040,7 @@ public class DecompilerProvider extends NavigatableComponentProviderAdapter
 		addLocalAction(convertAction);
 		addLocalAction(findAction);
 		addLocalAction(findReferencesAction);
+		addLocalAction(toggleTypeCastsAction);
 		addLocalAction(propertiesAction);
 		addLocalAction(cloneDecompilerAction);
 		addLocalAction(goToNextBraceAction);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ToggleTypeCastsAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/ToggleTypeCastsAction.java
@@ -1,0 +1,36 @@
+package ghidra.app.plugin.core.decompile.actions;
+
+import docking.ActionContext;
+import docking.action.DockingAction;
+import docking.action.MenuData;
+import docking.options.OptionsService;
+import ghidra.framework.options.ToolOptions;
+import ghidra.framework.plugintool.PluginTool;
+
+public class ToggleTypeCastsAction extends DockingAction  {
+	private final static String OPTIONS_TITLE = "Decompiler";
+	private final static String OPTION_PRINT_TYPE_CASTS = "Display.Disable printing of type casts";
+
+	private final PluginTool tool;
+
+	public ToggleTypeCastsAction(String owner, PluginTool tool) {
+		super("Toggle Printing of Type Casts", owner);
+
+		this.tool = tool;
+		setPopupMenuData(new MenuData( new String[]{ "Toggle Printing of Type Casts" }, "ZED" ));
+	}
+
+	@Override
+	public boolean isEnabledForContext(ActionContext context) {
+		return tool.getService(OptionsService.class) != null;
+	}
+
+	@Override
+	public void actionPerformed(ActionContext context) {
+		final OptionsService service = tool.getService(OptionsService.class);
+		final ToolOptions options = service.getOptions(OPTIONS_TITLE);
+		final boolean b = options.getBoolean(OPTION_PRINT_TYPE_CASTS, false);
+		options.setBoolean(OPTION_PRINT_TYPE_CASTS, !b);
+	}
+
+}


### PR DESCRIPTION
Includes a menu item in the Decompiler pane that allows for quickly enabling/disabling the printing of type casts in the decompiler output.

Demo:
![demo](https://github.com/NationalSecurityAgency/ghidra/assets/3613449/65b2c92a-7bcd-46e2-9de2-6234dfeeed21)

Closes #4801 
