### PR TITLE
x86: Fix issue with PACKUSWB when the value to convert is exactly 0x00ff

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -5956,7 +5956,7 @@ define pcodeop packssdw;
 #otherwise ubyte = sword
 macro sswub(sword, ubyte) {
     ubyte = (sword s> 0xff:2) * 0xff:1;
-    ubyte = ubyte + (sword s> 0:2) * (sword s< 0xff:2) * sword:1;
+    ubyte = ubyte + (sword s> 0:2) * (sword s<= 0xff:2) * sword:1;
 }
 
 :PACKUSWB      mmxreg, m64      is vexMode=0 &  mandover=0 & byte=0x0F; byte=0x67; mmxreg ... & m64


### PR DESCRIPTION
The PACKUSWB instruction performs a lane-wise conversion of signed 16-bit integers to 8-bit integers, saturating the results if they are out-of-range (i.e., to the range 0 to 255).

In the SLEIGH implementation of the saturation operation, if the signed 16-bit integer is exactly equal to `0x00ff` it will be converted to the byte `0x00` (instead of `0xff`).

The issue with the value `0x00ff` in particular is that that both `(sword s> 0xff:2)` and `(sword s< 0xff:2)` are false causing neither of the conditions. In the patch I choose to change the second condition to `s<=` (matching the comment above the macro), however changing the first condition would also fix the issue.

e.g.:

`660f67db` "PACKUSWB XMM3, XMM3" with XMM3=0x00ff_00ff

* Hardware Reference (AMD CPU): { XMM3 = 0xff_ff_00_00_00_00_00_00_ff_ff }
* `x86:LE:64:default` (Existing): { XMM3 = 0x0 }
* `x86:LE:64:default` (This patch): { XMM3 = 0xff_ff_00_00_00_00_00_00_ff_ff }

(Note: The repetition of the bytes is correct because XMM3 is both the source and destination register).
