### PR TITLE
Add "hex" into "Loadable files" filter to highlight support for loading hex filex.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/plugin/importer/ImporterUtilities.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugin/importer/ImporterUtilities.java
@@ -60,7 +60,7 @@ public class ImporterUtilities {
 	 * TODO: will be refactored to use file_extension_icon.xml file info.
 	 */
 	public static final GhidraFileFilter LOADABLE_FILES_FILTER = ExtensionFileFilter.forExtensions(
-		"Loadable files", "exe", "dll", "obj", "drv", "bin", "o", "a", "so", "class", "lib");
+		"Loadable files", "exe", "dll", "obj", "drv", "bin", "hex", "o", "a", "so", "class", "lib");
 
 	/**
 	 * File extension filter for well known 'container' files for GhidraFileChoosers.


### PR DESCRIPTION
I was under impression that ghidra can't load hex files... just because the "hex" was omitted from the filter :)