### PR TITLE
Fixed logic error in ElfHeader::parseDynamicTable

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -707,15 +707,16 @@ public class ElfHeader implements StructConverter {
 			}
 
 			ElfProgramHeader loadHeader = getProgramLoadHeaderContaining(vaddr);
-			if (loadHeader != null) {
-				long dynamicTableOffset = loadHeader.getOffset() +
-					(dynamicHeaders[0].getVirtualAddress() - loadHeader.getVirtualAddress());
-				dynamicTable = new ElfDynamicTable(reader, this, dynamicTableOffset,
-					dynamicHeaders[0].getVirtualAddress());
-				return;
+			if (loadHeader == null) {
+				loadHeader = dynamicHeaders[0];
 			}
+			long dynamicTableOffset = loadHeader.getOffset() +
+				(dynamicHeaders[0].getVirtualAddress() - loadHeader.getVirtualAddress());
+			dynamicTable = new ElfDynamicTable(reader, this, dynamicTableOffset,
+				dynamicHeaders[0].getVirtualAddress());
+			return;
 		}
-		else if (dynamicHeaders.length > 1) {
+		if (dynamicHeaders.length > 1) {
 			errorConsumer.accept("Multiple ELF Dynamic table program headers found");
 		}
 


### PR DESCRIPTION
This fixes a logic error in `ElfHeader::parseDynamicTable` header exists and the dynamic table is not also in a PT_LOAD segment. I'm not sure why you would have a `PT_DYNAMIC` program header and have the dynamic table in a `PT_LOAD` segment but I left the check in just incase it wasn't a copy/paste mistake.