### PR TITLE
fix CParser diagnostic output (_CParser.out)

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/ParseDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/cparser/ParseDialog.java
@@ -228,6 +228,7 @@ class ParseDialog extends ReusableDialogComponentProvider {
 				pathName = (pathName == null ? "" : pathName.trim());
 
 				if (pathName.length() == 0 || pathName.startsWith("#")) {
+					label.setForeground(getUneditableForegroundColor(data.isSelected()));
 					return label;
 				}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
@@ -482,7 +482,7 @@ public class CParserUtils {
 				e.printStackTrace();
 			}
         }
-        
+
         return parseHeaderFiles(openDTMgrs, filenames, includePaths, args, existingDTMgr, monitor);
     }
 	

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
@@ -535,7 +535,7 @@ public class CParserUtils {
 		String fName = dtMgr.getName();
 		
 		// make a path to tmpdir with name of data type manager
-		String path = System.getProperty("java.io.tmpdir") + File.pathSeparator + fName;
+		String path = System.getProperty("java.io.tmpdir") + File.separator + fName;
 		// if file data type manager, use path to .gdt file
 		if (dtMgr instanceof FileDataTypeManager) {
 			path = ((FileDataTypeManager) dtMgr).getPath();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
@@ -572,7 +572,7 @@ public class CParserUtils {
 						continue;
 					}
 					for (String element : children) {
-						File child = new File(file.getAbsolutePath() + "/" + element);
+						File child = new File(file.getAbsolutePath() + File.separator + element);
 						if (child.getName().endsWith(".h")) {
 							parseFile(child.getAbsolutePath(), monitor, cpp);
 						}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/C/CParserUtils.java
@@ -628,11 +628,11 @@ public class CParserUtils {
 			throws ghidra.app.util.cparser.CPP.ParseException {
 		monitor.setMessage("PreProcessing " + filename);
 		try {
-			Msg.info(CParserUtils.class, "parse " + filename);
+			Msg.info(CParserUtils.class, "parse: " + filename);
 			cpp.parse(filename);
 		}
 		catch (Throwable e) {
-			Msg.error(CParserUtils.class, "Parsing file :" + filename);
+			Msg.error(CParserUtils.class, "Parsing file: " + filename);
 			Msg.error(CParserUtils.class, "Unexpected Exception: " + e.getMessage(), e);
 
 			throw new ghidra.app.util.cparser.CPP.ParseException(e.getMessage());
@@ -693,7 +693,7 @@ public class CParserUtils {
 	// the error message contains an 'after' text, which is the text that comes after the
 	// invalid text
 	private static int getTokenMgrErrorIndexOfInvalidText(String message, String functionString) {
-		String invalidCharMarker = "after : ";
+		String invalidCharMarker = "after: ";
 		int index = message.indexOf(invalidCharMarker);
 		if (index >= 0) {
 			String remainder = message.substring(index + invalidCharMarker.length());


### PR DESCRIPTION
On Linux, this file fails to open (permission denied: `/tmp:xyz_CParser.out`), due to use of `File.pathSeparator` vs `File.separator`.

Also, fixes some message formatting re: colon+space.

Also, colors "ignored/commented" files differently (gray, default), as they are unused when actually executing the plugin.

Last, there is an issue with the default/included profiles: they use Microsoft Windows file separators, which Linux systems do not support.  I will create another PR to work-around this issue, but a better solution would be to change the default/included profiles to use UNIX file separators, as these are supported on Microsoft Windows, and so should work everywhere.

Due to the last note, the logic (which searches for a file in the "current" directory) will cause a file like `directory\file.h` to actually match a file `file.h` in the "current" directory.  This is not a huge concern given what the plugin does, but confused me for a little bit initially.