### PR TITLE
PIC: Fix PIC16F description

### DIFF
--- a/Ghidra/Processors/PIC/data/languages/pic16.ldefs
+++ b/Ghidra/Processors/PIC/data/languages/pic16.ldefs
@@ -24,7 +24,7 @@
             processorspec="pic16f.pspec"
             manualindexfile="../manuals/PIC-16F.idx"
             id="PIC-16:LE:16:PIC-16F">
-    <description>PIC-16F(L)XXX</description>
+    <description>PIC-16(L)FXXX</description>
     <compiler name="default" spec="pic16f.cspec" id="default"/>
     <external_name tool="IDA-PRO" name="pic16fxx"/>
   </language>


### PR DESCRIPTION
Fix PIC16F description typo to match Microchip documentation. See [datasheet](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/40001452F.pdf) screenshot below:
![imagen](https://github.com/NationalSecurityAgency/ghidra/assets/304193/28612b6c-09d1-46d9-8115-9df08f1e1c27)


I would further propose to remove all dashes between PIC and the family number. Microchip documentation and naming seems to always refer to those devices without any dash... I did not want to rename them without a confirmation from maintainers as it may break things.

Here a list of reasons I found in favour of renaming:
- Improves searchability
- Consistency

Cons:
- Backwards compat?
