### PR TITLE
x86: Carry flag calculated incorrectly for LZCNT if source=dest

### DIFF
--- a/Ghidra/Processors/x86/data/languages/lzcnt.sinc
+++ b/Ghidra/Processors/x86/data/languages/lzcnt.sinc
@@ -10,23 +10,25 @@ macro lzcntflags(input, output) {
 
 
 :LZCNT Reg16, rm16	is vexMode=0 & opsize=0 & $(PRE_66) & $(PRE_F3) & byte=0x0F; byte=0xBD; Reg16 ... & rm16 {
-
-  Reg16 = lzcount(rm16);
-  lzcntflags(rm16, Reg16);
+  local tmp = rm16;
+  Reg16 = lzcount(tmp);
+  lzcntflags(tmp, Reg16);
 }
 
 :LZCNT Reg32, rm32	is vexMode=0 & opsize=1 & $(PRE_F3) & byte=0x0F; byte=0xBD; Reg32 ... & check_Reg32_dest ... & rm32 {
 
-  Reg32 = lzcount(rm32);
-  lzcntflags(rm32, Reg32);
+  local tmp = rm32;
+  Reg32 = lzcount(tmp);
+  lzcntflags(tmp, Reg32);
   build check_Reg32_dest;
 }
 
 @ifdef IA64
 :LZCNT Reg64, rm64	is $(LONGMODE_ON) & vexMode=0 & opsize=2 & $(PRE_F3) & $(REX_W) & byte=0x0F; byte=0xBD; Reg64 ... & rm64 {
 
-  Reg64 = lzcount(rm64);
-  lzcntflags(rm64, Reg64);
+  local tmp = rm64;
+  Reg64 = lzcount(tmp);
+  lzcntflags(tmp, Reg64);
 }
 @endif
 


### PR DESCRIPTION
The carry flag for the LZCNT instruction should be calculated based on the input value of the source operand. However, if the destination operand is the same as the source operand (e.g., `LZCNT EAX,EAX`) then the carry flag is computed based the _result_ of the LZCNT operation instead of the input value.

This PR fixes this by storing the input value into a temporary which is later used for computing the carry flag.

e.g.,

* 66f30fbdc0 "LZCNT AX,AX" wwith AX=ffff
    - Hardware Reference (AMD CPU & Intel CPU): { AX=0x0, ZF=1, CF=0 }
    - `x86:LE:64:default` (Existing): { AX=0x0, ZF=1, CF=1 }
    - `x86:LE:64:default` (This patch): { AX=0x0, ZF=1, CF=0 }

* f30fbdc0 "LZCNT EAX,EAX" with EAX=0xffff_ffff
    - Hardware Reference (AMD CPU & Intel CPU): { EAX=0x0, ZF=1, CF=0 }
    - `x86:LE:64:default` (Existing): { EAX=0x0, ZF=1, CF=1 }
    - `x86:LE:64:default` (This patch): { EAX=0x0, ZF=1, CF=0 }

* f3480fbdc0 "LZCNT RAX,RAX" with RAX=0xffff_ffff_ffff_ffff
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0x0, ZF=1, CF=0 }
    - `x86:LE:64:default` (Existing): { RAX=0x0, ZF=1, CF=1 }
    - `x86:LE:64:default` (This patch): { RAX=0x0, ZF=1, CF=0 }
