### PR TITLE
Add a devcontainer for GitHub CodeSpaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/java",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {"version": "17", "installGradle": true},
+    "ghcr.io/devcontainers/features/sshd:1": {"version": "latest"}
+},
+"hostRequirements": {
+   "cpus": 4,
+   "memory": "16gb",
+   "storage": "32gb"
+},
+"customizations": {
+  "vscode": {
+    "extensions": [
+      "vscjava.vscode-java-debug",
+      "vscjava.vscode-java-pack",
+      "vscjava.vscode-gradle",
+      "ms-vscode.cpptools-extension-pack"
+    ]
+  }
+}
+}


### PR DESCRIPTION
Add a configuration for a [devcontainer](https://github.com/features/codespaces) that can build Ghidra.

I am not sure if this is something that you would like in the repository,
but I built this to help with some training on Ghidra development I will
deliver and it might be useful for the project. Please close if this is not
wanted.

This integrates with GitHub and allows for creating a small VM
with the required dependencies to build Ghidra. This is useful
for remote situations (I am using this for training so students
don't need a VM locally).

This can be tested with the [command line tool from GitHub](https://cli.github.com)
or with the web UI. Note if this is merged the `--repo` and `--branch` are
not required.

I have configured the dev container so the cost of storage and compute
is on the user, not the project. The machine is built from the specification
on demand rather than pre-built and stored (which would incur a cost
to the project).

The container has the recommended version of Java installed (17)
and Gradle. It also includes the recommended Java and C++ extensions
and the base image contains build-essential.

```sh
gh codespace create --repo cyberkaida/ghidra --branch cyberkaida-devcontainer
gh codespace code # Or gh codespace ssh if you prefer
```

When you are finished be sure to delete the codespace, you get
~40 hours for free I believe.

```sh
gh codespace delete
```