### PR TITLE
x86: Fix evaluation order of CMOV

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -2191,10 +2191,10 @@ define pcodeop clzero;
 
 :CMC			is vexMode=0 & byte=0xf5						{ CF = CF==0; }
 
-:CMOV^cc Reg16,rm16 is vexMode=0 & opsize=0 & byte=0xf; row=4 & cc; rm16 & Reg16 ...    { if (!cc) goto inst_next; Reg16 = rm16; }
-:CMOV^cc Reg32,rm32 is vexMode=0 & opsize=1 & byte=0xf; row=4 & cc; rm32 & Reg32 ... & check_Reg32_dest ...   { build check_Reg32_dest; if (!cc) goto inst_next; Reg32 = rm32;}
+:CMOV^cc Reg16,rm16 is vexMode=0 & opsize=0 & byte=0xf; row=4 & cc; rm16 & Reg16 ...    { local tmp = rm16; if (!cc) goto inst_next; Reg16 = tmp; }
+:CMOV^cc Reg32,rm32 is vexMode=0 & opsize=1 & byte=0xf; row=4 & cc; rm32 & Reg32 ... & check_Reg32_dest ...   { local tmp = rm32; build check_Reg32_dest; if (!cc) goto inst_next; Reg32 = tmp; }
 @ifdef IA64
-:CMOV^cc Reg64,rm64 is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf; row=4 & cc; rm64 & Reg64 ...    { if (!cc) goto inst_next; Reg64 = rm64; }
+:CMOV^cc Reg64,rm64 is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf; row=4 & cc; rm64 & Reg64 ...    { local tmp = rm64; if (!cc) goto inst_next; Reg64 = tmp; }
 @endif
 
 :CMP AL,imm8        is vexMode=0 & byte=0x3c; AL & imm8                                 { subflags(   AL,imm8 ); local tmp =    AL -   imm8; resultflags(tmp); }


### PR DESCRIPTION
When the register holding the source address of a CMOV instruction is the 64-bit register that overlaps with the 32-bit destination (e.g., `CMOV EAX, dword ptr [RAX]`) then the wrong address will be loaded from if the upper bits are non-zero. (e.g. the previous example will load from  `RAX & 0xffff_ffff` instead of `RAX`).

This is directly caused by the `build check_Reg32_dest` statement, but the actual issue is that the source address should be loaded into a temporary before before checking the condition. Notably, it _is_ still correct to zero the upper 32-bit of the 64-bit register in x64 mode even if the condition is false, so this behavior has been kept.

e.g.,

0f4000 "CMOVO EAX, dword ptr [RAX]" with RAX=0x1_0000_0000, OF=1, mem[0x1_0000_0000]=aaaaaaaa, mem[0x0]=bbbbbbbb.

* Hardware Reference (AMD CPU & Intel CPU): { RAX=0xaaaaaaaa }
* `x86:LE:64:default` (Existing): "CMOV EAX, dword ptr [RAX]" { RAX=0xbbbbbbbb }
* `x86:LE:64:default` (This patch): CMOV EAX, dword ptr [RAX]" { RAX=0xaaaaaaaa }

The other constructors have been adjusted even though this issue doesn't directly affect them, to more closely match the real semantics, i.e. the manual states: "CMOVcc loads data from its source operand into a temporary register unconditionally (regardless of the condition code and the status flags in the EFLAGS register)".
