### PR TITLE
SPARC: Do not pass g0 to zeroflags

### DIFF
--- a/Ghidra/Processors/Sparc/data/languages/SparcV9.sinc
+++ b/Ghidra/Processors/Sparc/data/languages/SparcV9.sinc
@@ -486,8 +486,9 @@ macro unpackflags(ccr) {
 :addcc RS1,regorimm,RD               is op=2 & RD & op3=0x10 & RS1 & regorimm 
 {
 	addflags(RS1,regorimm);
-	RD = RS1 + regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 + regorimm;
+	zeroflags(res);
+	RD = res;
 }
 
 :addc RS1,regorimm,RD                is op=2 & RD & op3=0x8 & RS1 & regorimm {RD = RS1 + regorimm + zext(i_cf);}
@@ -496,8 +497,9 @@ macro unpackflags(ccr) {
 {
 	local original_i_cf:$(SIZE) = zext(i_cf);
 	addCarryFlags(RS1,regorimm);
-	RD = RS1 + regorimm + original_i_cf;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 + regorimm + original_i_cf;
+	zeroflags(res);
+	RD = res;
 }
 #-----------------------
 :and RS1,regorimm,RD                 is op=2 & RD & op3=0x1 & RS1 & regorimm {RD = RS1 & regorimm;}
@@ -505,16 +507,18 @@ macro unpackflags(ccr) {
 :andcc RS1,regorimm,RD               is op=2 & RD & op3=0x11 & RS1 & regorimm 
 {   
 	logicflags();
-	RD = RS1 & regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 & regorimm;
+	zeroflags(res);
+	RD = res;
 }
 :andn RS1,regorimm,RD                is op=2 & RD & op3=0x5 & RS1 & regorimm {RD = RS1 & ~regorimm;}
 
 :andncc RS1,regorimm,RD              is op=2 & RD & op3=0x15 & RS1 & regorimm 
 {   
 	logicflags();
-	RD = RS1 & ~regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 & ~regorimm;
+	zeroflags(res);
+	RD = res;
 }
 
 :or RS1,regorimm,RD                  is op=2 & RD & op3=0x2 & RS1 & regorimm {RD = RS1 | regorimm;}
@@ -522,24 +526,27 @@ macro unpackflags(ccr) {
 :orcc RS1,regorimm,RD                is op=2 & RD & op3=0x12 & RS1 & regorimm 
 {
 	logicflags();
-	RD = RS1 | regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 | regorimm;
+	zeroflags(res);
+	RD = res;
 }
 :orn RS1,regorimm,RD                 is op=2 & RD & op3=0x6 & RS1 & regorimm {RD = RS1 | ~regorimm;}
 
 :orncc RS1,regorimm,RD               is op=2 & RD & op3=0x16 & RS1 & regorimm 
 {
 	logicflags();
-	RD = RS1 | ~regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 | ~regorimm;
+	zeroflags(res);
+	RD = res;
 }
 :xor RS1,regorimm,RD                 is op=2 & RD & op3=0x3 & RS1 & regorimm {RD = RS1 ^ regorimm;}
 
 :xorcc RS1,regorimm,RD               is op=2 & RD & op3=0x13 & RS1 & regorimm 
 {
 	logicflags();
-	RD = RS1 ^ regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 ^ regorimm;
+	zeroflags(res);
+	RD = res;
 }
 
 :xnor RS1,regorimm,RD                is op=2 & RD & op3=0x7 & RS1 & regorimm {RD = RS1 ^ ~regorimm;}
@@ -547,8 +554,9 @@ macro unpackflags(ccr) {
 :xnorcc RS1,regorimm,RD              is op=2 & RD & op3=0x17 & RS1 & regorimm 
 {
 	logicflags();
-	RD = RS1 ^ ~regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 ^ ~regorimm;
+	zeroflags(res);
+	RD = res;
 }
 
 # ---------------
@@ -609,8 +617,9 @@ macro unpackflags(ccr) {
 :subcc RS1,regorimm,RD               is op=2 & RD & op3=0x14 & RS1 & regorimm 
 {
 	subflags(RS1,regorimm);
-	RD = RS1 - regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 - regorimm;
+	zeroflags(res);
+	RD = res;
 }
 
 :subc RS1,regorimm,RD                is op=2 & RD & op3=0xc & RS1 & regorimm 
@@ -622,8 +631,9 @@ macro unpackflags(ccr) {
 {
 	local original_cf:$(SIZE) = zext(i_cf);
 	subCarryFlags(RS1,regorimm);
-	RD = RS1 - regorimm - original_cf;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 - regorimm - original_cf;
+	zeroflags(res);
+	RD = res;
 }
 
 # ---------------
@@ -635,8 +645,8 @@ macro unpackflags(ccr) {
 :cmp RS1,regorimm                    is op=0x2 & rd=0x0 & op3=0x14 & RS1 & regorimm 
 {
 	subflags(RS1,regorimm);
-	local tmp = RS1 - regorimm;
-	zeroflags(tmp);
+	local res:$(SIZE) = RS1 - regorimm;
+	zeroflags(res);
 }
 
 
@@ -819,43 +829,45 @@ callreloff: reloc  is disp30 [reloc=inst_start+4*disp30;] { export *:$(SIZE) rel
 
 #----------------MULTIPLY 32 bit
 @if SIZE=="8"
-:umul    RS1,regorimm,RD             is op=2 & RD & op3=0x0a & RS1 & regorimm {RD = zext(RS1:4) * zext(regorimm:4); Y=RD>>32;}
-:smul    RS1,regorimm,RD             is op=2 & RD & op3=0x0b & RS1 & regorimm {RD = sext(RS1:4) * sext(regorimm:4); Y=RD>>32;}
-:umulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1a & RS1 & regorimm {RD = zext(RS1:4) * zext(regorimm:4); Y=RD>>32; zeroflags(RD); logicflags();}
-:smulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1b & RS1 & regorimm {RD = sext(RS1:4) * sext(regorimm:4); Y=RD>>32; zeroflags(RD); logicflags();}
+:umul    RS1,regorimm,RD             is op=2 & RD & op3=0x0a & RS1 & regorimm {local res:8 = zext(RS1:4) * zext(regorimm:4); Y=res>>32; RD = res:4;}
+:smul    RS1,regorimm,RD             is op=2 & RD & op3=0x0b & RS1 & regorimm {local res:8 = sext(RS1:4) * sext(regorimm:4); Y=res>>32; RD = res:4;}
+:umulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1a & RS1 & regorimm {local res:8 = zext(RS1:4) * zext(regorimm:4); Y=res>>32; zeroflags(res); RD = res:4; logicflags();}
+:smulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1b & RS1 & regorimm {local res:8 = sext(RS1:4) * sext(regorimm:4); Y=res>>32; zeroflags(res); RD = res:4; logicflags();}
 
 @else
 # size = 4
-:umul    RS1,regorimm,RD             is op=2 & RD & op3=0x0a & RS1 & regorimm 
+:umul    RS1,regorimm,RD             is op=2 & RD & op3=0x0a & RS1 & regorimm
 {
-	tmp_RS1:8 = zext(RS1); 
+	tmp_RS1:8 = zext(RS1);
 	tmp_regorimm:8 = zext(regorimm);
-	tmp:8 = tmp_RS1 * tmp_regorimm; 
-	RD = tmp:4; tmp2:8 = tmp >> 32; 
+	tmp:8 = tmp_RS1 * tmp_regorimm;
+	RD = tmp:4; tmp2:8 = tmp >> 32;
 	Y = tmp2:4;
 }
 
-:smul    RS1,regorimm,RD             is op=2 & RD & op3=0x0b & RS1 & regorimm 
+:smul    RS1,regorimm,RD             is op=2 & RD & op3=0x0b & RS1 & regorimm
 {
-	tmp_RS1:8 = sext(RS1); 
+	tmp_RS1:8 = sext(RS1);
 	tmp_regorimm:8 = sext(regorimm);
-	tmp:8 = tmp_RS1 * tmp_regorimm; 
-	RD = tmp:4; tmp2:8 = tmp >> 32; 
+	tmp:8 = tmp_RS1 * tmp_regorimm;
+	RD = tmp:4; tmp2:8 = tmp >> 32;
 	Y = tmp2:4;
 }
 
-:umulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1a & RS1 & regorimm 
+:umulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1a & RS1 & regorimm
 {
-	RD = zext(RS1:4) * zext(regorimm:4); 
-	Y=RD>>32; 
-	zeroflags(RD); 
+	local res:8 = zext(RS1:4) * zext(regorimm:4);
+	Y=res[32,32];
+	zeroflags(res);
+	RD = res:4;
 	logicflags();
 }
-:smulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1b & RS1 & regorimm 
+:smulcc  RS1,regorimm,RD             is op=2 & RD & op3=0x1b & RS1 & regorimm
 {
-	RD = zext(RS1:4) * zext(regorimm:4); 
-	Y=RD>>32; 
-	zeroflags(RD); 
+	local res:8 = zext(RS1:4) * zext(regorimm:4);
+	Y=res[32,32];
+	zeroflags(res);
+	RD = res:4;
 	logicflags();
 }
 
@@ -863,7 +875,7 @@ callreloff: reloc  is disp30 [reloc=inst_start+4*disp30;] { export *:$(SIZE) rel
 
 #----------------MULTIPLY Step
 
-:mulscc  RS1,regorimm,RD             is op=2 & RD & op3=0x24 & RS1 & regorimm 
+:mulscc  RS1,regorimm,RD             is op=2 & RD & op3=0x24 & RS1 & regorimm
 {
 	local ccr:4 = zext(i_nf ^^ i_vf);
 	ccr = ccr << 31;
@@ -877,48 +889,69 @@ callreloff: reloc  is disp30 [reloc=inst_start+4*disp30;] { export *:$(SIZE) rel
 	addflags32(addend,shifted);
 	#upper 32 bits of RD are undefined according to the manual
 	local tbit:4 = (RS1:4 & 0x1:4) << 31;
-	RD = zext(sum);
-	zeroflags(RD);
+	local res:$(SIZE) = zext(sum);
+	zeroflags(res);
+	RD = res;
 	#Y is 64 bits in Sparc 9 but the high 32 are fixed to 0
 	Y = zext((Y:4 >> 1:4) | tbit);
 }
-    
+
 #----------------DIVIDE (64-bit / 32-bit)
 
 # NB- Beware, the plus + operator has higher precedence than shift <<
 # (These are Java rules. C rules have shift and + at the same level, so left to right)
 
-:udiv    RS1,regorimm,RD             is op=2 & RD & op3=0x0e & RS1 & regorimm 
+:udiv    RS1,regorimm,RD             is op=2 & RD & op3=0x0e & RS1 & regorimm
 {
-	numerator:$(SIZE)= (Y << 32) + (RS1 & 0xffffffff);
-	denom:$(SIZE) = regorimm & 0xffffffff;
-	RD = numerator / denom;
+	numerator:8 = (zext(Y) << 32) + (zext(RS1) & 0xffffffff);
+	denom:8 = zext(regorimm) & 0xffffffff;
+	local res:8 = numerator / denom;
+@if SIZE=="8"
+	RD = res;
+@else
+	RD = res:$(SIZE);
+@endif
 }
-:sdiv    RS1,regorimm,RD             is op=2 & RD & op3=0x0f & RS1 & regorimm 
+:sdiv    RS1,regorimm,RD             is op=2 & RD & op3=0x0f & RS1 & regorimm
 {
-	numerator:$(SIZE)= (Y << 32) + (RS1 & 0xffffffff);
-	denom:$(SIZE) = regorimm & 0xffffffff;
-	RD = numerator s/ denom;
-}                                         					 
+	numerator:8 = (zext(Y) << 32) + (zext(RS1) & 0xffffffff);
+	denom:8 = zext(regorimm) & 0xffffffff;
+	local res:8 = numerator s/ denom;
+@if SIZE=="8"
+	RD = res;
+@else
+	RD = res:$(SIZE);
+@endif
+}
 
-:udivcc    RS1,regorimm,RD           is op=2 & RD & op3=0x1e & RS1 & regorimm 
+:udivcc    RS1,regorimm,RD           is op=2 & RD & op3=0x1e & RS1 & regorimm
 {
-	numerator:$(SIZE)= ( Y << 32) + (RS1 & 0xffffffff);
-	denom:$(SIZE) = regorimm & 0xffffffff;
-	RD = numerator / denom;
-	zeroflags(RD);
-	i_vf = RD > 0xffffffff;
+	numerator:8 = (zext(Y) << 32) + (zext(RS1) & 0xffffffff);
+	denom:8 = zext(regorimm) & 0xffffffff;
+	local res:8 = numerator / denom;
+	zeroflags(res);
+@if SIZE=="8"
+	RD = res;
+@else
+	RD = res:$(SIZE);
+@endif
+	i_vf = res > 0xffffffff;
 	i_cf = 0;
 	x_vf = 0;
 	x_cf = 0;
 }
-:sdivcc    RS1,regorimm,RD           is op=2 & RD & op3=0x1f & RS1 & regorimm 
+:sdivcc    RS1,regorimm,RD           is op=2 & RD & op3=0x1f & RS1 & regorimm
 {
-	numerator:$(SIZE)= (Y << 32) + (RS1 & 0xffffffff);
-	denom:$(SIZE) = regorimm & 0xffffffff;
-	RD = numerator s/ denom;
-	zeroflags(RD);
-	i_vf = (RD s>= 0x80000000) || (RD s<= -0x7ffffffff);
+	numerator:8 = (sext(Y) << 32) + (zext(RS1) & 0xffffffff);
+	denom:8 = sext(regorimm);
+	local res:8 = numerator s/ denom;
+	zeroflags(res);
+@if SIZE=="8"
+	RD = res;
+@else
+	RD = res:$(SIZE);
+@endif
+	i_vf = (res s>= 0x80000000) || (res s<= -0x7ffffffff);
 	i_cf = 0;
 	x_vf = 0;
 	x_cf = 0;
@@ -1024,29 +1057,33 @@ casa_ea: [RS1]%ASI     is i=1 & RS1 & ASI     { local tmp = RS1+segment(ASI); ex
 :swap  ea,RD                         is op=0x3 & RD & op3=0xF & ea { tmp:4=RD:4; RD = zext(*:4 ea); *:4 ea = tmp; }
 :swapa ea_alt,RD                     is op=0x3 & RD & op3=0x1F & ea_alt { tmp:4=RD:4; RD = zext(*:4 ea_alt); *:4 ea_alt = tmp; }
 
-:taddcc   RS1,regorimm,RD            is op=2 & RD & op3=0x20 & RS1 & regorimm 
+:taddcc   RS1,regorimm,RD            is op=2 & RD & op3=0x20 & RS1 & regorimm
 {
 	taddflags(RS1,regorimm);
-	RD = RS1 + regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 + regorimm;
+	zeroflags(res);
+	RD = res;
 }
-:taddcctv RS1,regorimm,RD            is op=2 & RD & op3=0x22 & RS1 & regorimm 
+:taddcctv RS1,regorimm,RD            is op=2 & RD & op3=0x22 & RS1 & regorimm
 {
 	taddflags(RS1,regorimm);
-	RD = RS1 + regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 + regorimm;
+	zeroflags(res);
+	RD = res;
 }
-:tsubcc   RS1,regorimm,RD            is op=2 & RD & op3=0x21 & RS1 & regorimm 
+:tsubcc   RS1,regorimm,RD            is op=2 & RD & op3=0x21 & RS1 & regorimm
 {
 	tsubflags(RS1,regorimm);
-	RD = RS1 - regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 - regorimm;
+	zeroflags(res);
+	RD = res;
 }
-:tsubcctv RS1,regorimm,RD            is op=2 & RD & op3=0x23 & RS1 & regorimm 
+:tsubcctv RS1,regorimm,RD            is op=2 & RD & op3=0x23 & RS1 & regorimm
 {
 	tsubflags(RS1,regorimm);
-	RD = RS1 - regorimm;
-	zeroflags(RD);
+	local res:$(SIZE) = RS1 - regorimm;
+	zeroflags(res);
+	RD = res;
 }
 
 tcc: icc  is cc1_4=0 & cc0_4=0 & icc { export icc; }


### PR DESCRIPTION
RD cannot be used with the zeroflags() macro as it could be hardcoded zero g0 register