### PR TITLE
x86: Add missing float-to-integer cast operation to CVTSD2SI/CVTSD2SI

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -5207,12 +5207,12 @@ CMPSS_OPERAND: ", "^imm8 is imm8   { }
 @ifdef IA64
 :CVTSD2SI     Reg64, m64    is $(LONGMODE_ON) & vexMode=0 & opsize=2 & $(PRE_F2) & byte=0x0F; byte=0x2D; Reg64 ... & m64
 {
-  Reg64 = round(m64);
+  Reg64 = trunc(round(m64));
 }
 
 :CVTSD2SI     Reg64, XmmReg2 is vexMode=0 & opsize=2 & $(PRE_F2) & byte=0x0F; byte=0x2D; xmmmod=3 & Reg64 & XmmReg2
 {
-  Reg64 = round(XmmReg2[0,64]);
+  Reg64 = trunc(round(XmmReg2[0,64]));
 }
 @endif
 
@@ -5262,12 +5262,12 @@ CMPSS_OPERAND: ", "^imm8 is imm8   { }
 
 :CVTSS2SI     Reg32, m32    is vexMode=0 & $(PRE_F3) & byte=0x0F; byte=0x2D; Reg32 ... & m32
 {
-  Reg32 = round(m32);
+  Reg32 = trunc(round(m32));
 }
 
 :CVTSS2SI     Reg32, XmmReg2 is vexMode=0 & $(PRE_F3) & byte=0x0F; byte=0x2D; xmmmod=3 & Reg32 & XmmReg2
 {
-  Reg32 = round(XmmReg2[0,32]);
+  Reg32 = trunc(round(XmmReg2[0,32]));
 }
 
 @ifdef IA64


### PR DESCRIPTION
CVTSS2SI/CVTSD2SI are instructions for converting scalar floating point values to integers. 

In the SLEIGH spec, the float-to-integer cast operation (`trunc`) is missing in the constructors for handling the case where the size destination operand matches the floating point source operand size. (My guess is that the original author assumed that the `round` operation performed the cast not the `trunc` op).

e.g.:

`f30f2dc0` "CVTSS2SI EAX, XMM0" with XMM0=0x41200000 (10.0)

* Hardware Reference (AMD CPU): { RAX = 0xa }
* `x86:LE:64:default` (Existing): { RAX = 0x41200000 }
* `x86:LE:64:default` (This patch): { RAX = 0xa }
