### PR TITLE
AArch64: fix stlrb and stlrh store sizes

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
@@ -5651,7 +5651,7 @@ is size.ldstr=2 & b_2429=0x8 & b_23=1 & L=0 & b_21=0 & b_15=1 & addrReg & Rt_GPR
 :stlrb Rt_GPR32, addrReg
 is size.ldstr=0 & b_2429=0x8 & b_23=1 & L=0 & b_21=0 & b_15=1 & addrReg & Rt_GPR32
 {
-	*addrReg = Rt_GPR32;
+	*:1 addrReg = Rt_GPR32:1;
 }
 
 # C6.2.312 STLRH page C6-1849 line 108967 MATCH x48808000/mask=xffe08000
@@ -5662,7 +5662,7 @@ is size.ldstr=0 & b_2429=0x8 & b_23=1 & L=0 & b_21=0 & b_15=1 & addrReg & Rt_GPR
 :stlrh Rt_GPR32, addrReg
 is size.ldstr=1 & b_2429=0x8 & b_23=1 & L=0 & b_21=0 & b_15=1 & addrReg & Rt_GPR32
 {
-	*addrReg = Rt_GPR32;
+	*:2 addrReg = Rt_GPR32:2;
 }
 
 # C6.2.313 STLUR page C6-1850 line 109030 MATCH x99000000/mask=xbfe00c00


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the stlrb and stlrh instructions for AARCH64. According to Section C6.2.311 and C6.2.312, the expected behaviour is an 8 and 16 bit store respectively. While the current behaviour instead stores a 32 bit value.