### PR TITLE
MZloader: some MZ header shorts are now treated as unsigned

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
@@ -184,7 +184,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 		relocationFixups.forEach(rf -> knownSegments.add(space.getAddress(rf.segment, 0)));
 		knownSegments.add(space.getAddress(INITIAL_SEGMENT_VAL, 0));
 		if (header.e_cs() > 0) {
-			knownSegments.add(space.getAddress((INITIAL_SEGMENT_VAL + Short.toUnsignedInt(header.e_cs())) & 0xffff, 0));
+			knownSegments.add(space.getAddress((INITIAL_SEGMENT_VAL + header.e_cs()) & 0xffff, 0));
 		}
 		// Allocate an initialized memory block for each segment we know about
 		int endOffset = pagesToBytes(Short.toUnsignedInt(header.e_cp()) - 1) + Short.toUnsignedInt(header.e_cblp());

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
@@ -67,7 +67,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 		OldDOSHeader header = mz.getHeader();
 		if (header.isDosSignature() && !header.hasNewExeHeader() && !header.hasPeHeader()) {
 			List<QueryResult> results =
-					QueryOpinionService.query(getName(), "" + header.e_magic(), null);
+				QueryOpinionService.query(getName(), "" + header.e_magic(), null);
 			for (QueryResult result : results) {
 				loadSpecs.add(new LoadSpec(this, 0, result));
 			}
@@ -340,7 +340,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 		int ipValue = Short.toUnsignedInt(header.e_ip());
 
 		Address addr =
-				space.getAddress((INITIAL_SEGMENT_VAL + header.e_cs()) & 0xffff, ipValue);
+			space.getAddress((INITIAL_SEGMENT_VAL + header.e_cs()) & 0xffff, ipValue);
 		SymbolTable symbolTable = program.getSymbolTable();
 
 		try {
@@ -397,7 +397,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 				BigInteger.valueOf(Short.toUnsignedLong(header.e_sp())));
 			context.setValue(ss, entry.getAddress(), entry.getAddress(),
 				BigInteger.valueOf(
-						Integer.toUnsignedLong((header.e_ss() + INITIAL_SEGMENT_VAL) & 0xffff)));
+					Integer.toUnsignedLong((header.e_ss() + INITIAL_SEGMENT_VAL) & 0xffff)));
 
 			for (MemoryBlock block : program.getMemory().getBlocks()) {
 				Address start = block.getStart();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/MzLoader.java
@@ -67,7 +67,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 		OldDOSHeader header = mz.getHeader();
 		if (header.isDosSignature() && !header.hasNewExeHeader() && !header.hasPeHeader()) {
 			List<QueryResult> results =
-				QueryOpinionService.query(getName(), "" + Short.toUnsignedInt(header.e_magic()), null);
+					QueryOpinionService.query(getName(), "" + header.e_magic(), null);
 			for (QueryResult result : results) {
 				loadSpecs.add(new LoadSpec(this, 0, result));
 			}
@@ -183,7 +183,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 		Set<SegmentedAddress> knownSegments = new TreeSet<>();
 		relocationFixups.forEach(rf -> knownSegments.add(space.getAddress(rf.segment, 0)));
 		knownSegments.add(space.getAddress(INITIAL_SEGMENT_VAL, 0));
-		if (Short.toUnsignedInt(header.e_cs()) > 0) {
+		if (header.e_cs() > 0) {
 			knownSegments.add(space.getAddress((INITIAL_SEGMENT_VAL + Short.toUnsignedInt(header.e_cs())) & 0xffff, 0));
 		}
 		// Allocate an initialized memory block for each segment we know about
@@ -340,7 +340,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 		int ipValue = Short.toUnsignedInt(header.e_ip());
 
 		Address addr =
-			space.getAddress((INITIAL_SEGMENT_VAL + Short.toUnsignedInt(header.e_cs())) & 0xffff, ipValue);
+				space.getAddress((INITIAL_SEGMENT_VAL + header.e_cs()) & 0xffff, ipValue);
 		SymbolTable symbolTable = program.getSymbolTable();
 
 		try {
@@ -397,7 +397,7 @@ public class MzLoader extends AbstractLibrarySupportLoader {
 				BigInteger.valueOf(Short.toUnsignedLong(header.e_sp())));
 			context.setValue(ss, entry.getAddress(), entry.getAddress(),
 				BigInteger.valueOf(
-					Integer.toUnsignedLong((Short.toUnsignedInt(header.e_ss()) + INITIAL_SEGMENT_VAL) & 0xffff)));
+						Integer.toUnsignedLong((header.e_ss() + INITIAL_SEGMENT_VAL) & 0xffff)));
 
 			for (MemoryBlock block : program.getMemory().getBlocks()) {
 				Address start = block.getStart();


### PR DESCRIPTION
Issue: MZ header info is stored as short (signed) but the actual data is unsigned. MZ loader uses these shorts in calculations and this might lead to wrong results if the number is treated as negative number instead of unsigned.

Fix: I added Short.toUnsignedInt() to each case to ensure correct outcome.

PS. Not sure it header.e_magic() if really needs it as it should always be the same. Anyway good to be consistant.

Fix compiles with
Fedora 39 (amd64)
Gradle 7.6.4