### PR TITLE
RISCV: nanboxing

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32d.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32d.sinc
@@ -56,7 +56,7 @@
 :fcvt.s.d frd,frs1D,FRM is frs1D & frd & FRM & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct7=0x20 & op2024=0x1
 {
 	local tmp:4 = float2float(frs1D);
-	frd = zext(tmp);
+	fassignS(frd, tmp);
 }
 
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.table.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.table.sinc
@@ -81,11 +81,33 @@ frs1: fr1519 is fr1519 { export fr1519; }
 frs2: fr2024 is fr2024 { export fr2024; }
 frs3: fr2731 is fr2731 { export fr2731; }
 
-#TODO  dest may be bad, might need an assign macro
-#frdS:  fr0711 is fr0711 { local tmp = fr0711:$(SFLEN); export tmp; }
+@if (FPSIZE == "32")
 frs1S: fr1519 is fr1519 { local tmp = fr1519:$(SFLEN); export tmp; }
 frs2S: fr2024 is fr2024 { local tmp = fr2024:$(SFLEN); export tmp; }
 frs3S: fr2731 is fr2731 { local tmp = fr2731:$(SFLEN); export tmp; }
+@else
+frs1S: fr1519 is fr1519 { 
+	local tmp:$(SFLEN) = fr1519:$(SFLEN);
+	if (fr1519 s>> 32 == ~0) goto <FR1519NOTNAN>;
+	tmp = 0x7FC00000;
+	<FR1519NOTNAN>
+	export tmp;
+}
+frs2S: fr2024 is fr2024 {
+	local tmp:$(SFLEN) = fr2024:$(SFLEN);
+	if (fr2024 s>> 32 == ~0) goto <fr2024NOTNAN>;
+	tmp = 0x7FC00000;
+	<fr2024NOTNAN>
+	export tmp;
+}
+frs3S: fr2731 is fr2731 {
+	local tmp:$(SFLEN) = fr2731:$(SFLEN);
+	if (fr2731 s>> 32 == ~0) goto <fr2731NOTNAN>;
+	tmp = 0x7FC00000;
+	<fr2731NOTNAN>
+	export tmp;
+}
+@endif
 
 @if ((FPSIZE == "64") || (FPSIZE == "128"))
 #TODO  dest may be bad, might need an assign macro


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the single precision float instructions for RISCV. According to Section 12.2, when multiple floating-point precisions are supported the narrower value must be NaN-boxed by setting all upper bits to 1's. When an incorrectly NaN-boxed value is read the input is treated as NaN. The current behaviour ignores the upper bits and zero extends single precision floats. While this pull request does not cover them this is also an issue for half and double precision floats. 

It was also found that the `fcvt.s.d` instruction did not use the `fassignS` macro and instead wrote directly to `frd`.

Correctly handling this cases does bloat disassembly. The or'ing of the value to `0xffffffff00000000` on lines 4 and 7 of "Decompilation with fix" are from the `flw` instructions as they are NaN-boxed after being read off the stack. The rest of the logic on lines 4-9 is from the `fadd.s` instruction checking if its inputs are NaN-boxed. The or'ing on line 11 is from the `fadd.s` instruction NaN-boxing its output. The rest of the logic on lines 11-13 is from the `fmv.x.w` instruction checking if its input is correctly NaN-boxed (both decompilations  includes the patch https://github.com/NationalSecurityAgency/ghidra/pull/6492).

**Compiler generated assembly**
```
0001015a 01 11           c.addi     sp,-0x20
	 assume gp = <UNKNOWN>
0001015c 22 ce           c.swsp     s0,0x1c(sp)
0001015e 00 10           c.addi4spn s0,sp,0x20
00010160 23 26 a4 fe     sw         a0,-0x14=>local_14(s0)
00010164 23 24 b4 fe     sw         a1,-0x18=>local_18(s0)
00010168 07 27 c4 fe     flw        fa4,-0x14=>local_14(s0)
0001016c 87 27 84 fe     flw        fa5,-0x18=>local_18(s0)
00010170 d3 77 f7 00     fadd.s     fa5,fa4,fa5,dyn
00010174 53 85 07 e0     fmv.x.w    a0,fa5
00010178 72 44           c.lwsp     s0,0x1c(sp)
0001017a 05 61           c.addi16sp sp,0x20
0001017c 82 80           ret
```

**Decompilation without fix**
```C
float float_add(float param_1,float param_2)
{
  gp = &__global_pointer$;
  return param_1 + param_2;
}
```
**Decompilation with fix**
```C
float float_add(float param_1,float param_2)
{
  gp = &__global_pointer$;
  if ((longlong)((ulonglong)(uint)param_2 | 0xffffffff00000000) >> 0x20 != -1) {
    param_2 = NAN;
  }
  if ((longlong)((ulonglong)(uint)param_1 | 0xffffffff00000000) >> 0x20 != -1) {
    param_1 = NAN;
  }
  param_1 = param_1 + param_2;
  if ((longlong)((ulonglong)(uint)param_1 | 0xffffffff00000000) >> 0x20 != -1) {
    param_1 = NAN;
  }
  return param_1;
}
```

It should be possible to include most of the functionality of this fix while also generating cleaner decompilation by changing the condition on lines 91, 98, and 105 to `nan(frXXXX)` instead of bit shifting and comparing. If you set "NaN operations" under the Analysis tab on the "Options for Code Brower" window to "ignore all", this should cut out all of the if statements but Ghidra seems to get confused and generates the following decompilation.

```C
undefined4 float_add(void)
{
  gp = &__global_pointer$;
  return 0x7fc00000;
}
```

As this greatly impacts the readability of the current decompilation without adding too much to analysis it has been left as a draft.