### PR TITLE
HCS12 processor: fix inproper name for analyzer plugin

### DIFF
--- a/Ghidra/Processors/HCS12/src/main/java/ghidra/app/plugin/core/analysis/HCS12ConventionAnalyzer.java
+++ b/Ghidra/Processors/HCS12/src/main/java/ghidra/app/plugin/core/analysis/HCS12ConventionAnalyzer.java
@@ -51,10 +51,11 @@ public class HCS12ConventionAnalyzer extends AbstractAnalyzer {
 
 	@Override
 	public boolean canAnalyze(Program program) {
-		// Only analyze HCS12 Programs
+		// Only analyze HCS-12 / HCS-12X Programs
 		Processor processor = program.getLanguage().getProcessor();
+		boolean canDo = "HCS-12".equals(processor.toString()) ||
+						"HCS-12X".equals(processor.toString());
 
-		boolean canDo = processor.equals(Processor.findOrPossiblyCreateProcessor("HCS12"));
 		if (canDo) {
 			xgate = program.getRegister("XGATE");
 		}


### PR DESCRIPTION
`HCS12ConventionAnalyzer` plugin cannot start because corresponding processor was renamed from `HCS12` to the `HCS-12` here https://github.com/NationalSecurityAgency/ghidra/commit/212b2638ea143fc4a53818c0f78771d38dd03de5