### PR TITLE
x86: Sign-extend 32-bit immediates for 64-bit SBB instructions

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -3677,13 +3677,13 @@ define pcodeop smm_restore_state;
 :SBB  AX,imm16     is vexMode=0 & opsize=0 & byte=0x1d; AX & imm16						{ subCarryFlags( AX, imm16 ); resultflags(AX); }
 :SBB  EAX,imm32    is vexMode=0 & opsize=1 & byte=0x1d; EAX & check_EAX_dest & imm32	{ subCarryFlags( EAX, imm32 ); build check_EAX_dest; resultflags(EAX); }
 @ifdef IA64
-:SBB  RAX,imm32    is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x1d; RAX & imm32						{ subCarryFlags( RAX, imm32 ); resultflags(RAX); }
+:SBB  RAX,simm32    is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x1d; RAX & simm32						{ subCarryFlags( RAX, simm32 ); resultflags(RAX); }
 @endif
 :SBB  Rmr8,imm8     is vexMode=0 & (byte=0x80 | byte=0x82); mod=3 & Rmr8 & reg_opcode=3; imm8								{ subCarryFlags( Rmr8, imm8 ); resultflags(Rmr8); }
 :SBB  Rmr16,imm16       is vexMode=0 & opsize=0 & byte=0x81; mod=3 & Rmr16 & reg_opcode=3; imm16							{ subCarryFlags( Rmr16, imm16 ); resultflags(Rmr16); }
 :SBB  Rmr32,imm32       is vexMode=0 & opsize=1 & byte=0x81; mod=3 & Rmr32 & check_Rmr32_dest & reg_opcode=3; imm32	{ subCarryFlags( Rmr32, imm32 ); build check_Rmr32_dest; resultflags(Rmr32); }
 @ifdef IA64
-:SBB  Rmr64,imm32       is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x81; mod=3 & Rmr64 & reg_opcode=3; imm32							{ subCarryFlags( Rmr64, imm32 ); resultflags(Rmr64); }
+:SBB  Rmr64,simm32       is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x81; mod=3 & Rmr64 & reg_opcode=3; simm32							{ subCarryFlags( Rmr64, simm32 ); resultflags(Rmr64); }
 @endif
 
 :SBB  Rmr16,simm8_16       is vexMode=0 & opsize=0 & byte=0x83; mod=3 & Rmr16 & reg_opcode=3; simm8_16						{ subCarryFlags( Rmr16, simm8_16 ); resultflags(Rmr16); }

--- a/Ghidra/Processors/x86/data/languages/lockable.sinc
+++ b/Ghidra/Processors/x86/data/languages/lockable.sinc
@@ -979,11 +979,11 @@
 }
 
 @ifdef IA64
-:SBB^lockx  m64,imm32       is $(LONGMODE_ON) & vexMode=0 & lockx & unlock & opsize=2 & byte=0x81; m64 & reg_opcode=3 ...; imm32							
+:SBB^lockx  m64,simm32       is $(LONGMODE_ON) & vexMode=0 & lockx & unlock & opsize=2 & byte=0x81; m64 & reg_opcode=3 ...; simm32							
 {
     build lockx;
     build m64;
-    subCarryFlags( m64, imm32 );
+    subCarryFlags( m64, simm32 );
     resultflags(m64);
     build unlock; 
 }


### PR DESCRIPTION
The 64-bit immediate form of the SBB (Integer Subtraction With Borrow) instruction, uses the wrong field variant for the immediate, causing it to be zero-extended instead of sign-extended.

e.g.:

`4f1dffffffff` "SBB RAX,-0x1"

* Hardware Reference (AMD CPU): { RAX=0x1, CF=1, SF=0 }
* `x86:LE:64:default` (Existing): "SBB RAX,0xffffffff" { RAX=0xffffffff00000001, CF=1, SF=1 }
* `x86:LE:64:default` (This patch): "SBB RAX,-0x1" { RAX=0x1, CF=1, SF=0 }
