### PR TITLE
fix function inlining with more than one function

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
@@ -1082,6 +1082,21 @@ void FlowInfo::inlineEZClone(const FlowInfo &inlineflow,const Address &calladdr)
   // address, we don't touch unprocessed, addrlist, or visited
 }
 
+/// Checks whether the function has already been inlined
+/// \param inlinefd is the function being in-lined into \b this flow
+/// \param op is CALL instruction at the site of the in-line
+bool FlowInfo::testAlreadyInlined(Funcdata *inlinefd, PcodeOp *op)
+{
+  if (inline_recursion->find( inlinefd->getAddress() ) != inline_recursion->end()) {
+    // This function has already been included with current inlining
+    inline_head->warning("Could not inline here",op->getAddr());
+    return false;
+  }
+
+  inline_recursion->insert(inlinefd->getAddress());
+  return true;
+}
+
 /// \brief For in-lining using the \e hard model, make sure some restrictions are met
 ///
 ///   - Can only in-line the function once.
@@ -1096,12 +1111,6 @@ void FlowInfo::inlineEZClone(const FlowInfo &inlineflow,const Address &calladdr)
 bool FlowInfo::testHardInlineRestrictions(Funcdata *inlinefd,PcodeOp *op,Address &retaddr)
 
 {
-  if (inline_recursion->find( inlinefd->getAddress() ) != inline_recursion->end()) {
-    // This function has already been included with current inlining
-    inline_head->warning("Could not inline here",op->getAddr());
-    return false;
-  }
-  
   if (!inlinefd->getFuncProto().isNoReturn()) {
     list<PcodeOp *>::iterator iter = op->getInsertIter();
     ++iter;
@@ -1119,7 +1128,6 @@ bool FlowInfo::testHardInlineRestrictions(Funcdata *inlinefd,PcodeOp *op,Address
     data.opMarkStartBasic(nextop);
   }
 
-  inline_recursion->insert(inlinefd->getAddress());
   return true;
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/flow.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/flow.hh
@@ -151,6 +151,7 @@ public:
   void generateOps(void);			///< Generate raw control-flow from the function's base address
   void generateBlocks(void);			///< Generate basic blocks from the raw control-flow
   bool testHardInlineRestrictions(Funcdata *inlinefd,PcodeOp *op,Address &retaddr);
+  bool testAlreadyInlined(Funcdata *inlinefd, PcodeOp *op);
   bool checkEZModel(void) const;		///< Check if \b this flow matches the EX in-lining model
   void injectPcode(void);			///< Perform substitution on any op that requires \e injection
   void forwardRecursion(const FlowInfo &op2);	///< Pull in-lining recursion information from another flow

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_op.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_op.cc
@@ -808,6 +808,10 @@ void Funcdata::truncatedFlow(const Funcdata *fd,const FlowInfo *flow)
 bool Funcdata::inlineFlow(Funcdata *inlinefd,FlowInfo &flow,PcodeOp *callop)
 
 {
+  // checks that the function has not already been inlined
+  if (!flow.testAlreadyInlined(inlinefd, callop))
+    return false;
+
   inlinefd->getArch()->clearAnalysis(inlinefd);
   FlowInfo inlineflow(*inlinefd,inlinefd->obank,inlinefd->bblocks,inlinefd->qlst);
   inlinefd->obank.setUniqId( obank.getUniqId() );


### PR DESCRIPTION
### Description of the bug:
There are two issues currently when inlining more than one function.
- If there is a recursion, the decompiler will be stuck in an infinite loop.
- Otherwise if function A calls function B, function B calls function C, and functions B and C are marked as inline, the decompiler will always wrongfully detect function C as having already been inlined recursively and will thus fail to inline it.

Fixes #3091 

### Description of the fix
The fix moves the code that verifies whether the function to inline has already been processed to the new function `FlowInfo::testAlreadyInlined` and calls this function before the `Funcdata::inlineFlow` function does anything. Doing so prevents `FlowInfo::generateOps` to be called infinitely due to `inline_recursion` being checked after the recursive call.

### Exemple
Take the following C code and mark `func2`, `func3`, `dont_inline_me` and `inlined_recursive_func` as inlined.
```c
void func1()
{
    printf("func1\n");
    func2();
}
void func2()
{
    printf("func2\n");
    func3();
}
void func3()
{
    printf("func3\n");
}

void dont_inline_me()
{
    printf("Don't inline me\n");
    inlined_recursive_func();
}
void inlined_recursive_func()
{
    printf("The bellow call should not be inlined\n");
    dont_inline_me();
}
```

[Debug output of `func1` and `dont_inline_me`](https://github.com/NationalSecurityAgency/ghidra/files/12709535/debug_output.zip)


#### Before the Fix:
```c
void func1(void)

{
  puts("func1");
                    /* WARNING: Could not inline here */
  func2();
  return;
}

// dont_inline_me:
 Exception while decompiling 00100047: Decompiler process died
```

#### After the Fix:
```c
/* WARNING: Inlined function: func2 */

void func1(void)

{
  puts("func1");
  puts((char *)0x100086);
  puts((char *)0x10008c);
  return;
}

/* WARNING: Inlined function: inlined_recursive_func */
/* WARNING: This is an inlined function */

void dont_inline_me(void)

{
  puts((char *)0x100092);
  puts((char *)0x1000a8);
                    /* WARNING: Could not inline here */
  dont_inline_me();
  return;
}
```