### PR TITLE
Fix typo in GTree.java "Exapnd" -> "Expand"

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/tree/GTree.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/tree/GTree.java
@@ -1693,7 +1693,7 @@ public class GTree extends JPanel implements BusyListener {
 		};
 		//@formatter:off
 		expandAction.setPopupMenuData(new MenuData(
-				new String[] { "Exapnd" },
+				new String[] { "Expand" },
 				Icons.EXPAND_ALL_ICON,
 				actionMenuGroup, NO_MNEMONIC,
 				Integer.toString(subGroupIndex++)


### PR DESCRIPTION
Typo found in [Ghidra/Framework/Docking/src/main/java/docking/widgets/tree/GTree.java](https://github.com/NationalSecurityAgency/ghidra/blob/3410dc1ad99bcc0449a993a054a38c2c5670269f/Ghidra/Framework/Docking/src/main/java/docking/widgets/tree/GTree.java#L1696)