### PR TITLE
(Proof of concept) Width 4 boolean

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Bool4DataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Bool4DataType.java
@@ -24,32 +24,28 @@ import ghidra.program.model.mem.MemBuffer;
 import ghidra.program.model.mem.MemoryAccessException;
 
 /**
- * Provides a definition of an Ascii byte in a program.
+ * Provides a definition of an Width-4 boolean in a program.
  */
-public class BooleanDataType extends AbstractUnsignedIntegerDataType {
+public class Bool4DataType extends BooleanDataType {
 
 	private static SettingsDefinition[] SETTINGS_DEFS = {};
 
-	public static final BooleanDataType dataType = new BooleanDataType();
+	public static final Bool4DataType dataType = new Bool4DataType();
 
 	/**
 	 * Constructs a new Boolean datatype.
 	 */
-	public BooleanDataType() {
+	public Bool4DataType() {
 		this(null);
 	}
 
-	public BooleanDataType(DataTypeManager dtm) {
-		super("bool", dtm);
-	}
-
-	public BooleanDataType(String name, DataTypeManager dtm) {
-		super(name, dtm);
+	public Bool4DataType(DataTypeManager dtm) {
+		super("bool4", dtm);
 	}
 
 	@Override
 	public String getMnemonic(Settings settings) {
-		return "bool";
+		return "bool4";
 	}
 
 	@Override
@@ -57,7 +53,7 @@ public class BooleanDataType extends AbstractUnsignedIntegerDataType {
 		if (language == DecompilerLanguage.JAVA_LANGUAGE) {
 			return "boolean";
 		}
-		return name;
+		return "bool4";
 	}
 
 	@Override
@@ -67,12 +63,12 @@ public class BooleanDataType extends AbstractUnsignedIntegerDataType {
 
 	@Override
 	public int getLength() {
-		return 1; // TODO: Size should probably be based upon data organization
+		return 4;
 	}
 
 	@Override
 	public String getDescription() {
-		return "Boolean";
+		return "Boolean4";
 	}
 
 	@Override
@@ -111,12 +107,12 @@ public class BooleanDataType extends AbstractUnsignedIntegerDataType {
 
 	@Override
 	public DataType clone(DataTypeManager dtm) {
-		return new BooleanDataType(dtm);
+		return new Bool4DataType(dtm);
 	}
 
 	@Override
 	public String getDefaultLabelPrefix() {
-		return "BOOL";
+		return "BOOL4";
 	}
 
 	@Override


### PR DESCRIPTION
It is not uncommon for a program to clear the high bits of registers for booleans. For example, the following are (separate instructions) from a MIPS (32 bit, big endian) binary which precede a return, illustrating different ways the function returns ``true`` and ``false``

![image](https://github.com/NationalSecurityAgency/ghidra/assets/55233728/b71aa1bf-396f-4908-8df5-257a7d502855)

![image](https://github.com/NationalSecurityAgency/ghidra/assets/55233728/2ed422c0-7f8b-452f-bd11-a4681b3c7680)

Callers can access the full register and treat it as a boolean value, which the decompiler does not know about.
![image](https://github.com/NationalSecurityAgency/ghidra/assets/55233728/9a8ed22c-67f1-4172-ac78-ec8abbc30981)
This leads to decompilation like:
![image](https://github.com/NationalSecurityAgency/ghidra/assets/55233728/fe7f4017-ecd2-4d09-8ff8-9c33bd937e56)

This PR introduces a ``bool4`` (``Bool4DataType extends BooleanDataType``)  which tries to behave as much like a width4 boolean as possible.

After: (changing return type to ``bool4``)
![image](https://github.com/NationalSecurityAgency/ghidra/assets/55233728/baf245a5-2409-45c7-bbab-f915b92ca905)

It doesn't decompile better in the base function and might not completely capture the meaning of a "width 4 boolean" , especially where the decompiler is concerned (for example, the ``if (bVar3 != false) {...}`` line); This PR is intended to be a proof of concept rather than used as is
![image](https://github.com/NationalSecurityAgency/ghidra/assets/55233728/bc9aa7c5-a225-42d2-acce-c7fbf3da8ae7)
