### PR TITLE
Tricore, fix DEXTR, `Extract from Double Register` instruction

### DIFF
--- a/Ghidra/Processors/tricore/data/languages/tricore.sinc
+++ b/Ghidra/Processors/tricore/data/languages/tricore.sinc
@@ -2011,15 +2011,15 @@ SC: [a10]const0815Z10zz is PCPMode=0 & a10 & const0815Z10zz & op0003=8 & op0404=
 # DEXTR D[c], D[a], D[b], pos (RRPW)
 :dextr Rd2831,Rd0811,Rd1215,const2327Z is PCPMode=0 & Rd0811 & Rd1215 & op0007=0x77 ; Rd2831 & const2327Z & op1622=0x0
 {
-	local tmp:8 = (zext(Rd0811) << 32) | (zext(Rd1215) << const2327Z);
-	Rd2831 = tmp[32,32];
+	local shift = const2327Z;
+	Rd2831 = (Rd0811 << shift) | (Rd1215 >> (32 - shift));
 }
 
 # DEXTR D[c], D[a], D[b], D[d] (RRRR)
 :dextr Rd2831,Rd0811,Rd1215,Rd2427 is PCPMode=0 & Rd0811 & Rd1215 & op0007=0x17 ; Rd2427 & Rd2831 & op1623=0x80
 {
-	local tmp:8 = (zext(Rd0811) << 32) | (zext(Rd1215) << Rd2427[0,5]);
-	Rd2831 = tmp[32,32];
+	local shift = Rd2427[0,5];
+	Rd2831 = (Rd0811 << shift) | (Rd1215 >> (32 - shift));
 }
 
 # DISABLE (SYS)


### PR DESCRIPTION
As stated in TriCore specs, `DEXTR` should:
- concatenate D[a] and D[b]
- shift result left on `pos` or D[d] bits
- write result bits 63..32 to the D[c]

Actual code shifts only D[b] which is wrong.

I tried to rewrite this code close to spec, but using 64-bit variables makes a lot of 'noise'.
My code gives the same result using only 32-bit variables.


### Steps to reporoduce
It is a function to reverse byte order in dword from real firmware.
Save it as .HEX file and open with any Tricore processor.

After fix code looks slightly weird (from my perspective, Ghidra should use more parentheses in such cases), but it works fine.

Before:
```
uint FUN_00000000(uint param_1)
{
  uint uVar1;
 
  uVar1 = param_1 | param_1 >> 8;
  return uVar1 & 0xff00ff00 | (uVar1 & 0xff) << 0x10 | param_1 >> 0x18;
}
```

After:
```
uint FUN_00000000(uint param_1)
{
  return param_1 << 0x18 | param_1 >> 8 & 0xff00ff00 | (param_1 >> 8 & 0xff) << 0x10 |
         param_1 >> 0x18;
}
```

Binary to test (in the Intel Hex format):
```
:120000007744002C8F841E4037220828374208200090DC
:00000001FF
```
