### PR TITLE
AArch32: (Thumb32) BranchWritePC does not clear bit-0

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARM.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARM.sinc
@@ -205,7 +205,7 @@ macro SetThumbMode(value) {
 #
 # simple branch, not inter-working
 macro BranchWritePC(addr) {
-   pc = addr;
+	pc = addr & (~0x1);
 }
 
 #


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `add` &  `mov` instruction to `pc` for Thumb (`ARM:LE:32:v8T`). 

According to the manual, BranchWritePC in Thumb clears bit-0 to 0. However, we noticed the output was incorrect. 

-----
e.g, for Thumb with,

Instruction:         `0xc746, mov pc,r8`
initial_registers: `{ "r8": 0x5165fa67 }`

We get:

Hardware:        `{ "pc": 0x5165fa66 }`
Patched Spec: `{ "pc": 0x5165fa66 }`
Existing Spec:  `{ "pc": 0x5165fa67 }`

and, 

Instruction:         `0xc744, add pc,r8`
initial_registers: `{ "r8": 0x42728a67, "pc": 0x10000000 }`

We get:

Hardware:        `{ "pc": 0x52728a6a }`
Patched Spec: `{ "pc": 0x52728a6a }`
Existing Spec:  `{ "pc":0x52728a6b }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
