### PR TITLE
Fix several bugs in 6502 ops

### DIFF
--- a/Ghidra/Processors/6502/data/languages/6502.slaspec
+++ b/Ghidra/Processors/6502/data/languages/6502.slaspec
@@ -35,7 +35,6 @@ macro popSR() {
 	local ccr = *:1 SP;
 	N = ccr[7,1];
 	V = ccr[6,1];
-	B = ccr[4,1];
 	D = ccr[3,1];
 	I = ccr[2,1];
 	Z = ccr[1,1];
@@ -43,10 +42,9 @@ macro popSR() {
 }
 
 macro pushSR() {
-	local ccr:1 = 0xff;
+	local ccr:1 = 0xff;  # Break (B) flag and bit 5 set to 1
 	ccr[7,1] = N;
 	ccr[6,1] = V;
-	ccr[4,1] = B;
 	ccr[3,1] = D;
 	ccr[2,1] = I;
 	ccr[1,1] = Z;
@@ -60,13 +58,12 @@ macro resultFlags(value) {
 	N = (value s< 0);
 }
 
-macro subtraction_flags1(register, operand, result) {
-	local complement_register = ~register;
-	
-	V = ( ((register & ~operand & ~result) | (complement_register & operand & result)) & 0b10000000 ) != 0;
-	N = (result s< 0);
-	Z = (result == 0);
-	C = ( ((complement_register & operand) | (operand & result) | (result & complement_register)) & 0b10000000 ) != 0;
+macro adc(op1) {
+    local result:2 = zext(A) + zext(op1) + zext(C);
+    resultFlags(result:1);
+    V = (~(A ^ op1) & (A ^ result:1) & 0x80) != 0;
+    C = (result & 0x100) != 0;
+    A = result:1;
 }
 
 
@@ -92,9 +89,28 @@ OP1: imm16,X    is bbb=7 & X; imm16		{ tmp:2 = imm16 + zext(X); export *:1 tmp; 
 # Absolute Indexed Y
 OP1: imm16,Y    is bbb=6 & Y; imm16		{ tmp:2 = imm16 + zext(Y); export *:1 tmp; }
 # Indirect X
-OP1: (imm8,X)   is bbb=0 & X; imm8		{ addr:2 = zext(imm8 + X); tmp:2 = *:2 addr; export *:1 tmp; }
+OP1: (imm8,X)   is bbb=0 & X; imm8		{
+    # When the first (low) byte of address to load is 0xff,
+    # the second (high) byte to load is at 0x0000, not 0x0100
+    addr8_lo:1 = imm8 + X;
+    addr8_hi:1 = addr8_lo + 1;
+    addr16_lo:2 = zext(addr8_lo);
+    addr16_hi:2 = zext(addr8_hi);
+    tmp:2 = zext(*:1 addr16_hi) << 8 | zext(*:1 addr16_lo);
+    export *:1 tmp;
+}
 # Indirect Y
-OP1: (imm8),Y   is bbb=4 & Y; imm8		{ addr:2 = imm8; tmp:2 = *:2 addr; tmp = tmp + zext(Y); export *:1 tmp; }
+OP1: (imm8),Y   is bbb=4 & Y; imm8		{
+    # When the first (low) byte of address to load is 0xff,
+    # the second (high) byte to load is at 0x0000, not 0x0100
+    addr8_lo:1 = imm8;
+    addr8_hi:1 = addr8_lo + 1;
+    addr16_lo:2 = zext(addr8_lo);
+    addr16_hi:2 = zext(addr8_hi);
+    tmp:2 = zext(*:1 addr16_hi) << 8 | zext(*:1 addr16_lo);
+    tmp = tmp + zext(Y);
+    export *:1 tmp;
+}
 
 # Immediate
 OP2: "#"imm8    is bbb=0; imm8			{ tmp:1 = imm8; export tmp; }
@@ -118,7 +134,18 @@ OP2LD: imm16,Y  is bbb=7 & Y; imm16		{ tmp:2 = imm16 + zext(Y); export *:1 tmp; 
 
 ADDR8:  imm8    is imm8		{ export *:1 imm8; }
 ADDR16: imm16   is imm16   	{ export *:1 imm16; }
-ADDRI:  (imm16)   is imm16    { tmp:2 = imm16; export *:2 tmp; }
+ADDRI:  (imm16)   is imm16    {
+    # With page given by high byte of imm16 (e.g. 0x01),
+    # when the first (low) byte of address to load is 0xff,
+    # the second (high) byte to load is at 0x0100, not 0x0200
+    addr8_lo:1 = imm16:1;
+    addr8_hi:1 = addr8_lo + 1;
+    page:2 = imm16 & 0xff00;
+    addr16_lo:2 = page | zext(addr8_lo);
+    addr16_hi:2 = page | zext(addr8_hi);
+    tmp:2 = zext(*:1 addr16_hi) << 8 | zext(*:1 addr16_lo);
+    export tmp;
+}
 
 
 # Instructions
@@ -126,15 +153,7 @@ ADDRI:  (imm16)   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 
 :ADC OP1     is (cc=1 & aaa=3) ... & OP1
 {
-	local op1 = OP1;
-	local tmpC = C;
-	
-	C = carry(A, op1);
-	
-	A = A + op1 + tmpC;
-
-	resultFlags(A);
-	V = C;
+	adc(OP1);
 }
 
 :AND OP1     is (cc=1 & aaa=1) ... & OP1
@@ -194,7 +213,6 @@ ADDRI:  (imm16)   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 {
 	*:2 (SP - 1) = inst_next;
 	SP = SP - 2;
-	B = 1;
 	pushSR();
 	I = 1;
 	local target:2 = 0xFFFE;
@@ -313,8 +331,10 @@ ADDRI:  (imm16)   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 
 :JSR   ADDR16    is op=0x20; ADDR16
 {
-	*:2 (SP-1) = inst_next;
-	SP=SP-2; 
+	# Value stored is actually the address before the location the program
+	# will eventually return to. Thus, the effective return address is PC + 1.
+	*:2 (SP-1) = inst_next - 1;
+	SP=SP-2;
 	call ADDR16;
 }
 
@@ -418,20 +438,12 @@ ADDRI:  (imm16)   is imm16    { tmp:2 = imm16; export *:2 tmp; }
 	tmp:2 = *:2 SP;
 	SP = SP+1;
 	
-	return [tmp];
+	return [tmp + 1];
 }
 
 :SBC OP1     is (cc=1 & aaa=7) ... & OP1
 {
-	local op1 = OP1;
-	local result = A - op1 - !C;
-	
-	subtraction_flags1(A, op1, result);
-	A = result;	
-	
-	# resultFlags(tmp);
-	# C = ((A <= op1) * C) | (A < op1);
-	# A = tmp;
+	adc(~OP1);
 }
 
 :SEC     is op=0x38

--- a/Ghidra/Processors/6502/data/languages/65c02.slaspec
+++ b/Ghidra/Processors/6502/data/languages/65c02.slaspec
@@ -31,13 +31,7 @@ ADDRIX: (imm16,X) is X; imm16     { addr:2 = imm16 + zext(X); tmp:2 = *:2 addr; 
 
 :ADC ZIOP                      is (cc=2 & aaa=3) ... & ZIOP
 {
-    local op1 = ZIOP;
-    local tmpC = C;
-
-    C = carry(A, op1);
-    A = A + op1 + tmpC;
-    resultFlags(A);
-    V = C;
+    adc(ZIOP);
 }
 
 :AND ZIOP                      is (cc=2 & aaa=1) ... & ZIOP
@@ -162,11 +156,7 @@ ADDRIX: (imm16,X) is X; imm16     { addr:2 = imm16 + zext(X); tmp:2 = *:2 addr; 
 
 :SBC ZIOP                      is (cc=2 & aaa=7) ... & ZIOP
 {
-    local op1 = ZIOP;
-    local result = A - op1 - !C;
-
-    subtraction_flags1(A, op1, result);
-    A = result;
+    adc(~ZIOP);
 }
 
 :SMB "#"bitindex, imm8         is (action=1 & optype=7) & bitindex ; imm8 {


### PR DESCRIPTION
These changes fix several incorrect results identified when comparing Ghidra's PCode emulator against NES emulators.

I'll describe each fix on a separate section, including instruction trace log diffs. Lines prefixed with `-` are logged by a standalone NES emulator, and lines prefixed with `+` are logged by Ghidra's PCode emulator before these fixes were applied.

# ADC/SBC flags incorrectly updated

SBC carry flag was being cleared when `A=0, [0x7dc]=0, C=1`, which is equivalent to `0 + 0xff + 1 = 0x100`, where the carry bit should remain set:

```
8f9e a0 05           LDY        #0x5
8fa0 38              SEC
8fa1 bd dd 07        LDA        DAT_07dd,X
8fa4 f9 d7 07        SBC        0x7d7,Y=>DAT_07dc
8fa7 ca              DEX
```

```diff
 8fa0 A:00 X:05 Y:05 S:f8 P:04
 8fa1 A:00 X:05 Y:05 S:f8 P:05
 8fa4 A:00 X:05 Y:05 S:f8 P:07
-8fa7 A:00 X:05 Y:05 S:f8 P:07
+8fa7 A:00 X:05 Y:05 S:f8 P:06
```

ADC overflow flag was not set on `0x70 + 0x10 + 0 = 0x80`, even though adding two positive numbers overflows and ends up as a negative result:

```
94fa 18              CLC
94fb 69 10           ADC        #0x10
94fd a8              TAY
```

```diff
 94fa A:70 X:07 Y:70 S:f5 P:04
 94fb A:70 X:07 Y:70 S:f5 P:04
-94fd A:80 X:07 Y:70 S:f5 P:c4
+94fd A:80 X:07 Y:70 S:f5 P:84
```

I've opted to rewrite these operations in a more well-known approach, where `SBC` is implemented by negating the loaded operand and applying the same arithmetic as `ADC`.

Reference implementations:

- https://github.com/SourMesen/Mesen2/blob/80f44271088bf9a02eab8b811e605312607d3c65/Core/NES/NesCpu.h#L289
- https://github.com/ares-emulator/ares/blob/b11ff923b93c0f232af5eb3855317c5690ed5c4d/ares/component/processor/mos6502/algorithms.cpp#L209

Arithmetic explanations:

- https://forums.nesdev.org/viewtopic.php?p=19080#p19080
- https://stackoverflow.com/questions/29193303/6502-emulation-proper-way-to-implement-adc-and-sbc

# JSR pushed return address is off-by-one

Consider this subroutine:

```
 8212 ad 70 07        LDA        OperMode
 8215 20 04 8e        JSR        JumpEngine
 8218 31 82           addr       LAB_8231
 821a dc ae           addr       LAB_aedc
 821c 8b 83           addr       LAB_838b
 821e 18 92           addr       LAB_9218
```

Calling `JSR` will push the address of the next instruction to the stack. However, the value stored must be the address before the return address. Thus, the effective return address is `PC + 1`.

This assumption applies to the case below, where the program will not execute the pushed address, but instead pull it from the stack and use some arithmetic to calculate the offset of the actual address to jump to:

```
8e04 0a              ASL        A
8e05 a8              TAY
8e06 68              PLA
8e07 85 04           STA        DAT_0004
8e09 68              PLA
8e0a 85 05           STA        DAT_0005
8e0c c8              INY
8e0d b1 04           LDA        (DAT_0004),Y
8e0f 85 06           STA        DAT_0006
8e11 c8              INY
8e12 b1 04           LDA        (DAT_0004),Y
8e14 85 07           STA        DAT_0007
8e16 6c 06 00        JMP        (DAT_0006)
```

Given `Y=0`, the expected address to jump to is `8231`, however Ghidra jumps to `dc82`, since it pushed address `8218` instead of `8217`:

```diff
 8e06 A:00 X:07 Y:00 S:f7 P:06
-8e07 A:17 X:07 Y:00 S:f8 P:04
-8e09 A:17 X:07 Y:00 S:f8 P:04
+8e07 A:18 X:07 Y:00 S:f8 P:04
+8e09 A:18 X:07 Y:00 S:f8 P:04
 8e0a A:82 X:07 Y:00 S:f9 P:84
 8e0c A:82 X:07 Y:00 S:f9 P:84
 8e0d A:82 X:07 Y:01 S:f9 P:04
-8e0f A:31 X:07 Y:01 S:f9 P:04
-8e11 A:31 X:07 Y:01 S:f9 P:04
-8e12 A:31 X:07 Y:02 S:f9 P:04
-8e14 A:82 X:07 Y:02 S:f9 P:84
-8e16 A:82 X:07 Y:02 S:f9 P:84
-8231 A:82 X:07 Y:02 S:f9 P:84
+8e0f A:82 X:07 Y:01 S:f9 P:84
+8e11 A:82 X:07 Y:01 S:f9 P:84
+8e12 A:82 X:07 Y:02 S:f9 P:04
+8e14 A:dc X:07 Y:02 S:f9 P:84
+8e16 A:dc X:07 Y:02 S:f9 P:84
+dc82 A:dc X:07 Y:02 S:f9 P:84
```

# Indirect offsets incorrectly crossing pages

This issue affects all indirect address calculations. Suppose the bytes to fetch are stored in the zero page. When the first (low) byte of address to load is 0xff, the second (high) byte to load is at 0x0000, not 0x0100, as Ghidra was calculating.

Test case for `LDA (indirect,X)`:

* Expected to load `addr=[0x0000][0x00ff]=0x0400, [addr]=0x5d`, got `addr=[0x0100][0x00ff]=0x0000, [addr]=0x04`:

```
00000000: 04ff 0000 0000 0000 0000 0000 0000 0000  ................
...
000000f0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000100: 0000 0000 0000 0000 0000 0000 0000 0000  ................
...
00000400: 5d00 0000 0000 0000 0000 0000 0000 0000  ]...............
```

```
cfee d0 10           BNE        LAB_d000
cff0 a2 00           LDX        #0x0
cff2 a1 ff           LDA        (0xff,X)
cff4 c9 5d           CMP        #0x5d
```

```diff
   cfee A:5c X:03 Y:69 S:fb P:07
   cff0 A:5c X:03 Y:69 S:fb P:07
   cff2 A:5c X:00 Y:69 S:fb P:07
-  cff4 A:5d X:00 Y:69 S:fb P:05
+  cff4 A:04 X:00 Y:69 S:fb P:05
```

Test case for `LDA (indirect),Y`:

* Expected to load `addr=([0x0000])([0x00ff]+0xff)=(0x01)(0x46+0xff)=0x0245, [addr]=0x12`, got `addr=[[0x00ff]+0xff]=[0x0046+0xff]=0x0145, [addr]=0x00`);

```
00000000: 01ff 0000 0000 0000 0000 0000 0000 0000  ................
...
00000040: 0000 0000 0000 0000 0000 0000 0000 0000  ................
...
000000f0: 0000 0000 0000 0000 0000 0000 0000 0046  ...............F
00000100: 0000 0000 0000 0000 0000 0000 0000 0000  ................
...
00000140: 0000 0000 0000 0000 0000 0000 0000 0000  ................
...
00000240: 0000 0000 0012 0000 0000 0000 0000 0000  ................
```

```
d955 85 00           STA        DAT_0000
d957 a0 ff           LDY        #0xff
d959 b1 ff           LDA        (DAT_00ff),Y
d95b c9 12           CMP        #0x12
```

```diff
   d955 A:01 X:65 Y:34 S:f8 P:45
   d957 A:01 X:65 Y:34 S:f8 P:45
   d959 A:01 X:65 Y:ff S:f8 P:c5
-  d95b A:12 X:65 Y:ff S:f8 P:45
+  d95b A:00 X:65 Y:ff S:f8 P:47
```

# Incorrect flags on push/pop SR

It looks like the same case that was already [previously submitted](https://github.com/NationalSecurityAgency/ghidra/pull/4839). If it makes sense I can remove this fix from my MR. For completeness, here's the test case:

```
c7e7 08   PHP
c7e8 68   PLA
```

```diff
   c7e8 A:00 X:04 Y:f2 S:fa P:4f
-  c7e9 A:7f X:04 Y:f2 S:fb P:4d
+  c7e9 A:6f X:04 Y:f2 S:fb P:4d
```
