### PR TITLE
ArrayDataType: add constructor without elementLength parameter

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/ArrayDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/ArrayDataType.java
@@ -36,6 +36,15 @@ public class ArrayDataType extends DataTypeImpl implements Array {
 	 * Constructs a new Array dataType.
 	 * @param dataType the dataType of the elements in the array (null is not permitted).
 	 * @param numElements the number of elements in the array (0 is permitted).
+	 */
+	public ArrayDataType(DataType dataType, int numElements) {
+		this(dataType, numElements, -1, null);
+	}
+
+	/**
+	 * Constructs a new Array dataType.
+	 * @param dataType the dataType of the elements in the array (null is not permitted).
+	 * @param numElements the number of elements in the array (0 is permitted).
 	 * @param elementLength the length of an individual element in the array.  This value
 	 * is only used for {@link Dynamic} dataType where {@link Dynamic#canSpecifyLength()} 
 	 * returns true.


### PR DESCRIPTION
The elementLength parameter is unused when the base type isn't dynamic, but the existing constructors require it to be specified.