### PR TITLE
x86: opsize override prefix not handled for 16-bit MOVSX/MOVZX

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -3222,7 +3222,8 @@ define pcodeop swap_bytes;
 @ifdef IA64
 :MOVSX Reg64,spec_rm8    is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf; byte=0xbe; spec_rm8 & Reg64 ...  { Reg64 = sext(spec_rm8); }
 @endif
-:MOVSX Reg32,spec_rm16   is vexMode=0 &            byte=0xf; byte=0xbf; spec_rm16 & Reg32 ... & check_Reg32_dest ...    { Reg32 = sext(spec_rm16); build check_Reg32_dest; }
+:MOVSX Reg16,spec_rm16   is vexMode=0 & opsize=0 & byte=0xf; byte=0xbf; spec_rm16 & Reg16 ... { Reg16 = spec_rm16; }
+:MOVSX Reg32,spec_rm16   is vexMode=0 & opsize=1 & byte=0xf; byte=0xbf; spec_rm16 & Reg32 ... & check_Reg32_dest ... { Reg32 = sext(spec_rm16); build check_Reg32_dest; }
 @ifdef IA64
 :MOVSX Reg64,spec_rm16   is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf; byte=0xbf; spec_rm16 & Reg64 ...     { Reg64 = sext(spec_rm16); }
 @endif
@@ -3237,8 +3238,8 @@ define pcodeop swap_bytes;
 @ifdef IA64
 :MOVZX Reg64,spec_rm8    is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf; byte=0xb6; spec_rm8 & Reg64 ...  { Reg64 = zext(spec_rm8); }
 @endif
-
-:MOVZX Reg32,spec_rm16   is vexMode=0 &            byte=0xf; byte=0xb7; spec_rm16 & Reg32 ... & check_Reg32_dest ...    { Reg32 = zext(spec_rm16); build check_Reg32_dest; }
+:MOVZX Reg16,spec_rm16   is vexMode=0 & opsize=0 & byte=0xf; byte=0xb7; spec_rm16 & Reg16 ... { Reg16 = spec_rm16; }
+:MOVZX Reg32,spec_rm16   is vexMode=0 & opsize=1 & byte=0xf; byte=0xb7; spec_rm16 & Reg32 ... & check_Reg32_dest ...    { Reg32 = zext(spec_rm16); build check_Reg32_dest; }
 @ifdef IA64
 :MOVZX Reg64,spec_rm16   is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf; byte=0xb7; spec_rm16 & Reg64 ...     { Reg64 = zext(spec_rm16); }
 @endif


### PR DESCRIPTION
The MOVSX/MOVZX constructors with a 16-bit source do not handle the opsize size override prefix (0x66). This PR fixes the following:

* 660fbfc1 "MOVSX AX,CX" with RAX=0xaaaaaaaa, CX=0xcccc
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0xaaaacccc }
    - `x86:LE:64:default` (Existing): "MOVSX EAX,CX" { RAX=0xffffcccc }
    - `x86:LE:64:default` (This patch): "MOVSX AX,CX" { RAX=0xaaaacccc }

* 660fb7c1 "MOVZX AX,CX" with RAX=0xaaaaaaaa, CX=0xcccc
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0xaaaacccc }
    - `x86:LE:64:default` (Existing): "MOVZX EAX,CX" { RAX=0x0000cccc }
    - `x86:LE:64:default` (This patch): "MOVZX AX,CX" { RAX=0xaaaacccc }