### PR TITLE
M68000: Implement BKPT opcode

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -329,6 +329,7 @@ attach values quick [ 8 1 2 3 4 5 6 7 ];
 define pcodeop kfactor;
 define pcodeop ftrap;
 define pcodeop __m68k_trap;
+define pcodeop __m68k_bkpt;
 define pcodeop __m68k_trapv;
 define pcodeop reset;
 define pcodeop saveFPUStateFrame;
@@ -1115,7 +1116,7 @@ with : extGUARD=1 {
 	resbitflags(tmp, f_wd-1);
 }
 
-:bkpt "#"op02			is opbig=0x48 & op67=1 & op5=0 & op34=1 & op02			unimpl
+:bkpt "#"^op02			is opbig=0x48 & op67=1 & op5=0 & op34=1 & op02	{ breakpoint:1 = op02; __m68k_bkpt(breakpoint); }
 
 :bra.b addr8			is opbig=0x60 & addr8						{ goto addr8; }
 :bra.w addr16			is opbig=0x60 & d8base=0; addr16				{ goto addr16; }


### PR DESCRIPTION
This enables `BKPT (Breakpoint)` instructions to show up in the decompiler in the same way as `trap` is shown - with a new pcode `__m68k_bkpt(#)`

Technically, this instruction was only added in the 68010. From the Motorola manual:

> For the MC68000 and MC68008, the breakpoint cycle is not run, but an illegal
instruction exception is taken.

> For the MC68010, a breakpoint acknowledge bus cycle is run with function codes driven high and zeros on all address lines. Whether the breakpoint acknowledge bus cycle is terminated with DTACK, BERR, or VPA, the processor always takes an illegal instruction exception. During exception processing, a debug monitor can distinguish different software breakpoints by decoding the field in the BKPT instruction.

It may therefore be more correct to specify this only for 68010 and newer, and only show `ILLEGAL` on 68000, but Ghidra currently makes no distinction between the 000 and 010, so I opted to keep this PR minimal by not adding the multiple files needed. This patch already enables a better decompile of affected code.