### PR TITLE
RISCV: clear lsb in compressed jump instructions

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rvc.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rvc.sinc
@@ -169,20 +169,23 @@
 # c.jalr d 00009002 0000f07f JSR (0, 0) 
 :c.jalr crd is crd & cop0001=0x2 & cop1315=0x4 & cop0206=0x0 & cop1212=0x1
 {
+	local tmp:$(XLEN) = crd & ~1;
 	ra = inst_next;
-	call [crd];
+	call [tmp];
 }
 
 # c.jr d 00008002 0000f07f BRANCH (0, 0) 
 :c.jr crd is crd & cop0001=0x2 & cop1315=0x4 & cop0206=0x0 & cop1212=0x0
 {
-	goto [crd];
+	local tmp:$(XLEN) = crd & ~1;
+	goto [tmp];
 }
 
 # ret  00008082 0000ffff BRANCH|ALIAS (0, 0)
 :ret is cop0001=0x2 & cop1315=0x4 & cop0206=0x0 & cop1212=0x0 & cop0711=1
 {
-	return [ra];
+	local tmp:$(XLEN) = ra & ~1;
+	return [tmp];
 }
 
 @if (ADDRSIZE == "64") || (ADDRSIZE == "128")


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the `c.jalr`, `c.jr`, and `ret` instructions for RISCV. According to section 16.4 of the 20191213 unprivileged specification, these instructions expand to the `jalr` instruction. In section 2.5 it says that when calculating the address for `jalr` the least significant bit is cleared. While the current behaviour leaves this bit as is. Current behaviour for the `c.jalr` instruction also jumps to the `inst_next` address instead of the registers value when the `ra` register is used.