### PR TITLE
Fixed false error in GhidraJarBuilder.java

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
@@ -340,11 +340,9 @@ public class GhidraJarBuilder implements GhidraLaunchable {
 		}
 		if (!wroteToZip) {
 			System.out.println("Can't create source zip!  Has source been downloaded and installed?");
-			// zip.close reports error if nothing has been written to it
-			zip.close();
-		} else {
-			zip.close(); // close it anyway to prevent a memory leak
 		}
+		// zip.close reports error if nothing has been written to it
+		zip.close();
 	}
 
 	private void writeModuleSrcZipToOverallSrcZip(Zip zip, File srcZipFileForModule)

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
@@ -338,11 +338,12 @@ public class GhidraJarBuilder implements GhidraLaunchable {
 				wroteToZip |= writeZipRecursively(zip, srcDir.getAbsolutePath(), srcDir);
 			}
 		}
-		if (wroteToZip) {
-			System.out
-					.println("Can't create source zip!  Has source been downloaded and installed?");
+		if (!wroteToZip) {
+			System.out.println("Can't create source zip!  Has source been downloaded and installed?");
 			// zip.close reports error if nothing has been written to it
 			zip.close();
+		} else {
+			zip.close(); // close it anyway to prevent a memory leak
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/GhidraJarBuilder.java
@@ -342,7 +342,12 @@ public class GhidraJarBuilder implements GhidraLaunchable {
 			System.out.println("Can't create source zip!  Has source been downloaded and installed?");
 		}
 		// zip.close reports error if nothing has been written to it
-		zip.close();
+		try {
+			zip.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		
 	}
 
 	private void writeModuleSrcZipToOverallSrcZip(Zip zip, File srcZipFileForModule)


### PR DESCRIPTION
Changed from "only giving an error if we WERE able to write to the sources jar" to "only giving an error if we were NOT able to write to the sources jar".