### PR TITLE
RISCV: add rm to fcvt.d.

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32d.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32d.sinc
@@ -27,7 +27,7 @@
 
 
 # fcvt.d.s D,S 42000053 fff0707f SIMPLE (0, 0) 
-:fcvt.d.s frd,frs1S is frs1S & frd & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct3=0x0 & funct7=0x21 & op2024=0x0
+:fcvt.d.s frd,frs1S,FRM is frs1S & frd & FRM & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x21 & op2024=0x0
 {
 	local tmp:8 = float2float(frs1S);
 	frd = tmp;
@@ -35,7 +35,7 @@
 
 
 # fcvt.d.w D,s d2000053 fff0707f SIMPLE (0, 0) 
-:fcvt.d.w frd,rs1W is frd & rs1W & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct3=0x0 & funct7=0x69 & op2024=0x0
+:fcvt.d.w frd,rs1W,FRM is frd & rs1W & FRM & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x69 & op2024=0x0
 {
 	local tmp:8 = int2float(rs1W);
 	frd = tmp;
@@ -43,7 +43,7 @@
 
 
 # fcvt.d.wu D,s d2100053 fff0707f SIMPLE (0, 0) 
-:fcvt.d.wu frd,rs1W is frd & rs1W & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct3=0x0 & funct7=0x69 & op2024=0x1
+:fcvt.d.wu frd,rs1W,FRM is frd & rs1W & FRM & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x69 & op2024=0x1
 {
 	#ATTN  unsigned can be an issue here
 	local u32:$(XLEN2) = zext(rs1W);


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed a difference in the disassembly of the `fcvt.d.[s/w/wu]` instructions. Bits 12-14 of the instruction represent the rounding mode to use and can take a value from 0-7. The current behaviour restricts this field to 0 in the disassembly of the instruction. This causes any `fcvt.d.[s/w/wu]` instruction which has a rounding mode other than 'round to nearest' to failed to disassemble. 