### PR TITLE
ghidra: fixed paths with spaces unable to be imported into ghidra

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/framework/main/datatree/LinuxFileUrlHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/framework/main/datatree/LinuxFileUrlHandler.java
@@ -61,7 +61,9 @@ public final class LinuxFileUrlHandler extends AbstractFileListFlavorHandler {
 
 		return toFiles(transferData, s -> {
 			try {
-				return new File(new URL(s).toURI());
+				// Replacing the spaces with "%20" will allow for file paths with spaces to be parsed correctly
+                // and not cause an exception
+                return new File(new URL(s.replaceAll(" ", "%20")).toURI());
 			}
 			catch (MalformedURLException e) {
 				// this could be the case that this handler is attempting to process an arbitrary


### PR DESCRIPTION
I was unable to import any executables to my project in Ghidra, which contained a space in the path name on Linux. I traced the error down to line 66 in 'LinuxFileUrlHandler.java`. I replaced this line:
```java
return new File(new URL(s).toURI());
```
with:
```java
return new File(new URL(s.replaceAll(" ", "%20")).toURI());
```
This allowed for spaces to be used in file paths which were added into Ghidra.