### PR TITLE
x86: Fix issue with comparison of bits 96 to 128 in CMPPS instruction

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -4893,7 +4893,7 @@ CMPPS_OPERAND: ", "^imm8 is imm8   { }
 	xmmTmp2_Da = XmmReg2[0,32];
 	xmmTmp2_Db = XmmReg2[32,32];
 	xmmTmp2_Dc = XmmReg2[64,32];
-	xmmTmp2_Dc = XmmReg2[96,32];
+	xmmTmp2_Dd = XmmReg2[96,32];
 	
 	build XmmCondPS;
 	


### PR DESCRIPTION
The CMPPS instruction is meant to do a lane-wise comparison of packed single precision floating points.

In the CMPPS constructor involving two registers the `xmmTmp2_Dc` is assigned to twice (instead of an assignment to `xmmTmp2_Dd`) when preparing the temporary varnodes for the XmmCondPS operation. This causes the wrong value to be used in the comparison.

e.g.:

`0fc2c000` "CMPEQPS XMM0,XMM0" with XMM0=0x400000003f8000003f8000003f800000 ([1.0, 1.0, 1.0, 2.0]):

* Hardware Reference (AMD CPU): { XMM0 = 0xffffffffffffffffffffffffffffffff }
* `x86:LE:64:default` (Existing): { XMM0 = 0x0000000000000000ffffffffffffffff}
* `x86:LE:64:default` (This patch): { XMM0 = 0xffffffffffffffffffffffffffffffff }