### PR TITLE
AArch32: vmvn had incorrect double-word order and number of bytes provided instead of bits in bitwise left shift

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -4456,7 +4456,7 @@ vmlDmA: Dm_4^"["^thv_M5^"]"	is TMode=1 & thv_c2021=2 & Dm_4 & thv_M5											{
 	tmp2:8 = Qm(8);
 	tmp1 = ~ tmp1;
 	tmp2 = ~ tmp2;
-	Qd = (zext(tmp1) << 8) | zext(tmp2);
+	Qd = (zext(tmp2) << 64) | zext(tmp1);
 }
 
 define pcodeop FloatVectorNeg;


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `vmvn` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, it takes a value from a register, inverts the value of each bit, and places the result in the destination register. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0xe005f0f3, vmvn q8,q8`
initial_registers: `{ "q8": 0xffffffffffffffff }`

We get:

Hardware:         `{ "q8": 0xffffffffffffffff0000000000000000 }`
Patched Spec: `{ "q8": 0xffffffffffffffff0000000000000000 }`
Existing Spec:  `{ "q8": 0xffffffffffffffff }`

-----
e.g, for Thumb with,

Instruction:         `0xf0ffe005, vmvn q8,q8`
initial_registers: `{ "q8": 0x0 }`

We get:

Hardware:        `{ "q8": 0xffffffffffffffffffffffffffffffff }`
Patched Spec: `{ "q8": 0xffffffffffffffffffffffffffffffff }`
Existing Spec:  `{ "q8": 0xffffffffffffffffff }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
