### PR TITLE
Update avr32a_instruction_flow.sinc

### DIFF
--- a/Ghidra/Processors/Atmel/data/languages/avr32a_instruction_flow.sinc
+++ b/Ghidra/Processors/Atmel/data/languages/avr32a_instruction_flow.sinc
@@ -154,8 +154,9 @@ RJMPdisp: disp is disp4_8 & sdisp0_2
 # 0101 1101 0001 dddd
 
 :ICALL rd0 is op4_12=0x5d1 & rd0 {
+        tmp:4 = LR;
         LR = inst_next;
-        call [rd0];
+        call [tmp];
 }
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
The specification for avr32 says the LR register should be reserved for using return addresses, but in reality older compilers still use it to hold addresses for subroutine calls with ICALL. When they do so without this fix the value in LR is immediately overwritten and during analysis only appears to be a function call to the opcode immediately after ICALL.