### PR TITLE
GP-5656 6x09 - Fix logicalShiftRight

### DIFF
--- a/Ghidra/Processors/MC6800/data/languages/6x09.sinc
+++ b/Ghidra/Processors/MC6800/data/languages/6x09.sinc
@@ -438,7 +438,7 @@ macro complement(op)
 # P-code INT_SRIGHT.
 macro arithmeticShiftRight(op)
 {
-        $(C) = op & 1;
+        $(C) = ((op & 1) != 0);
         op = (op s>> 1);
         setNZFlags(op);
 }


### PR DESCRIPTION
The logicalShiftRight macro had incorrect carry flag handling. Closes #5656
Reported-by: @pjanetzek