### PR TITLE
AArch64: Prevent resize in general FMOV for 16 bit floats

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64neon.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64neon.sinc
@@ -8206,7 +8206,7 @@ is b_31=1 & b_2430=0b0011110 & b_2223=0b00 & b_21=1 & b_1920=0b00 & b_1618=0b111
 :fmov Rd_GPR32, Rn_FPR16
 is b_31=0 & b_2430=0b0011110 & b_2223=0b11 & b_21=1 & b_1920=0b00 & b_1618=0b110 & b_1015=0b000000 & Rd_GPR32 & Rn_FPR16 & Rd_GPR64
 {
-	Rd_GPR32 = float2float(Rn_FPR16);
+	Rd_GPR32 = zext(Rn_FPR16);
 	zext_rs(Rd_GPR64); # zero upper 28 bytes of Rd_GPR64
 }
 
@@ -8220,7 +8220,7 @@ is b_31=0 & b_2430=0b0011110 & b_2223=0b11 & b_21=1 & b_1920=0b00 & b_1618=0b110
 :fmov Rd_GPR64, Rn_FPR16
 is b_31=1 & b_2430=0b0011110 & b_2223=0b11 & b_21=1 & b_1920=0b00 & b_1618=0b110 & b_1015=0b000000 & Rd_GPR64 & Rn_FPR16
 {
-	Rd_GPR64 = float2float(Rn_FPR16);
+	Rd_GPR64 = zext(Rn_FPR16);
 }
 
 # C7.2.131 FMOV (general) page C7-2312 line 135254 MATCH x1e260000/mask=x7f36fc00


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the FMOV instruction for AARCH64. According to Section C7.2.131, the expected behaviour is to zero-extend float values when the operation is `FPConvOp_MOV_FtoI`. While the current behaviour instead resizes the float to the destination register size.