### PR TITLE
fix keybinding javadoc reference

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/KeyBindingPrecedence.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/KeyBindingPrecedence.java
@@ -18,7 +18,7 @@ package docking;
 /**
  * An enum that holds the values for order of keybinding precedence, in order from 
  * highest priority to lowest.  For a more detailed description of how Ghidra processes
- * key events see <code>ghidra.KeyBindingOverrideKeyDispatcher.dispatchKeyEvent(KeyEvent)</code>
+ * key events see {@link KeyBindingOverrideKeyEventDispatcher#dispatchKeyEvent(KeyEvent)}.
  */
 public enum KeyBindingPrecedence {
     


### PR DESCRIPTION
Correct class name from `KeyBindingOverrideKeyDispatcher` to `KeyBindingOverrideKeyEventDispatcher` and add javadoc link for easier navigation.