### PR TITLE
PowerPC: allow 'xor.' instruction in VLE mode

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
@@ -4516,7 +4516,7 @@ define pcodeop TLBSynchronize; # Outputs/affect TBD
 }
 
 #xor. r0,r0,r0	0x7c 00 02 79
-:xor. A,S,B		is $(NOTVLE) & OP=31 & S & A & B & XOP_1_10=316 & Rc=1
+:xor. A,S,B		is OP=31 & S & A & B & XOP_1_10=316 & Rc=1
 {
 	A = S ^ B;
 	cr0flags(A);


### PR DESCRIPTION
For some reason `xor.` opcode disabled in VLE mode. I am not an expert in the whole PPC family, but looks like it is a valid instruction.
1) `xor.` is mentioned in [Freescale doc](https://www.nxp.com/docs/en/reference-manual/MPC82XINSET.pdf) (page 154) and original (?) [IBM doc](https://www.nxp.com/docs/en/reference-manual/MPC82XINSET.pdf) (page 74) the same as a normal `xor` opcode.

2) it is used in the real binary from MPC5607 MCU (sample below).

To reproduce load attached hex file as `PowerPC:BE:64:VLE-32addr` and press F12.
```
:2000000001302A04E20762032DF72A007C63381E00047C06FE707C07327806677C85FE70B3
:200020007C862A7806567C67339669F069F47C002279E6097C073396056006072A07E60281
:2000400020030033000401302A04E208707078002CF72A007C63381EE8147C07FE707C05B5
:200060003A7806757C87FE707C863A7806767C65339669F069F47C002279E602003300F32D
:0400800000F3000485
:00000001FF
```
