### PR TITLE
AArch32: sha1su1.32 had destructive left shifts on 32-bit values before zext

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -637,15 +637,15 @@ define pcodeop SHA1HashUpdateParity;
 	local X = Qd;
 	local Y = Qm;
 	local Tm = X ^ (Y >> 32);
-	local t0:4 = Tm(0);
-	local t1:4 = Tm(4);
-	local t2:4 = Tm(8);
-	local t3:4 = Tm(12);
+	local t0:4 = Tm[0, 32];
+	local t1:4 = Tm[32, 32];
+	local t2:4 = Tm[64, 32];
+	local t3:4 = Tm[96, 32];
 	local W0:4 = (t0 << 1 | t0 >> 31);
 	local W1:4 = (t1 << 1 | t1 >> 31);
 	local W2:4 = (t2 << 1 | t2 >> 31);
 	local W3:4 = (t3 << 1 | t3 >> 31) ^ (t0 << 2 | t0 >> 30);
-	Qd = zext(W3 << 96) | zext(W2 << 64) | zext(W1 << 32) | zext(W0);
+	Qd = (zext(W3) << 96) | (zext(W2) << 64) | (zext(W1) << 32) | zext(W0);
 }
 
 #######


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `sha1su1.32` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, the expected behaviour is to perform SHA1 schedule update 1 and store the value in the destination register. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0xa003faf3, sha1su1.32 q8,q8`
initial_registers: `{ "q8": 0x80000000000000000000000000000000 }`

We get:

Hardware:         `{ "q8": 0x1000000010000000000000000 }`
Patched Spec: `{ "q8": 0x1000000010000000000000000 }`
Existing Spec:  `{ "q8": 0x0 }`

-----
e.g, for Thumb with,

Instruction:         `0xfaffa003, sha1su1.32 q8,q8`
initial_registers: `{ "q8": 0x80000000000000000000000000000000 }`

We get:

Hardware:        `{ "q8": 0x1000000010000000000000000 }`
Patched Spec: `{ "q8": 0x1000000010000000000000000 }`
Existing Spec:  `{ "q8": 0x0 }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
