### PR TITLE
ARM: Fix alignment requirement for switch8_r3 patterns

### DIFF
--- a/Ghidra/Processors/ARM/data/patterns/ARM_switch_patterns.xml
+++ b/Ghidra/Processors/ARM/data/patterns/ARM_switch_patterns.xml
@@ -94,7 +94,7 @@
            add        ip,lr,r3, lsl #0x1   |   add lr,lr,r3, lsl #0x1
            bx         ip                   |   bx lr
        -->
-      <align mark="0" bits="3"/>
+      <align mark="0" bits="2"/>
       <setcontext name="TMode" value="0"/>
       <funcstart label="switch8_r3"/>
   </pattern>
@@ -108,7 +108,7 @@
            add        ip,lr,r3, lsl #0x1   |   add lr,lr,r3, lsl #0x1
            bx         ip                   |   bx lr
        -->
-      <align mark="0" bits="3"/>
+      <align mark="0" bits="2"/>
       <setcontext name="TMode" value="0"/>
       <funcstart label="switch8_r3"/>
   </pattern>


### PR DESCRIPTION
While analyzing a program in which the switch8_r3 pattern occurs, the pattern was not detected, and thus switch statements could not be decompiled properly.

The cause turned out to be that the alignment requirement `<align mark="0" bits="3"/>` means that 8-byte aligment is required, but the switch8_r3 function in this program was only 4-byte aligned.

This commit adjusts the alignment requirements listed for switch8_r3 in ARM_switch_patterns.xml to permit 4-byte alignment.