### PR TITLE
x86: XADD stores to the wrong address if destination is used as part of the address calculation

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -705,24 +705,24 @@ addr16: [BP + imm16]  is mod=2 & r_m=6 & BP; imm16        { local tmp=BP+imm16; 
 addr16: [BX + imm16]  is mod=2 & r_m=7 & BX; imm16        { local tmp=BX+imm16; export tmp; }
 
 # 32-bit addressing modes   (the offset portion)
-addr32: [Rmr32]							is mod=0 & Rmr32  							 { export Rmr32; }
+addr32: [Rmr32]							is mod=0 & Rmr32  							 { local tmp=Rmr32; export tmp; }
 addr32: [Rmr32 + simm8_32]				is mod=1 & Rmr32; simm8_32       			 { local tmp=Rmr32+simm8_32; export tmp; }
-addr32: [Rmr32]							is mod=1 & r_m!=4 & Rmr32; simm8=0			 { export Rmr32; }
+addr32: [Rmr32]							is mod=1 & r_m!=4 & Rmr32; simm8=0			 { local tmp=Rmr32; export tmp; }
 addr32: [Rmr32 + imm32]					is mod=2 & Rmr32; imm32                      { local tmp=Rmr32+imm32; export tmp; }
-addr32: [Rmr32]							is mod=2 & r_m!=4 & Rmr32; imm32=0           { export Rmr32; }
+addr32: [Rmr32]							is mod=2 & r_m!=4 & Rmr32; imm32=0           { local tmp=Rmr32; export tmp; }
 addr32: [imm32]							is mod=0 & r_m=5; imm32                      { export *[const]:4 imm32; }
 addr32: [Base + Index*ss]				is mod=0 & r_m=4; Index & Base & ss          { local tmp=Base+Index*ss; export tmp; }
-addr32: [Base]							is mod=0 & r_m=4; index=4 & Base             { export Base; }
+addr32: [Base]							is mod=0 & r_m=4; index=4 & Base             { local tmp=Base; export tmp; }
 addr32: [Index*ss + imm32]				is mod=0 & r_m=4; Index & base=5 & ss; imm32 { local tmp=imm32+Index*ss; export tmp; }
 addr32: [imm32]							is mod=0 & r_m=4; index=4 & base=5; imm32    { export *[const]:4 imm32; }
 addr32: [Base + Index*ss + simm8_32]	is mod=1 & r_m=4; Index & Base & ss; simm8_32    { local tmp=simm8_32+Base+Index*ss; export tmp; }
 addr32: [Base + simm8_32]				is mod=1 & r_m=4; index=4 & Base; simm8_32   { local tmp=simm8_32+Base; export tmp; }
 addr32: [Base + Index*ss]				is mod=1 & r_m=4; Index & Base & ss; simm8=0 { local tmp=Base+Index*ss; export tmp; }
-addr32: [Base]							is mod=1 & r_m=4; index=4 & Base; simm8=0    { export Base; }
+addr32: [Base]							is mod=1 & r_m=4; index=4 & Base; simm8=0    { local tmp=Base; export tmp; }
 addr32: [Base + Index*ss + imm32]		is mod=2 & r_m=4; Index & Base & ss; imm32   { local tmp=imm32+Base+Index*ss; export tmp; }
 addr32: [Base + imm32]					is mod=2 & r_m=4; index=4 & Base; imm32      { local tmp=imm32+Base; export tmp; }
 addr32: [Base + Index*ss]				is mod=2 & r_m=4; Index & Base & ss; imm32=0 { local tmp=Base+Index*ss; export tmp; }
-addr32: [Base]							is mod=2 & r_m=4; index=4 & Base; imm32=0    { export Base; }
+addr32: [Base]							is mod=2 & r_m=4; index=4 & Base; imm32=0    { local tmp=Base; export tmp; }
 @ifdef IA64
 addr32: [pcRelSimm32]					is bit64=1 & mod=0 & r_m=4; index=4 & base=5; pcRelSimm32 { export *[const]:4 pcRelSimm32; }
 
@@ -735,14 +735,14 @@ Addr32_64: addr32						is addr32									 { tmp:8 = sext(addr32); export tmp; }
 # 64-bit addressing modes   (the offset portion)
 
 @ifdef IA64
-addr64: [Rmr64]							is mod=0 & Rmr64                                   { export Rmr64; }
+addr64: [Rmr64]							is mod=0 & Rmr64                                   { local tmp=Rmr64; export tmp; }
 addr64: [Rmr64 + simm8_64]				is mod=1 & Rmr64; simm8_64                         { local tmp=Rmr64+simm8_64; export tmp; }
 addr64: [Rmr64 + simm32_64]				is mod=2 & Rmr64; simm32_64                        { local tmp=Rmr64+simm32_64; export tmp; }
-addr64: [Rmr64]							is mod=1 & r_m!=4 & Rmr64; simm8=0                 { export Rmr64; }
-addr64: [Rmr64]							is mod=2 & r_m!=4 & Rmr64; simm32=0                { export Rmr64; }
+addr64: [Rmr64]							is mod=1 & r_m!=4 & Rmr64; simm8=0                 { local tmp=Rmr64; export tmp; }
+addr64: [Rmr64]							is mod=2 & r_m!=4 & Rmr64; simm32=0                { local tmp=Rmr64; export tmp; }
 addr64: [pcRelSimm32]					is mod=0 & r_m=5; pcRelSimm32                      { export *[const]:8 pcRelSimm32; }
 addr64: [Base64 + Index64*ss]			is mod=0 & r_m=4; Index64 & Base64 & ss            { local tmp=Base64+Index64*ss; export tmp; }
-addr64: [Base64]						is mod=0 & r_m=4; rexXprefix=0 & index64=4 & Base64    { export Base64; }
+addr64: [Base64]						is mod=0 & r_m=4; rexXprefix=0 & index64=4 & Base64    { local tmp = Base64; export tmp; }
 addr64: [simm32_64 + Index64*ss]		is mod=0 & r_m=4; Index64 & base64=5 & ss; simm32_64   { local tmp=simm32_64+Index64*ss; export tmp; }
 addr64: [Index64*ss]					is mod=0 & r_m=4; Index64 & base64=5 & ss; imm32=0 { local tmp=Index64*ss; export tmp; }
 addr64: [simm32_64]						is mod=0 & r_m=4; rexXprefix=0 & index64=4 & base64=5; simm32_64      { export *[const]:8 simm32_64; }
@@ -750,7 +750,7 @@ addr64: [Base64 + simm8_64]				is mod=1 & r_m=4; rexXprefix=0 & index64=4 & Base
 addr64: [Base64 + Index64*ss + simm8_64] is mod=1 & r_m=4; Index64 & Base64 & ss; simm8_64 { local tmp=simm8_64+Base64+Index64*ss; export tmp; }
 addr64: [Base64 + Index64*ss]			is mod=1 & r_m=4; Index64 & Base64 & ss; simm8=0   { local tmp=Base64+Index64*ss; export tmp; }
 addr64: [Base64 + simm32_64]			is mod=2 & r_m=4; rexXprefix=0 & index64=4 & Base64; simm32_64        { local tmp=simm32_64+Base64; export tmp; }
-addr64: [Base64]						is mod=2 & r_m=4; rexXprefix=0 & index64=4 & Base64; imm32=0      { export Base64; }
+addr64: [Base64]						is mod=2 & r_m=4; rexXprefix=0 & index64=4 & Base64; imm32=0      { local tmp = Base64; export tmp; }
 addr64: [Base64 + Index64*ss + simm32_64] is mod=2 & r_m=4; Index64 & Base64 & ss; simm32_64     { local tmp=simm32_64+Base64+Index64*ss; export tmp; }
 addr64: [Base64 + Index64*ss]			is mod=2 & r_m=4; Index64 & Base64 & ss; imm32=0   { local tmp=Base64+Index64*ss; export tmp; }
 @endif
@@ -4048,8 +4048,8 @@ macro xadd(dst,src) {
     local tmp = dst;
     addflags(tmp,src);
     local result = tmp + src;
-    dst = result; 
     src = tmp;
+    dst = result; 
     resultflags(result);
 }
 

--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -4044,12 +4044,21 @@ define pcodeop wrpkru;
 define pcodeop wrmsr;
 :WRMSR is vexMode=0 & byte=0xf; byte=0x30 { tmp:8 = (zext(EDX) << 32) | zext(EAX); wrmsr(ECX,tmp); }
 
+macro xadd(dst,src) {
+    local tmp = dst;
+    addflags(tmp,src);
+    local result = tmp + src;
+    dst = result; 
+    src = tmp;
+    resultflags(result);
+}
+
 # See 'lockable.sinc' for memory destination, lockable variants
 :XADD       Rmr8,Reg8 	is vexMode=0 & byte=0x0F; byte=0xC0; mod=3 & Rmr8 & Reg8        { addflags( Rmr8,Reg8 ); local tmp =  Rmr8 +  Reg8;  Reg8 = Rmr8; Rmr8 = tmp;     resultflags(tmp); }
-:XADD      Rmr16,Reg16	is vexMode=0 & opsize=0 & byte=0x0F; byte=0xC1; mod=3 & Rmr16 & Reg16 { addflags(Rmr16,Reg16); local tmp = Rmr16 + Reg16; Reg16 = Rmr16; Rmr16 = tmp; resultflags(tmp); }
-:XADD      Rmr32,Reg32	is vexMode=0 & opsize=1 & byte=0x0F; byte=0xC1; mod=3 & Rmr32 & check_Rmr32_dest & Reg32 & check_Reg32_dest { addflags(Rmr32,Reg32); local tmp = Rmr32 + Reg32; Reg32 = Rmr32; Rmr32 = tmp; build check_Rmr32_dest; build check_Reg32_dest; resultflags(tmp); }
+:XADD      Rmr16,Reg16	is vexMode=0 & opsize=0 & byte=0x0F; byte=0xC1; mod=3 & Rmr16 & Reg16                                       { xadd(Rmr16,Reg16); }
+:XADD      Rmr32,Reg32	is vexMode=0 & opsize=1 & byte=0x0F; byte=0xC1; mod=3 & Rmr32 & check_Rmr32_dest & Reg32 & check_Reg32_dest { xadd(Rmr32,Reg32); build check_Rmr32_dest; build check_Reg32_dest; }
 @ifdef IA64
-:XADD      Rmr64,Reg64	is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x0F; byte=0xC1; mod=3 & Rmr64 & Reg64 { addflags(Rmr64,Reg64); local tmp = Rmr64 + Reg64; Reg64 = Rmr64; Rmr64 = tmp; resultflags(tmp); }
+:XADD      Rmr64,Reg64	is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x0F; byte=0xC1; mod=3 & Rmr64 & Reg64                      { xadd(Rmr64,Reg64); }
 @endif
 
 define pcodeop xabort;

--- a/Ghidra/Processors/x86/data/languages/lockable.sinc
+++ b/Ghidra/Processors/x86/data/languages/lockable.sinc
@@ -1176,11 +1176,7 @@
 {
     build lockx;
     build m8;
-    addflags( m8,Reg8 );
-    local tmp =  m8 +  Reg8;
-    Reg8 = m8;
-    m8 = tmp;
-    resultflags(tmp);
+    xadd(m8,Reg8);
     build unlock; 
 }
 
@@ -1188,11 +1184,7 @@
 {
     build lockx;
     build m16;
-    addflags(m16,Reg16);
-    local tmp = m16 + Reg16;
-    Reg16 = m16;
-    m16 = tmp;
-    resultflags(tmp);
+    xadd(m16,Reg16);
     build unlock; 
 }
 
@@ -1200,11 +1192,7 @@
 {
     build lockx;
     build m32;
-    addflags(m32,Reg32);
-    local tmp = m32 + Reg32;
-    Reg32 = m32;
-    m32 = tmp;
-    resultflags(tmp);
+    xadd(m32,Reg32);
     build unlock; 
 }
 
@@ -1213,11 +1201,7 @@
 {
     build lockx;
     build m64;
-    addflags(m64,Reg64);
-    local tmp = m64 + Reg64;
-    Reg64 = m64;
-    m64 = tmp;
-    resultflags(tmp);
+    xadd(m64,Reg64);
     build unlock; 
 }
 @endif


### PR DESCRIPTION
XADD loads the current value pointed by the destination operand, adds the source operand, then stores the result back in the destination operand and the previous value into the source operand.

If the destination operand is a memory location with an address calculated based on the same register as the source operand then the existing SLEIGH specification will store the result to the wrong address.

Originally, this was fixed (first commit) by re-ordering the writes to the source/destination register, however the pseudocode listed in the reference manual performs the writes in the original order.

After further triaging, the issue appears to be caused by the fact that the target address is precomputed in some contexts but not others. This is because some addressing modes export a reference to the computed address stored in a temporary (in the implicit build statement injected at the start of the constructor), while others export a varnode reference. The second commit fixes this by storing the effective address in a temporary in all cases.

Although both commits technically fix the same problem, since the first commit also avoids redundant pcode LOAD ops by loading the memory location into a temporary first, and the second commit allows us to use the same order as the pseudocode, both have been included in this PR.

e.g,

* 0fc000 "XADD dword ptr [RAX],AL" with RAX=0x1001, mem[0x1001]=[0xaa]
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0x10aa, mem[0x1001]=[0xab], PF=1, SF=1 }
    - `x86:LE:64:default` (Existing): "XADD dword ptr [RAX],AL" { RAX=0x10aa, mem[0x10aa]=[0xaa], PF=1, SF=1 }
    - `x86:LE:64:default` (This patch): "XADD dword ptr [RAX],AL" { RAX=0x10aa, mem[0x1001]=[0xab], PF=1, SF=1 }
