### PR TITLE
decomp_dbg: Fix output of `print C xml` to be XML instead of binary.

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ifacedecomp.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ifacedecomp.cc
@@ -963,9 +963,10 @@ void IfcPrintCXml::execute(istream &s)
     throw IfaceExecutionError("No function selected");
 
   dcp->conf->print->setOutputStream(status->fileoptr);
-  dcp->conf->print->setMarkup(true);
+  dcp->conf->print->setMarkup(true, EmitMarkup::format_xml);
   dcp->conf->print->docFunction(dcp->fd);
   dcp->conf->print->setMarkup(false);
+  *status->fileoptr << endl;
 }
 
 /// \class IfcPrintCStruct

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.cc
@@ -294,7 +294,14 @@ void EmitMarkup::setOutputStream(ostream *t)
   if (encoder != (Encoder *)0)
     delete encoder;
   s = t;
-  encoder = new PackedEncode(*s);
+  switch (markup_format) {
+  case format_xml:
+    encoder = new XmlEncode(*s);
+    break;
+  case format_packed:
+    encoder = new PackedEncode(*s);
+    break;
+  }
 }
 
 int4 TokenSplit::countbase = 0;
@@ -1170,13 +1177,13 @@ void EmitPrettyPrint::flush(void)
 /// This method toggles the low-level emitter between EmitMarkup and EmitNoMarkup depending
 /// on whether markup is desired.
 /// \param val is \b true if markup is desired
-void EmitPrettyPrint::setMarkup(bool val)
+void EmitPrettyPrint::setMarkup(bool val, EmitMarkup::MarkupFormat format)
 
 {
   ostream *t = lowlevel->getOutputStream();
   delete lowlevel;
   if (val)
-    lowlevel = new EmitMarkup;
+    lowlevel = new EmitMarkup(format);
   else
     lowlevel = new EmitNoMarkup;
   lowlevel->setOutputStream(t);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
@@ -454,11 +454,17 @@ public:
 /// This class can be used as the low-level back-end to EmitPrettyPrint to provide a solution
 /// that does both pretty printing and markup.
 class EmitMarkup : public Emit {
+public:
+  enum MarkupFormat {
+    format_xml,
+    format_packed,
+  };
 protected:
   ostream *s;				///< Stream being emitted to
   Encoder *encoder;			///< How markup is encoded to the output stream
+  MarkupFormat markup_format;		///< How to format the markup.
 public:
-  EmitMarkup(void) : Emit() { s = (ostream *)0; encoder = (Encoder *)0; }		///< Constructor
+  EmitMarkup(MarkupFormat format) : Emit() { s = (ostream *)0; encoder = (Encoder *)0; markup_format = format; }		///< Constructor
 
   virtual ~EmitMarkup(void);
   virtual int4 beginDocument(void);
@@ -1064,7 +1070,7 @@ public:
   virtual void setCommentFill(const string &fill) { commentfill = fill; }
   virtual bool emitsMarkup(void) const { return lowlevel->emitsMarkup(); }
   virtual void resetDefaults(void);
-  void setMarkup(bool val);	///< Toggle whether the low-level emitter emits markup or not
+  void setMarkup(bool val, EmitMarkup::MarkupFormat format);	///< Toggle whether the low-level emitter emits markup or not
 };
 
 /// \brief Helper class for sending cancelable print commands to an ExitXml

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
@@ -653,7 +653,16 @@ void PrintLanguage::emitLineComment(int4 indent,const Comment *comm)
 void PrintLanguage::setMarkup(bool val)
 
 {
-  ((EmitPrettyPrint *)emit)->setMarkup(val);
+  setMarkup(val, EmitMarkup::format_packed);
+}
+
+/// Tell the emitter whether to emit just the raw tokens or if additional mark-up should be provided.
+/// \param val is \b true for additional mark-up
+/// \param format is the format (packed or XML) to use for the markup.
+void PrintLanguage::setMarkup(bool val, EmitMarkup::MarkupFormat format)
+
+{
+  ((EmitPrettyPrint *)emit)->setMarkup(val, format);
 }
 
 /// Emitting formal code structuring can be turned off, causing all control-flow

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
@@ -455,6 +455,7 @@ public:
   void setHeaderComment(uint4 val) { head_comment_type = val; }		///< Set the type of comments suitable for a function header
   bool emitsMarkup(void) const { return emit->emitsMarkup(); }		///< Does the low-level emitter, emit markup
   void setMarkup(bool val);						///< Set whether the low-level emitter, emits markup
+  void setMarkup(bool val, EmitMarkup::MarkupFormat format);		///< Set whether the low-level emitter, emits markup in the given format.
   void setFlat(bool val);						///< Set whether nesting code structure should be emitted
 
   virtual void initializeFromArchitecture(void)=0;		///< Initialize architecture specific aspects of printer


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/ghidra/issues/5860