### PR TITLE
AArch32: ldaexd addr src register aliased as first dest register causing second word load at the value of first load

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMv8.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMv8.sinc
@@ -119,13 +119,14 @@ dcps_lev:3		is TMode=1 & thv_c0001=0b11 { export 3:1; }
 :ldaexd^COND Rd,Rd2,[Rn]
 	is TMode=0 & ARMcond=1 & COND & c2027=0x1b & Rn & Rd & Rd2 & c0011=0xe9f
 	{
+		local addr:4 = Rn;
 		build COND;
 @if ENDIAN == "big"
-		Rd = *(Rn + 4);
-		Rd2 = *(Rn);
+		Rd = *(addr + 4);
+		Rd2 = *(addr);
 @else	# ENDIAN == "little"
-		Rd = *(Rn);
-		Rd2 = *(Rn + 4);
+		Rd = *(addr);
+		Rd2 = *(addr + 4);
 @endif	# ENDIAN == "little"
 	}
 
@@ -134,13 +135,14 @@ dcps_lev:3		is TMode=1 & thv_c0001=0b11 { export 3:1; }
 	is TMode=1 & thv_c2031=0b111010001101 & thv_c0407=0b1111
 	& ItCond & thv_Rt & thv_Rt2 & thv_Rn
 	{
+		local addr:4 = thv_Rn;
 		build ItCond;
 @if ENDIAN == "big"
-		thv_Rt = *(thv_Rn + 4);
-		thv_Rt2 = *(thv_Rn);
+		thv_Rt = *(addr + 4);
+		thv_Rt2 = *(addr);
 @else	# ENDIAN == "little"
-		thv_Rt = *(thv_Rn);
-		thv_Rt2 = *(thv_Rn + 4);
+		thv_Rt = *(addr);
+		thv_Rt2 = *(addr + 4);
 @endif	# ENDIAN == "little"
 	}
 


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `ldaexd` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, the expected behaviour is to load a double-word from address specified in the source register and write it to the two destination registers. However, when the source register and the first destination register are aliased, it causes the second word to load at an incorrect address, i.e, the value retrieved from the first load.

-----
e.g, for AArch32 with,

Instruction: `0x9f0eb061, ldaexdvs r0,r1,[r0]`
initial_memory: `{ "0xF0000000": [ 0x0, 0x0, 0x0, 0x0 ] }`
initial_registers: `{ "r0": 0xf0000000, "OV": 0x1 }`

We get:

Hardware: `{ "r0": 0x0, "r1": 0x86369acc }`
Patched Spec: `{ "r0": 0x0, "r1": 0x86369acc }`
Existing Spec: `{ "r0": 0x0, "r1": 0xcf267ce8 }`

-----
e.g, for Thumb with,

Instruction: `0xd2e8f02b, ldaexd r2,r11,[r2]`
initial_memory: `{ "0xF0000000": [ 0xff, 0xf, 0x0, 0x0 ] }`
initial_registers: `{ "r2": 0xf0000000 }`

We get:

Hardware: `{ "r11": 0x86369acc, "r2": 0xfff }`
Patched Spec: `{ "r11": 0x86369acc, "r2": 0xfff }`
Existing Spec: `{ "r11": 0x50d3b340, "r2": 0xfff }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
