### PR TITLE
x86: Add constraint to mod field of instructions that can only encode registers

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -5767,7 +5767,7 @@ define pcodeop movmskps;
     XmmReg2 = zext(XmmReg1[0,64]);
 }
 
-:MOVQ2DQ      XmmReg, mmxreg2  is vexMode=0 &  $(PRE_F3) & byte=0x0F; byte=0xD6; XmmReg & mmxreg2
+:MOVQ2DQ      XmmReg, mmxreg2  is vexMode=0 &  $(PRE_F3) & byte=0x0F; byte=0xD6; xmmmod = 3 & XmmReg & mmxreg2
 {
     XmmReg = zext(mmxreg2);
 # may need to model x87 FPU state changes too ?????
@@ -6727,13 +6727,13 @@ define pcodeop pavgw;
     XmmReg1[96,32] = zext(XmmReg1[96,32] s> XmmReg2[96,32]) * 0xFFFFFFFF;
 }
 
-:PEXTRW        Reg32, mmxreg2, imm8 is vexMode=0 &  mandover=0 & byte=0x0F; byte=0xC5; Reg32 & mmxreg2; imm8
+:PEXTRW        Reg32, mmxreg2, imm8 is vexMode=0 &  mandover=0 & byte=0x0F; byte=0xC5; xmmmod = 3 & Reg32 & mmxreg2; imm8
 {
     temp:8 = mmxreg2 >> ( (imm8 & 0x03) * 16 );
     Reg32 = zext(temp:2);
 }
 
-:PEXTRW        Reg32, XmmReg2, imm8 is vexMode=0 &  $(PRE_66) & byte=0x0F; byte=0xC5; Reg32 & XmmReg2 & check_Reg32_dest; imm8
+:PEXTRW        Reg32, XmmReg2, imm8 is vexMode=0 &  $(PRE_66) & byte=0x0F; byte=0xC5; xmmmod = 3 & Reg32 & XmmReg2 & check_Reg32_dest; imm8
 {
     local shift:1 = (imm8 & 0x7) * 16:1;
     local low:1 = shift < 64:1;


### PR DESCRIPTION
The `0fc5` encoding for PEXTRW can only encode register values so ModRM.mod must be equal to 3. Currently, the SLEIGH specification just ignores the ModRM.mod field when decoding PEXTRW, however any case where ModRM.mod!=1 should be treated as invalid instruction. The same thing is also true for the MOVQ2DQ instruction.

This PR adds the additional constraint to the PEXTRW and MOVQ2DQ constructors.

e.g.,

* 0fc50000 (mod=0b00), 0fc54000 (mod=0b01), 0fc58000 (mod=0b10):
    - Hardware Reference (AMD CPU & Intel CPU): #UD (Invalid Opcode Exception)
    - `x86:LE:64:default` (Existing): "PEXTRW EAX, MM0, 0x0"
    - `x86:LE:64:default` (This patch): (Invalid)

* 0fc5c000 (mod=0b11) with MM0=1
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=1 }
    - `x86:LE:64:default` (Unchanged): "PEXTRW EAX, MM0, 0x0" { RAX=1 }

* f30fd600 (mod=0b00), f30fd640 (mod=0b01), f30fd680 (mod=0b10):
    - Hardware Reference (AMD CPU & Intel CPU): #UD (Invalid Opcode Exception)
    - `x86:LE:64:default` (Existing): "MOVQ2DQ XMM0, MM0"
    - `x86:LE:64:default` (This patch): (Invalid)