### PR TITLE
decompiler-cpp: Open sla files as 'binary'

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
@@ -560,7 +560,7 @@ void Sleigh::initialize(DocumentStorage &store)
     if (el == (const Element *)0)
       throw LowlevelError("Could not find sleigh tag");
     sla::FormatDecode decoder(this);
-    ifstream s(el->getContent());
+    ifstream s(el->getContent(), std::ios_base::binary);
     if (!s)
       throw LowlevelError("Could not open .sla file: " + el->getContent());
     decoder.ingestStream(s);


### PR DESCRIPTION
Compressed files need to be opened as binaries when reading. Fixes opening sla files on Windows.

Found and fixed after having issues in https://github.com/lifting-bits/sleigh/pull/245 (particularly issues from commit https://github.com/NationalSecurityAgency/ghidra/commit/8fbd171cdf290acd7563c062fec9015bb7b01498) where only Windows tests were failing. You can see when the CI turns green near the bottom of the PR page. This bug took a while to find.

Related to
- #6276 
- #6373 