### PR TITLE
Fix 132 typos 

### DIFF
--- a/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
+++ b/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
@@ -467,7 +467,7 @@
     <li><I>Build</I>. Added support for building with Gradle 8. (GP-2476, Issue #3527, #5003)</li>
     <li><I>Build</I>. The build now enforces a maximum-supported Gradle version. The current supported versions are Gradle 7.3 or later. (GP-3111)</li>
     <li><I>Build</I>. Ghidra can now run from development/repository mode using Gradle's compiled jars, instead of just relying on Eclipse's compilation output. (GP-3140)</li>
-    <li><I>C Parsing</I>. Provided GDT archives have been updated to include new ProgramArchitecture settings for processor, data organization, and endianess. (GP-1377)</li>
+    <li><I>C Parsing</I>. Provided GDT archives have been updated to include new ProgramArchitecture settings for processor, data organization, and endianness. (GP-1377)</li>
     <li><I>CParser</I>. Removed unnecessary <span class="gcode">-D</span> defines related to wchar_t from CParser <span class="gcode">prf</span> files and GDT parsing scripts. (GP-3294, Issue #5196)</li>
     <li><I>Data Types</I>. Function definitions can now be applied from selected Category instead of only from an entire Archive. (GP-199)</li>
     <li><I>Data Types</I>. Changed Structure/Union editor to show numbers in hex format by default. Also added <span class="gcode">Shift-H</span> keybinding action for toggling hex/decimal view. (GP-2943)</li>
@@ -1760,7 +1760,7 @@
     <li><I>Data Types</I>. Fixed a NullPointerException that occurred when trying to edit a function datatype in a datatype archive when there was no open program in the tool. (GP-356, Issue #2407)</li>
     <li><I>Data Types</I>. Corrected the retention of datatype archive search paths, which did not properly remember disabled paths. (GP-639)</li>
     <li><I>Data Types</I>. Fixed potential deadlock encountered when working with the DataTypes tree. (GP-774, Issue #2832)</li>
-    <li><I>Decompiler</I>. Fixed endianess issue for joined, two-register returns of <code>longlong</code> values for MIPS 32-bit little endian variants. (GP-513)</li>
+    <li><I>Decompiler</I>. Fixed endianness issue for joined, two-register returns of <code>longlong</code> values for MIPS 32-bit little endian variants. (GP-513)</li>
     <li><I>Decompiler</I>. The Decompiler no longer emits comments in the middle of conditional expressions. (GP-621, Issue #1670)</li>
     <li><I>Decompiler</I>. Fixed <code>Redefinition of structure...</code> exceptions in the Decompiler caused by a PNG Image and other opaque datatypes. (GP-820, Issue #2734)</li>
     <li><I>Decompiler</I>. Fixed infinite loop in the Decompiler when analyzing return values. (GP-821, Issue #2851)</li>
@@ -1921,7 +1921,7 @@
     <li><I>Decompiler</I>. Fixed issue with the Auto Create/Fill Structure command that caused it to silently miss some pointer accesses. (GP-344)</li>
     <li><I>Decompiler</I>. Jump table recovery now takes into account encoded bits, like ARM/THUMB mode transition, that may be present in address tables. (GP-387, Issue #2420)</li>
     <li><I>Decompiler</I>. Fixed a bug in the Decompiler <B>renaming</B> action when applied to function references. (GP-477, Issue #2415)</li>
-    <li><I>Decompiler</I>. Corrected 8-byte return value storage specification in compiler-spec affecting <code>longlong</code> and <code>double</code> return values.  Endianess ordering of <code>r0</code>/<code>r1</code> was incorrect. (GP-512, Issue #2547)</li>
+    <li><I>Decompiler</I>. Corrected 8-byte return value storage specification in compiler-spec affecting <code>longlong</code> and <code>double</code> return values.  Endianness ordering of <code>r0</code>/<code>r1</code> was incorrect. (GP-512, Issue #2547)</li>
     <li><I>Graphing</I>. Fixed the Function Graph's <B>drag-to-select-nodes</B> feature. (GP-430)</li>
     <li><I>Graphing</I>. Fixed issue where the graph in the satellite view is sometimes truncated. (GP-469)</li>
     <li><I>Graphing</I>. Fixed a stack trace issue caused by reusing a graph display window to show a graph that is larger than is allowed. (GP-492)</li>

--- a/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/pcode_test.h
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/c_src/pcode_test.h
@@ -42,7 +42,7 @@ typedef struct PACKED_STRUCTURE TestInfo
 {
 	char id[8];			/* id constains a "Magic Number" which will allow us to find this in a binary */
 	u4 ptrSz;			/* how many bytes in a pointer? */
-	u4 byteOrder;			/* value 0x01020304 used to detect endianess */
+	u4 byteOrder;			/* value 0x01020304 used to detect endianness */
 	void *onPass;			/* address of breakOnPass function, (where it goes on test pass) */
 	void *onError;		/* address of breakOnError function, (where it goes on test failure) */
 	void *onDone;		/* address of breakOnDone function, (where it goes when all test done) */

--- a/Ghidra/Features/Base/src/main/help/help/topics/DataTypeEditors/StructureEditor.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/DataTypeEditors/StructureEditor.htm
@@ -362,7 +362,7 @@
       		bit-size is generally appended to the base datatype for datatype specification and 
       		presentation purposes (e.g., char:1).</li>
       		<li>A zero-length bitfield may be defined within a byte but its precise bit position
-      		is controlled by endianess alone.  A zero-length bitfield has no affect within a non-packed
+      		is controlled by endianness alone.  A zero-length bitfield has no affect within a non-packed
       		structure and is intended for use within packed structures where it may impart alignment
       		affects based upon compiler conventions.</li> 
       		<li>Inserting a bitfield within a non-packed structure may cause component shifts based 
@@ -382,7 +382,7 @@
     
     <P><IMG alt="Note:" src="help/shared/note.png">While packing of bitfields within packed 
     structures is controlled by the compiler specification (e.g., data organization), bit-packing
-    order is currently fixed based upon endianess.  Little-endian packs starting with bit-0 (lsb)
+    order is currently fixed based upon endianness.  Little-endian packs starting with bit-0 (lsb)
     while big-endian packs starting with bit-7 (msb).</P>
     
     <P><IMG alt="Note:" src="help/shared/note.png">The use of bitfield components is not 

--- a/Ghidra/Features/Base/src/main/help/help/topics/ImporterPlugin/importer.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/ImporterPlugin/importer.htm
@@ -802,7 +802,7 @@
 
           <LI><B>Size</B> - the size in bits of the processor address space</LI>
 
-          <LI><B>Endian</B> - the endianess of the processor</LI>
+          <LI><B>Endian</B> - the endianness of the processor</LI>
 
           <LI><B>Compile</B> - the compiler specification used to build the program</LI>
         </UL>

--- a/Ghidra/Features/Base/src/main/help/help/topics/Tables/GhidraTableHeaders.html
+++ b/Ghidra/Features/Base/src/main/help/help/topics/Tables/GhidraTableHeaders.html
@@ -130,7 +130,7 @@
 		<img border="0" src="images/BytesSettingsDialog.png">
    	</center>
    	<p>
-   		This dialog allows you to change various features of the bytes column, such as endianess
+   		This dialog allows you to change various features of the bytes column, such as endianness
    		and the number of bytes that appear in the display.
    	</p>
    	

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchDialog.java
@@ -113,7 +113,7 @@ class MemSearchDialog extends ReusableDialogComponentProvider {
 		mainPanel = buildMainPanel();
 		addWorkPanel(mainPanel);
 		buildButtons();
-		setEndianess(isBigEndian);
+		setEndianness(isBigEndian);
 		setAlignment(1);
 		setUseSharedLocation(true);
 	}
@@ -135,7 +135,7 @@ class MemSearchDialog extends ReusableDialogComponentProvider {
 		updateDisplay();
 	}
 
-	void setEndianess(boolean isBigEndian) {
+	void setEndianness(boolean isBigEndian) {
 		if (isBigEndian) {
 			bigEndian.setSelected(isBigEndian);
 		}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchmem/MemSearchPlugin.java
@@ -280,7 +280,7 @@ public class MemSearchPlugin extends Plugin implements OptionsChangeListener,
 			searchDialog.setShowAdvancedOptions(showAdvancedOptions);
 		}
 		else {
-			searchDialog.setEndianess(navigatable.getProgram().getLanguage().isBigEndian());
+			searchDialog.setEndianness(navigatable.getProgram().getLanguage().isBigEndian());
 			searchDialog.close(); // close it to make sure it gets parented to the current focused window.
 		}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/debug/GenerateOldLanguagePlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/debug/GenerateOldLanguagePlugin.java
@@ -545,7 +545,7 @@ public class GenerateOldLanguagePlugin extends Plugin implements ApplicationLeve
 		 */
 		@Override
 		public List<LanguageDescription> getLanguageDescriptions(Processor processor,
-				Endian endianess, Integer size, String variant) {
+				Endian endianness, Integer size, String variant) {
 			throw new UnsupportedOperationException();
 		}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -117,7 +117,7 @@ public class ElfHeader implements StructConverter {
 			e_ident_magic_num = ElfConstants.MAGIC_NUM;
 			e_ident_magic_str = ElfConstants.MAGIC_STR;
 
-			determineHeaderEndianess();
+			determineHeaderEndianness();
 
 			// reader uses unbounded provider wrapper to allow handling of missing/truncated headers
 			reader = new BinaryReader(new UnlimitedByteProviderWrapper(provider),
@@ -1328,7 +1328,7 @@ public class ElfHeader implements StructConverter {
 		return false;
 	}
 
-	private void determineHeaderEndianess() throws ElfException, IOException {
+	private void determineHeaderEndianness() throws ElfException, IOException {
 
 		if (provider.length() < INITIAL_READ_LEN) {
 			throw new ElfException("Not enough bytes to be a valid ELF executable.");
@@ -1344,10 +1344,10 @@ public class ElfHeader implements StructConverter {
 				Integer.toHexString(bytes[ElfConstants.EI_DATA]) + ")");
 		}
 		if (!hasLittleEndianHeaders && bytes[ElfConstants.EI_NIDENT] != 0) {
-			// Header endianess sanity check
+			// Header endianness sanity check
 			// Some toolchains always use little endian Elf Headers
 
-			// TODO: unsure if forced endianess applies to relocation data
+			// TODO: unsure if forced endianness applies to relocation data
 
 			// Check first byte of version (allow switch if equal 1)
 			if (bytes[ElfConstants.EI_NIDENT + 4] == 1) {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/XmlLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/XmlLoader.java
@@ -134,7 +134,7 @@ public class XmlLoader extends AbstractProgramLoader {
 		}
 
 		if (loadSpecs.isEmpty()) {
-			// just put 'em all in (give endianess preference)
+			// just put 'em all in (give endianness preference)
 			Endian endian = Endian.toEndian(info.endian);
 			List<LanguageDescription> languageDescriptions =
 				getLanguageService().getLanguageDescriptions(false);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/ProgramInfo.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/ProgramInfo.java
@@ -49,7 +49,7 @@ public class ProgramInfo {
 	public String version;
 	/**The size of the addressing (eg, "32 bit"). @deprecated since version 2.1.*/
 	public String addressModel;
-	/**The endianess (eg, big or little).*/
+	/**The endianness (eg, big or little).*/
 	public String endian;
 	/**The absolute path of where the original executable was imported.*/
 	public String exePath;

--- a/Ghidra/Features/Base/src/main/java/ghidra/test/ToyProgramBuilder.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/test/ToyProgramBuilder.java
@@ -53,7 +53,7 @@ public class ToyProgramBuilder extends ProgramBuilder {
 	 * Construct toy program builder using toy language "builder" variant.
 	 * This builder will be the program consumer and must be disposed
 	 * @param name program name
-	 * @param bigEndian language endianess
+	 * @param bigEndian language endianness
 	 * @throws Exception
 	 */
 	public ToyProgramBuilder(String name, boolean bigEndian) throws Exception {
@@ -64,7 +64,7 @@ public class ToyProgramBuilder extends ProgramBuilder {
 	 * Construct toy program builder using toy language "builder" variant.
 	 * This builder will be the program consumer and must be disposed
 	 * @param name program name
-	 * @param bigEndian language endianess
+	 * @param bigEndian language endianness
 	 * @param consumer program consumer (if null this builder will be used as consumer and must be disposed to release program)
 	 * @throws Exception
 	 */
@@ -76,7 +76,7 @@ public class ToyProgramBuilder extends ProgramBuilder {
 	 * Construct toy program builder using toy language "builder" variant.
 	 * This builder will be the program consumer and must be disposed
 	 * @param name program name
-	 * @param bigEndian language endianess
+	 * @param bigEndian language endianness
 	 * @param consumer program consumer (if null this builder will be used as consumer and must be disposed to release program)
 	 * @throws Exception
 	 */

--- a/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/PCodeTestControlBlock.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/test/processors/support/PCodeTestControlBlock.java
@@ -204,7 +204,7 @@ public class PCodeTestControlBlock extends PCodeTestAbstractControlBlock {
 			if (byteOrder != 0x1020304) {
 				throw new InvalidControlBlockException(
 					"TestInfo @ " + infoStructAddr.toString(true) +
-						" has invalid byteOrder - language endianess may be incorrect (" +
+						" has invalid byteOrder - language endianness may be incorrect (" +
 						Integer.toHexString(byteOrder) + ")");
 			}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/state/ContextState.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/state/ContextState.java
@@ -692,7 +692,7 @@ public class ContextState {
 
 	/**
 	 * Combine byte values into a single varnode value.
-	 * @param byteValues bytes stored with LSB in bytes[0] and MSB in bytes[bytes.length-1] with correct endianess.
+	 * @param byteValues bytes stored with LSB in bytes[0] and MSB in bytes[bytes.length-1] with correct endianness.
 	 * @return varnode or null
 	 */
 	private Varnode combineByteValues(Varnode[] byteValues, TaskMonitor monitor)

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/table/field/BytesTableColumn.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/table/field/BytesTableColumn.java
@@ -34,11 +34,11 @@ public class BytesTableColumn extends ProgramLocationTableColumnExtensionPoint<A
 	private static final ByteCountSettingsDefinition BYTE_COUNT = ByteCountSettingsDefinition.DEF;
 	private static final MemoryOffsetSettingsDefinition MEMORY_OFFSET =
 		MemoryOffsetSettingsDefinition.DEF;
-	private static final EndianSettingsDefinition ENDIANESS = EndianSettingsDefinition.DEF;
+	private static final EndianSettingsDefinition ENDIANNESS = EndianSettingsDefinition.DEF;
 	private static final FormatSettingsDefinition FORMAT = FormatSettingsDefinition.DEF;
 
 	private static SettingsDefinition[] SETTINGS_DEFS =
-		{ BYTE_COUNT, MEMORY_OFFSET, ENDIANESS, FORMAT };
+		{ BYTE_COUNT, MEMORY_OFFSET, ENDIANNESS, FORMAT };
 
 	private final GColumnRenderer<Byte[]> monospacedRenderer = new MonospacedByteRenderer();
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/table/projectdata/column/EndianProjectDataColumn.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/table/projectdata/column/EndianProjectDataColumn.java
@@ -25,7 +25,7 @@ import ghidra.util.table.column.AbstractGhidraColumnRenderer;
 import ghidra.util.table.column.GColumnRenderer;
 
 /**
- * Column for the ProjectDataTable (Frontend) to display the endianess of a program.
+ * Column for the ProjectDataTable (Frontend) to display the endianness of a program.
  */
 public class EndianProjectDataColumn extends ProjectDataColumn<Endian> {
 

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/AbstractMemSearchTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/AbstractMemSearchTest.java
@@ -297,7 +297,7 @@ public abstract class AbstractMemSearchTest extends AbstractProgramBasedTest {
 		return hlProvider.createHighlights(bytes, field, -1);
 	}
 
-	protected void setEndianess(String text) {
+	protected void setEndianness(String text) {
 		// we use this method because the given button may be disabled, which means we cannot
 		// click it, but we can select it
 		AbstractButton button = findAbstractButtonByText(pane, text);

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MemSearchAsciiTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/plugin/core/searchmem/MemSearchAsciiTest.java
@@ -191,7 +191,7 @@ public class MemSearchAsciiTest extends AbstractMemSearchTest {
 	public void testUnicodeBigEndian() throws Exception {
 
 		// with Big Endian selected, unicode bytes should be reversed
-		setEndianess("Big Endian");
+		setEndianness("Big Endian");
 
 		setEncoding(StandardCharsets.UTF_16);
 		setValueText("start");

--- a/Ghidra/Features/Base/src/test/java/ghidra/program/model/data/CompositeZeroArrayTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/program/model/data/CompositeZeroArrayTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 public class CompositeZeroArrayTest extends AbstractCompositeZeroArrayTest {
 
-	// NOTE: In the absence of bit-fields these tests are not sensitive to endianess
+	// NOTE: In the absence of bit-fields these tests are not sensitive to endianness
 
 	private static DataTypeManager dataMgr;
 

--- a/Ghidra/Features/Base/src/test/java/ghidra/program/model/data/StructureDataTypeTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/program/model/data/StructureDataTypeTest.java
@@ -1936,7 +1936,7 @@ public class StructureDataTypeTest extends AbstractGenericTest {
 	public void testReplaceWith2() throws InvalidDataTypeException {
 
 		// NOTE: pack(disabled) bitfields should remain unchanged when
-		// transitioning endianess even though it makes little sense.
+		// transitioning endianness even though it makes little sense.
 		// pack(disabled) structures are not intended to be portable! 
 
 		TypeDef td = new TypedefDataType("Foo", IntegerDataType.dataType);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/cast.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/cast.hh
@@ -128,7 +128,7 @@ public:
   /// \return \b true if the SUBPIECE should be represented as a cast
   virtual bool isSubpieceCast(Datatype *outtype,Datatype *intype,uint4 offset) const=0;
 
-  /// \brief Is the given data-type truncation considered a cast, given endianess concerns.
+  /// \brief Is the given data-type truncation considered a cast, given endianness concerns.
   ///
   /// This is equivalent to isSubpieceCast() but where the truncation is accomplished by pulling
   /// bytes directly out of memory.  We assume the input data-type is layed down in memory, and

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/emulateutil.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/emulateutil.hh
@@ -49,7 +49,7 @@ protected:
   /// \brief Pull a value from the load-image given a specific address
   ///
   /// A contiguous chunk of memory is pulled from the load-image and returned as a
-  /// constant value, respecting the endianess of the address space. The default implementation
+  /// constant value, respecting the endianness of the address space. The default implementation
   /// of this method pulls the value directly from the LoadImage object.
   /// \param spc is the address space to pull the value from
   /// \param offset is the starting address offset (from within the space) to pull the value from
@@ -121,7 +121,7 @@ class EmulateSnippet : public Emulate {
   /// \brief Pull a value from the load-image given a specific address
   ///
   /// A contiguous chunk of memory is pulled from the load-image and returned as a
-  /// constant value, respecting the endianess of the address space.
+  /// constant value, respecting the endianness of the address space.
   /// \param spc is the address space to pull the value from
   /// \param offset is the starting address offset (from within the space) to pull the value from
   /// \param sz is the number of bytes to pull from memory

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.hh
@@ -140,7 +140,7 @@ public:
   virtual string getDescription(void) const;
 
   static string normalizeProcessor(const string &nm);		///< Try to recover a \e language \e id processor field
-  static string normalizeEndian(const string &nm);		///< Try to recover a \e language \e id endianess field
+  static string normalizeEndian(const string &nm);		///< Try to recover a \e language \e id endianness field
   static string normalizeSize(const string &nm);		///< Try to recover a \e language \e id size field
   static string normalizeArchitecture(const string &nm);	///< Try to recover a \e language \e id string
   static void scanForSleighDirectories(const string &rootpath);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slgh_compile.cc
@@ -973,7 +973,7 @@ bool ConsistencyChecker::checkVarnodeTruncation(Constructor *ct,int4 slot,
 ///
 /// Run through all Varnodes looking for offset templates marked as ConstTpl::v_offset_plus,
 /// which indicates they were constructed using truncation notation. These truncation expressions
-/// are checked for validity and adjusted depending on the endianess of the address space.
+/// are checked for validity and adjusted depending on the endianness of the address space.
 /// \param ct is the Constructor
 /// \param cttpl is the given p-code section
 /// \param isbigendian is set to \b true if the SLEIGH specification is big endian
@@ -2589,7 +2589,7 @@ void SleighCompile::setEndian(int4 end)
 
 {
   setBigEndian( (end == 1) );
-  predefinedSymbols();		// Set up symbols now that we know endianess
+  predefinedSymbols();		// Set up symbols now that we know endianness
 }
 
 /// \brief Definition a set of Varnodes

--- a/Ghidra/Features/Decompiler/src/main/doc/decompileplugin.xml
+++ b/Ghidra/Features/Decompiler/src/main/doc/decompileplugin.xml
@@ -1326,7 +1326,7 @@
     <informalexample>
       <itemizedlist spacing='compact'>
 	<listitem>Processor family</listitem>
-	<listitem>Endianess</listitem>
+	<listitem>Endianness</listitem>
 	<listitem>Size of the address bus</listitem>
 	<listitem>Processor variant</listitem>
 	<listitem>Compiler producing the Program</listitem>

--- a/Ghidra/Features/Decompiler/src/main/doc/pcoderef.xml
+++ b/Ghidra/Features/Decompiler/src/main/doc/pcoderef.xml
@@ -198,7 +198,7 @@ of RAM. It is defined simply as an indexed sequence of bytes that can
 be read and written by the p-code operations. For a specific byte, the unique index
 that labels it is the byte's <emphasis role="bold">address</emphasis>. An address space has a
 name to identify it, a size that indicates the number of distinct
-indices into the space, and an <emphasis role="bold">endianess</emphasis>
+indices into the space, and an <emphasis role="bold">endianness</emphasis>
 associated with it that indicates how integers and other multi-byte
 values are encoded into the space. A typical processor
 will have a <emphasis role="bold">ram</emphasis> space, to model
@@ -249,7 +249,7 @@ on the varnodes: integer, boolean, and floating-point.
 <itemizedlist mark='bullet' spacing='compact'>
   <listitem>
     Operations that manipulate integers always interpret a varnode as a
-    twos-complement encoding using the endianess associated with the
+    twos-complement encoding using the endianness associated with the
     address space containing the varnode.
   </listitem>
   <listitem>
@@ -878,7 +878,7 @@ subroutine.
 </table>
 </informalexample>
 <para>
-This is a concatenation operator that understands the endianess of the
+This is a concatenation operator that understands the endianness of the
 data. The size of input0 and input1 must add up to the size of
 output. The data from the inputs is concatenated in such a way that,
 if the inputs and output are considered integers, the first input
@@ -928,7 +928,7 @@ makes up the most significant part of the output.
 </table>
 </informalexample>
 <para>
-This is a truncation operator that understands the endianess of the
+This is a truncation operator that understands the endianness of the
 data. Input1 indicates the number of least significant bytes of input0
 to be thrown away. Output is then filled with any remaining bytes of
 input0 <emphasis>up to the size of output</emphasis>. If the size of

--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
@@ -294,7 +294,7 @@ forces an interpretation on each varnode that it uses, as either an
 integer, a floating-point number, or a boolean value. In the case of
 an integer, the varnode is interpreted as having a big endian or
 little endian encoding, depending on the specification (see
-<xref linkend="sleigh_endianess_definition"/>). Certain instructions
+<xref linkend="sleigh_endianness_definition"/>). Certain instructions
 also distinguish between signed and unsigned interpretations. For a
 signed integer, the varnode is considered to have a standard twos
 complement encoding. For a boolean interpretation, the varnode must be
@@ -645,10 +645,10 @@ SLEIGH files must start with all the definitions needed by the rest of
 the specification. All definition statements start with the keyword
 <emphasis role="bold">define</emphasis> and end with a semicolon ‘;’.
 </para>
-<sect2 id="sleigh_endianess_definition">
-<title>Endianess Definition</title>
+<sect2 id="sleigh_endianness_definition">
+<title>Endianness Definition</title>
 <para>
-The first definition in any SLEIGH specification must be for endianess. Either
+The first definition in any SLEIGH specification must be for endianness. Either
 <informalexample>
 <programlisting>
 define endian=big;            <emphasis>OR</emphasis>
@@ -659,11 +659,11 @@ This defines how the processor interprets contiguous sequences of
 bytes as integers or other values and globally affects values across
 all address spaces. It also affects how integer fields
 within an instruction are interpreted, (see <xref linkend="sleigh_defining_tokens"/>),
-although it is possible to override this setting in the rare case that endianess is
+although it is possible to override this setting in the rare case that endianness is
 different for data versus instruction encoding.
 The specification designer generally only needs to worry about
-endianess when labeling instruction fields and when defining overlapping registers,
-otherwise the specification language hides endianess issues.
+endianness when labeling instruction fields and when defining overlapping registers,
+otherwise the specification language hides endianness issues.
 </para>
 </sect2>
 <sect2 id="sleigh_alignment_definition">
@@ -1147,9 +1147,9 @@ field and the range of bits within the token making up the field. The
 size of a field does <emphasis>not</emphasis> need to be a multiple of
 8. The range is inclusive where the least significant bit in the token
 is labeled 0. When defining tokens that are bigger than 1 byte, the
-global endianess setting (See <xref linkend="sleigh_endianess_definition"/>)
+global endianness setting (See <xref linkend="sleigh_endianness_definition"/>)
 will affect this labeling. Although it is rarely required, it is possible to override
-the global endianess setting for a specific token by appending either the qualifier
+the global endianness setting for a specific token by appending either the qualifier
 <emphasis role="bold">endian=little</emphasis> or <emphasis role="bold">endian=big</emphasis>
 immediately after the token name and size. For instance:
 <informalexample>

--- a/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerConcepts.html
+++ b/Ghidra/Features/Decompiler/src/main/help/help/topics/DecompilePlugin/DecompilerConcepts.html
@@ -1226,7 +1226,7 @@
 <div class="informalexample">
       <div class="itemizedlist"><ul class="itemizedlist compact" style="list-style-type: disc; ">
 <li class="listitem">Processor family</li>
-<li class="listitem">Endianess</li>
+<li class="listitem">Endianness</li>
 <li class="listitem">Size of the address bus</li>
 <li class="listitem">Processor variant</li>
 <li class="listitem">Compiler producing the Program</li>

--- a/Ghidra/Features/Sarif/src/main/java/sarif/SarifLoader.java
+++ b/Ghidra/Features/Sarif/src/main/java/sarif/SarifLoader.java
@@ -149,7 +149,7 @@ public class SarifLoader extends AbstractProgramLoader {
 		}
 
 		if (loadSpecs.isEmpty() && provider.getName().endsWith(FILE_EXTENSION)) {
-			// just put 'em all in (give endianess preference)
+			// just put 'em all in (give endianness preference)
 			List<LanguageDescription> languageDescriptions =
 				getLanguageService().getLanguageDescriptions(false);
 			for (LanguageDescription languageDescription : languageDescriptions) {

--- a/Ghidra/Features/Sarif/src/main/java/sarif/managers/ProgramInfo.java
+++ b/Ghidra/Features/Sarif/src/main/java/sarif/managers/ProgramInfo.java
@@ -49,7 +49,7 @@ public class ProgramInfo {
 	public String version;
 	/**The size of the addressing (eg, "32 bit"). @deprecated since version 2.1.*/
 	public String addressModel;
-	/**The endianess (eg, big or little).*/
+	/**The endianness (eg, big or little).*/
 	public String endian;
 	/**The absolute path of where the original executable was imported.*/
 	public String exePath;

--- a/Ghidra/Framework/Emulation/src/main/java/ghidra/pcode/memstate/MemoryBank.java
+++ b/Ghidra/Framework/Emulation/src/main/java/ghidra/pcode/memstate/MemoryBank.java
@@ -30,7 +30,7 @@ public abstract class MemoryBank {
 	 * A MemoryBank must be associated with a specific address space, have a preferred or natural
 	 * pagesize.  The pagesize must be a power of 2.
 	 * @param spc is the associated address space
-	 * @param isBigEndian memory endianess
+	 * @param isBigEndian memory endianness
 	 * @param ps ps is the number of bytes in a page (must be a power of 2)
 	 * @param faultHandler memory fault handler
 	 */

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/DataConverter.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/DataConverter.java
@@ -37,7 +37,7 @@ public interface DataConverter extends Serializable {
 	}
 
 	/**
-	 * Returns the endianess of this DataConverter instance.
+	 * Returns the endianness of this DataConverter instance.
 	 * 
 	 * @return boolean flag, true means big-endian
 	 */

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SleighDebugLogger.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/SleighDebugLogger.java
@@ -98,7 +98,7 @@ public class SleighDebugLogger {
 			append("\nNOTE: bitrange's number leftmost/most-significant bit as 0 (zero).\n");
 			append("      This bit numbering agrees with the context field specification\n");
 			append("      but differs from token field specification.  The bit correspondence\n");
-			append("      for token fields depends upon the specific token size/endianess and\n");
+			append("      for token fields depends upon the specific token size/endianness and\n");
 			append("      current byte-offset of pattern matcher.\n\n");
 
 			int contextSize = contextCache.getContextSize();

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slgh_compile/SleighCompile.java
@@ -1017,7 +1017,7 @@ public class SleighCompile extends SleighBase {
 	public void setEndian(int end) {
 		entry("setEndian", end);
 		target_endian = end;
-		predefinedSymbols(); // Set up symbols now that we know endianess
+		predefinedSymbols(); // Set up symbols now that we know endianness
 	}
 
 	public void setAlignment(int val) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/mem/MemoryMapDB.java
@@ -88,7 +88,7 @@ public class MemoryMapDB implements Memory, ManagerDB, LiveMemoryListener {
 	 * @param handle the open database handle.
 	 * @param addrMap the address map.
 	 * @param openMode the open mode for the program.
-	 * @param isBigEndian endianess flag
+	 * @param isBigEndian endianness flag
 	 * @param lock the program synchronization lock
 	 * @param monitor Task monitor for upgrading
 	 * @throws IOException if a database io error occurs.

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DataOrganizationImpl.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DataOrganizationImpl.java
@@ -75,7 +75,7 @@ public class DataOrganizationImpl implements DataOrganization {
 	private int doubleSize = DEFAULT_DOUBLE_SIZE;
 	private int longDoubleSize = DEFAULT_LONG_DOUBLE_SIZE;
 
-	// Endianess explicitly set and not supported by saveXml/restore
+	// Endianness explicitly set and not supported by saveXml/restore
 	private boolean bigEndian = false;
 
 	private BitFieldPackingImpl bitFieldPacking = new BitFieldPackingImpl();
@@ -99,7 +99,7 @@ public class DataOrganizationImpl implements DataOrganization {
 	 * Creates a new default DataOrganization. This has a mapping which defines the alignment
 	 * of a data type based on its size. The map defines pairs for data types that are
 	 * 1, 2, 4, and 8 bytes in length.
-	 * @param language optional language used to initialize defaults (pointer size, endianess, etc.)
+	 * @param language optional language used to initialize defaults (pointer size, endianness, etc.)
 	 *  (may be null)
 	 * @return a new default DataOrganization.
 	 */
@@ -112,7 +112,7 @@ public class DataOrganizationImpl implements DataOrganization {
 		if (language != null) {
 			// NOTE: Ensure that saveXml always saves pointer size
 			dataOrganization.setPointerSize(language.getDefaultSpace().getPointerSize());
-			// NOTE: Endianess is not handled by saveXml/restore
+			// NOTE: Endianness is not handled by saveXml/restore
 			dataOrganization.setBigEndian(language.isBigEndian());
 		}
 		return dataOrganization;
@@ -195,7 +195,7 @@ public class DataOrganizationImpl implements DataOrganization {
 	}
 
 	/**
-	 * Set data endianess
+	 * Set data endianness
 	 * @param bigEndian true if big-endian, false if little-endian
 	 */
 	public void setBigEndian(boolean bigEndian) {
@@ -803,7 +803,7 @@ public class DataOrganizationImpl implements DataOrganization {
 	public void encode(Encoder encoder) throws IOException {
 		encoder.openElement(ELEM_DATA_ORGANIZATION);
 
-		// NOTE: endianess intentionally omitted from output
+		// NOTE: endianness intentionally omitted from output
 
 		if (absoluteMaxAlignment != NO_MAXIMUM_ALIGNMENT) {
 			encoder.openElement(ELEM_ABSOLUTE_MAX_ALIGNMENT);
@@ -905,13 +905,13 @@ public class DataOrganizationImpl implements DataOrganization {
 	 * Restore settings from an XML stream. This expects to see parser positioned on the
 	 * &lt;data_organization&gt; start tag.  The XML is designed to override existing language-specific
 	 * default settings which are pre-populated with {@link #getDefaultOrganization(Language)}.  This
-	 * will will ensure that the endianess setting is properly established since it is not included
+	 * will will ensure that the endianness setting is properly established since it is not included
 	 * in the XML.
 	 * @param parser is the XML stream
 	 */
 	public void restoreXml(XmlPullParser parser) {
 
-		// NOTE: endianess intentionally omitted from XML.
+		// NOTE: endianness intentionally omitted from XML.
 
 		parser.start();
 		while (parser.peek().isStart()) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/EndianSettingsDefinition.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/EndianSettingsDefinition.java
@@ -21,7 +21,7 @@ import ghidra.program.model.lang.Endian;
 import ghidra.program.model.mem.MemBuffer;
 
 /**
- *  SettingsDefinition for endianess
+ *  SettingsDefinition for endianness
  */
 public class EndianSettingsDefinition implements EnumSettingsDefinition {
 
@@ -41,11 +41,11 @@ public class EndianSettingsDefinition implements EnumSettingsDefinition {
 	}
 
 	/**
-	 * Returns the endianess settings.  First looks in settings, then defaultSettings
+	 * Returns the endianness settings.  First looks in settings, then defaultSettings
 	 * and finally returns a default value if the first two have no value for this definition.
 	 * @param settings the instance settings to search for the value
 	 * @param buf the data context
-	 * @return a boolean value for the endianess setting
+	 * @return a boolean value for the endianness setting
 	 */
 	public boolean isBigEndian(Settings settings, MemBuffer buf) {
 		int val = getChoice(settings);
@@ -55,7 +55,7 @@ public class EndianSettingsDefinition implements EnumSettingsDefinition {
 		return val == BIG;
 	}
 
-	public Endian getEndianess(Settings settings, Endian defaultValue) {
+	public Endian getEndianness(Settings settings, Endian defaultValue) {
 		int val = getChoice(settings);
 		switch (val) {
 			default:
@@ -115,7 +115,7 @@ public class EndianSettingsDefinition implements EnumSettingsDefinition {
 
 	@Override
 	public String getDescription() {
-		return "Selects the endianess of the data";
+		return "Selects the endianness of the data";
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StringDataInstance.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StringDataInstance.java
@@ -324,7 +324,7 @@ public class StringDataInstance {
 		this.showTranslation = TRANSLATION.isShowTranslated(settings);
 		this.translatedValue = getTranslatedValue(settings, buf);
 		this.renderSetting = RENDER.getEnumValue(settings);
-		this.endianSetting = ENDIAN.getEndianess(settings, null);
+		this.endianSetting = ENDIAN.getEndianness(settings, null);
 
 		this.length = length;
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Structure.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Structure.java
@@ -511,7 +511,7 @@ public interface Structure extends Composite {
 		/**
 		 * Compute the normalized bit offset of a bitfield relative to the start of a structure.
 		 * 
-		 * NOTE: This implementation currently relies only on endianess to dictate bit allocation
+		 * NOTE: This implementation currently relies only on endianness to dictate bit allocation
 		 * ordering. If future support is added for alternate bitfield packing, this implementation
 		 * will require modification.
 		 * 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StructureDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StructureDataType.java
@@ -1097,7 +1097,7 @@ public class StructureDataType extends CompositeDataTypeImpl implements Structur
 	 * Create copy of structure for target dtm (source archive information is discarded). 
 	 * <p>
 	 * WARNING! copying non-packed structures which contain bitfields can produce invalid results when
-	 * switching endianess due to the differences in packing order.
+	 * switching endianness due to the differences in packing order.
 	 * 
 	 * @param dtm target data type manager
 	 * @return cloned structure
@@ -1114,7 +1114,7 @@ public class StructureDataType extends CompositeDataTypeImpl implements Structur
 	/**
 	 * Create cloned structure for target dtm preserving source archive information. WARNING!
 	 * cloning non-packed structures which contain bitfields can produce invalid results when
-	 * switching endianess due to the differences in packing order.
+	 * switching endianness due to the differences in packing order.
 	 * 
 	 * @param dtm target data type manager
 	 * @return cloned structure

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Union.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/Union.java
@@ -20,7 +20,7 @@ package ghidra.program.model.data;
  * <p>
  * NOTE: The use of bitfields within all unions assumes a default packing where bit allocation 
  * always starts with byte-0 of the union.  Bit allocation order is dictated by data organization
- * endianess (byte-0 msb allocated first for big-endian, while byte-0 lsb allocated first for little-endian).
+ * endianness (byte-0 msb allocated first for big-endian, while byte-0 lsb allocated first for little-endian).
  */
 public interface Union extends Composite {
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/Endian.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/Endian.java
@@ -28,14 +28,14 @@ public enum Endian {
 		this.shortName = shortName;
 	}
 
-	public static Endian toEndian(String endianess) {
-		if (endianess != null) {
-			if ((Endian.BIG.toString().equalsIgnoreCase(endianess)) ||
-				(Endian.BIG.toShortString().equalsIgnoreCase(endianess))) {
+	public static Endian toEndian(String endianness) {
+		if (endianness != null) {
+			if ((Endian.BIG.toString().equalsIgnoreCase(endianness)) ||
+				(Endian.BIG.toShortString().equalsIgnoreCase(endianness))) {
 				return Endian.BIG;
 			}
-			else if ((Endian.LITTLE.toString().equalsIgnoreCase(endianess)) ||
-				(Endian.LITTLE.toShortString().equalsIgnoreCase(endianess))) {
+			else if ((Endian.LITTLE.toString().equalsIgnoreCase(endianness)) ||
+				(Endian.LITTLE.toShortString().equalsIgnoreCase(endianness))) {
 				return Endian.LITTLE;
 			}
 			else {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/LanguageService.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/LanguageService.java
@@ -58,14 +58,14 @@ public interface LanguageService {
 	 * Returns all known language descriptions which satisfy the criteria identify by the
 	 * non-null parameters.  A null value implies a don't-care wildcard value.
 	 * @param processor the processor for which to get a language
-	 * @param endianess big or little
+	 * @param endianness big or little
 	 * @param size processor address space size (in bits)
 	 * @param variant the processor version (usually 'default')
 	 * @return the language descriptions that fit the parameters
 	 * @deprecated use {@link #getLanguageDescriptions(Processor)} instead
 	 */
 	@Deprecated
-	List<LanguageDescription> getLanguageDescriptions(Processor processor, Endian endianess,
+	List<LanguageDescription> getLanguageDescriptions(Processor processor, Endian endianness,
 			Integer size, String variant);
 
 	/**

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/SleighLanguageDescription.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/SleighLanguageDescription.java
@@ -36,8 +36,8 @@ public class SleighLanguageDescription extends BasicLanguageDescription {
 	 * @param id the name of the language
 	 * @param description language description text
 	 * @param processor processor name/family
-	 * @param endian data endianess
-	 * @param instructionEndian instruction endianess
+	 * @param endian data endianness
+	 * @param instructionEndian instruction endianness
 	 * @param size processor size 
 	 * @param variant processor variant name
 	 * @param version the major version of the language.

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/VariableStorage.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/VariableStorage.java
@@ -927,7 +927,7 @@ public class VariableStorage implements Comparable<VariableStorage> {
 		}
 		if (oldReg != null && !(oldReg instanceof UnknownRegister)) {
 			Register newReg = translator.getNewRegister(oldReg);
-			if (newReg != null) { // assume reg endianess unchanged
+			if (newReg != null) { // assume reg endianness unchanged
 				// NOTE: could produce bad results if not careful with mapping
 				int origByteShift = (int) offset - oldReg.getOffset();
 				offset = newReg.getOffset() + origByteShift;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/mem/MemBuffer.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/mem/MemBuffer.java
@@ -126,9 +126,9 @@ public interface MemBuffer {
 	public boolean isBigEndian();
 
 	/**
-	 * returns the short at the given offset, taking into account the endianess.
+	 * returns the short at the given offset, taking into account the endianness.
 	 * @param offset the offset from the membuffers origin (the address that it is set at)
-	 * @return the short at the given offset, taking into account the endianess.
+	 * @return the short at the given offset, taking into account the endianness.
 	 * @throws MemoryAccessException if a 2-byte short value cannot be read at the specified offset
 	 */
 	public short getShort(int offset) throws MemoryAccessException;
@@ -136,7 +136,7 @@ public interface MemBuffer {
 	/**
 	 * Returns the unsigned short at the given offset, taking into account the endian-ness.
 	 * @param offset the offset from the membuffers origin (the address that it is set at)
-	 * @return the unsigned short at the given offset, as a {@code int}, taking into account the endianess.
+	 * @return the unsigned short at the given offset, as a {@code int}, taking into account the endianness.
 	 * @throws MemoryAccessException if a 2-byte short value cannot be read at the specified offset
 	 */
 	default public int getUnsignedShort(int offset) throws MemoryAccessException {
@@ -144,17 +144,17 @@ public interface MemBuffer {
 	}
 
 	/**
-	 * returns the int at the given offset, taking into account the endianess.
+	 * returns the int at the given offset, taking into account the endianness.
 	 * @param offset the offset from the membuffers origin (the address that it is set at)
-	 * @return the int at the given offset, taking into account the endianess.
+	 * @return the int at the given offset, taking into account the endianness.
 	 * @throws MemoryAccessException if a 4-byte integer value cannot be read at the specified offset
 	 */
 	public int getInt(int offset) throws MemoryAccessException;
 
 	/**
-	 * Returns the unsigned int at the given offset, taking into account the endianess.
+	 * Returns the unsigned int at the given offset, taking into account the endianness.
 	 * @param offset the offset from the membuffers origin (the address that it is set at)
-	 * @return the unsigned int at the given offset, as a {@code long}, taking into account the endianess.
+	 * @return the unsigned int at the given offset, as a {@code long}, taking into account the endianness.
 	 * @throws MemoryAccessException if a 4-byte integer value cannot be read at the specified offset
 	 */
 	default public long getUnsignedInt(int offset) throws MemoryAccessException {
@@ -162,19 +162,19 @@ public interface MemBuffer {
 	}
 
 	/**
-	 * returns the long at the given offset, taking into account the endianess.
+	 * returns the long at the given offset, taking into account the endianness.
 	 * @param offset the offset from the membuffers origin (the address that it is set at)
-	 * @return the long at the given offset, taking into account the endianess.
+	 * @return the long at the given offset, taking into account the endianness.
 	 * @throws MemoryAccessException if a 8-byte long value cannot be read at the specified offset
 	 */
 	public long getLong(int offset) throws MemoryAccessException;
 
 	/**
-	 * returns the value at the given offset, taking into account the endianess.
+	 * returns the value at the given offset, taking into account the endianness.
 	 * @param offset the offset from the membuffers origin (the address that it is set at)
 	 * @param size the number of bytes to include in the value
 	 * @param signed true if value should be treated as a signed twos-compliment value.
-	 * @return the value at the given offset, taking into account the endianess.
+	 * @return the value at the given offset, taking into account the endianness.
 	 * @throws MemoryAccessException if the request size value cannot be read at the specified offset
 	 */
 	public BigInteger getBigInteger(int offset, int size, boolean signed)

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/AddressEvaluator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/AddressEvaluator.java
@@ -206,7 +206,7 @@ public class AddressEvaluator {
 		}
 
 		/*
-		 * Make sure we account for endianess of the program.
+		 * Make sure we account for endianness of the program.
 		 * Computing the number of bits to shift the current byte value
 		 * is different for Little vs. Big Endian. Need to multiply by
 		 * 8 to shift in 1-byte increments.

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/DefaultLanguageService.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/DefaultLanguageService.java
@@ -86,7 +86,7 @@ public class DefaultLanguageService implements LanguageService {
 	}
 
 		@Override
-	public List<LanguageDescription> getLanguageDescriptions(Processor processor, Endian endianess,
+	public List<LanguageDescription> getLanguageDescriptions(Processor processor, Endian endianness,
 			Integer size, String variant) {
 		List<LanguageDescription> languageDescriptions = new ArrayList<>();
 		for (LanguageInfo info : languageInfos) {
@@ -94,7 +94,7 @@ public class DefaultLanguageService implements LanguageService {
 			if (processor != null && processor != description.getProcessor()) {
 				continue;
 			}
-			if (endianess != null && endianess != description.getEndian()) {
+			if (endianness != null && endianness != description.getEndian()) {
 				continue;
 			}
 			if (size != null && size.intValue() != description.getSize()) {
@@ -129,7 +129,7 @@ public class DefaultLanguageService implements LanguageService {
 	}
 
 	public List<LanguageDescription> getExternalLanguageDescriptions(String externalProcessorName,
-			String externalTool, Endian endianess, Integer size) {
+			String externalTool, Endian endianness, Integer size) {
 
 		List<LanguageDescription> languageDescriptions = new ArrayList<>();
 		for (LanguageInfo info : languageInfos) {
@@ -140,7 +140,7 @@ public class DefaultLanguageService implements LanguageService {
 				continue;
 			}
 
-			if (endianess != null && endianess != description.getEndian()) {
+			if (endianness != null && endianness != description.getEndian()) {
 				continue;
 			}
 			if (size != null && size.intValue() != description.getSize()) {

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/database/data/StructureDBTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/database/data/StructureDBTest.java
@@ -60,7 +60,7 @@ public class StructureDBTest extends AbstractGenericTest {
 		DataOrganizationImpl dataOrg = (DataOrganizationImpl) dataMgr.getDataOrganization();
 		dataOrg.setBigEndian(true);
 
-		// re-resolve with modified endianess
+		// re-resolve with modified endianness
 		struct = (StructureDB) dataMgr.resolve(structClone, null);
 	}
 
@@ -1312,7 +1312,7 @@ public class StructureDBTest extends AbstractGenericTest {
 	public void testReplaceWith2() throws InvalidDataTypeException {
 
 		// NOTE: non-packed bitfields should remain unchanged when
-		// transitioning endianess even though it makes little sense.
+		// transitioning endianness even though it makes little sense.
 		// Unaligned structures are not intended to be portable! 
 
 		TypeDef td = new TypedefDataType("Foo", IntegerDataType.dataType);

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/database/data/UnionDBTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/database/data/UnionDBTest.java
@@ -58,7 +58,7 @@ public class UnionDBTest extends AbstractGenericTest {
 		DataOrganizationImpl dataOrg = (DataOrganizationImpl) dataMgr.getDataOrganization();
 		dataOrg.setBigEndian(true);
 
-		// re-resolve with modified endianess
+		// re-resolve with modified endianness
 		union = (UnionDB) dataMgr.resolve(unionClone, null);
 	}
 

--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -4940,7 +4940,7 @@ macro BitReverse_arm(val) {
 
 @endif # VERSION_6K
 
-# Hopefully we never encounter this instruction since we can not change the effective endianess of the language
+# Hopefully we never encounter this instruction since we can not change the effective endianness of the language
 armEndianNess: "LE" is c0031=0xf1010000 { export 0:1; }
 armEndianNess: "BE" is c0031=0xf1010200 { export 1:1; }
 

--- a/Ghidra/Processors/Toy/data/languages/old/v01stuff/toy.sinc
+++ b/Ghidra/Processors/Toy/data/languages/old/v01stuff/toy.sinc
@@ -1,4 +1,4 @@
-# Main slaspec must define endianess and alignment
+# Main slaspec must define endianness and alignment
 
 @ifndef WORDSIZE
 @define WORDSIZE "1"

--- a/Ghidra/Processors/Xtensa/data/languages/xtensa.cspec
+++ b/Ghidra/Processors/Xtensa/data/languages/xtensa.cspec
@@ -55,7 +55,7 @@
         <pentry minsize="1" maxsize="4" extension="inttype">
           <register name="a2"/>
         </pentry>
-        <!-- TODO: Are joins impacted by endianess ? -->
+        <!-- TODO: Are joins impacted by endianness ? -->
         <pentry minsize="5" maxsize="8" extension="inttype">
           <addr space="join" piece1="a3" piece2="a2"/>
         </pentry>
@@ -126,7 +126,7 @@
       <pentry minsize="1" maxsize="4" extension="inttype">
         <register name="a2"/>
       </pentry>
-      <!-- TODO: Are joins impacted by endianess ? -->
+      <!-- TODO: Are joins impacted by endianness ? -->
       <pentry minsize="5" maxsize="8" extension="inttype">
         <addr space="join" piece1="a3" piece2="a2"/>
       </pentry>

--- a/GhidraDocs/languages/html/pcodedescription.html
+++ b/GhidraDocs/languages/html/pcodedescription.html
@@ -572,7 +572,7 @@ subroutine.
 </table>
 </div></div>
 <p>
-This is a concatenation operator that understands the endianess of the
+This is a concatenation operator that understands the endianness of the
 data. The size of input0 and input1 must add up to the size of
 output. The data from the inputs is concatenated in such a way that,
 if the inputs and output are considered integers, the first input
@@ -621,7 +621,7 @@ makes up the most significant part of the output.
 </table>
 </div></div>
 <p>
-This is a truncation operator that understands the endianess of the
+This is a truncation operator that understands the endianness of the
 data. Input1 indicates the number of least significant bytes of input0
 to be thrown away. Output is then filled with any remaining bytes of
 input0 <span class="emphasis"><em>up to the size of output</em></span>. If the size of

--- a/GhidraDocs/languages/html/pcoderef.html
+++ b/GhidraDocs/languages/html/pcoderef.html
@@ -228,7 +228,7 @@ of RAM. It is defined simply as an indexed sequence of bytes that can
 be read and written by the p-code operations. For a specific byte, the unique index
 that labels it is the byte's <span class="bold"><strong>address</strong></span>. An address space has a
 name to identify it, a size that indicates the number of distinct
-indices into the space, and an <span class="bold"><strong>endianess</strong></span>
+indices into the space, and an <span class="bold"><strong>endianness</strong></span>
 associated with it that indicates how integers and other multi-byte
 values are encoded into the space. A typical processor
 will have a <span class="bold"><strong>ram</strong></span> space, to model
@@ -280,7 +280,7 @@ on the varnodes: integer, boolean, and floating-point.
 <div class="informalexample"><div class="itemizedlist"><ul class="itemizedlist compact" style="list-style-type: bullet; ">
 <li class="listitem" style="list-style-type: disc">
     Operations that manipulate integers always interpret a varnode as a
-    twos-complement encoding using the endianess associated with the
+    twos-complement encoding using the endianness associated with the
     address space containing the varnode.
   </li>
 <li class="listitem" style="list-style-type: disc">

--- a/GhidraDocs/languages/html/sleigh.html
+++ b/GhidraDocs/languages/html/sleigh.html
@@ -57,7 +57,7 @@
 </dl></dd>
 <dt><span class="sect1"><a href="sleigh_definitions.html">4. Basic Definitions</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_endianess_definition">4.1. Endianess Definition</a></span></dt>
+<dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_endianness_definition">4.1. Endianness Definition</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_alignment_definition">4.2. Alignment Definition</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_space_definitions">4.3. Space Definitions</a></span></dt>
 <dt><span class="sect2"><a href="sleigh_definitions.html#sleigh_naming_registers">4.4. Naming Registers</a></span></dt>
@@ -344,7 +344,7 @@ forces an interpretation on each varnode that it uses, as either an
 integer, a floating-point number, or a boolean value. In the case of
 an integer, the varnode is interpreted as having a big endian or
 little endian encoding, depending on the specification (see
-<a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1. Endianess Definition">Section 4.1, “Endianess Definition”</a>). Certain instructions
+<a class="xref" href="sleigh_definitions.html#sleigh_endianness_definition" title="4.1. Endianness Definition">Section 4.1, “Endianness Definition”</a>). Certain instructions
 also distinguish between signed and unsigned interpretations. For a
 signed integer, the varnode is considered to have a standard twos
 complement encoding. For a boolean interpretation, the varnode must be

--- a/GhidraDocs/languages/html/sleigh_definitions.html
+++ b/GhidraDocs/languages/html/sleigh_definitions.html
@@ -34,9 +34,9 @@ the specification. All definition statements start with the keyword
 </p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="sleigh_endianess_definition"></a>4.1. Endianess Definition</h3></div></div></div>
+<a name="sleigh_endianness_definition"></a>4.1. Endianness Definition</h3></div></div></div>
 <p>
-The first definition in any SLEIGH specification must be for endianess. Either
+The first definition in any SLEIGH specification must be for endianness. Either
 </p>
 <div class="informalexample"><pre class="programlisting">
 define endian=big;            <span class="emphasis"><em>OR</em></span>
@@ -47,11 +47,11 @@ This defines how the processor interprets contiguous sequences of
 bytes as integers or other values and globally affects values across
 all address spaces. It also affects how integer fields
 within an instruction are interpreted, (see <a class="xref" href="sleigh_tokens.html#sleigh_defining_tokens" title="6.1. Defining Tokens and Fields">Section 6.1, “Defining Tokens and Fields”</a>),
-although it is possible to override this setting in the rare case that endianess is
+although it is possible to override this setting in the rare case that endianness is
 different for data versus instruction encoding.
 The specification designer generally only needs to worry about
-endianess when labeling instruction fields and when defining overlapping registers,
-otherwise the specification language hides endianess issues.
+endianness when labeling instruction fields and when defining overlapping registers,
+otherwise the specification language hides endianness issues.
 </p>
 </div>
 <div class="sect2">

--- a/GhidraDocs/languages/html/sleigh_tokens.html
+++ b/GhidraDocs/languages/html/sleigh_tokens.html
@@ -57,9 +57,9 @@ field and the range of bits within the token making up the field. The
 size of a field does <span class="emphasis"><em>not</em></span> need to be a multiple of
 8. The range is inclusive where the least significant bit in the token
 is labeled 0. When defining tokens that are bigger than 1 byte, the
-global endianess setting (See <a class="xref" href="sleigh_definitions.html#sleigh_endianess_definition" title="4.1. Endianess Definition">Section 4.1, “Endianess Definition”</a>)
+global endianness setting (See <a class="xref" href="sleigh_definitions.html#sleigh_endianness_definition" title="4.1. Endianness Definition">Section 4.1, “Endianness Definition”</a>)
 will affect this labeling. Although it is rarely required, it is possible to override
-the global endianess setting for a specific token by appending either the qualifier
+the global endianness setting for a specific token by appending either the qualifier
 <span class="bold"><strong>endian=little</strong></span> or <span class="bold"><strong>endian=big</strong></span>
 immediately after the token name and size. For instance:
 </p>


### PR DESCRIPTION
Fix all typos `endianess` --> `endianness` in the whole repo.