### PR TITLE
AArch64: Switch register order in faddp 4H constructor

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64neon.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64neon.sinc
@@ -3495,18 +3495,18 @@ is b_3131=0 & q=1 & u=1 & b_2428=0xe & advSIMD3.size=0 & b_21=1 & Rm_VPR128.4S &
 is b_31=0 & b_30=0 & b_2129=0b101110010 & b_1015=0b000101 & Rd_VPR64.4H & Rn_VPR64.4H & Rm_VPR64.4H & Zd
 {
 	TMPD1 = 0;
-	# sipd infix TMPD1 = f+(Rm_VPR64.4H,Rn_VPR64.4H) on pairs lane size (2 to 2)
-	local tmp2 = Rm_VPR64.4H[0,16];
-	local tmp3 = Rm_VPR64.4H[16,16];
+	# sipd infix TMPD1 = f+(Rn_VPR64.4H,Rm_VPR64.4H) on pairs lane size (2 to 2)
+	local tmp2 = Rn_VPR64.4H[0,16];
+	local tmp3 = Rn_VPR64.4H[16,16];
 	TMPD1[0,16] = tmp2 f+ tmp3;
-	tmp2 = Rm_VPR64.4H[32,16];
-	tmp3 = Rm_VPR64.4H[48,16];
-	TMPD1[16,16] = tmp2 f+ tmp3;
-	tmp2 = Rn_VPR64.4H[0,16];
-	tmp3 = Rn_VPR64.4H[16,16];
-	TMPD1[32,16] = tmp2 f+ tmp3;
 	tmp2 = Rn_VPR64.4H[32,16];
 	tmp3 = Rn_VPR64.4H[48,16];
+	TMPD1[16,16] = tmp2 f+ tmp3;
+	tmp2 = Rm_VPR64.4H[0,16];
+	tmp3 = Rm_VPR64.4H[16,16];
+	TMPD1[32,16] = tmp2 f+ tmp3;
+	tmp2 = Rm_VPR64.4H[32,16];
+	tmp3 = Rm_VPR64.4H[48,16];
 	TMPD1[48,16] = tmp2 f+ tmp3;
 	Rd_VPR64.4H = TMPD1;
 	zext_zd(Zd); # zero upper 24 bytes of Zd


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the faddp instruction for AARCH64. According to Section C7.2.52, the expected behaviour is to concatenate vector Rn to vector Rm, with vector Rn making up the least significant bits of the newly formed vector. While the current behaviour instead concatenates the vectors in the reverse order, with Rm being the least significant bits in the new vector.

e.g.:
`0x5215432e` "faddp v18.4H, v10.4H, v3.4H" with z3=0x9b9d, z10=0x0f35

Hardware Reference: z18 = 0x9b9d00000f35
Existing Spec: z18 = 0x0f3500009b9d
Patched Spec: z18 = 0x9b9d00000f35