### PR TITLE
Fix C++ sleighexample

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleighexample.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleighexample.cc
@@ -315,12 +315,12 @@ int main(int argc,char **argv)
   ContextInternal context;
 
   // Set up the assembler/pcode-translator
-  string sleighfilename = "specfiles/x86.sla";
+  istringstream sleighfilename("<sleigh>specfiles/x86.sla</sleigh>");
   Sleigh trans(&loader,&context);
 
   // Read sleigh file into DOM
   DocumentStorage docstorage;
-  Element *sleighroot = docstorage.openDocument(sleighfilename)->getRoot();
+  Element *sleighroot = docstorage.parseDocument(sleighfilename)->getRoot();
   docstorage.registerTag(sleighroot);
   trans.initialize(docstorage); // Initialize the translator
 
@@ -356,7 +356,7 @@ int main(int argc,char **argv)
 --# libraries
 --INCLUDES=-I./src
 --
---LNK=src/libsla.a
+--LNK=src/libsla.a -lz
 --
 --libsla.a:
 --	$(MAKE) -C src/ $@


### PR DESCRIPTION
Commit 8fbd171cdf290acd7563c062fec9015bb7b01498 broke the example.

Steps to build the example:

```sh
git clone https://github.com/NationalSecurityAgency/ghidra
cd ghidra
gradle -I gradle/support/fetchDependencies.gradle init
gradle x86:sleighCompile
cd Ghidra/Features/Decompiler/src/decompile/cpp
make sleighexamp_dir
cd sleigh-2.1.0
make sleighexample
```

and then you can run it
```
./sleighexample disassemble
./sleighexample pcode
./sleighexample emulate
```

Found and fixed after having issues in https://github.com/lifting-bits/sleigh/pull/245.

Related to:
- #6372
- #6373 