### PR TITLE
improved x86_64 golang cspec

### DIFF
--- a/Ghidra/Processors/x86/data/languages/x86-64-golang.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-64-golang.cspec
@@ -26,82 +26,211 @@
 	<global>
 		<range space="ram"/>
 	</global>
-  
+
 	<context_data>
 	</context_data>
-  
+
 	<stackpointer register="RSP" space="ram"/>
-  
+
 	<returnaddress>
 		<varnode space="stack" offset="0" size="8"/>
 	</returnaddress>
-  
+
 	<default_proto>
 		<prototype name="abi-internal" extrapop="8" stackshift="8">
-			<input>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM0_Qa"/>
+			<input killedbycall="true">
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM0"/>
 				</pentry>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM1_Qa"/>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM1"/>
 				</pentry>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM2_Qa"/>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM2"/>
 				</pentry>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM3_Qa"/>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM3"/>
 				</pentry>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM4_Qa"/>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM4"/>
 				</pentry>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM5_Qa"/>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM5"/>
 				</pentry>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM6_Qa"/>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM6"/>
 				</pentry>
-				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM7_Qa"/>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM7"/>
 				</pentry>
-		        
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM8"/>
+				</pentry>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM9"/>
+				</pentry>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM10"/>
+				</pentry>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM11"/>
+				</pentry>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM12"/>
+				</pentry>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM13"/>
+				</pentry>
+				<pentry minsize="4" maxsize="16" metatype="float">
+					<register name="XMM14"/>
+				</pentry>
+
 				<pentry minsize="1" maxsize="8">
 					<register name="RAX"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="RBX"/>
 				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="RAX" piece1="RBX"/>
+				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="RCX"/>
+				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="RBX" piece1="RCX"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="RAX" piece2="RBX" piece1="RCX"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="RDI"/>
 				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="RCX" piece1="RDI"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="RBX" piece2="RCX" piece1="RDI"/>
+				</pentry>
+				<pentry minsize="25" maxsize="32">
+					<addr space="join" piece4="RAX" piece3="RBX" piece2="RCX" piece1="RDI"/>
+				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="RSI"/>
+				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="RDI" piece1="RSI"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="RCX" piece2="RDI" piece1="RSI"/>
+				</pentry>
+				<pentry minsize="25" maxsize="32">
+					<addr space="join" piece4="RBX" piece3="RCX" piece2="RDI" piece1="RSI"/>
+				</pentry>
+				<pentry minsize="33" maxsize="40">
+					<addr space="join" piece5="RAX" piece4="RBX" piece3="RCX" piece2="RDI" piece1="RSI"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="R8"/>
 				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="RSI" piece1="R8"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="RDI" piece2="RSI" piece1="R8"/>
+				</pentry>
+				<pentry minsize="25" maxsize="32">
+					<addr space="join" piece4="RCX" piece3="RDI" piece2="RSI" piece1="R8"/>
+				</pentry>
+				<pentry minsize="33" maxsize="40">
+					<addr space="join" piece5="RBX" piece4="RCX" piece3="RDI" piece2="RSI" piece1="R8"/>
+				</pentry>
+				<pentry minsize="41" maxsize="48">
+					<addr space="join" piece6="RAX" piece5="RBX" piece4="RCX" piece3="RDI" piece2="RSI" piece1="R8"/>
+				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="R9"/>
+				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="R8" piece1="R9"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="RSI" piece2="R8" piece1="R9"/>
+				</pentry>
+				<pentry minsize="25" maxsize="32">
+					<addr space="join" piece4="RDI" piece3="RSI" piece2="R8" piece1="R9"/>
+				</pentry>
+				<pentry minsize="33" maxsize="40">
+					<addr space="join" piece5="RCX" piece4="RDI" piece3="RSI" piece2="R8" piece1="R9"/>
+				</pentry>
+				<pentry minsize="41" maxsize="48">
+					<addr space="join" piece6="RBX" piece5="RCX" piece4="RDI" piece3="RSI" piece2="R8" piece1="R9"/>
+				</pentry>
+				<pentry minsize="49" maxsize="56">
+					<addr space="join" piece7="RAX" piece6="RBX" piece5="RCX" piece4="RDI" piece3="RSI" piece2="R8" piece1="R9"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="R10"/>
 				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="R9" piece1="R10"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="R8" piece2="R9" piece1="R10"/>
+				</pentry>
+				<pentry minsize="25" maxsize="32">
+					<addr space="join" piece4="RSI" piece3="R8" piece2="R9" piece1="R10"/>
+				</pentry>
+				<pentry minsize="33" maxsize="40">
+					<addr space="join" piece5="RDI" piece4="RSI" piece3="R8" piece2="R9" piece1="R10"/>
+				</pentry>
+				<pentry minsize="41" maxsize="48">
+					<addr space="join" piece6="RCX" piece5="RDI" piece4="RSI" piece3="R8" piece2="R9" piece1="R10"/>
+				</pentry>
+				<pentry minsize="49" maxsize="56">
+					<addr space="join" piece7="RBX" piece6="RCX" piece5="RDI" piece4="RSI" piece3="R8" piece2="R9" piece1="R10"/>
+				</pentry>
+				<pentry minsize="57" maxsize="64">
+					<addr space="join" piece8="RAX" piece7="RBX" piece6="RCX" piece5="RDI" piece4="RSI" piece3="R8" piece2="R9" piece1="R10"/>
+				</pentry>
 				<pentry minsize="1" maxsize="8">
 					<register name="R11"/>
 				</pentry>
-		        
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="R10" piece1="R11"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+				<pentry minsize="25" maxsize="32">
+					<addr space="join" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+				<pentry minsize="33" maxsize="40">
+					<addr space="join" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+				<pentry minsize="41" maxsize="48">
+					<addr space="join" piece6="RDI" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+				<pentry minsize="49" maxsize="56">
+					<addr space="join" piece7="RCX" piece6="RDI" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+				<pentry minsize="57" maxsize="64">
+					<addr space="join" piece8="RBX" piece7="RCX" piece6="RDI" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+				<pentry minsize="65" maxsize="72">
+					<addr space="join" piece9="RAX" piece8="RBX" piece7="RCX" piece6="RDI" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+
 				<pentry minsize="1" maxsize="500" align="8">
 					<addr offset="8" space="stack"/>
 				</pentry>
 			</input>
-	      
+
 			<output>
 				<pentry minsize="4" maxsize="8" metatype="float">
 					<register name="XMM0_Qa"/>
 				</pentry>
-		        
+
 				<pentry minsize="1" maxsize="8">
 					<register name="RAX"/>
 				</pentry>
@@ -130,7 +259,7 @@
 					<addr space="join" piece9="RAX" piece8="RBX" piece7="RCX" piece6="RDI" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
 				</pentry>
 			</output>
-	      
+
 			<killedbycall>
 				<register name="RAX"/>
 				<register name="RBX"/>
@@ -145,21 +274,24 @@
 			<unaffected>
 				<register name="RSP"/>
 				<register name="RBP"/>
-				<register name="R14"/>        
+				<register name="R14"/>
 			</unaffected>
 		</prototype>
 	</default_proto>
-  
+
 	<prototype name="abi0" extrapop="8" stackshift="8">
 		<input>
 			<pentry minsize="1" maxsize="500" align="8">
 				<addr offset="8" space="stack"/>
 			</pentry>
 		</input>
-      
+
 		<output>
+			<pentry minsize="1" maxsize="500" align="8">
+				<addr offset="8" space="stack"/>
+			</pentry>
 		</output>
-      
+
 		<killedbycall>
 			<register name="RAX"/>
 			<register name="RBX"/>
@@ -174,33 +306,33 @@
 		<unaffected>
 			<register name="RSP"/>
 			<register name="RBP"/>
-			<register name="R14"/>        
+			<register name="R14"/>
 		</unaffected>
 	</prototype>
-    
+
 	<prototype name="duffzero" extrapop="8" stackshift="8">
 		<input>
 			<pentry minsize="1" maxsize="8">
 				<register name="RDI"/>
 			</pentry>
 		</input>
-      
+
 		<output>
 			<pentry minsize="1" maxsize="8">
 				<register name="RDI"/>
 			</pentry>
 		</output>
-      
+
 		<killedbycall>
 			<register name="RDI"/>
 		</killedbycall>
 		<unaffected>
 			<register name="RSP"/>
 			<register name="RBP"/>
-			<register name="R14"/>        
+			<register name="R14"/>
 		</unaffected>
 	</prototype>
-	
+
 	<prototype name="duffcopy" extrapop="8" stackshift="8">
 		<input>
 			<pentry minsize="1" maxsize="8">
@@ -210,7 +342,7 @@
 				<register name="RSI"/>
 			</pentry>
 		</input>
-      
+
 		<output>
 			<pentry minsize="1" maxsize="8">
 				<register name="RDI"/>
@@ -219,7 +351,7 @@
 				<addr space="join" piece2="RDI" piece1="RSI"/>
 			</pentry>
 		</output>
-      
+
 		<killedbycall>
 			<register name="RDI"/>
 			<register name="RSI"/>
@@ -236,10 +368,10 @@
 			<register name="R11"/>
 			<register name="RSP"/>
 			<register name="RBP"/>
-			<register name="R14"/>        
+			<register name="R14"/>
 		</unaffected>
 	</prototype>
-	
+
 	<prototype name="__stdcall" extrapop="8" stackshift="8">
 		<!-- Derived from "System V Application Binary Interface AMD64 Architecture Processor Supplement" April 2016 -->
 		<input>
@@ -376,7 +508,7 @@
 			<range space="stack" first="8" last="39"/>
 		</localrange>
 	</prototype>
-	
+
 	<prototype name="syscall" extrapop="8" stackshift="8">
 		<input pointermax="8">
 			<pentry minsize="1" maxsize="8">

--- a/Ghidra/Processors/x86/data/languages/x86-64-golang.register.info
+++ b/Ghidra/Processors/x86/data/languages/x86-64-golang.register.info
@@ -1,6 +1,6 @@
 <golang>
 	<!-- see https://github.com/golang/go/blob/master/src/internal/abi/abi_amd64.go -->
-	<register_info versions="V1_17,V1_18,V1_19,V1_20"> <!-- "all", or comma list of: V1_2,V1_16,V1_17,V1_18 -->
+	<register_info versions="V1_17,V1_18,V1_19,V1_20,V1_21"> <!-- "all", or comma list of: V1_2,V1_16,V1_17,V1_18 -->
 		<int_registers list="RAX,RBX,RCX,RDI,RSI,R8,R9,R10,R11"/>
 		<float_registers list="XMM0,XMM1,XMM2,XMM3,XMM4,XMM5,XMM6,XMM7,XMM8,XMM9,XMM10,XMM11,XMM12,XMM13,XMM14"/>
 		<stack initialoffset="8" maxalign="8"/>


### PR DESCRIPTION
@dev747368 this isn't perfect, since there is no way to account for the spill space, but it is much better than it was.

I have no idea about the 32-bit x86 golang calling convention.