### PR TITLE
x86: XSAVEOPT is under-constrained preventing CLRSSBSY from being decoded

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -4151,9 +4151,9 @@ define pcodeop xrstors64;
 :XSAVEC64  Mem    is $(LONGMODE_ON) & vexMode=0 & $(REX_W) & byte=0x0F; byte=0xC7; ( mod != 0b11 & reg_opcode=4 ) ... & Mem { tmp:4 = 512; xsavec64(Mem, tmp); }
 @endif
 
-:XSAVEOPT  Mem    is vexMode=0 & byte=0x0F; byte=0xAE; ( mod != 0b11 & reg_opcode=6 ) ... & Mem { tmp:4 = 512; xsaveopt(Mem, tmp); }
+:XSAVEOPT  Mem    is vexMode=0 & $(PRE_NO) & byte=0x0F; byte=0xAE; ( mod != 0b11 & reg_opcode=6 ) ... & Mem { tmp:4 = 512; xsaveopt(Mem, tmp); }
 @ifdef IA64
-:XSAVEOPT64  Mem    is $(LONGMODE_ON) & vexMode=0 & $(REX_W) & byte=0x0F; byte=0xAE; ( mod != 0b11 & reg_opcode=6 ) ... & Mem { tmp:4 = 512; xsaveopt64(Mem, tmp); }
+:XSAVEOPT64  Mem    is $(LONGMODE_ON) & vexMode=0 & $(PRE_NO) & $(REX_W) & byte=0x0F; byte=0xAE; ( mod != 0b11 & reg_opcode=6 ) ... & Mem { tmp:4 = 512; xsaveopt64(Mem, tmp); }
 @endif
 
 :XSAVES  Mem    is vexMode=0 & byte=0x0F; byte=0xC7; ( mod != 0b11 & reg_opcode=5 ) ... & Mem { tmp:4 = 512; xsaves(Mem, tmp); }


### PR DESCRIPTION

`CLRSSBSY qword ptr [RAX]` has an almost identical instruction encoding to `XSAVEOPT [RAX]` except that `CLRSSBSY` has a required prefix of `0xf3`. However, because the `0xf3` prefix is decoded before opcode matching, `XSAVEOPT` also matches the `CLRSSBSY` encoding.

To fix this, we add an `$(PRE_NO)` constraint to `XSAVEOPT` (matching the encoding listed in the manual).

* f30fae30 "CLRSSBSY qword ptr [RAX]"
    - `x86:LE:64:default` (Existing): "XSAVEOPT [RAX]"
    - `x86:LE:64:default` (This patch): "CLRSSBSY qword ptr [RAX]"


`FXRSTOR`, `FXSAVE`, `LDMXCSR` and `CLFLUSH` also appear to be missing `$(PRE_NO)` constraints. However, these don't appear to cause any issues because each of the overlaps are resovled via the `ModRM.mod` field (without a prefix `ModRM.mod != 3`, with a prefix `ModRM.mod == 3`). These have been left alone for now, but the PR can be updated to add the constraints to the extra constructors.