### PR TITLE
GP-5767 6x09 - Fix COM instruction

### DIFF
--- a/Ghidra/Processors/MC6800/data/languages/6x09.sinc
+++ b/Ghidra/Processors/MC6800/data/languages/6x09.sinc
@@ -430,7 +430,7 @@ macro complement(op)
 {
         $(V) = 0;
         $(C) = 1;
-        A = ~A;
+        op = ~op;
         setNZFlags(op);
 }
 


### PR DESCRIPTION
The complement macro was erroneosly always complementing A register instead of the macro parameter op. Closes #5767.