### PR TITLE
Fix two bugs in LoongArch sleigh code

### DIFF
--- a/Ghidra/Processors/Loongarch/data/languages/loongarch32_instructions.sinc
+++ b/Ghidra/Processors/Loongarch/data/languages/loongarch32_instructions.sinc
@@ -1154,8 +1154,8 @@ csr: csr is imm10_14 [csr = $(CSR_OFFSET) + imm10_14 * $(REGSIZE);] {
 :csrxchg  RD, RJsrc, csr is op24_31=0x4 & RD & RJsrc & csr {
 	local csrval:$(REGSIZE) = csr;
 	local mask = RJsrc;
-	csr = RD & mask;
-	RD = csrval & mask;
+	csr = (RD & mask) | (csrval & ~mask);
+	RD = csrval;
 }
 
 :csrrd  RD, csr is op24_31=0x4 & RD & op5_9=0 & csr {

--- a/Ghidra/Processors/Loongarch/data/languages/loongarch_main.sinc
+++ b/Ghidra/Processors/Loongarch/data/languages/loongarch_main.sinc
@@ -143,7 +143,7 @@ define register offset=$(CSR_OFFSET) size=$(REGSIZE) [
 	save0     save1     save2     save3     save4     save5     save6     save7
 	save8     save9     save10    save11    save12    save13    save14    save15
 	tid       tcfg      tval      cntc      ticlr     csr69     csr70     csr71
-	csr72     csr73     csr74     csr75     csr76     csr78     csr79
+	csr72     csr73     csr74     csr75     csr76     csr77	    csr78     csr79
 	csr80     csr81     csr82     csr83     csr84     csr85     csr86     csr87
 	csr88     csr89     csr90     csr91     csr92     csr93     csr94     csr95
 	llbctl    csr97     csr98     csr99     csr100    csr101    csr102    csr103


### PR DESCRIPTION
Add missing csr77 to LoongArch, and fix csrxchg definition: `The CSRXCHG instruction writes the old value of the general register rd to the bits of the specified CSR corresponding to the write mask of 1 according to the write mask information stored in the general register rj. The rest of the bits in the CSR remain unchanged, and the old value of the CSR is updated to the general register rd.`.