### PR TITLE
decompiler-cpp: Add missing for-loop index variable check

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ifacedecomp.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ifacedecomp.cc
@@ -1844,7 +1844,7 @@ void IfcProtooverride::execute(istream &s)
   s >> ws;
   Address callpoint(parse_machaddr(s,discard,*dcp->conf->types));
   int4 i;
-  for(i=0;dcp->fd->numCalls();++i)
+  for(i=0;i<dcp->fd->numCalls();++i)
     if (dcp->fd->getCallSpecs(i)->getOp()->getAddr() == callpoint) break;
   if (i == dcp->fd->numCalls())
     throw IfaceExecutionError("No call is made at this address");


### PR DESCRIPTION
Prevent indexing out of bounds

Found and fixed after having issues in https://github.com/lifting-bits/sleigh/pull/245 (particularly issues from commit https://github.com/NationalSecurityAgency/ghidra/commit/8fbd171cdf290acd7563c062fec9015bb7b01498) where only Windows tests were failing. You can see when the CI turns green near the bottom of the PR page.

Related to:
- #6276 
- #6372