### PR TITLE
HCS12 processor: fix conversion from Logical address to Global one

### DIFF
--- a/Ghidra/Processors/HCS12/data/languages/HCS_HC12.sinc
+++ b/Ghidra/Processors/HCS12/data/languages/HCS_HC12.sinc
@@ -333,10 +333,10 @@ macro Store(addr, value) {
 #
 
 macro pageCAddr(addr, shift, page, offset) {
-     addr = (page << shift) | offset;
+     addr = addr | (page << shift) | offset;
 }
 macro pagePAddr(addr, shift, page, offset) {
-     addr = (zext(page) << shift) | offset;
+     addr = addr | (zext(page) << shift) | offset;
 }
 
 @if defined(HCS12X)


### PR DESCRIPTION
According to [this](https://www.nxp.com/docs/en/application-note/AN3784.pdf) and [this](https://www.nxp.com/docs/en/application-note/AN2734.pdf) specifications, HCS12 / HCS12X flash memory located at the addresses 0x40'0000 .. 0x7F'FFFF.
So, to access it MCU converts 16-bit Logical address by the following formula: `GlobAddr = 0x40'0000 + (PPAGE << 14) + (LogAddr & 0x3FFF)`.
Looks like the first number in this formula was lost after some refactoring.
