### PR TITLE
i8085: enable io space to show OUT instructions in decompilation

### DIFF
--- a/Ghidra/Processors/8085/data/languages/8085.cspec
+++ b/Ghidra/Processors/8085/data/languages/8085.cspec
@@ -3,6 +3,7 @@
 <compiler_spec>
   <global>
     <range space="ram"/>
+    <range space="io"/>
   </global>
   <stackpointer register="SP" space="ram" growth="negative"/>
   <default_proto>


### PR DESCRIPTION
This change was suggest by @GhidorahRex and still seems to be the best working solution
https://github.com/NationalSecurityAgency/ghidra/issues/4557#issuecomment-1243992813
