### PR TITLE
Fix Mach-O import when no segment contains the header

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MachoProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MachoProgramBuilder.java
@@ -998,7 +998,7 @@ public class MachoProgramBuilder {
 
 	/**
 	 * Sets up the {@link MachHeader} in memory and returns its address.  If the header was not 
-	 * intended to reside in memory (like for Mach-O object files}, then this method will create an 
+	 * intended to reside in memory (like for Mach-O object files), then this method will create an
 	 * area in the "OTHER" address space for the header to live in.
 	 * 
 	 * @param segments A {@link Collection} of {@link SegmentCommand Mach-O segments}
@@ -1011,12 +1011,15 @@ public class MachoProgramBuilder {
 		long lowestFileOffset = Long.MAX_VALUE;
 
 		// Check to see if the header resides in an existing segment.  If it does, we know its
-		// address and we are done.  Keep track of the lowest file offset of later use.
+		// address and we are done.  Keep track of the lowest file offset for later use.
 		for (SegmentCommand segment : segments) {
-			if (segment.getFileOffset() == 0 && segment.getFileSize() > 0) {
-				return space.getAddress(segment.getVMaddress());
+			if (segment.getFileOffset() == 0) {
+				if (segment.getFileSize() > 0) {
+					return space.getAddress(segment.getVMaddress());
+				}
+			} else {
+				lowestFileOffset = Math.min(lowestFileOffset, segment.getFileOffset());
 			}
-			lowestFileOffset = Math.min(lowestFileOffset, segment.getFileOffset());
 		}
 
 		// The header did not live in a defined segment.  Create a memory region in the OTHER space 


### PR DESCRIPTION
Certain Mach-O files don't have a segment that contains the header. In this case, `MachoProgramBuilder.setupHeaderAddr` is supposed to create an area in the "OTHER" address space for the header. `setupHeaderAddr` keeps track of the lowest file offset for each segment that it looks at to find the one with the lowest start address.  It then adds the "HEADER" memory block as 0 to the lowest start address.

Before, if there were any segments that were empty (`segment.getFileOffset() == 0 && segment.getFileSize() == 0`), then `setupHeaderAddr` would mistakenly set the lowest start address to 0 instead of ignoring the segment.  This would cause `MemoryMapDB.checkFileBytesRange` to throw an `IllegalArgumentException`.

With this change, `setupHeaderAddr` ignores empty segments.

This change passes all of the unit and integration tests.  There are no explicit tests for `MachoProgramBuilder`.