### PR TITLE
AArch64: fix ldpsw adddress increment amount to match load size

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
@@ -3041,7 +3041,7 @@ is b_3031=0b10 & b_2529=0b10100 & (b_24=1 | b_23=1) & b_22=1 & Rt2_GPR64 & addrP
 is b_2531=0b0110100 & (b_24=1 | b_23=1) & b_22=1 & Rt2_GPR64 & addrPairIndexed & Rt_GPR64
 {
 	local addrval1:8 = sext(*:4 addrPairIndexed);
-	local addrval2:8 = sext(*:4 (addrPairIndexed + 8));
+	local addrval2:8 = sext(*:4 (addrPairIndexed + 4));
 	Rt_GPR64 = addrval1;
 	Rt2_GPR64 = addrval2;
 }


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the ldpsw instruction for AARCH64. According to Section C6.2.165, the expected behaviour is a pair of 32 bit loads, at addresses 4 bytes apart. While the current behaviour instead separates the loaded addresses by 8 bytes.