### PR TITLE
Fix tricore instruction st.da circular addr mode

### DIFF
--- a/Ghidra/Processors/tricore/data/languages/tricore.sinc
+++ b/Ghidra/Processors/tricore/data/languages/tricore.sinc
@@ -7824,8 +7824,8 @@ macro multiply_u_u(mres0, rega, regb, n) {
 	local EA0:4;
 	local EA4:4;
 	CircularAddressingMode2(Rpe1215, Rpo1215, EA0, EA4, off10, 4);
-	*[ram]:2 EA0 = Rp0811[0,32];
-	*[ram]:2 EA4 = Rp0811[32,32];
+	*[ram]:4 EA0 = Rp0811[0,32];
+	*[ram]:4 EA4 = Rp0811[32,32];
 }
 
 # ST.DA off18, P[a] (ABS)(Absolute Addressing Mode)


### PR DESCRIPTION
At the manual https://www.infineon.com/dgdl/tc_v131_instructionset_v138.pdf?fileId=db3a304412b407950112b409b6dd0352
It defines word as 32bits, and the instruction define a memory write of word len `(M(EA0, word) = A[a];`, so those are two 4bytes writes and not 2bytes writes