### PR TITLE
Fix avr8gcc so decompiler doesn't treat memory-mapped registers as global variables

### DIFF
--- a/Ghidra/Processors/Atmel/data/languages/avr8egcc.cspec
+++ b/Ghidra/Processors/Atmel/data/languages/avr8egcc.cspec
@@ -31,7 +31,7 @@
   
   <global>
     <range space="code"/>
-    <range space="mem"/>
+    <range space="mem" first="40" last="0xffff"/>
     <range space="codebyte"/>
   </global>
   

--- a/Ghidra/Processors/Atmel/data/languages/avr8gcc.cspec
+++ b/Ghidra/Processors/Atmel/data/languages/avr8gcc.cspec
@@ -32,7 +32,7 @@
   <global>
     <range space="code"/>
     <range space="codebyte"/>
-    <range space="mem"/>
+    <range space="mem" first="40" last="0xffff"/>
   </global>
   
   <stackpointer register="SP" space="mem" growth="negative"/>


### PR DESCRIPTION
The GPRs on this architecture are accessed through the `mem` address space. The cspec for IAR includes these attributes to keep the decompiler from seeing register accesses as global variable accesses, but they were missing for gcc.

Here's a test binary: [Blink.ino.elf.zip](https://github.com/NationalSecurityAgency/ghidra/files/12386753/Blink.ino.elf.zip). Import it as AVR8 16-bit little endian gcc (this is the Arduino Blink sketch targeting Arduino Uno).


### Before:
```c

undefined4 delay.constprop.1(void)

{
  byte bVar1;
  char cVar2;
  byte bVar3;
  byte bVar4;
  undefined2 uVar5;
  undefined2 uVar6;
  bool bVar7;
  bool bVar8;
  undefined4 uVar9;
  undefined uVar10;
  undefined uVar11;
  undefined uVar12;
  undefined uVar13;
  undefined uVar14;
  
  uVar6 = R11R10;
  uVar5 = R9R8;
  R1 = 0;
  uVar10 = (byte)R9R8;
  uVar11 = R15R14._1_1_;
  uVar12 = (byte)R15R14;
  uVar13 = R13R12._1_1_;
  uVar14 = (char)R13R12;
  R23R22._0_1_ = 0;
  R23R22._1_1_ = 0;
  R25R24._0_1_ = 0;
  R25R24._1_1_ = '\0';
  micros();
  R9R8._0_1_ = (byte)R23R22;
  R9R8._1_1_ = R23R22._1_1_;
  R11R10._0_1_ = (byte)R25R24;
  R11R10._1_1_ = R25R24._1_1_;
  R13R12._0_1_ = -0x18;
  R13R12._1_1_ = 3;
  R15R14._0_1_ = 0;
  R15R14._1_1_ = '\0';
  do {
    do {
      uVar9 = micros();
      R23R22._0_1_ = (byte)uVar9;
      bVar1 = (byte)R23R22 - (byte)R9R8;
      R23R22._1_1_ = (byte)((ulong)uVar9 >> 8);
      bVar3 = R23R22._1_1_ - (R9R8._1_1_ + ((byte)R23R22 < (byte)R9R8));
      bVar7 = R23R22._1_1_ < R9R8._1_1_ ||
              (byte)(R23R22._1_1_ - R9R8._1_1_) < ((byte)R23R22 < (byte)R9R8);
      R25R24._0_1_ = (byte)((ulong)uVar9 >> 0x10);
      R25R24._1_1_ = (char)((ulong)uVar9 >> 0x18);
      bVar4 = R25R24._1_1_ -
              (R11R10._1_1_ +
              ((byte)R25R24 < (byte)R11R10 || (byte)((byte)R25R24 - (byte)R11R10) < bVar7));
      R23R22 = CONCAT11(bVar3 - ((bVar1 < 0xe8) + '\x03'),bVar1);
    } while (bVar4 < ((byte)((byte)R25R24 - ((byte)R11R10 + bVar7)) <
                     (bVar3 < 3 || (byte)(bVar3 - 3) < (bVar1 < 0xe8))));
    R18 = 1;
    cVar2 = (char)R13R12 + -1;
    bVar1 = R13R12._1_1_ - ((char)R13R12 == '\0');
    bVar7 = R13R12._1_1_ < ((char)R13R12 == '\0');
    bVar3 = (byte)R15R14 - bVar7;
    R15R14._1_1_ = R15R14._1_1_ - ((byte)R15R14 < bVar7);
    bVar7 = 0x17 < (byte)R9R8;
    R25R24 = CONCAT11(bVar4,3);
    bVar8 = 0xfc < R9R8._1_1_ || CARRY1(R9R8._1_1_ + 3,bVar7);
    R11R10._1_1_ = R11R10._1_1_ + CARRY1((byte)R11R10,bVar8);
    R13R12._0_1_ = cVar2;
    R13R12._1_1_ = bVar1;
    R15R14._0_1_ = bVar3;
    R9R8._0_1_ = (byte)R9R8 - 0x18;
    R9R8._1_1_ = R9R8._1_1_ + 3 + bVar7;
    R11R10._0_1_ = (byte)R11R10 + bVar8;
  } while (((cVar2 != '\0' || bVar1 != 0) || bVar3 != 0) || R15R14._1_1_ != '\0');
  R15R14._1_1_ = uVar11;
  R15R14._0_1_ = uVar12;
  R13R12._1_1_ = uVar13;
  R13R12._0_1_ = uVar14;
  R11R10 = uVar6;
  R9R8 = CONCAT11((char)((uint)uVar5 >> 8),uVar10);
  return CONCAT22(R25R24,R23R22);
}
```

### After:
```c
void delay.constprop.1(void)

{
  char cVar1;
  byte bVar2;
  bool bVar3;
  bool bVar4;
  byte bVar5;
  byte bVar6;
  byte bVar7;
  char cVar8;
  char cVar9;
  byte bVar10;
  byte bVar11;
  char cVar12;
  byte bVar13;
  byte bVar14;
  undefined4 uVar15;
  
  bVar5 = 0;
  bVar6 = 0;
  bVar7 = 0;
  cVar8 = '\0';
  micros();
  cVar12 = '\0';
  cVar9 = -0x18;
  bVar10 = 3;
  bVar11 = 0;
  do {
    do {
      uVar15 = micros();
      bVar13 = (byte)uVar15;
      bVar14 = (byte)((ulong)uVar15 >> 8);
      bVar2 = bVar14 - (bVar6 + (bVar13 < bVar5));
      bVar3 = bVar14 < bVar6 || (byte)(bVar14 - bVar6) < (bVar13 < bVar5);
      bVar14 = (byte)((ulong)uVar15 >> 0x10);
    } while ((byte)((char)((ulong)uVar15 >> 0x18) -
                   (cVar8 + (bVar14 < bVar7 || (byte)(bVar14 - bVar7) < bVar3))) <
             ((byte)(bVar14 - (bVar7 + bVar3)) <
             (bVar2 < 3 || (byte)(bVar2 - 3) < ((byte)(bVar13 - bVar5) < 0xe8))));
    cVar1 = cVar9 + -1;
    bVar2 = bVar10 - (cVar9 == '\0');
    bVar3 = bVar10 < (cVar9 == '\0');
    bVar13 = bVar11 - bVar3;
    cVar12 = cVar12 - (bVar11 < bVar3);
    bVar3 = 0x17 < bVar5;
    bVar4 = 0xfc < bVar6 || CARRY1(bVar6 + 3,bVar3);
    cVar8 = cVar8 + CARRY1(bVar7,bVar4);
    cVar9 = cVar1;
    bVar10 = bVar2;
    bVar11 = bVar13;
    bVar5 = bVar5 - 0x18;
    bVar6 = bVar6 + 3 + bVar3;
    bVar7 = bVar7 + bVar4;
  } while (((cVar1 != '\0' || bVar2 != 0) || bVar13 != 0) || cVar12 != '\0');
  return;
}
```