### PR TITLE
Decompiler: Fix inputs sometimes being swapped for operations `FLOAT_LESS` and `FLOAT_LESSEQUAL` in rule `subflow_convert`

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/subflow.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/subflow.cc
@@ -2652,8 +2652,8 @@ bool SubfloatFlow::traceForward(TransformVar *rvn)
       }
       if (preexistingGuard(slot, rvn2)) {
 	TransformOp *rop = newPreexistingOp(2, op->code(), op);
-	opSetInput(rop, rvn, 0);
-	opSetInput(rop, rvn2, 1);
+	opSetInput(rop, rvn, slot);
+	opSetInput(rop, rvn2, 1 - slot);
 	terminatorCount += 1;
       }
       break;


### PR DESCRIPTION
The decompiler rule `subflow_convert` would sometimes swap the inputs to the P-Code ops `FLOAT_LESS` and `FLOAT_LESSEQUAL` if the float that was traced happened to be the second input of the operation, because the transformed operation had its inputs hardcoded: the traced float would always be the first input. While this also affected `FLOAT_EQUAL` and `FLOAT_NOTEQUAL`, it does not matter in those cases, because swapping the inputs for those operations is still logically equivalent.

Fixes #6528.

Also see that issue for a more detailed analysis of the problem. 