### PR TITLE
AArch32: vdup had destructive bitwise AND operations instead of OR and missing Thumb constructor constraints

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -2483,7 +2483,7 @@ vdupDm: Dm^"["^vdupIndex^"]"	is Dm & vdupIndex & ((TMode=0 & c1618=4) | (TMode=1
 vdupDm16: vdupDm	is vdupDm	
 { 
 	val:16 = zext(vdupDm); 
-	val = val & (val << 64); 
+	val = val | (val << 64); 
 	export val; 
 }
 
@@ -2503,25 +2503,28 @@ vdupDm16: vdupDm	is vdupDm
 # VDUP (ARM core register)
 #
 
-vdupSize2: 8	is c2222=1 & c0505=0	{ }
-vdupSize2: 16	is c2222=0 & c0505=1	{ }
-vdupSize2: 32	is c2222=0 & c0505=0	{ }
+vdupSize2: 8		is TMode=0 & c2222=1 & c0505=0	{ }
+vdupSize2: 16		is TMode=0 & c2222=0 & c0505=1	{ }
+vdupSize2: 32		is TMode=0 & c2222=0 & c0505=0	{ }
+vdupSize2: 8	    is TMode=1 & thv_c2222=1 & thv_c0505=0		{ }
+vdupSize2: 16		is TMode=1 & thv_c2222=0 & thv_c0505=1 		{ }
+vdupSize2: 32		is TMode=1 & thv_c2222=0 & thv_c0505=0		{ }
 
-vdupRd8: VRd	is VRd & c2222=1 & c0505=0
+vdupRd8: VRd	is VRd & ((TMode=0 & c2222=1 & c0505=0) | (TMode=1 & thv_c2222=1 & thv_c0505=0))
 {
 	val:8 = 0;
 	local tmpRd = VRd;
 	replicate1to8(tmpRd:1, val);
 	export val;
 }
-vdupRd8: VRd	is VRd & c2222=0 & c0505=1
+vdupRd8: VRd	is VRd & ((TMode=0 & c2222=0 & c0505=1) | (TMode=1 & thv_c2222=0 & thv_c0505=1))
 {
 	val:8 = 0;
 	local tmpRd = VRd;
 	replicate2to8(tmpRd:2, val);
 	export val;
 }
-vdupRd8: VRd	is VRd & c2222=0 & c0505=0
+vdupRd8: VRd	is VRd & ((TMode=0 & c2222=0 & c0505=0) | (TMode=1 & thv_c2222=0 & thv_c0505=0))
 {
 	val:8 = 0;
 	local tmpRd = VRd;
@@ -2532,7 +2535,7 @@ vdupRd8: VRd	is VRd & c2222=0 & c0505=0
 vdupRd16: vdupRd8	is vdupRd8	
 { 
 	val:16 = zext(vdupRd8); 
-	val = val & (val << 64); 
+	val = val | (val << 64); 
 	export val; 
 }
 


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `vdup` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, it duplicates a single element of a vector/general-purpose register into every element of the destination vector. However, we noticed the output was incorrect. This was due to destructive bitwise AND operations instead of OR & missing thumb constructor constraints causing a thumb instruction to execute like AArch32 instruction.

-----
e.g, for AArch32 with,

Instruction:         `0x600cf1f3, vdup.8 q8,d16[0x0]`
initial_registers: `{ "q8": 0xdf60afddae76036c20f35d532cdd79eb }`

We get:

Hardware:         `{ "q8": 0xebebebebebebebebebebebebebebebeb }`
Patched Spec: `{ "q8": 0xebebebebebebebebebebebebebebebeb }`
Existing Spec:  `{ "q8": 0x0 }`

and,

Instruction:         `0x900ba0be, vduplt.32 q8,r0`
initial_registers: `{ "r0": 0x80, "NG": 0x1, "OV": 0x0 }`

We get:

Hardware:         `{ "q8": 80000000800000008000000080 }`
Patched Spec: `{ "q8": 80000000800000008000000080 }`
Existing Spec:  `{ "q8": 0x0 }`

-----
e.g, for Thumb with,

Instruction:         `0xa0ee900b, vdup.32 q8,r0`
initial_registers: `{ "r0": 0xd1c8a9dc, "lr": 0xaa41700d }`

We get:

Hardware:        `{ "q8": 0xd1c8a9dcd1c8a9dcd1c8a9dcd1c8a9dc }`
Patched Spec: `{ "q8": 0xd1c8a9dcd1c8a9dcd1c8a9dcd1c8a9dc }`
Existing Spec (with AND/OR fix):  `{ "q8": 0x700d700d700d700d700d700d700d700d }`
Existing Spec:  `{ "q8": 0x0 }`


-----

_Note: The patched spec does introduce disassembly changes for the patched thumb variant. (eg, 0xa0ee900b is vdup.32 q8,r0 instead of vdup.32 q8,lr in Thumb.)_
