### PR TITLE
Add Copy Special option for byte source offset

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/ClipboardPlugin/Clipboard.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/ClipboardPlugin/Clipboard.htm
@@ -182,8 +182,8 @@
         current selection.   The text is formatted to show the offset from the entry point of the
         function, for example: <CODE>main + 0x2</CODE></LI>
         
-        <LI><B>Byte Source Offset</B> - Copies the byte source offset from the start of the flie at the 
-        cursor or each address in the current selection.</LI>
+        <LI><B>Byte Source Offset</B> - Copies the byte source offset from the start of the file for 
+        each address in the current selection.</LI>
         
 	<LI><B>GhidraURL</B> <A name="GhidraURL"></A> - Creates a GhidraURL for the address under the 
 	cursor then copies that URL to the clipboard.</LI>

--- a/Ghidra/Features/Base/src/main/help/help/topics/ClipboardPlugin/Clipboard.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/ClipboardPlugin/Clipboard.htm
@@ -183,7 +183,8 @@
         function, for example: <CODE>main + 0x2</CODE></LI>
         
         <LI><B>Byte Source Offset</B> - Copies the byte source offset from the start of the file for 
-        each address in the current selection.</LI>
+        each address in the current selection. If the address is not backed by a file, 
+        <CODE>%3CNO_OFFSET%3E</CODE> is copied.</LI>
         
 	<LI><B>GhidraURL</B> <A name="GhidraURL"></A> - Creates a GhidraURL for the address under the 
 	cursor then copies that URL to the clipboard.</LI>

--- a/Ghidra/Features/Base/src/main/help/help/topics/ClipboardPlugin/Clipboard.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/ClipboardPlugin/Clipboard.htm
@@ -182,6 +182,9 @@
         current selection.   The text is formatted to show the offset from the entry point of the
         function, for example: <CODE>main + 0x2</CODE></LI>
         
+        <LI><B>Byte Source Offset</B> - Copies the byte source offset from the start of the flie at the 
+        cursor or each address in the current selection.</LI>
+        
 	<LI><B>GhidraURL</B> <A name="GhidraURL"></A> - Creates a GhidraURL for the address under the 
 	cursor then copies that URL to the clipboard.</LI>
       </UL>

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
@@ -390,15 +390,24 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 		return createStringTransferable(StringUtils.join(strings, "\n"));
 	}
 
-	private Transferable copyByteSourceOffset(TaskMonitor monitor) {
+	private	Transferable copyByteSourceOffset(TaskMonitor monitor) {
 		AddressSetView addrs = getSelectedAddresses();
 		Memory currentMemory = currentProgram.getMemory();
 		List<String> strings = new ArrayList<>();
-		AddressIterator addresses = addrs.getAddresses(true);
+		AddressIterator	addresses = addrs.getAddresses(true);
 		while (addresses.hasNext() && !monitor.isCancelled()) {
 			AddressSourceInfo addressSourceInfo = currentMemory.getAddressSourceInfo(addresses.next());
 			if (addressSourceInfo != null) {
-				strings.add(String.format("%x", addressSourceInfo.getFileOffset()));
+				long fileOffset	= addressSourceInfo.getFileOffset();
+				String fileOffsetString;
+
+				if (fileOffset == -1) {
+					fileOffsetString = "<NO_OFFSET>";
+				} else {
+					fileOffsetString = String.format("%x", addressSourceInfo.getFileOffset());
+				}
+
+				strings.add(fileOffsetString);
 			}
 		}
 		return createStringTransferable(StringUtils.join(strings, "\n"));

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
@@ -394,10 +394,9 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 		AddressSetView addrs = getSelectedAddresses();
 		Memory currentMemory = currentProgram.getMemory();
 		List<String> strings = new ArrayList<>();
-		AddressIterator ranges = addrs.getAddresses(true);
-		while (ranges.hasNext() && !monitor.isCancelled()) {
-			Address nextAddress = ranges.next();
-			AddressSourceInfo addressSourceInfo = currentMemory.getAddressSourceInfo(nextAddress);
+		AddressIterator addresses = addrs.getAddresses(true);
+		while (addresses.hasNext() && !monitor.isCancelled()) {
+			AddressSourceInfo addressSourceInfo = currentMemory.getAddressSourceInfo(addresses.next());
 			if (addressSourceInfo != null) {
 				strings.add(String.format("%x", addressSourceInfo.getFileOffset()));
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/clipboard/CodeBrowserClipboardProvider.java
@@ -67,7 +67,7 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 		new ClipboardType(DataFlavor.stringFlavor, "Address");
 	public static final ClipboardType ADDRESS_TEXT_WITH_OFFSET_TYPE =
 		new ClipboardType(DataFlavor.stringFlavor, "Address w/ Offset");
-	public static final ClipboardType BYTE_SOURCE_OFFSET =
+	public static final ClipboardType BYTE_SOURCE_OFFSET_TYPE =
 		new ClipboardType(DataFlavor.stringFlavor, "Byte Source Offset");
 	public static final ClipboardType CODE_TEXT_TYPE =
 		new ClipboardType(DataFlavor.stringFlavor, "Formatted Code");
@@ -98,7 +98,7 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 		list.add(CPP_BYTE_ARRAY_TYPE);
 		list.add(ADDRESS_TEXT_TYPE);
 		list.add(ADDRESS_TEXT_WITH_OFFSET_TYPE);
-		list.add(BYTE_SOURCE_OFFSET);
+		list.add(BYTE_SOURCE_OFFSET_TYPE);
 
 		return list;
 	}
@@ -226,7 +226,7 @@ public class CodeBrowserClipboardProvider extends ByteCopier
 		else if (copyType == ADDRESS_TEXT_WITH_OFFSET_TYPE) {
 			return copySymbolString(monitor);
 		}
-		else if (copyType == BYTE_SOURCE_OFFSET) {
+		else if (copyType == BYTE_SOURCE_OFFSET_TYPE) {
 			return copyByteSourceOffset(monitor);
 		}
 		else if (copyType == CODE_TEXT_TYPE) {


### PR DESCRIPTION
This is a patch to add the offset from the start of the file (as discussed here: #154) to the `Copy Special...` menu. Useful for patching in external programs, or jumping to locations in other programs like IDA.

The term `Byte Source Offset` and associated logic was taken from: https://github.com/NationalSecurityAgency/ghidra/blob/33f90ba1c168cf4fa2b7631c7f0787d774c25c1d/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/codebrowser/hover/ProgramAddressRelationshipListingHover.java#L157-L159

Please advise if any changes are required for this PR.