### PR TITLE
Fix typo in `GhidraAdvancedDevelopment.html`

### DIFF
--- a/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment.html
+++ b/GhidraDocs/GhidraClass/AdvancedDevelopment/GhidraAdvancedDevelopment.html
@@ -1143,7 +1143,7 @@
 <br>
 <ul>
   <li>Add a local action to the component provider</li>
-  <li>Make the action toogle the label's background color between red and blue</li>
+  <li>Make the action toggle the label's background color between red and blue</li>
 </ul>
 </section>
 


### PR DESCRIPTION
`GhidraAdvancedDevelopment.html` contained a typo: `toogle` -> `toggle`