### PR TITLE
Select all text in Edit field name

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/EditFieldNameDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/EditFieldNameDialog.java
@@ -115,6 +115,7 @@ public class EditFieldNameDialog extends DialogComponentProvider {
 		String name = getCurrentFieldName();
 		setTitle("Edit Field Name: " + dataTypeComponent.getParent().getName() + "." + name);
 		fieldName.setText(name);
+		fieldName.selectAll();
 		clearStatusText();
 		tool.showDialog(this);
 	}


### PR DESCRIPTION
Select all text when renaming structure field in the listing window

This style matches the RenameTask in the decompiler

Fixes #1415 