### PR TITLE
golang support 1.21+

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/GoVer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/GoVer.java
@@ -28,7 +28,9 @@ public enum GoVer {
 	V1_17(1, 17),
 	V1_18(1, 18),
 	V1_19(1, 19),
-	V1_20(1, 20);
+	V1_20(1, 20),
+	V1_21(1, 21),
+	V1_22(1, 22);
 
 	private final int major;
 	private final int minor;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoArrayType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoArrayType.java
@@ -26,7 +26,7 @@ import ghidra.program.model.data.DataType;
 /**
  * {@link GoType} structure that defines an array.
  */
-@StructureMapping(structureName = "runtime.arraytype")
+@StructureMapping(structureName = {"runtime.arraytype", "internal/abi.ArrayType"})
 public class GoArrayType extends GoType {
 
 	@FieldMapping

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoBaseType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoBaseType.java
@@ -35,7 +35,7 @@ import ghidra.app.util.bin.format.golang.structmapping.*;
  * struct specialized_type { basetype_struct; (various_fields)* } struct uncommon; 
  * </pre>
  */
-@StructureMapping(structureName = "runtime._type")
+@StructureMapping(structureName = {"runtime._type", "internal/abi.Type"})
 public class GoBaseType {
 
 	@ContextField
@@ -44,17 +44,17 @@ public class GoBaseType {
 	@ContextField
 	private GoRttiMapper programContext;
 
-	@FieldMapping(signedness = Signedness.Unsigned)
+	@FieldMapping(fieldName = {"size", "Size_"}, signedness = Signedness.Unsigned)
 	private long size;
 
-	@FieldMapping
+	@FieldMapping(fieldName = {"ptrdata", "PtrBytes"})
 	private long ptrdata;
 
 	@FieldMapping
 	@EOLComment("flags")
 	private int tflag;
 
-	@FieldMapping
+	@FieldMapping(fieldName = {"kind", "Kind_"})
 	@EOLComment
 	private int kind;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoChanType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoChanType.java
@@ -25,7 +25,7 @@ import ghidra.util.Msg;
 /**
  * A {@link GoType} structure that defines a go channel
  */
-@StructureMapping(structureName = "runtime.chantype")
+@StructureMapping(structureName = {"runtime.chantype", "internal/abi.ChanType"})
 public class GoChanType extends GoType {
 
 	@FieldMapping

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoFuncType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoFuncType.java
@@ -27,7 +27,7 @@ import ghidra.program.model.data.*;
 /**
  * A {@link GoType} structure that defines a function type.
  */
-@StructureMapping(structureName = "runtime.functype")
+@StructureMapping(structureName = {"runtime.functype", "internal/abi.FuncType"})
 public class GoFuncType extends GoType {
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoIMethod.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoIMethod.java
@@ -22,7 +22,7 @@ import ghidra.app.util.bin.format.golang.structmapping.*;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.data.FunctionDefinition;
 
-@StructureMapping(structureName = "runtime.imethod")
+@StructureMapping(structureName = {"runtime.imethod", "internal/abi.Imethod"})
 public class GoIMethod implements StructureMarkup<GoIMethod> {
 
 	@ContextField
@@ -36,7 +36,7 @@ public class GoIMethod implements StructureMarkup<GoIMethod> {
 	@EOLComment("getName")
 	private long name;
 
-	@FieldMapping
+	@FieldMapping(fieldName = {"ityp", "Typ"})
 	@MarkupReference("getType")
 	private long ityp;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoInterfaceType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoInterfaceType.java
@@ -28,14 +28,14 @@ import ghidra.util.exception.CancelledException;
 /**
  * A {@link GoType} structure that defines a golang interface. 
  */
-@StructureMapping(structureName = "runtime.interfacetype")
+@StructureMapping(structureName = {"runtime.interfacetype", "internal/abi.InterfaceType"})
 public class GoInterfaceType extends GoType {
 
 	@FieldMapping
 	@MarkupReference("getPkgPath")
 	private long pkgpath;	// pointer to name 
 
-	@FieldMapping
+	@FieldMapping(fieldName = {"mhdr", "Methods"})
 	private GoSlice mhdr;
 
 	public GoInterfaceType() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoMapType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoMapType.java
@@ -30,7 +30,7 @@ import ghidra.util.Msg;
  * See {@link GoRttiMapper#getMapGoType()} or the "runtime.hmap" type for the definition of
  * a instance of a map variable in memory. 
  */
-@StructureMapping(structureName = "runtime.maptype")
+@StructureMapping(structureName = {"runtime.maptype", "internal/abi.MapType"})
 public class GoMapType extends GoType {
 
 	@FieldMapping
@@ -51,7 +51,7 @@ public class GoMapType extends GoType {
 	@FieldMapping
 	private int keysize;
 
-	@FieldMapping
+	@FieldMapping(fieldName = {"elemsize", "ValueSize"})
 	private int elemsize;
 
 	@FieldMapping

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoMethod.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoMethod.java
@@ -28,7 +28,7 @@ import ghidra.util.NumericUtilities;
 /**
  * Structure that defines a method for a GoType, found in the type's {@link GoUncommonType} struct.
  */
-@StructureMapping(structureName = "runtime.method")
+@StructureMapping(structureName = {"runtime.method", "internal/abi.Method"})
 public class GoMethod implements StructureMarkup<GoMethod> {
 	@ContextField
 	private GoRttiMapper programContext;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoPlainType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoPlainType.java
@@ -32,7 +32,7 @@ import ghidra.util.Msg;
  * <p>
  * {@link GoType} structure that defines a built-in primitive type.
  */
-@StructureMapping(structureName = "runtime._type")
+@StructureMapping(structureName = {"runtime._type", "internal/abi.Type"})
 public class GoPlainType extends GoType implements StructureReader<GoType> {
 	@Override
 	public void readStructure() throws IOException {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoPointerType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoPointerType.java
@@ -26,7 +26,7 @@ import ghidra.program.model.data.PointerDataType;
 /**
  * {@link GoType} structure that defines a pointer.
  */
-@StructureMapping(structureName = "runtime.ptrtype")
+@StructureMapping(structureName = {"runtime.ptrtype", "internal/abi.PtrType"})
 public class GoPointerType extends GoType {
 	@FieldMapping
 	@MarkupReference("getElement")

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoSliceType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoSliceType.java
@@ -29,7 +29,7 @@ import ghidra.program.model.data.*;
  * See {@link GoRttiMapper#getGenericSliceDT()} or the "runtime.slice" type for the definition of
  * a instance of a slice variable in memory. 
 */
-@StructureMapping(structureName = "runtime.slicetype")
+@StructureMapping(structureName = {"runtime.slicetype", "internal/abi.SliceType"})
 public class GoSliceType extends GoType {
 
 	@FieldMapping

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoStructField.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoStructField.java
@@ -24,7 +24,7 @@ import ghidra.app.util.bin.format.golang.structmapping.*;
 /**
  * Structure used to define a field in a {@link GoStructType struct type}.
  */
-@StructureMapping(structureName = "runtime.structfield")
+@StructureMapping(structureName = {"runtime.structfield", "internal/abi.StructField"})
 public class GoStructField {
 
 	@ContextField

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoStructType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoStructType.java
@@ -29,7 +29,7 @@ import ghidra.util.exception.CancelledException;
 /**
  * Golang type information about a specific structure type.
  */
-@StructureMapping(structureName = "runtime.structtype")
+@StructureMapping(structureName = {"runtime.structtype", "internal/abi.StructType"})
 public class GoStructType extends GoType {
 
 	@FieldMapping

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoType.java
@@ -69,7 +69,7 @@ public abstract class GoType implements StructureMarkup<GoType> {
 	@ContextField
 	protected StructureContext<GoType> context;
 
-	@FieldMapping
+	@FieldMapping(fieldName = {"typ", "Type"})
 	@Markup
 	@FieldOutput
 	protected GoBaseType typ;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoTypeDetector.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoTypeDetector.java
@@ -21,9 +21,9 @@ import ghidra.app.util.bin.format.golang.structmapping.StructureMapping;
 /**
  * Small stub that is only used to fetch the "kind" field so that the real gotype can be detected
  */
-@StructureMapping(structureName = "runtime._type")
+@StructureMapping(structureName = {"runtime._type", "internal/abi.Type"})
 public class GoTypeDetector {
-	@FieldMapping
+	@FieldMapping(fieldName = {"kind", "Kind_"})
 	private int kind;
 
 	public GoKind getKind() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoUncommonType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoUncommonType.java
@@ -26,7 +26,7 @@ import ghidra.util.Msg;
  * Structure found immediately after a {@link GoType} structure, if it has the uncommon flag
  * set.
  */
-@StructureMapping(structureName = "runtime.uncommontype")
+@StructureMapping(structureName = {"runtime.uncommontype", "internal/abi.UncommonType"})
 public class GoUncommonType {
 
 	@ContextField

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/structmapping/DataTypeMapper.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/structmapping/DataTypeMapper.java
@@ -170,11 +170,16 @@ public class DataTypeMapper implements AutoCloseable {
 	 */
 	public <T> void registerStructure(Class<T> clazz) throws IOException {
 		Structure structDT = null;
-		String structName = StructureMappingInfo.getStructureDataTypeNameForClass(clazz);
-		if (structName != null && !structName.isBlank()) {
-			structDT = getType(structName, Structure.class);
+		for (String structName : StructureMappingInfo.getStructureDataTypeNameForClass(clazz)) {
+			if (structName != null && !structName.isBlank()) {
+				structDT = getType(structName, Structure.class);
+				if (structDT != null) {
+					break;
+				}
+			}
 		}
 		if (!StructureReader.class.isAssignableFrom(clazz) && structDT == null) {
+			String structName = StructureMappingInfo.getStructureDataTypeNameForClass(clazz)[0];
 			if (structName == null || structName.isBlank()) {
 				structName = "<missing>";
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/structmapping/StructureMapping.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/structmapping/StructureMapping.java
@@ -63,7 +63,7 @@ public @interface StructureMapping {
 	 * 
 	 * @return name of a Ghidra structure data type
 	 */
-	String structureName();
+	String[] structureName();
 
 	/**
 	 * Optional reference to a 'function' (implemented via a class) that will be called to do 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/structmapping/StructureMappingInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/structmapping/StructureMappingInfo.java
@@ -39,7 +39,7 @@ public class StructureMappingInfo<T> {
 	 * @param targetClass structure mapped class
 	 * @return the structure name
 	 */
-	public static String getStructureDataTypeNameForClass(Class<?> targetClass) {
+	public static String[] getStructureDataTypeNameForClass(Class<?> targetClass) {
 		StructureMapping sma = targetClass.getAnnotation(StructureMapping.class);
 		return sma != null ? sma.structureName() : null;
 	}
@@ -68,7 +68,7 @@ public class StructureMappingInfo<T> {
 	private final Class<T> targetClass;
 	private final ObjectInstanceCreator<T> instanceCreator;
 
-	private final String structureName;
+	private final String[] structureName;
 	private final Structure structureDataType;	// null if variable length fields
 
 	private final List<FieldMappingInfo<T>> fields = new ArrayList<>();
@@ -84,7 +84,7 @@ public class StructureMappingInfo<T> {
 		this.targetClass = targetClass;
 		this.structureDataType = structDataType;
 		this.structureName = structureDataType != null
-				? structureDataType.getName()
+				? new String[]{structureDataType.getName()}
 				: sma.structureName();
 		this.useFieldMappingInfo = !StructureReader.class.isAssignableFrom(targetClass);
 		this.instanceCreator = findInstanceCreator();
@@ -109,7 +109,7 @@ public class StructureMappingInfo<T> {
 	}
 
 	public String getDescription() {
-		return "%s-%s".formatted(targetClass.getSimpleName(), structureName);
+		return "%s-%s".formatted(targetClass.getSimpleName(), structureName[0]);
 	}
 
 	public Structure getStructureDataType() {
@@ -117,7 +117,7 @@ public class StructureMappingInfo<T> {
 	}
 
 	public String getStructureName() {
-		return structureName;
+		return structureName[0];
 	}
 
 	public int getStructureLength() {
@@ -187,7 +187,7 @@ public class StructureMappingInfo<T> {
 
 		Structure newStruct = new StructureDataType(
 			context.getDataTypeMapper().getDefaultVariableLengthStructCategoryPath(),
-			structureName,
+			structureName[0],
 			0,
 			context.getDataTypeMapper().getDTM());
 
@@ -204,7 +204,7 @@ public class StructureMappingInfo<T> {
 		}
 		if (!nameSuffix.isEmpty()) {
 			try {
-				newStruct.setName(structureName + nameSuffix);
+				newStruct.setName(structureName[0] + nameSuffix);
 			}
 			catch (InvalidNameException | DuplicateNameException e) {
 				throw new IOException(e);
@@ -264,7 +264,7 @@ public class StructureMappingInfo<T> {
 			return null;
 		}
 		for (DataTypeComponent dtc : structureDataType.getDefinedComponents()) {
-			if (name.equals(dtc.getFieldName())) {
+			if (name.equalsIgnoreCase(dtc.getFieldName())) {
 				return dtc;
 			}
 		}


### PR DESCRIPTION
I haven't actually tested go 1.22 yet since it hasn't been released. I did confirm that this works for 1.21.

I completely forgot about the "trim trailing whitespace" option. If it is too much I will try to work up the motivation to fix it.