### PR TITLE
mz source get and set added to mz adjustSegmentStarts

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
@@ -294,10 +294,12 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 					// split here and join to previous
 					Address splitAddr = offAddr.add(1);
 					String oldName = block.getName();
+					String oldSourceName = block.getSourceName();
 					memory.split(block, splitAddr);
 					memory.join(blocks[i - 1], blocks[i]);
 					blocks = memory.getBlocks();
 					blocks[i].setName(oldName);
+					blocks[i].setSourceName(oldSourceName);
 					break;
 				}
 			}


### PR DESCRIPTION
Issue: Currently MZloader does not copy block source information to new block in adjustSegmentStarts.

Fix: Add get / set combination similar to the block name copy.

Patch compiles without errors on Fedora 39 with Gradle 7.6.4.

![before](https://github.com/NationalSecurityAgency/ghidra/assets/32195719/8ab36763-1d5c-4692-a1ad-f8ee331f4da0)
![after](https://github.com/NationalSecurityAgency/ghidra/assets/32195719/fd7cad7b-2341-4cf0-8e58-0128dca5a59f)

