### PR TITLE
Fug fix: 'lldb, lldb-java library now found'.

### DIFF
--- a/Ghidra/Debug/Debugger-gadp/src/main/java/ghidra/dbg/gadp/server/AbstractGadpLocalDebuggerModelFactory.java
+++ b/Ghidra/Debug/Debugger-gadp/src/main/java/ghidra/dbg/gadp/server/AbstractGadpLocalDebuggerModelFactory.java
@@ -116,6 +116,9 @@ public abstract class AbstractGadpLocalDebuggerModelFactory implements DebuggerM
 				String javaCommand = System.getProperty("java.home") + File.separator + "bin" +
 					File.separator + "java";
 				cmd.add(javaCommand);
+				if (System.getProperty("additional.java.library.path") != null) {
+					cmd.add("-Djava.library.path=" + System.getProperty("java.library.path") + ":" + System.getProperty("additional.java.library.path"));
+				}
 				cmd.add("-cp");
 				cmd.add(System.getProperty("java.class.path"));
 				if (jdwpPort >= 0) {

--- a/Ghidra/Debug/Debugger-swig-lldb/InstructionsForBuildingLLDBInterface.txt
+++ b/Ghidra/Debug/Debugger-swig-lldb/InstructionsForBuildingLLDBInterface.txt
@@ -41,7 +41,7 @@ If you have the most current version or have completed step (2), you can:
 	- gradle build
 	
 (4) To run:
-	- add -Djava.library.path=/path_to_liblldb:/path_to_liblldb-java:etc (not including the actual library name)
+	- add -Dadditional.java.library.path=/path_to_liblldb:/path_to_liblldb-java:etc (not including the actual library name)
 	  in support/launch.properties or, if you're running out of Eclipse, to the arguments in the Run/Debug Configuration
 	  
 TROUBLESHOOTING:
@@ -53,7 +53,7 @@ TROUBLESHOOTING:
     in mind that different generators for LLVM, esp. for Window, may put liblldb.xxx in unusual 
     places. Check "build/lib", "build/bin", and subdirs like "build/Release/bin".
 (4) If you get an "Unsatisfied Link Error" when you start the debugger,  make sure both liblldb
-    and liblldb-java are in the path described by java.library.path.
+    and liblldb-java are in the path described by additional.java.library.path.
 (5) Link errors can also be caused by different architectures or platforms for the libraries.
 (6) You may need to set up the development environment before running gradle:
 		gradle -I gradle/support/fetchDependencies.gradle init

--- a/Ghidra/Debug/Debugger-swig-lldb/macos_debugger_lldb_build_from_brew.sh
+++ b/Ghidra/Debug/Debugger-swig-lldb/macos_debugger_lldb_build_from_brew.sh
@@ -73,4 +73,4 @@ fi
 # Patch the launch.properties with our library location
 LAUNCH_PROPERTIES=${GHIDRA_INSTALL_DIR}/support/launch.properties
 sed -i '' /llvm/d ${LAUNCH_PROPERTIES}
-echo "VMARGS=-Djava.library.path=${GHIDRA_INSTALL_DIR}/${LIBLLDB_JAVA_DIR}:${BREW_LLVM}/lib" >> ${LAUNCH_PROPERTIES}
+echo "VMARGS=-Dadditional.java.library.path=${GHIDRA_INSTALL_DIR}/${LIBLLDB_JAVA_DIR}:${BREW_LLVM}/lib" >> ${LAUNCH_PROPERTIES}


### PR DESCRIPTION
…path' added at launch.properties and thus loaded in Ghidra JVM is not used to start a child process in Agent Thread.\nFix: use 'additional.java.library.path' instead of 'java.library.path' since the latter will overwrite default java library path and can cause problems, and then append 'additional.java.library.path' to 'java.library.path' when starting child process.

---------

Tested in MacOS.

Issue: lldb and lldb-java library can't be found in a child process started in AgentThread.

analysis: As settled in the script for MacOS provided by @cyberkaida, Ghidra set "-Djava.library.path" for lldb and lldb-java. But this JVM setting is not passed to child process. Thus causing library not found Exception.

Solution: As overriding 'java.library.path' can cause problems (for example, if this patch is accepted, users who place lldb, lldb-java in there default library path as suggested in related trouble shooting, can't use lldb debugger.), I suggest 'additional.java.library.path' for additional libraries and Add it to java.library.path when starting child process.

Further development: change launch script and launch process so that the 'additional.java.library.path' used in main thread not only Agent Thread



