### PR TITLE
AArch32: (Thumb32) ldrsh.w & ldrsb.w (pc-relative) had double memory load

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -2396,7 +2396,7 @@ define pcodeop ExclusiveAccess;
 :ldrsb^ItCond^".w"  Rt1215,PcrelOffset12         is TMode=1 & ItCond & (op8=0xf9 & thc0506=0 & thc0404=1 & sop0003=15; Rt1215) & PcrelOffset12
 {
    build ItCond;
-   tmp:1 = *PcrelOffset12;
+   tmp:1 = PcrelOffset12:1;
    Rt1215 = sext(tmp);
 }
 
@@ -2437,7 +2437,7 @@ define pcodeop ExclusiveAccess;
 {
    build ItCond;
    build PcrelOffset12;
-   tmp:2 = *PcrelOffset12;
+   tmp:2 = PcrelOffset12:2;
    Rt1215 = sext(tmp);
 }
 


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `ldrsh.w` & `ldrsb.w` instructions for Thumb (`ARM:LE:32:v8T`). 

According to the manual, it calculates an address from the PC value and an immediate offset, loads a halfword/byte from memory, sign-extends it to form a 32-bit word, and writes it to a register. However, we noticed the output was incorrect. 

-----
e.g, for Thumb with,

Instruction:         `0xbff90000, ldrsh.w r0,[0x10000004]`
initial_registers: `{ "pc": 0x10000000 }`

We get:

Hardware:        `{ "r0": 0xffffe82d }`
Patched Spec: `{ "r0": 0xffffe82d }`
Existing Spec:  `{ "r0": 0xffffbcc6 }`

and,

Instruction:         `0x1ff90000, ldrsb.w r0,[0x10000004]`
initial_registers: `{ "pc": 0x10000000 }`

We get:

Hardware:        `{ "r0": 0x2d }`
Patched Spec: `{ "r0": 0x2d }`
Existing Spec:  `{ "r0": 0xffffffc6 }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
