### PR TITLE
Fix warnings that have become errors with GCC 14

### DIFF
--- a/Ghidra/Debug/Framework-Debugging/src/expCloneExec/c/expCloneExec.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expCloneExec/c/expCloneExec.c
@@ -15,6 +15,7 @@
  */
 #include <pthread.h>
 #include <stdio.h>
+#include <unistd.h>
 
 pthread_t thread;
 

--- a/Ghidra/Debug/Framework-Debugging/src/expFork/c/expFork.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expFork/c/expFork.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <stdio.h>
+#include <unistd.h>
 
 int func(int id) {
     if (id) {

--- a/Ghidra/Debug/Framework-Debugging/src/expSpin/c/expSpin.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expSpin/c/expSpin.c
@@ -15,6 +15,8 @@
  */
 #ifdef WIN32
 #include <Windows.h>
+#else
+#include <unistd.h>
 #endif
 
 #ifdef WIN32

--- a/Ghidra/Debug/Framework-Debugging/src/expTypes/c/expTypes.c
+++ b/Ghidra/Debug/Framework-Debugging/src/expTypes/c/expTypes.c
@@ -38,7 +38,7 @@ typedef enum _myenum {
 typedef void (*myfunc_p)(int arg0, long arg1);
 typedef void (*myvargfunc_p)(int arg0, long arg1, ...);
 
-typedef myundef;
+typedef int myundef; // forbidding to be "undefined" in C99 and later
 
 int int_var;
 void* void_p_var;
@@ -86,11 +86,11 @@ int main(int argc, char** argv) {
     printf("complex: %d\n", sizeof(complex_var));
     printf("double complex: %d\n", sizeof(double_complex_var));
     
-    register mycomplex_p cparts = &complex_var;
+    register mycomplex_p cparts = (mycomplex_p)&complex_var;
     printf("single real: %f\n", cparts->real);
     printf("single imag: %f\n", cparts->imag);
     
-    mydoublex_p dparts = &double_complex_var;
+    mydoublex_p dparts = (mydoublex_p)&double_complex_var;
     printf("double real: %g\n", dparts->real);
     printf("double imag: %g\n", dparts->imag);
     


### PR DESCRIPTION
- Add missing includes
- Add casts

There is one open point. There is a `typdef` in `Ghidra/Debug/Framework-Debugging/src/expTypes/c/expTypes.c` that has been explicitly left "undefined" (defaulting to int). It needs to be discussed how to fix this. The current fix sets this typedef to `int` explicitly.

Fixes #6495