### PR TITLE
Increase MAX_SYMBOL_NAME_LENGTH

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/SymbolUtilities.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/SymbolUtilities.java
@@ -33,7 +33,7 @@ import ghidra.util.exception.*;
  */
 public class SymbolUtilities {
 
-	public static final int MAX_SYMBOL_NAME_LENGTH = 2000;
+	public static final int MAX_SYMBOL_NAME_LENGTH = 4000;
 
 	//
 	// The standard prefixes for default labels.


### PR DESCRIPTION
Doubled the size of `MAX_SYMBOL_NAME_LENGTH` as I commonly encounter Windows C++ binaries with mangled names exceeding the limit, resulting in the ["Symbol name exceeds maximum length" exception](https://github.com/NationalSecurityAgency/ghidra/blob/8b5f6daf4ec8f8678b857c98724563ccbf9d7055/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/SymbolUtilities.java#L234-L236). I doubled the value for now, but would be open to doubling it again if we don't think it would have an adverse effect.