### PR TITLE
AArch32: sha1su0.32 had a destructive 64-bit left shift on a 64-bit value before zext

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -619,9 +619,9 @@ define pcodeop SHA1HashUpdateParity;
 	local op1 = Qd;
 	local op2 = Qn;
 	local op3 = Qm;
-	local op2lo:8 = op2(0);
-	local op1hi:8 = op1(8);
-	op2 = zext(op2lo << 64) | zext(op1hi);
+	local op2LowerHalf = zext(op2[0,64]) << 64;
+	local op1UpperHalf = zext(op1[64,64]);
+	op2 = op2LowerHalf | op1UpperHalf;
 	Qd = op1 ^ op2 ^ op3;
 }
 


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `sha1su0.32` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, the expected behaviour is perform SHA1 schedule update 0 and store the value in the destination register. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0xe00c70f2, sha1su0.32 q8,q8,q8`
initial_registers: `{ "q8": 0x8000000000000000 }`

We get:

Hardware:         `{ "q8": 0x80000000000000000000000000000000 }`
Patched Spec: `{ "q8": 0x80000000000000000000000000000000 }`
Existing Spec:  `{ "q8": 0x0 }`

-----
e.g, for Thumb with,

Instruction:         `0x70efe00c, sha1su0.32 q8,q8,q8`
initial_registers: `{ "q8": 0x8000000000000000 }`

We get:

Hardware:        `{ "q8": 0x80000000000000000000000000000000 }`
Patched Spec: `{ "q8": 0x80000000000000000000000000000000 }`
Existing Spec:  `{ "q8": 0x0 }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
