### PR TITLE
fix RegExMemSearcherAlgorithm search limiting

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/util/search/memory/RegExMemSearcherAlgorithm.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/search/memory/RegExMemSearcherAlgorithm.java
@@ -68,11 +68,16 @@ public class RegExMemSearcherAlgorithm implements MemorySearchAlgorithm {
 		else {
 			AddressRangeIterator rangeIterator = searchSet.getAddressRanges();
 			int progress = 0;
+			int searchLimit = searchInfo.getSearchLimit();
 			while (rangeIterator.hasNext()) {
 				AddressRange range = rangeIterator.next();
 				searchAddressSet(new AddressSet(range), accumulator, monitor, progress);
 				progress += (int) range.getLength();
 				monitor.setProgress(progress);
+
+				if (accumulator.size() >= searchLimit) {
+					return;
+				}
 			}
 		}
 	}
@@ -85,8 +90,13 @@ public class RegExMemSearcherAlgorithm implements MemorySearchAlgorithm {
 			return;
 		}
 		List<AddressSet> sets = breakSetsByMemoryBlock(addressSet);
+		int searchLimit = searchInfo.getSearchLimit();
 		for (AddressSet set : sets) {
 			searchSubAddressSet(set, accumulator, monitor, progressCount);
+
+			if (accumulator.size() >= searchLimit) {
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
`RegExMemSearcherAlgorithm` does not correctly limit searches when searching a large program where the number of addresses is greater than `Integer.MAX_VALUE`. This bug is also present if `spanAddressGaps` is `false`, regardless of program size. The search limit _is_ checked forcing the innermost loop to exit when the search limit is reached. However, the surrounding loops are not exited allowing additional matches to be added to the accumulator on subsequent loop iterations. This bug is apparent in methods that rely on `RegExMemSearcherAlgorithm`, e.g. `findBytes`.

I've also updated `RegExMemSearcherAlgorithm`'s integration test to exercise the two scenarios described above. The previous test missed the bug because it operated on a small program and set `spanAddressGaps` to `true`.

Before proposed fix:
```python
>>> for i in range(10):
... 	addrs = findBytes(currentProgram().getMinAddress(), '\x00\x01', i + 1)
... 	f"limit -> {i + 1}, result {len(addrs)}"
... 
'limit -> 1, result 4'
'limit -> 2, result 5'
'limit -> 3, result 6'
'limit -> 4, result 7'
'limit -> 5, result 8'
'limit -> 6, result 9'
'limit -> 7, result 10'
'limit -> 8, result 11'
'limit -> 9, result 12'
'limit -> 10, result 13'
```

After proposed fix:
```python
>>> for i in range(10):
... 	addrs = findBytes(currentProgram().getMinAddress(), '\x00\x01', i + 1)
... 	f"limit -> {i + 1}, result {len(addrs)}"
... 
'limit -> 1, result 1'
'limit -> 2, result 2'
'limit -> 3, result 3'
'limit -> 4, result 4'
'limit -> 5, result 5'
'limit -> 6, result 6'
'limit -> 7, result 7'
'limit -> 8, result 8'
'limit -> 9, result 9'
'limit -> 10, result 10'
```