### PR TITLE
x86: Fix interaction between REX.X and 67 prefix

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -712,17 +712,17 @@ addr32: [Rmr32 + imm32]					is mod=2 & Rmr32; imm32                      { local
 addr32: [Rmr32]							is mod=2 & r_m!=4 & Rmr32; imm32=0           { export Rmr32; }
 addr32: [imm32]							is mod=0 & r_m=5; imm32                      { export *[const]:4 imm32; }
 addr32: [Base + Index*ss]				is mod=0 & r_m=4; Index & Base & ss          { local tmp=Base+Index*ss; export tmp; }
-addr32: [Base]							is mod=0 & r_m=4; index=4 & Base             { export Base; }
+addr32: [Base]							is mod=0 & r_m=4; rexXprefix=0 & index=4 & Base             { export Base; }
 addr32: [Index*ss + imm32]				is mod=0 & r_m=4; Index & base=5 & ss; imm32 { local tmp=imm32+Index*ss; export tmp; }
-addr32: [imm32]							is mod=0 & r_m=4; index=4 & base=5; imm32    { export *[const]:4 imm32; }
+addr32: [imm32]							is mod=0 & r_m=4; rexXprefix=0 & index=4 & base=5; imm32    { export *[const]:4 imm32; }
 addr32: [Base + Index*ss + simm8_32]	is mod=1 & r_m=4; Index & Base & ss; simm8_32    { local tmp=simm8_32+Base+Index*ss; export tmp; }
-addr32: [Base + simm8_32]				is mod=1 & r_m=4; index=4 & Base; simm8_32   { local tmp=simm8_32+Base; export tmp; }
+addr32: [Base + simm8_32]				is mod=1 & r_m=4; rexXprefix=0 & index=4 & Base; simm8_32   { local tmp=simm8_32+Base; export tmp; }
 addr32: [Base + Index*ss]				is mod=1 & r_m=4; Index & Base & ss; simm8=0 { local tmp=Base+Index*ss; export tmp; }
-addr32: [Base]							is mod=1 & r_m=4; index=4 & Base; simm8=0    { export Base; }
+addr32: [Base]							is mod=1 & r_m=4; rexXprefix=0 & index=4 & Base; simm8=0    { export Base; }
 addr32: [Base + Index*ss + imm32]		is mod=2 & r_m=4; Index & Base & ss; imm32   { local tmp=imm32+Base+Index*ss; export tmp; }
-addr32: [Base + imm32]					is mod=2 & r_m=4; index=4 & Base; imm32      { local tmp=imm32+Base; export tmp; }
+addr32: [Base + imm32]					is mod=2 & r_m=4; rexXprefix=0 & index=4 & Base; imm32      { local tmp=imm32+Base; export tmp; }
 addr32: [Base + Index*ss]				is mod=2 & r_m=4; Index & Base & ss; imm32=0 { local tmp=Base+Index*ss; export tmp; }
-addr32: [Base]							is mod=2 & r_m=4; index=4 & Base; imm32=0    { export Base; }
+addr32: [Base]							is mod=2 & r_m=4; rexXprefix=0 & index=4 & Base; imm32=0    { export Base; }
 @ifdef IA64
 addr32: [pcRelSimm32]					is bit64=1 & mod=0 & r_m=4; index=4 & base=5; pcRelSimm32 { export *[const]:4 pcRelSimm32; }
 


### PR DESCRIPTION
x86 supports addresses of the form: `[Base + (Index * ss) + imm]`. When instruction encodes an value of `0b100` for the `Index` field, then the `(Index * ss)` section is treated as being equal to zero.

Long mode, extends the `Index` field with an extra bit (which is set with the 0x42 REX.X prefix) to allow the selecting one of upper 8 registers added in 64-bit mode as an index. With this extra bit, `0b0100` still represents no `Index` field but `0b1100` should be treated as `R12`.

In the `addr64` subtable, this is correctly handled using with the constraint `rexXprefix=0 & index64=4`. However, it is still possible for the `addr32` subtable to be used in long mode if an address size override prefix (0x67) is present. However, the `addr32` constructors are missing the constraint that checks whether the REX.X prefix is set causing addresses that encode an index register of `R12D` to be decoded incorrectly.

This PR fixes the issue by adding the missing constraints to the `addr32` table. In modes other than long mode, it should be impossible for `rexXprefix` to anything other than 0, so this change should only impact long mode decoding.

As an example, instruction encodings for `MOV` are shown below, but this affects all instructions that use the 'ModR/M' encoding:

* 6742890427 "MOV dword ptr [EDI + R12D*0x1],EAX" with RDI=0x100, R12=0x100, EAX=0x11223344
    - Hardware Reference (AMD CPU & Intel CPU): { mem[0x200]=[0x44 0x33 0x22 0x11] }
    - `x86:LE:64:default` (Existing): "MOV dword ptr [EDI],EAX" { mem[0x200]=[0x44 0x33 0x22 0x11] }
    - `x86:LE:64:default` (This patch): "MOV dword ptr [EDI + R12D*0x1],EAX" { mem[0x200]=[0x44 0x33 0x22 0x11] }


* 67428b0427 "MOV dword ptr [EDI + R12D*0x1],EAX" with RDI=0x100, R12=0x100, mem[0x100]=aaaaaaaa,mem[0x200]=bbbbbbbb
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0xbbbbbbbb }
    - `x86:LE:64:default` (Existing): "MOV EAX,dword ptr [EDI]" { RAX=0xaaaaaaaa }
    - `x86:LE:64:default` (This patch): "MOV EAX,dword ptr [EDI + R12D*0x1] " { RAX=0xbbbbbbbb }

(Note: this PR modifies some of the same constructors as #6557, so one will need to be rebased before they can both be merged).