### PR TITLE
Loc range

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeSyntaxTree.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeSyntaxTree.java
@@ -174,6 +174,16 @@ public class PcodeSyntaxTree implements PcodeFactory {
 	}
 
 	/**
+	 * return all Varnodes that start at a given Address
+	 * @param min -- Minimum Address of Varnodes
+	 * @param max -- Maximum Address of Varnodes
+	 * @return -- Iterator to Varnodes
+	 */
+	public Iterator<VarnodeAST> getVarnodes(Address min, Address max) {
+		return vbank.locRange(min, max);
+	}
+
+	/**
 	 * return all Varnodes of a given size that start at a given Address
 	 * @param sz -- Size of Varnodes
 	 * @param addr -- Starting Address of Varnodes

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeBank.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeBank.java
@@ -223,6 +223,13 @@ public class VarnodeBank {
 		searchvn2.setInput(true);
 		return locTree.subSet(searchvn1,searchvn2).iterator();
 	}
+
+	public Iterator<VarnodeAST> locRange(Address min, Address max) {
+		VarnodeAST searchvn1 = new VarnodeAST(min,0,0);
+		searchvn1.setInput(true);
+		VarnodeAST searchvn2 = new VarnodeAST(max, Integer.MAX_VALUE,0);
+		return locTree.subSet(searchvn1,searchvn2).iterator();
+	}
 	
 	public Iterator<VarnodeAST> locRange(int sz,Address addr) {
 		VarnodeAST searchvn1 = new VarnodeAST(addr,sz,0);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeBank.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/VarnodeBank.java
@@ -210,7 +210,7 @@ public class VarnodeBank {
 	}
 	
 	public Iterator<VarnodeAST> locRange(AddressSpace spaceid) {
-		VarnodeAST searchvn1 = new VarnodeAST(spaceid.getAddress(0),0,0);
+		VarnodeAST searchvn1 = new VarnodeAST(spaceid.getMinAddress(),0,0);
 		searchvn1.setInput(true);
 		VarnodeAST searchvn2 = new VarnodeAST(spaceid.getMaxAddress(), Integer.MAX_VALUE, 0);
 		return locTree.subSet(searchvn1, searchvn2).iterator();


### PR DESCRIPTION
This PR has two commits:

1) A fix for ``VarnodeBank.locRange(AddressSpace`` using ``0`` rather than ``AddressSpace.getMinAddress()`` as a minimum address. This causes the function to not return varnodes with a negative offset, which is particularly relevant on the stack.

2.) A helper function ``PcodeSyntaxTree.locRange`` that takes in a minimum and maximum Address. A variant that takes in min/max ``Varnode``s, or one that takes ``AddressSpace`` + min/max offsets might be worth considering as well. I am operating under the assumption that the ``VarnodeBank`` is not intended to be accessible from ``PcodeSyntaxTree``, or else a simple getter would work.