### PR TITLE
x86: Ensure that PEXTR instructions with memory destinations write to memory

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -8447,7 +8447,7 @@ define pcodeop extractps;
     local low:1 = shift < 64:1;
     local temp:8;
     conditionalAssign(temp,low,XmmReg[0,64] >> shift,XmmReg[64,64] >> (shift - 64));
-    Mem = temp:1;
+    *Mem = temp:1;
 }
 
 :PEXTRD Rmr32, XmmReg, imm8     is vexMode=0 & $(PRE_66) & byte=0x0F; byte=0x3A; byte=0x16; mod=3 & XmmReg & Rmr32 & check_Rmr32_dest; imm8 
@@ -8466,7 +8466,7 @@ define pcodeop extractps;
     local low:1 = shift < 64:1;
     local temp:8;
     conditionalAssign(temp,low,XmmReg[0,64] >> shift,XmmReg[64,64] >> (shift - 64));
-    Mem = temp:4;
+    *Mem = temp:4;
 }
 
 @ifdef IA64
@@ -8479,7 +8479,9 @@ define pcodeop extractps;
 :PEXTRQ Mem, XmmReg, imm8     is $(LONGMODE_ON) & vexMode=0 & bit64=1 & $(PRE_66) & $(REX_W) & byte=0x0F; byte=0x3A; byte=0x16; XmmReg ... & Mem; imm8 
 { 
     local high:1 = imm8 & 0x1;
-    conditionalAssign(Mem,high,XmmReg[64,64],XmmReg[0,64]);
+    local temp:8;
+    conditionalAssign(temp,high,XmmReg[64,64],XmmReg[0,64]);
+    *Mem = temp;
 }
 @endif
 


### PR DESCRIPTION
The PEXTRB/PEXTRD/PEXTRQ instructions extract byte/dword/qword values from the source SIMD register and store the result in the destination GPR or memory location.

In the SLEIGH constructor that handles the memory destination variant, the `Mem` subtable exports a reference to the address varnode, not a memory reference, so using an `*` operator is needed to actually store the result to memory. e.g.,

`66400f3a140200` "PEXTRB [RDX], XMM0, 0x0" with RDX=0x1000, XMM0=0x11:

* Hardware Reference (AMD CPU): { Mem[0x1000] = 0x11 }
* `x86:LE:64:default` (Existing): "PEXTRB [RDX], XMM0, 0x0" { RDX = 0x1011 }
* `x86:LE:64:default` (This patch): "PEXTRB [RDX], XMM0, 0x0" { Mem[0x1000] = 0x11 }
