### PR TITLE
6x09.sinc: Fix COM instruction

### DIFF
--- a/Ghidra/Processors/MC6800/data/languages/6x09.sinc
+++ b/Ghidra/Processors/MC6800/data/languages/6x09.sinc
@@ -430,7 +430,7 @@ macro complement(op)
 {
         $(V) = 0;
         $(C) = 1;
-        A = ~A;
+        op = ~op;
         setNZFlags(op);
 }
 


### PR DESCRIPTION
The complement macro was erroneously always complementing A register instead of the macro parameter op. This caused the COMB and COM OP1 instructions to have incorrect decompilation and lead to a false rabbithole while working with live code. 