### PR TITLE
RISCV: remove used of rdW and sign extend in fcvt/fmv

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32d.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32d.sinc
@@ -61,17 +61,19 @@
 
 
 # fcvt.w.d d,S,m c2000053 fff0007f SIMPLE (0, 0) 
-:fcvt.w.d rdW,frs1D,FRM is frs1D & FRM & rdW & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x61 & op2024=0x0
+:fcvt.w.d rd,frs1D,FRM is frs1D & FRM & rd & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x61 & op2024=0x0
 {
-	rdW = trunc(frs1D);
+	local tmp:$(WXLEN) = trunc(frs1D);
+	rd = sext(tmp);
 }
 
 
 # fcvt.wu.d d,S,m c2100053 fff0007f SIMPLE (0, 0) 
-:fcvt.wu.d rdW,frs1D,FRM is frs1D & FRM & rdW & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x61 & op2024=0x1
+:fcvt.wu.d rd,frs1D,FRM is frs1D & FRM & rd & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x61 & op2024=0x1
 {
+	local tmp:$(WXLEN) = trunc(frs1D);
 	#TODO  unsigned
-	rdW = trunc(frs1D);
+	rd = sext(tmp);
 }
 
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32f.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32f.sinc
@@ -45,17 +45,19 @@
 
 
 # fcvt.w.s d,S,m c0000053 fff0007f SIMPLE (0, 0) 
-:fcvt.w.s rdW,frs1S,FRM is frs1S & FRM & rdW & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x60 & op2024=0x0
+:fcvt.w.s rd,frs1S,FRM is frs1S & FRM & rd & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x60 & op2024=0x0
 {
-	rdW = trunc(frs1S);
+	local tmp:$(WXLEN) = trunc(frs1S);
+	rd = sext(tmp);
 }
 
 
 # fcvt.wu.s d,S,m c0100053 fff0007f SIMPLE (0, 0) 
-:fcvt.wu.s rdW,frs1S,FRM is frs1S & FRM & rdW & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x60 & op2024=0x1
+:fcvt.wu.s rd,frs1S,FRM is frs1S & FRM & rd & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x60 & op2024=0x1
 {
+	local tmp:$(WXLEN) = trunc(frs1S);
 	#TODO  unsigned
-	rdW = trunc(frs1S);
+	rd = sext(tmp);
 }
 
 
@@ -159,11 +161,9 @@
 }
 
 # fmv.x.w d,S e0000053 fff0707f SIMPLE (0, 0) 
-:fmv.x.w rdW,frs1S is frs1S & rdW & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct3=0x0 & funct7=0x70 & op2024=0x0
+:fmv.x.w rd,frs1S is frs1S & rd & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct3=0x0 & funct7=0x70 & op2024=0x0
 {
-	local tmpreg:4 = &frs1S;
-	local tmp:4 = *[register]:4 tmpreg;
-	rdW = tmp;
+	rd = sext(frs1S);
 }
 
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.table.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.table.sinc
@@ -41,11 +41,6 @@ rs1W: zero is r1519 & zero & op1519=0 { export 0:$(WXLEN); }
 rs2W: r2024 is r2024 { local tmp:$(WXLEN) = r2024:$(WXLEN); export tmp; }
 rs2W: zero is r2024 & zero & op2024=0 { export 0:$(WXLEN); }
 
-#TODO  dest may be bad, might need an assign macro
-rdW: r0711 is r0711 { local tmp:$(WXLEN) = r0711:$(WXLEN); export tmp; }
-rdW: zero is r0711 & zero & op0711=0 { export 0:$(WXLEN); }
-
-
 
 #TODO  does this need to be in an if/endif
 @if ADDRSIZE == "64"


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the `fcvt.w.s/d`, `fcvt.wu.s/d` and `fmv.x.w` instructions. According to section 11.7 of the 20191213 unprivileged specification, the expected behaviour is to sign extend the result to the width of the destination register. In the case of `fmv.x.w` the expected behaviour is to fill the upper bit with copies of the floating point numbers sign bit. While the current behaviour of these instructions writes no values to the destination register as they are written to the temporary export by `rdW` instead.

**Example Instruction**
```
fcvt.w.s a0,fa0 (fa0 = 0xFFFFFFFF_C0A00000)
```

**Current behaviour**
Before: `a0 = 0x9DCFE753_DAEC613E`, Hardware after: `a0 = 0xFFFFFFFF_FFFFFFFB`, Ghidra after: `0x9DCFE753_DAEC613E`.

**After fix**
Before: `a0 = 0x9DCFE753_DAEC613E`, Hardware after: `a0 = 0xFFFFFFFF_FFFFFFFB`, Ghidra after: `0xFFFFFFFF_FFFFFFFB`.