### PR TITLE
x86: Make redundant encoding of Grp1 instructions (0x82 alias) is invalid in long mode

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -579,6 +579,12 @@ define pcodeop vmxon;    # Enter VMX operation; opcode f3 0f C7 /6
 @endif
 
 @ifdef IA64
+@define BYTE_80_82 "(byte=0x80 | (longMode=0 & byte=0x82))"
+@else
+@define BYTE_80_82 "(byte=0x80 | byte=0x82)"
+@endif
+
+@ifdef IA64
 Reg8:   reg8        is rexprefix=0 & reg8                               { export reg8; }
 Reg8:   reg8_x0     is rexprefix=1 & rexRprefix=0 & reg8_x0             { export reg8_x0; }
 Reg8:   reg8_x1     is rexprefix=1 & rexRprefix=1 & reg8_x1             { export reg8_x1; }
@@ -1686,7 +1692,7 @@ with : lockprefx=0 {
 @ifdef IA64
 :ADC RAX,simm32     is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x15; RAX & simm32         { addCarryFlags( RAX, simm32 ); resultflags( RAX ); }
 @endif
-:ADC Rmr8,imm8		is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=2; imm8 { addCarryFlags( Rmr8, imm8:1 ); resultflags( Rmr8 ); }
+:ADC Rmr8,imm8		is vexMode=0 & $(BYTE_80_82); mod=3 & Rmr8 & reg_opcode=2; imm8 { addCarryFlags( Rmr8, imm8:1 ); resultflags( Rmr8 ); }
 :ADC Rmr16,imm16	is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=2; imm16 { addCarryFlags( Rmr16, imm16:2 ); resultflags( Rmr16 ); }
 :ADC Rmr32,imm32	is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_Rmr32_dest & reg_opcode=2; imm32 { addCarryFlags( Rmr32, imm32:4 ); build check_Rmr32_dest; resultflags( Rmr32 ); }
 @ifdef IA64
@@ -1717,7 +1723,7 @@ with : lockprefx=0 {
 @ifdef IA64
 :ADD RAX,simm32     is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x5; RAX & simm32          { addflags(  RAX,simm32);   RAX =   RAX + simm32; resultflags(  RAX); }
 @endif
-:ADD Rmr8,imm8		is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=0; imm8		{ addflags(  Rmr8,imm8 );   Rmr8 =   Rmr8 +  imm8; resultflags(  Rmr8); }
+:ADD Rmr8,imm8		is vexMode=0 & $(BYTE_80_82); mod=3 & Rmr8 & reg_opcode=0; imm8		{ addflags(  Rmr8,imm8 );   Rmr8 =   Rmr8 +  imm8; resultflags(  Rmr8); }
 :ADD Rmr16,imm16		is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=0; imm16	{ addflags( Rmr16,imm16);  Rmr16 =  Rmr16 + imm16; resultflags( Rmr16); }
 :ADD Rmr32,imm32		is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_Rmr32_dest & reg_opcode=0; imm32	{ addflags( Rmr32,imm32);  Rmr32 =  Rmr32 + imm32; build check_Rmr32_dest; resultflags( Rmr32); }
 @ifdef IA64
@@ -1748,7 +1754,7 @@ with : lockprefx=0 {
 @ifdef IA64
 :AND RAX,simm32     is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x25; RAX & simm32         { logicalflags();   RAX =   RAX & simm32; resultflags(  RAX); }
 @endif
-:AND Rmr8,imm8      is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=4; imm8     { logicalflags();   Rmr8 =   Rmr8 &  imm8; resultflags(  Rmr8); }
+:AND Rmr8,imm8      is vexMode=0 & $(BYTE_80_82); mod=3 & Rmr8 & reg_opcode=4; imm8     { logicalflags();   Rmr8 =   Rmr8 &  imm8; resultflags(  Rmr8); }
 :AND Rmr16,imm16    is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=4; imm16  { logicalflags();  Rmr16 =  Rmr16 & imm16; resultflags( Rmr16); }
 :AND Rmr32,imm32    is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_Rmr32_dest & reg_opcode=4; imm32  { logicalflags();  Rmr32 =  Rmr32 & imm32; build check_Rmr32_dest; resultflags( Rmr32); }
 @ifdef IA64
@@ -2203,7 +2209,7 @@ define pcodeop clzero;
 @ifdef IA64
 :CMP RAX,simm32      is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x3d; RAX & simm32            { subflags(  RAX,simm32); local tmp =   RAX -  simm32; resultflags(tmp); }
 @endif
-:CMP spec_rm8,imm8       is vexMode=0 & (byte=0x80 | byte=0x82); spec_rm8 & reg_opcode=7 ...; imm8        { local temp:1 = spec_rm8; subflags(temp,imm8 ); local diff = temp - imm8; resultflags(diff); }
+:CMP spec_rm8,imm8       is vexMode=0 & $(BYTE_80_82); spec_rm8 & reg_opcode=7 ...; imm8        { local temp:1 = spec_rm8; subflags(temp,imm8 ); local diff = temp - imm8; resultflags(diff); }
 :CMP spec_rm16,imm16     is vexMode=0 & opsize=0 & byte=0x81; spec_rm16 & reg_opcode=7 ...; imm16 { local temp:2 = spec_rm16; subflags(temp,imm16); local diff = temp - imm16; resultflags(diff); }
 :CMP spec_rm32,imm32     is vexMode=0 & opsize=1 & byte=0x81; spec_rm32 & reg_opcode=7 ...; imm32 { local temp:4 = spec_rm32; subflags(temp,imm32); local diff = temp - imm32; resultflags(diff); }
 @ifdef IA64
@@ -3286,7 +3292,7 @@ define pcodeop swap_bytes;
 @ifdef IA64
 :OR  RAX,simm32        is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xd; RAX & simm32         { logicalflags();   RAX =   RAX | simm32; resultflags(  RAX); }
 @endif
-:OR  Rmr8,imm8      is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=1; imm8     { logicalflags();   Rmr8 =   Rmr8 |  imm8; resultflags(  Rmr8); }
+:OR  Rmr8,imm8      is vexMode=0 & $(BYTE_80_82); mod=3 & Rmr8 & reg_opcode=1; imm8     { logicalflags();   Rmr8 =   Rmr8 |  imm8; resultflags(  Rmr8); }
 :OR  Rmr16,imm16        is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=1; imm16  { logicalflags();  Rmr16 =  Rmr16 | imm16; resultflags( Rmr16); }
 :OR  Rmr32,imm32        is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_rm32_dest & reg_opcode=1; imm32  { logicalflags();  Rmr32 =  Rmr32 | imm32; build check_rm32_dest; resultflags( Rmr32); }
 @ifdef IA64
@@ -3679,7 +3685,7 @@ define pcodeop smm_restore_state;
 @ifdef IA64
 :SBB  RAX,imm32    is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x1d; RAX & imm32						{ subCarryFlags( RAX, imm32 ); resultflags(RAX); }
 @endif
-:SBB  Rmr8,imm8     is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=3; imm8								{ subCarryFlags( Rmr8, imm8 ); resultflags(Rmr8); }
+:SBB  Rmr8,imm8     is vexMode=0 & $(BYTE_80_82); mod=3 & Rmr8 & reg_opcode=3; imm8								{ subCarryFlags( Rmr8, imm8 ); resultflags(Rmr8); }
 :SBB  Rmr16,imm16       is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=3; imm16							{ subCarryFlags( Rmr16, imm16 ); resultflags(Rmr16); }
 :SBB  Rmr32,imm32       is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_Rmr32_dest & reg_opcode=3; imm32	{ subCarryFlags( Rmr32, imm32 ); build check_Rmr32_dest; resultflags(Rmr32); }
 @ifdef IA64
@@ -3889,7 +3895,7 @@ define pcodeop skinit;
 @ifdef IA64
 :SUB  RAX,simm32        is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x2d; RAX & simm32         { subflags(  RAX,simm32);   RAX =   RAX - simm32; resultflags(  RAX); }
 @endif
-:SUB  Rmr8,imm8     is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=5; imm8     { subflags(  Rmr8,imm8 );   Rmr8 =   Rmr8 -  imm8; resultflags(  Rmr8); }
+:SUB  Rmr8,imm8     is vexMode=0 & $(BYTE_80_82); mod=3 & Rmr8 & reg_opcode=5; imm8     { subflags(  Rmr8,imm8 );   Rmr8 =   Rmr8 -  imm8; resultflags(  Rmr8); }
 :SUB  Rmr16,imm16       is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=5; imm16  { subflags( Rmr16,imm16);  Rmr16 =  Rmr16 - imm16; resultflags( Rmr16); }
 :SUB  Rmr32,imm32       is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_rm32_dest & reg_opcode=5; imm32  { subflags( Rmr32,imm32);  Rmr32 =  Rmr32 - imm32; build check_rm32_dest; resultflags( Rmr32); }
 @ifdef IA64
@@ -4091,7 +4097,7 @@ define pcodeop xend;
 @ifdef IA64
 :XOR RAX,simm32    is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x35; RAX & simm32            { logicalflags();   RAX =   RAX ^ simm32; resultflags(  RAX); }
 @endif
-:XOR Rmr8,imm8      is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=6; imm8     { logicalflags();   Rmr8 =   Rmr8 ^  imm8; resultflags(  Rmr8); }
+:XOR Rmr8,imm8      is vexMode=0 & $(BYTE_80_82); mod=3 & Rmr8 & reg_opcode=6; imm8     { logicalflags();   Rmr8 =   Rmr8 ^  imm8; resultflags(  Rmr8); }
 :XOR Rmr16,imm16    is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=6; imm16  { logicalflags();  Rmr16 =  Rmr16 ^ imm16; resultflags( Rmr16); }
 :XOR Rmr32,imm32    is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_rm32_dest & reg_opcode=6; imm32  { logicalflags();  Rmr32 =  Rmr32 ^ imm32; build check_rm32_dest; resultflags( Rmr32); }
 @ifdef IA64

--- a/Ghidra/Processors/x86/data/languages/lockable.sinc
+++ b/Ghidra/Processors/x86/data/languages/lockable.sinc
@@ -4,7 +4,7 @@
 #     is used with any instruction not in the above list.
 # The instructions in this file have their non-lockable counterparts in ia.sinc
 
-:ADC^lockx spec_m8,imm8		is vexMode=0 & lockx & unlock & (byte=0x80 | byte=0x82); spec_m8 & reg_opcode=2 ... ; imm8 
+:ADC^lockx spec_m8,imm8		is vexMode=0 & lockx & unlock & $(BYTE_80_82); spec_m8 & reg_opcode=2 ... ; imm8 
 { 
     build lockx; 
     build spec_m8;
@@ -109,7 +109,7 @@
 }
 @endif
 
-:ADD^lockx spec_m8,imm8		is vexMode=0 & lockx & unlock & (byte=0x80 | byte=0x82); spec_m8 & reg_opcode=0 ...; imm8		
+:ADD^lockx spec_m8,imm8		is vexMode=0 & lockx & unlock & $(BYTE_80_82); spec_m8 & reg_opcode=0 ...; imm8		
 {
     build lockx;
     build spec_m8;
@@ -225,7 +225,7 @@
 }
 @endif
 
-:AND^lockx m8,imm8      is vexMode=0 & lockx & unlock & (byte=0x80 | byte=0x82); m8 & reg_opcode=4 ...; imm8     
+:AND^lockx m8,imm8      is vexMode=0 & lockx & unlock & $(BYTE_80_82); m8 & reg_opcode=4 ...; imm8     
 {
     build lockx;
     build m8;
@@ -834,7 +834,7 @@
 }
 @endif
 
-:OR^lockx  spec_m8,imm8      is vexMode=0 & lockx & unlock & (byte=0x80 | byte=0x82); spec_m8 & reg_opcode=1 ...; imm8     
+:OR^lockx  spec_m8,imm8      is vexMode=0 & lockx & unlock & $(BYTE_80_82); spec_m8 & reg_opcode=1 ...; imm8     
 {
     build lockx;
     build spec_m8;
@@ -951,7 +951,7 @@
 }
 @endif
 
-:SBB^lockx  m8,imm8     is vexMode=0 & lockx & unlock & (byte=0x80 | byte=0x82); m8 & reg_opcode=3 ...; imm8								
+:SBB^lockx  m8,imm8     is vexMode=0 & lockx & unlock & $(BYTE_80_82); m8 & reg_opcode=3 ...; imm8								
 {
     build lockx;
     build m8;
@@ -1056,7 +1056,7 @@
 }
 @endif
 
-:SUB^lockx  spec_m8,imm8     is vexMode=0 & lockx & unlock & (byte=0x80 | byte=0x82); spec_m8 & reg_opcode=5 ...; imm8     
+:SUB^lockx  spec_m8,imm8     is vexMode=0 & lockx & unlock & $(BYTE_80_82); spec_m8 & reg_opcode=5 ...; imm8     
 {
     build lockx;
     build spec_m8;
@@ -1269,7 +1269,7 @@
 }
 @endif
 
-:XOR^lockx spec_m8,imm8      is vexMode=0 & lockx & unlock & (byte=0x80 | byte=0x82); spec_m8 & reg_opcode=6 ...; imm8     
+:XOR^lockx spec_m8,imm8      is vexMode=0 & lockx & unlock & $(BYTE_80_82); spec_m8 & reg_opcode=6 ...; imm8     
 {
     build lockx;
     build spec_m8;


### PR DESCRIPTION
In long mode, the 0x82 alias is not allowed for `Grp1 Eb, Ib` instructions (covered by "2.5.10 Invalid Instructions" in the AMD64 Manual Vol 2 and "A.2.4.1" in Volume 2 of Intel's manual).

This PR replaces all uses of this alias with the macro `$(BYTE_80_82)`, which checks the `longMode` context before allowing the `0x82` alias. The behaviour for 32-bit mode remains unchanged. Tested against both AMD and Intel CPUs, 

e.g.,

`82c800` "OR AL,0":

**Hardware Reference:**

* Intel CPU (long mode ON): InvalidInstruction Exception
* Intel CPU (long mode OFF): { PF=1, ZF=1 }
* AMD CPU (long mode ON): InvalidInstruction Exception
* AMD CPU (long mode OFF): { PF=1, ZF=1 }

**SLEIGH:**

* `x86:LE:64:default` (Existing): "OR AL,0x0" { PF=1, ZF=1 }
* `x86:LE:64:default` (This patch): (invalid)
* `x86:LE:32:default` (Existing): "OR AL,0x0" { PF=1, ZF=1 }
* `x86:LE:32:default` (This patch): "OR AL,0x0" { PF=1, ZF=1 }
