### PR TITLE
x86: Add missing reg_opcode constraint to lockable INC

### DIFF
--- a/Ghidra/Processors/x86/data/languages/lockable.sinc
+++ b/Ghidra/Processors/x86/data/languages/lockable.sinc
@@ -716,7 +716,7 @@
 }
 @endif
 
-:INC^lockx  spec_m8	is vexMode=0 & lockx & unlock & byte=0xfe; spec_m8 ...				
+:INC^lockx  spec_m8	is vexMode=0 & lockx & unlock & byte=0xfe; spec_m8 & reg_opcode=0 ...
 {
     build lockx;
     build spec_m8;
@@ -726,7 +726,7 @@
     build unlock; 
 }
 
-:INC^lockx spec_m16	is vexMode=0 & lockx & unlock & opsize=0 & byte=0xff; spec_m16 ...	
+:INC^lockx spec_m16	is vexMode=0 & lockx & unlock & opsize=0 & byte=0xff; spec_m16 & reg_opcode=0 ...
 {
     build lockx;
     build spec_m16;
@@ -736,7 +736,7 @@
     build unlock; 
 }
 
-:INC^lockx spec_m32	is vexMode=0 & lockx & unlock & opsize=1 & byte=0xff; spec_m32 ...	
+:INC^lockx spec_m32	is vexMode=0 & lockx & unlock & opsize=1 & byte=0xff; spec_m32 & reg_opcode=0 ...
 {
     build lockx;
     build spec_m32;
@@ -747,7 +747,7 @@
 }
 
 @ifdef IA64
-:INC^lockx spec_m64	is $(LONGMODE_ON) & vexMode=0 & lockx & unlock & opsize=2 & byte=0xff; spec_m64 ... 
+:INC^lockx spec_m64	is $(LONGMODE_ON) & vexMode=0 & lockx & unlock & opsize=2 & byte=0xff; spec_m64 & reg_opcode=0 ...
 {
     build lockx;
     build spec_m64;


### PR DESCRIPTION
The `INC` encoding is `FE /0` meaning that a `reg_opcode=0` constraint is needed in SLEIGH. This is missing from the memory variant (in `lockable.sinc`), which causes undefined `FE xx` instructions to be decoded as `INC`. 

(Without this constraint, the constructors technically overlap with the `DEC` instruction, however, since the `DEC` instruction has the correct constraints it ends up getting matched first).

e.g.,

* fe3f
    - Hardware Reference (AMD CPU & Intel CPU): #UD (Invalid Opcode Exception)
    - `x86:LE:64:default` (Existing): "INC byte ptr [RDI]"
    - `x86:LE:64:default` (This patch): (Invalid)
