### PR TITLE
CParser: prevent crash when parsing

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/CPP/DefineTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/cparser/CPP/DefineTable.java
@@ -881,10 +881,9 @@ public class DefineTable {
 			pos = startPos;
 			int endParen = strValue.indexOf(')', pos + 1);
 			if (endParen != -1) {
-				String subStr = strValue.substring(pos + 1, endParen);
+				String subStr = strValue.substring(pos + 1, endParen).trim();
 				if (subStr.length() > 0) {
 					int subPos = 0;
-					subStr = subStr.trim();
 					boolean isValid = Character.isJavaIdentifierStart(subStr.charAt(0));
 					while (isValid && subPos < subStr.length()) {
 						char ch = subStr.charAt(subPos++);


### PR DESCRIPTION
if the trimmed token length is zero, charAt() explodes

this is likely a bad macro, but CParser should not crash regardless