### PR TITLE
AArch32: (Thumb32) missing DecodeImmShift() defaults to 32 for type '01' (SRType_LSR ) & '10' (SRType_ASR)

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -509,6 +509,7 @@ ThumbExpandImm12: "#"^imm32           is   immed12_i=1 ; immed12_imm3 & thc0707 
 
 @if defined(VERSION_6T2) || defined(VERSION_7)
 
+thLsbImm: "#"^lsb	is imm3_shft=0 & imm2_shft=0 & (thc0405=0b01 | thc0405=0b10) [lsb = 32; ] { tmp:4 = lsb; export tmp; }
 thLsbImm: "#"^lsb	is imm3_shft & imm2_shft [ lsb= (imm3_shft<<2) | imm2_shft; ] { tmp:4 = lsb; export tmp; }
 thMsbImm: "#"^thc0004	is thc0004 { tmp:4 = thc0004; export tmp; }
 thWidthMinus1: "#"^width	is thc0004 [ width = thc0004 + 1; ] { tmp:4 = thc0004; export tmp; }


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `lsrs.w` instruction for Thumb (`ARM:LE:32:v8T`). 

According to the manual, DecodeImmShift() defaults to 32 for type '01' (SRType_LSR ) & '10' (SRType_ASR) if imm5 == '00000'. However, we noticed the output was incorrect. 

-----
e.g, for Thumb with,

Instruction:         `0x5fea1000, lsrs.w r0,r0,#0x20`
initial_registers: `{ "r0": 0xffffffff }`

We get:

Hardware:        `{ "CY": 0x1, "ZR": 0x1, "r0": 0x0 }`
Patched Spec: `{ "CY": 0x1, "ZR": 0x1, "r0": 0x0 }`
Existing Spec:  `{ "NG": 0x1 }`

-----

_Note: The patched spec does introduce disassembly changes for the patched thumb variant. (eg, 0x5fea1000 is lsrs.w r0,r0,#0x20 instead of lsrs.w r0,r0,#0x0 in Thumb.)_
