### PR TITLE
x86: PC-relative addressing with a 32-bit address size should mask upper bits.

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -677,6 +677,7 @@ usimm8_64: val is imm8 & imm8_7=1 [ val = 0xffffffffffffff00 | imm8; ] { export 
 
 # RIP/EIP relative address - NOTE: export of size 0 is intentional so it may be adjusted
 pcRelSimm32: addr	is simm32 [ addr=inst_next+simm32; ] { export addr; }
+pcRelSimm32_32: addr	is simm32 [ addr=(inst_next+simm32) & 0xffffffff; ] { export addr; }
 
 # 16-bit addressing modes   (the offset portion)
 addr16: [BX + SI]		is mod=0 & r_m=0 & BX & SI		{ local tmp=BX+SI; export tmp; }
@@ -724,9 +725,8 @@ addr32: [Base + imm32]					is mod=2 & r_m=4; index=4 & Base; imm32      { local 
 addr32: [Base + Index*ss]				is mod=2 & r_m=4; Index & Base & ss; imm32=0 { local tmp=Base+Index*ss; export tmp; }
 addr32: [Base]							is mod=2 & r_m=4; index=4 & Base; imm32=0    { export Base; }
 @ifdef IA64
-addr32: [pcRelSimm32]					is bit64=1 & mod=0 & r_m=4; index=4 & base=5; pcRelSimm32 { export *[const]:4 pcRelSimm32; }
 
-Addr32_64: [pcRelSimm32]				is mod=0 & r_m=5; pcRelSimm32                { export *[const]:8 pcRelSimm32; }
+Addr32_64: [pcRelSimm32_32]				is mod=0 & r_m=5; pcRelSimm32_32                { export *[const]:8 pcRelSimm32_32; }
 Addr32_64: [imm32]						is mod=0 & r_m=4; index=4 & base=5; imm32    { export *[const]:8 imm32; }
 Addr32_64: addr32						is addr32									 { tmp:8 = sext(addr32); export tmp; }
 	


### PR DESCRIPTION
When the 67 (address size override) prefix is used in long mode on an instruction that uses RIP-relative addressing, the effective address needs to be truncated and zero extended (see: "2.2.5.2 Effect of Address-Size Prefix on RIP-Relative Addressing" of AMD64-APM Vol.1).

This PR fixes this by introducing a new subtable `pcRelSimm32_32` that is used when decoding RIP-relative addresses in the `Addr32_64` subtable. (Note: The PR also removes a 64-bit only constructor for `addr32` which is impossible to reach, since `addrsize` must be equal to 1 for the `addr32` to be used which conflicts with the `bit64=1` constraint.)

e.g.:

* 678b0500000000 at RIP=0x1_0000_0000: "MOV EAX,[0x7]" with mem[0x7]=[0x11 0x11 0x11 0x11], mem[0x100000007]=[0x22 0x22 0x22 0x22]
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0x11111111 }
    - `x86:LE:64:default` (Existing): "MOV EAX,dword ptr [0x100000007]" { RAX=22222222 }
    - `x86:LE:64:default` (This patch): "MOV EAX,dword ptr [0x7]" { RAX=0x11111111 }