### PR TITLE
Decompiler: Add optimisation for LUTs encoded in constants

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -5450,6 +5450,7 @@ void ActionDatabase::universalAction(Architecture *conf)
 	actprop->addRule( new RuleOrMultiBool("analysis") );
 	actprop->addRule( new RuleXorSwap("analysis") );
 	actprop->addRule( new RuleLzcountShiftBool("analysis") );
+	actprop->addRule( new RuleSimplifyConstantLUT("analysis") );
 	actprop->addRule( new RuleSubvarAnd("subvar") );
 	actprop->addRule( new RuleSubvarSubpiece("subvar") );
 	actprop->addRule( new RuleSplitFlow("subvar") );

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -10446,4 +10446,120 @@ int4 RuleLzcountShiftBool::applyOp(PcodeOp *op,Funcdata &data)
   return 0;
 }
 
+/// \class RuleSimplifyConstantLUT
+///
+/// \brief
+///
+/// '(c >> V) & 1' -> 'V == x0 || V == x1 || ...'
+/// 'sub((c >> V), #0) & 1' is also supported
+///
+/// where the xs represents bit indices that are set in the constant 'c'.
+///
+/// If most bits in 'c' are set, 'c' and the output term are negated:
+///
+/// '(c >> V) & 1' -> '!(V == x0 || V == x1 || ...)'
+///
+void RuleSimplifyConstantLUT::getOpList(vector<uint4> &oplist) const
+{
+  oplist.push_back(CPUI_INT_AND);
+}
+
+
+int4 RuleSimplifyConstantLUT::applyOp(PcodeOp *op, Funcdata &data)
+
+{
+  Varnode* one = op->getIn(0);
+  Varnode* shift = op->getIn(1);
+  if (!one->constantMatch(1)) {
+    shift = one;
+    one = op->getIn(1);
+    if (!one->constantMatch(1)) return 0;
+  }
+
+  PcodeOp* shiftOp = shift->getDef();
+  if (shiftOp->code() != CPUI_INT_RIGHT) {
+    // Don't choke on an intermediate SUBPIECE(x, 0)
+    if (shiftOp->code() != CPUI_SUBPIECE) return 0;
+    if (!shiftOp->getIn(1)->constantMatch(0)) return 0;
+
+    shift = shiftOp->getIn(0);
+    shiftOp = shift->getDef();
+    if (shiftOp->code() != CPUI_INT_RIGHT) return 0;
+  }
+
+  // The left operand of the shift should be a constant != 0, the right operand
+  // should be not be a constant
+  Varnode* cons = shiftOp->getIn(0);
+  Varnode* var = shiftOp->getIn(1);
+  if ((!cons->isConstant()) || cons->constantMatch(0)) return 0;
+  if (var->isConstant()) return 0;
+
+  uintb constValue = cons->getOffset();
+  uint4 constSize = cons->getSize();
+  uint4 numBitsSet = popcount(constValue);
+
+  bool negateCondition = 2 * numBitsSet > 8 * constSize;
+  if (negateCondition) {
+    constValue = ~constValue;
+    numBitsSet = constSize * 8 - numBitsSet;
+  }
+
+  uint4 bitIdx = 0;
+  Varnode* prevEqOut = NULL;
+  Varnode* tempVar = NULL;
+  PcodeOp* prevEqOutOp = NULL;
+  PcodeOp* tempOp = NULL;
+
+  for (uint4 i = 0; i < numBitsSet; i++) {
+    // Find the next smallest bit set
+    while (bitIdx < constSize * 8) {
+      if (!(constValue & 1)) {
+	constValue >>= 1;
+	bitIdx++;
+	continue;
+      }
+
+      // Add INT_EQUAL(var, bitIdx)
+      tempOp = data.newOp(2, shiftOp->getAddr());
+      data.opSetOpcode(tempOp, CPUI_INT_EQUAL);
+      data.opSetInput(tempOp, var, 0);
+      data.opSetInput(tempOp, data.newConstant(var->getSize(), bitIdx), 1);
+      tempVar = data.newUniqueOut(1, tempOp);
+      data.opInsertAfter(tempOp, shiftOp);
+
+      // Link it to the previous INT_EQUAL with a BOOL_OR
+      if (i != 0) {
+	tempOp = data.newOp(2, shiftOp->getAddr());
+	data.opSetOpcode(tempOp, CPUI_BOOL_OR);
+	data.opSetInput(tempOp, prevEqOut, 0);
+	data.opSetInput(tempOp, tempVar, 1);
+	tempVar = data.newUniqueOut(1, tempOp);
+	data.opInsertAfter(tempOp, shiftOp);
+      }
+
+      prevEqOutOp = tempOp;
+      prevEqOut = tempVar;
+      constValue >>= 1;
+      bitIdx++;
+      break;
+    }
+  }
+
+  // negate the condition if more than half of the bits are set
+  if (negateCondition) {
+    tempOp = data.newOp(1, shiftOp->getAddr());
+    data.opSetOpcode(tempOp, CPUI_BOOL_NEGATE);
+    data.opSetInput(tempOp, prevEqOut, 0);
+    prevEqOut = data.newUniqueOut(1, tempOp);
+    data.opInsertAfter(tempOp, prevEqOutOp);
+  }
+
+  // replace the INT_AND by a INT_ZEXT, making sure the output is the right size
+  data.opSetOpcode(op, CPUI_INT_ZEXT);
+  data.opSetInput(op, prevEqOut, 0);
+  data.opRemoveInput(op, 1);
+
+  return 1;
+}
+
 } // End namespace ghidra

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
@@ -1643,5 +1643,16 @@ public:
   virtual int4 applyOp(PcodeOp *op,Funcdata &data);
 };
 
+class RuleSimplifyConstantLUT : public Rule {
+public:
+  RuleSimplifyConstantLUT(const string &g) : Rule( g, 0, "simplifyconstantlut") {}        ///< Constructor
+  virtual Rule *clone(const ActionGroupList &grouplist) const {
+    if (!grouplist.contains(getGroup())) return (Rule *)0;
+    return new RuleSimplifyConstantLUT(getGroup());
+  }
+  virtual void getOpList(vector<uint4> &oplist) const;
+  virtual int4 applyOp(PcodeOp *op,Funcdata &data);
+};
+
 } // End namespace ghidra
 #endif


### PR DESCRIPTION
gcc 13 and clang 16 at `-O1` or higher compile an "||" sequence of comparisons of a single variable with various small values to a single right shift of a magic constant functioning as a lookup table (LUT) by a variable amount and a binary and with 1. This rule replaces this magic constant by a series of integer comparisons, which leads to better decompilation, especially if enums are involved.

**Example**
Consider the following two related functions ([here][godbolt] is a godbolt link):
```c++
bool isWhitespace(char c)
{
    return (c == ' ' || c == '\r' || c == '\n' || c == '\t');
}

bool isNotWhitespace(char c)
{
    return !(c == ' ' || c == '\r' || c == '\n' || c == '\t');
}
```

After compiling both functions with gcc 13.2, with `-O1`, and loading the resulting binary in Ghidra (latest master at the time of submitting this PR), we find that Ghidra produces the decompiled output below for both functions (after being told the return type and param type). Notice how the lookup table constant is used, making the code hard to understand.

```c++
bool isWhitespace(char c)

{
  bool bVar1;
  
  bVar1 = false;
  if ((byte)c < 0x21) {
    bVar1 = (0x100002600U >> ((ulong)(byte)c & 0x3f) & 1) != 0;
  }
  return bVar1;
}

bool isNotWhitespace(char c)

{
  bool bVar1;
  
  bVar1 = true;
  if ((byte)c < 0x21) {
    bVar1 = (0xfffffffeffffd9ffU >> ((ulong)(byte)c & 0x3f) & 1) != 0;
  }
  return bVar1;
}
```

After applying this patch, the decompiled output looks like this:

```c++
bool isWhitespace(char c)

{
  byte bVar1;
  bool bVar2;
  
  bVar2 = false;
  if ((byte)c < 0x21) {
    bVar1 = c & 0x3f;
    bVar2 = ((bVar1 == 9 || bVar1 == 10) || bVar1 == 0xd) || bVar1 == 0x20;
  }
  return bVar2;
}

bool isNotWhitespace(char c)

{
  byte bVar1;
  bool bVar2;
  
  bVar2 = true;
  if ((byte)c < 0x21) {
    bVar1 = c & 0x3f;
    bVar2 = ((bVar1 != 9 && bVar1 != 10) && bVar1 != 0xd) && bVar1 != 0x20;
  }
  return bVar2;
}
```
Now the lookup table constant is replaced by a series of integer comparisons, it is a lot clearer what the code is doing. Unfortunately, the decompiler is unable to figure out that `bVar1` should have type `char`, but if you give it that information, it will even replace the integer by character literals. If this function had operated on an enum value, this optimisation would have increased understandability of the decompiled code even more, as it now contains the enum values the code checks for.

Note that clang outputs very similar (though not identical) code. However, these differences do not prevent this rule from working. The specific assembly instructions that this code compiles to can easily be checked and compared on [godbolt].

[godbolt]: https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:2,endLineNumber:9,positionColumn:2,positionLineNumber:9,selectionStartColumn:2,selectionStartLineNumber:9,startColumn:2,startLineNumber:9),source:'bool+isWhitespace(char+c)%0A%7B%0A++++return+(c+%3D%3D+!'+!'+%7C%7C+c+%3D%3D+!'%5Cr!'+%7C%7C+c+%3D%3D+!'%5Cn!'+%7C%7C+c+%3D%3D+!'%5Ct!')%3B%0A%7D%0A%0Abool+isNotWhitespace(char+c)%0A%7B%0A++++return+!!(c+%3D%3D+!'+!'+%7C%7C+c+%3D%3D+!'%5Cr!'+%7C%7C+c+%3D%3D+!'%5Cn!'+%7C%7C+c+%3D%3D+!'%5Ct!')%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:g132,deviceViewOpen:'1',filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'1',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-O1',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+gcc+13.2+(Editor+%231)',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4