### PR TITLE
Implement and document menu item mnemonic escaping

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/GhidraScriptMgrPlugin/ScriptDevelopment.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/GhidraScriptMgrPlugin/ScriptDevelopment.htm
@@ -128,9 +128,16 @@
 
         <BLOCKQUOTE>
           <P>The tag indicates the top-level menu path. Path levels are delimited using the "."
-          character.</P>
+          character. A mnemonic can be defined by adding an ampersand ("&") in front of the mnemonic 
+          key. Ampersands can be escaped by adding another ampersand ("&&"). </P>
 
-          <P>For example, <TT>"@menupath File.Run.My Script"</TT>.</P>
+          <P>For example:</P>
+          <BLOCKQUOTE>
+            <P><TT>@menupath File.Run.My Script<BR>
+             @menupath File.Run.My &Script<BR>
+             @menupath File.Run.Me && My &Script<BR>
+            </TT></P>
+          </BLOCKQUOTE>
         </BLOCKQUOTE>
 
         <P><CODE><B>@toolbar</B></CODE></P>

--- a/Ghidra/Framework/Docking/src/main/java/docking/action/MenuData.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/action/MenuData.java
@@ -117,7 +117,7 @@ public class MenuData {
 
 	/**
 	 * Returns the menu path as a string. This method filters accelerator chars('&') from the path.
-	 * @return the menu path as a string without '&' chars
+	 * @return the menu path as a string without unescaped '&' chars
 	 */
 	public String getMenuPathDisplayString() {
 		if (menuPath == null || menuPath.length == 0) {
@@ -260,7 +260,7 @@ public class MenuData {
 	}
 
 	/**
-	 * Sets the menu item name and the mnemonic, using the first '&amp;' found in the text
+	 * Sets the menu item name and the mnemonic, using the first unescaped '&amp;' found in the text
 	 * as a marker ("S&amp;ave As").
 	 * <p>
 	 * NOTE: do NOT use this method with strings that contain user-supplied text.  Instead, use
@@ -305,7 +305,12 @@ public class MenuData {
 	}
 
 	private static int getMnemonic(String string) {
-		int indexOf = string.indexOf('&');
+		int indexOf;
+		int fromIndex = 0;
+		do {
+			indexOf = string.indexOf('&', fromIndex);
+			fromIndex = indexOf + 2;
+		} while (indexOf >= 0 && indexOf < string.length() - 1 && string.charAt(indexOf + 1) == '&');
 		if (indexOf >= 0 && indexOf < string.length() - 1) {
 			return string.charAt(indexOf + 1);
 		}
@@ -321,7 +326,18 @@ public class MenuData {
 	}
 
 	private static String processMenuItemName(String string) {
-		return string.replaceFirst("&", "");
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < string.length(); i++) {
+			if (string.charAt(i) == '&') {
+				if (i < string.length() - 1 && string.charAt(i+1) == '&') {
+					builder.append('&');
+					i++;
+				}
+			} else {
+				builder.append(string.charAt(i));				
+			}
+		}
+		return builder.toString();
 	}
 
 	public String getMenuItemName() {

--- a/Ghidra/Framework/Docking/src/test/java/docking/action/MenuDataTest.java
+++ b/Ghidra/Framework/Docking/src/test/java/docking/action/MenuDataTest.java
@@ -34,6 +34,45 @@ public class MenuDataTest {
 		MenuData menuData = new MenuData(new String[] { "One", "Two", "&Three" });
 		assertEquals(menuData.getMnemonic(), 'T');
 	}
+	
+	/**
+	 * There should be no mnemonic, the ampersand is escaped.
+	 */
+	@Test
+	public void testMenuDataMnemonicSkipsEscapedAmpersand() {
+		MenuData menuData = new MenuData(new String[] { "One", "Two", "&&Three" });
+		assertEquals(menuData.getMnemonic(), MenuData.NO_MNEMONIC);
+	}
+
+	/**
+	 * The mnemonic should be 'h'. The first two ampersands form an escaped
+	 * ampersand. The third ampersand is not escaped.
+	 */
+	@Test
+	public void testMenuDataMnemonicEscapesAmpersandLeftToRight() {
+		MenuData menuData = new MenuData(new String[] { "One", "Two", "T&&&hree" });
+		assertEquals(menuData.getMnemonic(), 'h');
+	}
+
+	/**
+	 * There should be no mnemonic, the trailing ampersand is not followed by any
+	 * character.
+	 */
+	@Test
+	public void testMenuDataMnemonicIgnoresTrailingAmpersand() {
+		MenuData menuData = new MenuData(new String[] { "One", "Two", "Three&" });
+		assertEquals(menuData.getMnemonic(), MenuData.NO_MNEMONIC);
+	}
+
+	/**
+	 * The mnemonic should be 'T'. This is the expected behaviour as per the
+	 * "Desktop development with C++" workload in Visual Studio.
+	 */
+	@Test
+	public void testMenuDataMnemonicParsesLeftToRight() {
+		MenuData menuData = new MenuData(new String[] { "One", "Two", "&T&hree" });
+		assertEquals(menuData.getMnemonic(), 'T');
+	}
 
 	/**
 	 * Mnemonic should be 'h' based on the value that was explicitly set
@@ -85,5 +124,24 @@ public class MenuDataTest {
 		String[] newPath = { "Four", newName };
 		menuData.setMenuPath(newPath);
 		assertEquals(menuData.getMnemonic(), MenuData.NO_MNEMONIC);
+	}
+	
+	@Test
+	public void testGetMenuItemNameEscapesAmpersand() {
+		MenuData menuData = new MenuData(new String[] { "One", "Two", "&&Three" });
+		assertEquals(menuData.getMenuItemName(), "&Three");
+	}
+	
+	/**
+	 * Ampersands that are not escaped should be ignored regardless of use as
+	 * mnemonics.
+	 */
+	@Test
+	public void testGetMenuItemNameIgnoresUnescapedAmpersand() {
+		MenuData menuData = new MenuData(new String[] { "One", "Two", "Three&" });
+		assertEquals(menuData.getMenuItemName(), "Three");
+		
+		menuData.setMenuItemName("&T&hree");
+		assertEquals(menuData.getMenuItemName(), "Three");
 	}
 }


### PR DESCRIPTION
Menu item mnemonics can currently be specified by adding an ampersand character in front of the mnemonic key as part of the item's name. However the exact behaviour is not what one may expect for the following reasons:
1. The parsing bevahiour does not follow convention. For example, escaping is not implemented (`&&Text` is expected to have no mnemonic and render as `Text`, but the mnemonic is set to `&` and `&Text` is rendered), and repeated mnemonics are not removed (`&T&ext` is expected to render as `Text` but renders as `T&ext`).
2. Implementation of mnemonics is not documented in atleast one place, setting script developers up for a surprise:
https://github.com/NationalSecurityAgency/ghidra/blob/7360b14db0486b07aa996790d6b466ada64a53ca/Ghidra/Features/Base/src/main/help/help/topics/GhidraScriptMgrPlugin/ScriptDevelopment.htm#L126-L134

This change adds tests for, documents, and implements the conventional mnemonic parsing behaviour present in most libraries. The behaviour is validated with the [Menu Editor](https://learn.microsoft.com/en-us/cpp/windows/menu-editor?view=msvc-170) in Visual Studio's Desktop  Applications in C++ workload as a reference. If a better reference is found, further changes can be made as required.