### PR TITLE
RISCV: fixed fmv.x.d

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64d.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64d.sinc
@@ -41,7 +41,5 @@
 
 :fmv.x.d rdL,frs1D is frs1D & rdL & op0001=0x3 & op0204=0x4 & op0506=0x2 & funct3=0x0 & funct7=0x71 & op2024=0x0
 {
-	local tmpreg:4 = &frs1D;
-	local tmp:8 = *[register]:8 tmpreg;
-	rdL = tmp;
+	rdL = frs1D;
 }


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the `fmv.x.d` instruction. According to section 12.5 of the 20191213 unprivileged specification, the expected behaviour is to move the bit pattern in the floating point source register to the integer destination register. The current behaviour was found to write the value 0. This instructions single precision counterpart was fixed in the previous pull request https://github.com/NationalSecurityAgency/ghidra/pull/6492.