### PR TITLE
Use `uname -m` instead of `arch` as latter isn't available everywhere

### DIFF
--- a/Ghidra/Features/BSim/make-postgres.sh
+++ b/Ghidra/Features/BSim/make-postgres.sh
@@ -62,7 +62,7 @@ if [ ! -f "${POSTGRES_GZ_PATH}" ]; then
 fi
 
 OS=`uname -s`
-ARCH=`arch`
+ARCH=`uname -m`
 
 cd ${DIR}
 


### PR DESCRIPTION
In the `make-postgresql.sh` script, the system architecture is queried by `arch`. However, that command isn't present by default on a lot of systems (for example, Arch Linux). Since `uname` is already used elsewhere in the script, it is also presumed to exist, so favor `uname -m`, which provides the same functionality, so that the script completed successfully on a broader set of OSes, without expecting additional superfluous dependencies.