### PR TITLE
x86: Relax constraints for NOPs with REX prefix

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -3263,7 +3263,7 @@ define pcodeop swap_bytes;
 :NEG Rmr64      is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0xf7; mod=3 & Rmr64 & reg_opcode=3 { negflags(Rmr64); Rmr64 = -Rmr64; resultflags(Rmr64); }
 @endif
 
-:NOP            is vexMode=0 & byte=0x90 & (mandover=0 | mandover=4 | mandover=1) & (rexprefix=0 | rexWRXBprefix=8)  { }
+:NOP            is vexMode=0 & byte=0x90 & (mandover=0 | mandover=4 | mandover=1) & (rexprefix=0 | rexBprefix=0)  { }
 :NOP rm16       is vexMode=0 & mandover & opsize=0 & byte=0x0f; high5=3; rm16  ...    { }
 :NOP rm32       is vexMode=0 & mandover & opsize=1 & byte=0x0f; high5=3; rm32  ...    { }
 :NOP^"/reserved" rm16 is vexMode=0 & mandover & opsize=0 & byte=0x0f; byte=0x18; rm16 & reg_opcode_hb=1 ...    { }


### PR DESCRIPTION
0x90 `XCHG EAX,EAX` instructions are handled as a special-case by x86 processors in long mode to behave as a `NOP` (meaning they do not zero the upper 32-bits of RAX).

The current SLEIGH specification correctly treats `4890` (i.e. `XCHG RAX,RAX`) as a `NOP`, but does not allow any other REX prefix bits to be set. However, in practice (and based on what is documented in 2.5.7 of AMD64-APM Vol.2), any REX prefix other than REX.X (which would change second operand to R8D) should still result in a NOP.

To test this, we can set the upper bits of `RAX` which will be zeroed for instructions the hardware treats as an XCHG, but left alone for NOPs. This was tested against hardware (AMD & Intel) for all possible REX prefixes (i.e., `[40, 41, ..., 4f]`).

Any of the cases where REX.B=0 ([40,42,44,46]) are NOPs, e.g.:

* 4090 `NOP` with RAX=0xaaaaaaaa_aaaaaaaa
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0xaaaaaaaa_aaaaaaaa }
    - `x86:LE:64:default` (Existing): "XCHG EAX,EAX" { RAX=0x00000000_aaaaaaaa }
    - `x86:LE:64:default` (This patch): "NOP" { RAX=0xaaaaaaaa_aaaaaaaa }

Any of the cases where REX.B=1 ([41,43,45,47,49,4b,4d,4f]) should remain as XCHG operations, e.g.:

* 4190 `XCHG EAX,R8D` with RAX=0xaaaaaaaa_aaaaaaaa
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0x00000000_00000000, R8=0x00000000_aaaaaaaa }
    - `x86:LE:64:default` (unchanged): "XCHG EAX,R8D" { RAX=0x00000000_00000000, R8=0x00000000_aaaaaaaa }

If REX.W=1, and no other REX bits are set then the old code is correct (left unchanged):

* 4890 `NOP` (`XCHG RAX,RAX`) with RAX=0xaaaaaaaa_aaaaaaaa
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0xaaaaaaaa_aaaaaaaa }
    - `x86:LE:64:default` (unchanged): "NOP" { RAX=0xaaaaaaaa_aaaaaaaa }

If REX.W=1, and REX.B=0 ([4a,4c,4e]) then the old code decodes the instruction as `XCHG RAX,RAX` which is technically still correct and has the same semantics as a `NOP`. This PR also affects the disassembly in these cases (so that it matches the 0x48 case), but this could be modified:

* 4a90 `NOP` (`XCHG RAX,RAX`) with RAX=0xaaaaaaaa_aaaaaaaa
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0xaaaaaaaa_aaaaaaaa }
    - `x86:LE:64:default` (Existing): "XCHG RAX,RAX" { RAX=0xaaaaaaaa_aaaaaaaa }
    - `x86:LE:64:default` (This patch): "NOP" { RAX=0xaaaaaaaa_aaaaaaaa }
