### PR TITLE
x86: Fix aliasing issues with SIMD instructions

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -5055,8 +5055,9 @@ CMPSS_OPERAND: ", "^imm8 is imm8   { }
 
 :CVTDQ2PD     XmmReg1, XmmReg2  is vexMode=0 &  $(PRE_F3) & byte=0x0F; byte=0xE6; xmmmod=3 & XmmReg1 & XmmReg2
 {
-    XmmReg1[0,64] = int2float( XmmReg2[0,32] );
-    XmmReg1[64,64] = int2float( XmmReg2[32,32] );
+    local tmp:8 = XmmReg2[0,64];
+    XmmReg1[0,64] = int2float( tmp[0,32] );
+    XmmReg1[64,64] = int2float( tmp[32,32] );
 }
 
 :CVTDQ2PS     XmmReg, m128      is vexMode=0 &  mandover=0 & byte=0x0F; byte=0x5B; m128 & XmmReg ...
@@ -5175,8 +5176,9 @@ CMPSS_OPERAND: ", "^imm8 is imm8   { }
 
 :CVTPS2PD     XmmReg1, XmmReg2  is vexMode=0 &  mandover=0 & byte=0x0F; byte=0x5A; xmmmod=3 & XmmReg1 & XmmReg2
 {
-    XmmReg1[0,64] = float2float( XmmReg2[0,32] );
-    XmmReg1[64,64] = float2float( XmmReg2[32,32] );
+    local tmp:8 = XmmReg2[0,64];
+    XmmReg1[0,64] = float2float( tmp[0,32] );
+    XmmReg1[64,64] = float2float( tmp[32,32] );
 }
 
 :CVTPS2PI     mmxreg, m64         is vexMode=0 &  mandover=0 & byte=0x0F; byte=0x2D; mmxreg ... & m64
@@ -5429,8 +5431,9 @@ define pcodeop divps;
 
 :HADDPD        XmmReg1, XmmReg2    is vexMode=0 &  $(PRE_66) & byte=0x0F; byte=0x7C; xmmmod=3 & XmmReg1 & XmmReg2
 {
+    local tmp:16 = XmmReg2;
     XmmReg1[0,64] = XmmReg1[0,64] f+ XmmReg1[64,64];
-    XmmReg1[64,64] = XmmReg2[0,64] f+ XmmReg2[64,64];
+    XmmReg1[64,64] = tmp[0,64] f+ tmp[64,64];
 }
 
 :HADDPS        XmmReg, m128        is vexMode=0 &  $(PRE_F2) & byte=0x0F; byte=0x7C; m128 & XmmReg ...
@@ -5444,10 +5447,11 @@ define pcodeop divps;
 
 :HADDPS        XmmReg1, XmmReg2    is vexMode=0 &  $(PRE_F2) & byte=0x0F; byte=0x7C; xmmmod=3 & XmmReg1 & XmmReg2
 {
+    local tmp:16 = XmmReg2;
     XmmReg1[0,32] = XmmReg1[0,32] f+ XmmReg1[32,32];
     XmmReg1[32,32] = XmmReg1[64,32] f+ XmmReg1[96,32];
-    XmmReg1[64,32] = XmmReg2[0,32] f+ XmmReg2[32,32];
-    XmmReg1[96,32] = XmmReg2[64,32] f+ XmmReg2[96,32];
+    XmmReg1[64,32] = tmp[0,32] f+ tmp[32,32];
+    XmmReg1[96,32] = tmp[64,32] f+ tmp[96,32];
 }
 
 :HSUBPD        XmmReg, m128        is vexMode=0 &  $(PRE_66) & byte=0x0F; byte=0x7D; m128 & XmmReg ...
@@ -5459,8 +5463,9 @@ define pcodeop divps;
 
 :HSUBPD        XmmReg1, XmmReg2    is vexMode=0 &  $(PRE_66) & byte=0x0F; byte=0x7D; xmmmod=3 & XmmReg1 & XmmReg2
 {
+    local tmp:16 = XmmReg2;
     XmmReg1[0,64] = XmmReg1[0,64] f- XmmReg1[64,64];
-    XmmReg1[64,64] = XmmReg2[0,64] f- XmmReg2[64,64];
+    XmmReg1[64,64] = tmp[0,64] f- tmp[64,64];
 }
 
 :HSUBPS        XmmReg, m128        is vexMode=0 &  $(PRE_F2) & byte=0x0F; byte=0x7D; m128 & XmmReg ...
@@ -5474,10 +5479,11 @@ define pcodeop divps;
 
 :HSUBPS        XmmReg1, XmmReg2    is vexMode=0 &  $(PRE_F2) & byte=0x0F; byte=0x7D; xmmmod=3 & XmmReg1 & XmmReg2
 {
+    local tmp:16 = XmmReg2;
     XmmReg1[0,32] = XmmReg1[0,32] f- XmmReg1[32,32];
     XmmReg1[32,32] = XmmReg1[64,32] f- XmmReg1[96,32];
-    XmmReg1[64,32] = XmmReg2[0,32] f- XmmReg2[32,32];
-    XmmReg1[96,32] = XmmReg2[64,32] f- XmmReg2[96,32];
+    XmmReg1[64,32] = tmp[0,32] f- tmp[32,32];
+    XmmReg1[96,32] = tmp[64,32] f- tmp[96,32];
 }
 
 #--------------------


### PR DESCRIPTION
Several of the SIMD instructions have incorrect semantics when both the source and destination register are the same. Essentially, parts of the source register are modified via writes to the destination register while they are still needed.

This PR fixes the following:

* f30fe6c0 "CVTDQ2PD XMM0, XMM0" with XMM0=0x0000_000a_0000_000a
    - Hardware Reference (AMD CPU & Intel CPU): { XMM0=0x4024000000000000_4024000000000000 }
    - `x86:LE:64:default` (Existing): { RAX=0x41d0090000000000_4024000000000000 }
    - `x86:LE:64:default` (This patch): { XMM0=0x4024000000000000_4024000000000000 }

* 0f5ac0 "CVTPS2PD XMM0, XMM0" with XMM0=0x41200000_41200000
    - Hardware Reference (AMD CPU & Intel CPU): { XMM0=0x4024000000000000_4024000000000000 }
    - `x86:LE:64:default` (Existing): { RAX=0x4004800000000000_4024000000000000 }
    - `x86:LE:64:default` (This patch): { XMM0=0x4024000000000000_4024000000000000 }

* 660f7cc0 "HADDPD XMM0, XMM0" with XMM0=0x3fd3333333333333_3fd3333333333333
    - Hardware Reference (AMD CPU & Intel CPU): { XMM0=0x3fe3333333333333_3fe3333333333333 }
    - `x86:LE:64:default` (Existing): { RAX=0x3feccccccccccccc_3fe3333333333333 }
    - `x86:LE:64:default` (This patch): { XMM0=0x3fe3333333333333_3fe3333333333333 }

* f20f7cc0 "HADDPD XMM0, XMM0" with XMM0=0x3e99999a_3e99999a_3e99999a_3e99999a
    - Hardware Reference (AMD CPU & Intel CPU): { XMM0=0x3f19999a_3f19999a_3f19999a_3f19999a }
    - `x86:LE:64:default` (Existing): { RAX=0x3fc00000_3f99999a_3f19999a_3f19999a }
    - `x86:LE:64:default` (This patch): { XMM0=0x3f19999a_3f19999a_3f19999a_3f19999a }

* 660f7dc0 "HSUBPD XMM0, XMM0" with XMM0=0x3fd3333333333333_3fd3333333333333
    - Hardware Reference (AMD CPU & Intel CPU): { XMM0=0 }
    - `x86:LE:64:default` (Existing): { RAX=0xbfd3333333333333_0000000000000000 }
    - `x86:LE:64:default` (This patch): { XMM0=0 }

* f20f7dc0 "HSUBPD XMM0, XMM0" with XMM0=0x3e99999a_3e99999a_3e99999a_3e99999a
    - Hardware Reference (AMD CPU & Intel CPU): { XMM0=0 }
    - `x86:LE:64:default` (Existing): { RAX=0xbe99999a_00000000_00000000_00000000 }
    - `x86:LE:64:default` (This patch): { XMM0=0 }
