### PR TITLE
Decompiler: Add support for INT_REM in jumptable recovery.

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
@@ -505,7 +505,7 @@ uintb JumpBasic::backup2Switch(Funcdata *fd,uintb output,Varnode *outvn,Varnode 
   return output;
 }
 
-/// If the Varnode has a restricted range due to masking via INT_AND, the maximum value of this range is returned.
+/// If the Varnode has a restricted range due to masking via INT_AND or by INT_REM with a constant, the maximum value of this range is returned.
 /// Otherwise, 0 is returned, indicating that the Varnode can take all possible values.
 /// \param vn is the given Varnode
 /// \return the maximum value or 0
@@ -522,6 +522,12 @@ uintb JumpBasic::getMaxValue(Varnode *vn)
       maxValue = coveringmask( constvn->getOffset() );
       maxValue = (maxValue + 1) & calc_mask(vn->getSize());
     }
+  }
+  else if (op->code() == CPUI_INT_REM) {
+    // The largest value INT_REM(v, N) can take is N-1. The -1 is done elsewhere, so no need to do that here.
+    Varnode *constvn = op->getIn(1);
+    if (constvn->isConstant())
+      maxValue = constvn->getOffset();
   }
   else if (op->code() == CPUI_MULTIEQUAL) {	// Its possible the AND is duplicated across multiple blocks
     int4 i;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
@@ -513,11 +513,11 @@ uintb JumpBasic::backup2Switch(Funcdata *fd,uintb output,Varnode *outvn,Varnode 
 /// values.
 /// \param vn is the given Varnode
 /// \return one more than the largest value the varnode can take or 0
-uintb JumpBasic::getMaxValue(Varnode *vn)
+uintb JumpBasic::getMaxValue(Varnode *vn, int depth = 0)
 
 {
   uintb maxValue = 0;		// 0 indicates maximum possible value
-  if (!vn->isWritten())
+  if ((depth > 10) || !vn->isWritten())
     return maxValue;
   PcodeOp *op = vn->getDef();
   if (op->code() == CPUI_INT_AND) {
@@ -536,7 +536,7 @@ uintb JumpBasic::getMaxValue(Varnode *vn)
     int4 i;
     for(i=0;i<op->numInput();++i) {
       Varnode *subvn = op->getIn(i);
-      uintb submax = getMaxValue(subvn);
+      uintb submax = getMaxValue(subvn, depth + 1);
       if (submax == 0) {	// One of the inputs cannot be constrained -> the output cannot be constrained either
 	maxValue = 0;
 	break;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.cc
@@ -505,10 +505,14 @@ uintb JumpBasic::backup2Switch(Funcdata *fd,uintb output,Varnode *outvn,Varnode 
   return output;
 }
 
-/// If the Varnode has a restricted range due to masking via INT_AND or by INT_REM with a constant, the maximum value of this range is returned.
-/// Otherwise, 0 is returned, indicating that the Varnode can take all possible values.
+/// If the Varnode has a restricted range due to masking via INT_AND or by
+/// INT_REM with a constant, or the non-zero mask imposes a maximum value, or
+/// the Varnode is the result of a MULTIEQUAL of varnodes that all have a maximum,
+/// the largest value of this range plus one is returned.
+/// Otherwise, 0 is returned, indicating that the Varnode can take all possible
+/// values.
 /// \param vn is the given Varnode
-/// \return the maximum value or 0
+/// \return one more than the largest value the varnode can take or 0
 uintb JumpBasic::getMaxValue(Varnode *vn)
 
 {
@@ -523,30 +527,28 @@ uintb JumpBasic::getMaxValue(Varnode *vn)
       maxValue = (maxValue + 1) & calc_mask(vn->getSize());
     }
   }
-  else if (op->code() == CPUI_INT_REM) {
-    // The largest value INT_REM(v, N) can take is N-1. The -1 is done elsewhere, so no need to do that here.
+  else if (op->code() == CPUI_INT_REM) {	// The largest value INT_REM(v, N) can take is N-1. As such, return N.
     Varnode *constvn = op->getIn(1);
     if (constvn->isConstant())
       maxValue = constvn->getOffset();
   }
-  else if (op->code() == CPUI_MULTIEQUAL) {	// Its possible the AND is duplicated across multiple blocks
+  else if (op->code() == CPUI_MULTIEQUAL) {	// It's possible the AND is duplicated across multiple blocks
     int4 i;
     for(i=0;i<op->numInput();++i) {
       Varnode *subvn = op->getIn(i);
-      if (!subvn->isWritten()) break;
-      PcodeOp *andOp = subvn->getDef();
-      if (andOp->code() != CPUI_INT_AND) break;
-      Varnode *constvn = andOp->getIn(1);
-      if (!constvn->isConstant()) break;
-      if (maxValue < constvn->getOffset())
-	maxValue = constvn->getOffset();
+      uintb submax = getMaxValue(subvn);
+      if (submax == 0) {	// One of the inputs cannot be constrained -> the output cannot be constrained either
+	maxValue = 0;
+	break;
+      }
+      if (maxValue < submax)
+	maxValue = submax;
     }
-    if (i == op->numInput()) {
-      maxValue = coveringmask( maxValue );
-      maxValue = (maxValue + 1) & calc_mask(vn->getSize());
-    }
-    else
-      maxValue = 0;
+  }
+  if (maxValue == 0) {
+    // Try to see if the non-zero-mask can help out. Note that if the nzm has
+    // all bits set, the computed value of 'maxValue' will still be 0.
+    maxValue = (vn->getNZMask() + 1) & calc_mask(vn->getSize());
   }
   return maxValue;
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/jumptable.hh
@@ -383,7 +383,7 @@ protected:
   static bool ispoint(Varnode *vn);	///< Is it possible for the given Varnode to be a switch variable?
   static int4 getStride(Varnode *vn);	///< Get the step/stride associated with the Varnode
   static uintb backup2Switch(Funcdata *fd,uintb output,Varnode *outvn,Varnode *invn);
-  static uintb getMaxValue(Varnode *vn);	///< Get maximum value associated with the given Varnode
+  static uintb getMaxValue(Varnode *vn,int4 depth);	///< Get maximum value associated with the given Varnode
   static bool duplicateVarnodes(const vector<Varnode *> &arr);	///< Return \b true if all array elements are the same Varnode
   void findDeterminingVarnodes(PcodeOp *op,int4 slot);
   void analyzeGuards(BlockBasic *bl,int4 pathout);


### PR DESCRIPTION
This commit adds `INT_REM` handling to the `JumpBasic` class, which allows switch statements depending on expressions like `x % 10` to be properly recovered. Previously, a warning was emitted about there being "too many branches". This slightly improves the third problem mentioned in https://github.com/NationalSecurityAgency/ghidra/issues/2628#issuecomment-1869907358. 

**Screenshots**
These screenshots show the `main` function of the `switch` example from `GhidraDocs/GhidraClass/Advanced/Examples` after auto-analysis.

Before applying the patch
![image](https://github.com/NationalSecurityAgency/ghidra/assets/32435769/14313f59-50e5-406b-b164-e0d6b11d3e99)

After applying the patch
![image](https://github.com/NationalSecurityAgency/ghidra/assets/32435769/c7ea9a8e-ac99-4acb-a6cd-ea150c5ae24c)
