### PR TITLE
Add support for FreeBSD ARM 64bit (no debugger support)

### DIFF
--- a/GPL/DemanglerGnu/build.gradle
+++ b/GPL/DemanglerGnu/build.gradle
@@ -82,6 +82,7 @@ model {
 			targetPlatform "mac_x86_64"
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
+			targetPlatform "freebsd_arm_64"
 			sources {
 				c {
 					source {
@@ -104,6 +105,7 @@ model {
 			targetPlatform "mac_x86_64"
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
+			targetPlatform "freebsd_arm_64"
 			sources {
 				c {
 					source {

--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -54,7 +54,11 @@ model {
 		}
 		if (isCurrentFreeBSD()) {
 			gcc(Gcc) {
-				target("freebsd_x86_64")
+				if (isCurrentArm_64()) {
+					target("freebsd_arm_64")
+				} else {
+					target("freebsd_x86_64")
+				}
 			}
 		}
 		if (isCurrentWindows() && VISUAL_STUDIO_INSTALL_DIR) {

--- a/GPL/nativePlatforms.gradle
+++ b/GPL/nativePlatforms.gradle
@@ -25,7 +25,8 @@ project.ext.PLATFORMS = [
 	[name: "linux_arm_64", os: "linux", arch: "arm64"],
 	[name: "mac_x86_64", os: "osx", arch: "x86_64"],
 	[name: "mac_arm_64", os: "osx", arch: "arm64"],
-	[name: "freebsd_x86_64", os: "freebsd", arch: "x86_64"]
+	[name: "freebsd_x86_64", os: "freebsd", arch: "x86_64"],
+	[name: "freebsd_arm_64", os: "freebsd", arch: "arm64"]
 ]
 
 /*********************************************************************************

--- a/Ghidra/Features/Decompiler/buildNatives.gradle
+++ b/Ghidra/Features/Decompiler/buildNatives.gradle
@@ -43,6 +43,7 @@ model {
 			targetPlatform "mac_x86_64"
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
+			targetPlatform "freebsd_arm_64"
 			sources {
 				cpp {
 					// NOTE: The bison/flex generated files are assumed to be up-to-date.
@@ -149,6 +150,7 @@ model {
 			targetPlatform "mac_x86_64"
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
+			targetPlatform "freebsd_arm_64"
 			sources {
 				cpp {
 					// NOTE: The bison/flex generated files are assumed to be up-to-date.

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
@@ -71,6 +71,11 @@ public enum Platform {
 	FREEBSD_X86_64(OperatingSystem.FREE_BSD, Architecture.X86_64, "freebsd_x86_64", ".so", ""),
 
 	/**
+	 * Identifies a FreeBSD ARM 64-bit OS.
+	 */
+	FREEBSD_ARM_64(OperatingSystem.FREE_BSD, Architecture.ARM_64, "freebsd_arm_64", ".so", ""),
+
+	/**
 	 * Identifies an unsupported OS.
 	 */
 	UNSUPPORTED(OperatingSystem.UNSUPPORTED, Architecture.UNKNOWN, null, null, ""),

--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -317,6 +317,7 @@ Ghidra release includes native binaries for the following platforms:</p>
 <ul>
   <li>Linux ARM 64-bit</li>
   <li>FreeBSD x86 64-bit (no debugger support)</li>
+  <li>FreeBSD arm 64-bit (no debugger support)</li>
 </ul>
 <p>In order to build native binaries for your platform, you will need the following installed on your
 system:</p>


### PR DESCRIPTION
I would like to start by first saying thank you to everyone in this project for the amazing work on Ghidra!

The recent commit number 9f84cac6 added support for the FreeBSD x86_64 bit platform.
Following that commit, I have added support for FreeBSD ARM 64bit under the same conditions - no debugger support.
Also, I can confirm that the "gradle buildNatives" runs properly.

I am contributing this patch with the hope to get it merged and in for the next release :-)

Thanks!