### PR TITLE
Properly iterate through resolvemap when remove resolve ranges

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -2879,9 +2879,10 @@ void Database::clearResolve(Scope *scope)
     res = resolvemap.find(rng.getFirstAddr());
     while(res.first != res.second) {
       if ((*res.first).scope == scope) {
-	resolvemap.erase(res.first);
-	break;
+        resolvemap.erase(res.first);
+        break;
       }
+      res.first++;
     }
   }
 }


### PR DESCRIPTION
In `Database::clearResolve`, the iterator is not correctly updated if first element in the resolve map is different from given scope. This patch will increase the iterator if no erase happened.