### PR TITLE
Add golang register info for arm64 and apple silicon

### DIFF
--- a/Ghidra/Features/Base/data/noReturnFunctionConstraints.xml
+++ b/Ghidra/Features/Base/data/noReturnFunctionConstraints.xml
@@ -9,6 +9,9 @@
     <functionNamesFile>ElfFunctionsThatDoNotReturn</functionNamesFile>
   </executable_format>
   <executable_format name="Mac OS X Mach-O">
+    <compiler id="golang">
+      <functionNamesFile>GolangFunctionsThatDoNotReturn</functionNamesFile>
+  	</compiler>
     <functionNamesFile>MachOFunctionsThatDoNotReturn</functionNamesFile>
   </executable_format>
   <executable_format name="DYLD Cache">

--- a/Ghidra/Processors/AARCH64/certification.manifest
+++ b/Ghidra/Processors/AARCH64/certification.manifest
@@ -11,8 +11,10 @@ data/languages/AARCH64BE.slaspec||GHIDRA||||END|
 data/languages/AARCH64_AMXext.sinc||GHIDRA||||END|
 data/languages/AARCH64_AppleSilicon.slaspec||GHIDRA||||END|
 data/languages/AARCH64_base_PACoptions.sinc||GHIDRA||||END|
+data/languages/AARCH64_golang.register.info||GHIDRA||||END|
 data/languages/AARCH64_ilp32.cspec||GHIDRA||||END|
 data/languages/AARCH64_win.cspec||GHIDRA||||END|
+data/languages/AARCH64-golang.cspec||GHIDRA||||END|
 data/languages/AARCH64base.sinc||GHIDRA||||END|
 data/languages/AARCH64instructions.sinc||GHIDRA||||END|
 data/languages/AARCH64ldst.sinc||GHIDRA||||END|

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64-golang.cspec
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64-golang.cspec
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<compiler_spec>
+	<data_organization>
+		<absolute_max_alignment value="0" />
+		<machine_alignment value="2" />
+		<default_alignment value="1" />
+		<default_pointer_alignment value="8" />
+		<pointer_size value="8" />
+		<wchar_size value="4" /> <!-- matches go's 'rune' -->
+		<short_size value="2" />
+		<integer_size value="8" />
+		<long_size value="8" />
+		<long_long_size value="8" />
+		<float_size value="4" />
+		<double_size value="8" />
+		<long_double_size value="16" />
+		<size_alignment_map>
+				<entry size="1" alignment="1" />
+				<entry size="2" alignment="2" />
+				<entry size="4" alignment="4" />
+				<entry size="8" alignment="8" />
+		</size_alignment_map>
+	</data_organization>
+
+	<global>
+		<range space="ram"/>
+	</global>
+  
+	<context_data>
+	</context_data>
+
+    <stackpointer register="RSP" space="ram"/>
+  
+	<returnaddress>
+		<varnode space="stack" offset="0" size="8"/>
+	</returnaddress>
+
+    <default_proto>
+		<prototype name="abi-internal" extrapop="8" stackshift="8">
+			<input>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM0_Qa"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM1_Qa"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM2_Qa"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM3_Qa"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM4_Qa"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM5_Qa"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM6_Qa"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM7_Qa"/>
+				</pentry>
+		        
+				<pentry minsize="1" maxsize="8">
+					<register name="R0"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R1"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R2"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R3"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R4"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R5"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R6"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R7"/>
+				</pentry>
+				<pentry minsize="1" maxsize="8">
+					<register name="R8"/>
+				</pentry>
+                <pentry minsize="1" maxsize="8">
+					<register name="R9"/>
+				</pentry>
+                <pentry minsize="1" maxsize="8">
+					<register name="R10"/>
+				</pentry>
+                <pentry minsize="1" maxsize="8">
+					<register name="R11"/>
+				</pentry>
+                <pentry minsize="1" maxsize="8">
+					<register name="R12"/>
+				</pentry>
+                <pentry minsize="1" maxsize="8">
+					<register name="R13"/>
+				</pentry>
+                <pentry minsize="1" maxsize="8">
+					<register name="R14"/>
+				</pentry>
+                <pentry minsize="1" maxsize="8">
+					<register name="R15"/>
+				</pentry>
+		        
+				<pentry minsize="1" maxsize="500" align="8">
+					<addr offset="8" space="stack"/>
+				</pentry>
+			</input>
+	      
+			<output>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="XMM0_Qa"/>
+				</pentry>
+		        
+				<pentry minsize="1" maxsize="8">
+					<register name="RAX"/>
+				</pentry>
+				<pentry minsize="9" maxsize="16">
+					<addr space="join" piece2="RAX" piece1="RBX"/>
+				</pentry>
+				<pentry minsize="17" maxsize="24">
+					<addr space="join" piece3="RAX" piece2="RBX" piece1="RCX"/>
+				</pentry>
+				<pentry minsize="25" maxsize="32">
+					<addr space="join" piece4="RAX" piece3="RBX" piece2="RCX" piece1="RDI"/>
+				</pentry>
+				<pentry minsize="33" maxsize="40">
+					<addr space="join" piece5="RAX" piece4="RBX" piece3="RCX" piece2="RDI" piece1="RSI"/>
+				</pentry>
+				<pentry minsize="41" maxsize="48">
+					<addr space="join" piece6="RAX" piece5="RBX" piece4="RCX" piece3="RDI" piece2="RSI" piece1="R8"/>
+				</pentry>
+				<pentry minsize="49" maxsize="56">
+					<addr space="join" piece7="RAX" piece6="RBX" piece5="RCX" piece4="RDI" piece3="RSI" piece2="R8" piece1="R9"/>
+				</pentry>
+				<pentry minsize="57" maxsize="64">
+					<addr space="join" piece8="RAX" piece7="RBX" piece6="RCX" piece5="RDI" piece4="RSI" piece3="R8" piece2="R9" piece1="R10"/>
+				</pentry>
+				<pentry minsize="65" maxsize="72">
+					<addr space="join" piece9="RAX" piece8="RBX" piece7="RCX" piece6="RDI" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+				</pentry>
+			</output>
+	      
+			<killedbycall>
+				<register name="R0"/>
+				<register name="R1"/>
+				<register name="R2"/>
+				<register name="R3"/>
+				<register name="R4"/>
+				<register name="R5"/>
+				<register name="R6"/>
+                <register name="R7"/>
+				<register name="R8"/>
+				<register name="R9"/>
+				<register name="R10"/>
+				<register name="R11"/>
+				<register name="R12"/>
+				<register name="R13"/>
+				<register name="R14"/>
+                <register name="R15"/>
+			</killedbycall>
+			<unaffected>
+				<register name="R16"/>
+				<register name="R17"/>
+			</unaffected>
+		</prototype>
+	</default_proto>

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64-golang.cspec
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64-golang.cspec
@@ -89,52 +89,52 @@
 				</pentry>
 		        
 				<pentry minsize="1" maxsize="8">
-					<register name="R0"/>
+					<register name="x0"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R1"/>
+					<register name="x1"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R2"/>
+					<register name="x2"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R3"/>
+					<register name="x3"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R4"/>
+					<register name="x4"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R5"/>
+					<register name="x5"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R6"/>
+					<register name="x6"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R7"/>
+					<register name="x7"/>
 				</pentry>
 				<pentry minsize="1" maxsize="8">
-					<register name="R8"/>
+					<register name="x8"/>
 				</pentry>
                 <pentry minsize="1" maxsize="8">
-					<register name="R9"/>
+					<register name="x9"/>
 				</pentry>
                 <pentry minsize="1" maxsize="8">
-					<register name="R10"/>
+					<register name="x10"/>
 				</pentry>
                 <pentry minsize="1" maxsize="8">
-					<register name="R11"/>
+					<register name="x11"/>
 				</pentry>
                 <pentry minsize="1" maxsize="8">
-					<register name="R12"/>
+					<register name="x12"/>
 				</pentry>
                 <pentry minsize="1" maxsize="8">
-					<register name="R13"/>
+					<register name="x13"/>
 				</pentry>
                 <pentry minsize="1" maxsize="8">
-					<register name="R14"/>
+					<register name="x14"/>
 				</pentry>
                 <pentry minsize="1" maxsize="8">
-					<register name="R15"/>
+					<register name="x15"/>
 				</pentry>
 		        
 				<pentry minsize="1" maxsize="500" align="16">
@@ -148,55 +148,55 @@
 				</pentry>
 		        
 				<pentry minsize="1" maxsize="8">
-					<register name="R0"/>
+					<register name="x0"/>
 				</pentry>
 				<pentry minsize="9" maxsize="16">
-					<addr space="join" piece2="R0" piece1="R1"/>
+					<addr space="join" piece2="x0" piece1="x1"/>
 				</pentry>
 				<pentry minsize="17" maxsize="24">
-					<addr space="join" piece3="R0" piece2="R1" piece1="R2"/>
+					<addr space="join" piece3="x0" piece2="x1" piece1="x2"/>
 				</pentry>
 				<pentry minsize="25" maxsize="32">
-					<addr space="join" piece4="R0" piece3="R1" piece2="R2" piece1="R3"/>
+					<addr space="join" piece4="x0" piece3="x1" piece2="x2" piece1="x3"/>
 				</pentry>
 				<pentry minsize="33" maxsize="40">
-					<addr space="join" piece5="R0" piece4="R1" piece3="R2" piece2="R3" piece1="R4"/>
+					<addr space="join" piece5="x0" piece4="x1" piece3="x2" piece2="x3" piece1="x4"/>
 				</pentry>
 				<pentry minsize="41" maxsize="48">
-					<addr space="join" piece6="R0" piece5="R1" piece4="R2" piece3="R3" piece2="R4" piece1="R5"/>
+					<addr space="join" piece6="x0" piece5="x1" piece4="x2" piece3="x3" piece2="x4" piece1="x5"/>
 				</pentry>
 				<pentry minsize="49" maxsize="56">
-					<addr space="join" piece7="R0" piece6="R1" piece5="R2" piece4="R3" piece3="R4" piece2="R5" piece1="R6"/>
+					<addr space="join" piece7="x0" piece6="x1" piece5="x2" piece4="x3" piece3="x4" piece2="x5" piece1="x6"/>
 				</pentry>
 				<pentry minsize="57" maxsize="64">
-					<addr space="join" piece8="R0" piece7="R1" piece6="R2" piece5="R3" piece4="R4" piece3="R5" piece2="R6" piece1="R7"/>
+					<addr space="join" piece8="x0" piece7="x1" piece6="x2" piece5="x3" piece4="x4" piece3="x5" piece2="x6" piece1="x7"/>
 				</pentry>
 				<pentry minsize="65" maxsize="72">
-					<addr space="join" piece9="R0" piece8="R1" piece7="R2" piece6="R3" piece5="R4" piece4="R5" piece3="R6" piece2="R7" piece1="R8"/>
+					<addr space="join" piece9="x0" piece8="x1" piece7="x2" piece6="x3" piece5="x4" piece4="x5" piece3="x6" piece2="x7" piece1="x8"/>
 				</pentry>
 			</output>
 	      
 			<killedbycall>
-				<register name="R0"/>
-				<register name="R1"/>
-				<register name="R2"/>
-				<register name="R3"/>
-				<register name="R4"/>
-				<register name="R5"/>
-				<register name="R6"/>
-                <register name="R7"/>
-				<register name="R8"/>
-				<register name="R9"/>
-				<register name="R10"/>
-				<register name="R11"/>
-				<register name="R12"/>
-				<register name="R13"/>
-				<register name="R14"/>
-                <register name="R15"/>
+				<register name="x0"/>
+				<register name="x1"/>
+				<register name="x2"/>
+				<register name="x3"/>
+				<register name="x4"/>
+				<register name="x5"/>
+				<register name="x6"/>
+                <register name="x7"/>
+				<register name="x8"/>
+				<register name="x9"/>
+				<register name="x10"/>
+				<register name="x11"/>
+				<register name="x12"/>
+				<register name="x13"/>
+				<register name="x14"/>
+                <register name="x15"/>
 			</killedbycall>
 			<unaffected>
-				<register name="R16"/>
-				<register name="R17"/>
+				<register name="x16"/>
+				<register name="x17"/>
 			</unaffected>
 		</prototype>
 	</default_proto>

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64-golang.cspec
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64-golang.cspec
@@ -40,28 +40,52 @@
 		<prototype name="abi-internal" extrapop="8" stackshift="8">
 			<input>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM0_Qa"/>
+					<register name="F0"/>
 				</pentry>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM1_Qa"/>
+					<register name="F1"/>
 				</pentry>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM2_Qa"/>
+					<register name="F2"/>
 				</pentry>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM3_Qa"/>
+					<register name="F3"/>
 				</pentry>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM4_Qa"/>
+					<register name="F4"/>
 				</pentry>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM5_Qa"/>
+					<register name="F5"/>
 				</pentry>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM6_Qa"/>
+					<register name="F6"/>
 				</pentry>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM7_Qa"/>
+					<register name="F7"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F8"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F9"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F10"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F11"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F12"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F13"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F14"/>
+				</pentry>
+				<pentry minsize="4" maxsize="8" metatype="float">
+					<register name="F15"/>
 				</pentry>
 		        
 				<pentry minsize="1" maxsize="8">
@@ -113,42 +137,42 @@
 					<register name="R15"/>
 				</pentry>
 		        
-				<pentry minsize="1" maxsize="500" align="8">
+				<pentry minsize="1" maxsize="500" align="16">
 					<addr offset="8" space="stack"/>
 				</pentry>
 			</input>
 	      
 			<output>
 				<pentry minsize="4" maxsize="8" metatype="float">
-					<register name="XMM0_Qa"/>
+					<register name="F0"/>
 				</pentry>
 		        
 				<pentry minsize="1" maxsize="8">
-					<register name="RAX"/>
+					<register name="R0"/>
 				</pentry>
 				<pentry minsize="9" maxsize="16">
-					<addr space="join" piece2="RAX" piece1="RBX"/>
+					<addr space="join" piece2="R0" piece1="R1"/>
 				</pentry>
 				<pentry minsize="17" maxsize="24">
-					<addr space="join" piece3="RAX" piece2="RBX" piece1="RCX"/>
+					<addr space="join" piece3="R0" piece2="R1" piece1="R2"/>
 				</pentry>
 				<pentry minsize="25" maxsize="32">
-					<addr space="join" piece4="RAX" piece3="RBX" piece2="RCX" piece1="RDI"/>
+					<addr space="join" piece4="R0" piece3="R1" piece2="R2" piece1="R3"/>
 				</pentry>
 				<pentry minsize="33" maxsize="40">
-					<addr space="join" piece5="RAX" piece4="RBX" piece3="RCX" piece2="RDI" piece1="RSI"/>
+					<addr space="join" piece5="R0" piece4="R1" piece3="R2" piece2="R3" piece1="R4"/>
 				</pentry>
 				<pentry minsize="41" maxsize="48">
-					<addr space="join" piece6="RAX" piece5="RBX" piece4="RCX" piece3="RDI" piece2="RSI" piece1="R8"/>
+					<addr space="join" piece6="R0" piece5="R1" piece4="R2" piece3="R3" piece2="R4" piece1="R5"/>
 				</pentry>
 				<pentry minsize="49" maxsize="56">
-					<addr space="join" piece7="RAX" piece6="RBX" piece5="RCX" piece4="RDI" piece3="RSI" piece2="R8" piece1="R9"/>
+					<addr space="join" piece7="R0" piece6="R1" piece5="R2" piece4="R3" piece3="R4" piece2="R5" piece1="R6"/>
 				</pentry>
 				<pentry minsize="57" maxsize="64">
-					<addr space="join" piece8="RAX" piece7="RBX" piece6="RCX" piece5="RDI" piece4="RSI" piece3="R8" piece2="R9" piece1="R10"/>
+					<addr space="join" piece8="R0" piece7="R1" piece6="R2" piece5="R3" piece4="R4" piece3="R5" piece2="R6" piece1="R7"/>
 				</pentry>
 				<pentry minsize="65" maxsize="72">
-					<addr space="join" piece9="RAX" piece8="RBX" piece7="RCX" piece6="RDI" piece5="RSI" piece4="R8" piece3="R9" piece2="R10" piece1="R11"/>
+					<addr space="join" piece9="R0" piece8="R1" piece7="R2" piece6="R3" piece5="R4" piece4="R5" piece3="R6" piece2="R7" piece1="R8"/>
 				</pentry>
 			</output>
 	      

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64.ldefs
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64.ldefs
@@ -12,8 +12,10 @@
     <description>Generic ARM64 v8.5-A LE instructions, LE data, missing some 8.5 vector</description>
     <compiler name="default" spec="AARCH64.cspec" id="default"/>
     <compiler name="Visual Studio" spec="AARCH64_win.cspec" id="windows"/>
+    <compiler name="golang" spec="AARCH64-golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
+    <external_name tool="Golang.register.info.file" name="AARCH64_golang.register.info"/>
   </language>
   <language processor="AARCH64"
             endian="big"
@@ -27,8 +29,10 @@
             id="AARCH64:BE:64:v8A">
     <description>Generic ARM64 v8.5-A LE instructions, BE data, missing some 8.5 vector</description>
     <compiler name="default" spec="AARCH64.cspec" id="default"/>
+    <compiler name="golang" spec="AARCH64-golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
+    <external_name tool="Golang.register.info.file" name="AARCH64_golang.register.info"/>
   </language>
   <language processor="AARCH64"
             endian="little"
@@ -42,8 +46,10 @@
     <description>Generic ARM64 v8.5-A LE instructions, LE data, ilp32</description>
     <truncate_space space="ram" size="4"/>
     <compiler name="default" spec="AARCH64_ilp32.cspec" id="default"/>
+    <compiler name="golang" spec="AARCH64-golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64:ilp32"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
+    <external_name tool="Golang.register.info.file" name="AARCH64_golang.register.info"/>
   </language>
   <language processor="AARCH64"
             endian="big"
@@ -58,7 +64,9 @@
     <description>Generic ARM64 v8.5-A LE instructions, BE data, ilp32</description>
     <truncate_space space="ram" size="4"/>
     <compiler name="default" spec="AARCH64_ilp32.cspec" id="default"/>
+    <compiler name="golang" spec="AARCH64-golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64:ilp32"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
+    <external_name tool="Golang.register.info.file" name="AARCH64_golang.register.info"/>
   </language>
 </language_definitions>

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64_golang.register.info
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64_golang.register.info
@@ -1,0 +1,10 @@
+<golang>
+	<!-- see https://github.com/golang/go/blob/master/src/internal/abi/abi_arm64.go -->
+	<register_info versions="V1_17,V1_18,V1_19,V1_20,V1_21"> <!-- "all", or comma list of: V1_2,V1_16,etc -->
+		<int_registers list="R0,R1,R2,R3,R4,R5,R6,R7,R8,R9,R10,R11,R12,R13,R14,R15"/>
+		<float_registers list="F0,F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12,F13,F14,F15"/>
+		<stack initialoffset="8" maxalign="16"/>
+		<current_goroutine register="R28"/>
+		<zero_register register="ZR"/>
+	</register_info>
+</golang>

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64_golang.register.info
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64_golang.register.info
@@ -1,10 +1,10 @@
 <golang>
 	<!-- see https://github.com/golang/go/blob/master/src/internal/abi/abi_arm64.go -->
 	<register_info versions="V1_17,V1_18,V1_19,V1_20,V1_21"> <!-- "all", or comma list of: V1_2,V1_16,etc -->
-		<int_registers list="R0,R1,R2,R3,R4,R5,R6,R7,R8,R9,R10,R11,R12,R13,R14,R15"/>
+		<int_registers list="x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15"/>
 		<float_registers list="F0,F1,F2,F3,F4,F5,F6,F7,F8,F9,F10,F11,F12,F13,F14,F15"/>
 		<stack initialoffset="8" maxalign="16"/>
-		<current_goroutine register="R28"/>
+		<current_goroutine register="x28"/>
 		<zero_register register="ZR"/>
 	</register_info>
 </golang>

--- a/Ghidra/Processors/AARCH64/data/languages/AppleSilicon.ldefs
+++ b/Ghidra/Processors/AARCH64/data/languages/AppleSilicon.ldefs
@@ -11,8 +11,10 @@
             id="AARCH64:LE:64:AppleSilicon">
     <description>AppleSilicon ARM v8.5-A LE instructions, LE data, AMX extensions</description>
     <compiler name="default" spec="AARCH64.cspec" id="default"/>
+    <compiler name="golang" spec="AARCH64-golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64"/>
     <external_name tool="gnu" name="aarch64:ilp32"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
+    <external_name tool="Golang.register.info.file" name="AARCH64_golang.register.info"/>
   </language>
 </language_definitions>


### PR DESCRIPTION
First pull request to Ghidra, so if you have any suggestions please let me know! 

This PR adds information for registers and call conventions for golang AARCH64 and AppleSilicon (see macOS golang-based binaries).