### PR TITLE
Fix ARM64E_KERNEL chained pointer handling in Mach-O binaries (Issue #6144).

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldChainedPtr.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/dyld/DyldChainedPtr.java
@@ -186,6 +186,7 @@ public class DyldChainedPtr {
 
 		switch (ptrFormat) {
 			case DYLD_CHAINED_PTR_ARM64E:
+			case DYLD_CHAINED_PTR_ARM64E_KERNEL:
 			case DYLD_CHAINED_PTR_ARM64E_USERLAND:
 			case DYLD_CHAINED_PTR_ARM64E_USERLAND24:
 				return ((chainValue >>> 62) & 1) != 0;
@@ -199,7 +200,6 @@ public class DyldChainedPtr {
 
 			// Never bound
 			case DYLD_CHAINED_PTR_ARM64E_FIRMWARE:
-			case DYLD_CHAINED_PTR_ARM64E_KERNEL:
 			case DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE:
 			case DYLD_CHAINED_PTR_64_KERNEL_CACHE:
 			case DYLD_CHAINED_PTR_32_CACHE:
@@ -356,6 +356,7 @@ public class DyldChainedPtr {
 
 		switch (ptrFormat) {
 			case DYLD_CHAINED_PTR_ARM64E:
+			case DYLD_CHAINED_PTR_ARM64E_KERNEL:
 			case DYLD_CHAINED_PTR_ARM64E_USERLAND:
 				ordinal = chainValue & 0xFFFF;
 				break;
@@ -372,7 +373,6 @@ public class DyldChainedPtr {
 
 			// Never Ordinal
 			case DYLD_CHAINED_PTR_ARM64E_FIRMWARE:
-			case DYLD_CHAINED_PTR_ARM64E_KERNEL:
 			case DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE:
 			case DYLD_CHAINED_PTR_64_KERNEL_CACHE:
 			case DYLD_CHAINED_PTR_32_CACHE:


### PR DESCRIPTION
Ghidra errorneously assumes that ARM64E_KERNEL chained pointers in Mach-O binaries can not bind, causing it to not correctly resolve imports in macOS/arm64 kernel modules. This pull request fixes issue #6144.