### PR TITLE
PowerPC: improve e_rlwinm / e_rlwimi instructions

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -815,38 +815,36 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 
 # The manual uses MB instead of NB here, but because the "MB" symbol is already taken, NB it is
 :e_rlwimi A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=0 & MBL & ME & A & SHL & S {
-	tmpS:4 = S:4;
-	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
-	tmpM:4 = ~0:4;
-	if (ME:1 < MBL:1) goto <invert>;
-	tmpM = tmpM << MBL;
+	local tmpS:4 = S:4;
+	local tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
+
+	local tmpM = ~0:4 << MBL;
 	tmpM = tmpM >> ((31-ME) + MBL);
 	tmpM = tmpM << (31-ME);
-	goto <finish>;
-<invert>
-	tmpM = tmpM << ME;
-	tmpM = tmpM >> ((31-MBL) + ME);
-	tmpM = tmpM << (31-MBL);
-	tmpM = ~tmpM;
-<finish>
+
+	local tmpMi = ~0:4 << ME;
+	tmpMi = tmpMi >> ((31-MBL) + ME);
+	tmpMi = tmpMi << (31-MBL);
+	tmpMi = ~tmpMi;
+
+	tmpM = zext(ME:1 >= MBL:1)*tmpM + zext(ME:1 < MBL:1)*tmpMi;
 	A = zext(tmpA & tmpM) | (A & zext(~tmpM));	
 }
 
 :e_rlwinm A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=1 & MBL & ME & A & SHL & S {
-	tmpS:4 = S:4;
-	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
-	tmpM:4 = ~0:4;
-	if (ME:1 < MBL:1) goto <invert>;
-	tmpM = tmpM << MBL;
+	local tmpS:4 = S:4;
+	local tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
+
+	local tmpM = ~0:4 << MBL;
 	tmpM = tmpM >> ((31-ME) + MBL);
 	tmpM = tmpM << (31-ME);
-	goto <finish>;
-<invert>
-	tmpM = tmpM << ME;
-	tmpM = tmpM >> ((31-MBL) + ME);
-	tmpM = tmpM << (31-MBL);
-	tmpM = ~tmpM;
-<finish>
+
+	local tmpMi = ~0:4 << ME;
+	tmpMi = tmpMi >> ((31-MBL) + ME);
+	tmpMi = tmpMi << (31-MBL);
+	tmpMi = ~tmpMi;
+
+	tmpM = zext(ME:1 >= MBL:1)*tmpM + zext(ME:1 < MBL:1)*tmpMi;
 	A = zext(tmpA & tmpM);		
 }
 


### PR DESCRIPTION
It is not an error, just small improvement.
Current `e_rlwinm` implementation makes some noise in decompiled code.

Before fix:
```
  uint uVar1;
  uint uVar2;

  uVar2 = FUN(bla-bla-bla);
  if (false) {
    uVar1 = 0xffffffff;
  }
  else {
    uVar1 = 0xff;
  }
  if ((uVar2 & uVar1) == 0) {
    bla-bla-bla
  }
```

After this fix:
```
  uint uVar1;
  uVar1 = FUN(bla-bla-bla);
  if ((uVar1 & 0xff) == 0) {
    bla-bla-bla
  }
```