### PR TITLE
RISCV: handle divide by 0

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32m.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32m.sinc
@@ -1,8 +1,15 @@
 # RV32M Standard Extension
+macro checkDivByZero(reg, rd, adjustment) {
+	if (reg != 0) goto <NOTZERO>;
+	rd = adjustment;
+	goto inst_next;
+	<NOTZERO>
+}
 
 # div d,s,t 02004033 fe00707f SIMPLE (0, 0) 
 :div rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x4 & funct7=0x1
 {
+	checkDivByZero(rs2, rd, ~0);
 	rd = rs1 s/ rs2;
 }
 
@@ -10,6 +17,7 @@
 # divu d,s,t 02005033 fe00707f SIMPLE (0, 0) 
 :divu rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x5 & funct7=0x1
 {
+	checkDivByZero(rs2, rd, ~0);
 	rd = rs1 / rs2;
 }
 
@@ -54,6 +62,7 @@
 # rem d,s,t 02006033 fe00707f SIMPLE (0, 0) 
 :rem rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x6 & funct7=0x1
 {
+	checkDivByZero(rs2, rd, rs1);
 	rd = rs1 s% rs2;
 }
 
@@ -61,5 +70,6 @@
 # remu d,s,t 02007033 fe00707f SIMPLE (0, 0) 
 :remu rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x7 & funct7=0x1
 {
+	checkDivByZero(rs2, rd, rs1);
 	rd = rs1 % rs2;
 }

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64m.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64m.sinc
@@ -5,6 +5,7 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	checkDivByZero(tmpr2, rd, ~0);
 	rd = sext(tmpr1 / tmpr2);
 }
 
@@ -14,6 +15,7 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	checkDivByZero(tmpr2, rd, ~0);
 	rd = sext(tmpr1 s/ tmpr2);
 }
 
@@ -31,6 +33,7 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	checkDivByZero(tmpr2, rd, sext(tmpr1));
 	rd = sext(tmpr1 % tmpr2);
 }
 
@@ -40,5 +43,6 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	checkDivByZero(tmpr2, rd, sext(tmpr1));
 	rd = sext(tmpr1 s% tmpr2);
 }


### PR DESCRIPTION
As apart of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed unexpected behaviour in the divide and remainder instructions for RISCV. These include the `div`, `divu`, `rem`, `remu`, `divw`, `divuw`, `remw`, `remuw` instructions. According to section 7.2 of the riscv-spec-20191213 specification the result of dividing by zero is all 1's, and the result of the remainder of zero is the dividend. The current behaviour does not check if the divisor is zero which causes a division exception on these cases. Handling this case does add an if statement which shows in decompilation, but is how it is handled in both AARCH64 and ARM with the `SDIV` and `UDIV` instructions, and MIPS16 with the `div` and `divu` instructions. There is also an edge case for overflowing division which has not been handled.

**Decompilation without fix**
```c
int division(int param_1,int param_2)
{
  gp = &__global_pointer$;
  return param_1 / param_2;
}
```

**Decompilation with fix**
```c
int division(int param_1,int param_2)
{
  gp = &__global_pointer$;
  if (param_2 == 0) {
    param_1 = -1;
  }
  else {
    param_1 = param_1 / param_2;
  }
  return param_1;
}
```