### PR TITLE
AVR8: Fix DES operation reconstruction

### DIFF
--- a/Ghidra/Processors/Atmel/data/languages/avr8.sinc
+++ b/Ghidra/Processors/Atmel/data/languages/avr8.sinc
@@ -739,7 +739,7 @@ define pcodeop decrypt;
 
 :des op4to7                      is phase=1 & ophi8=0x94 & oplow4=0xb & op4to7 {
 	val:1  = op4to7;
-	if (Hflg) goto <enc>;
+	if (Hflg == 0) goto <enc>;
 	R15R14R13R12R11R10R9R8 = decrypt(R7R6R5R4R3R2R1R0, val);
 	goto inst_next;
   <enc>


### PR DESCRIPTION
The AVR Instruction Set Manual defines the DES operation as follows:

If H = 0 then Encrypt round (R7-R0, R15-R8, K)
If H = 1 then Decrypt round (R7-R0, R15-R8, K)

Closes #5235.