### PR TITLE
x86: Zero upper bits of 64-bit registers for XCHG and CMPXCHG8B without REX prefix

### DIFF
--- a/Ghidra/Processors/x86/data/languages/lockable.sinc
+++ b/Ghidra/Processors/x86/data/languages/lockable.sinc
@@ -643,14 +643,16 @@
 }
 @endif
 
-:CMPXCHG8B^lockx  m64        is vexMode=0 & lockx & unlock & byte=0xf; byte=0xc7; ( mod != 0b11 & reg_opcode=1 ) ... & m64 
+:CMPXCHG8B^lockx  m64        is vexMode=0 & lockx & unlock & byte=0xf; byte=0xc7; ( mod != 0b11 & reg_opcode=1 ) ... & m64 & check_EAX_dest & check_EDX_dest
 {
     build lockx;
     local dest = m64;
     ZF = ((zext(EDX) << 32) | zext(EAX)) == dest;
     if (ZF == 1) goto <equal>;
     EDX = dest(4);
+    build check_EDX_dest;
     EAX = dest:4;
+    build check_EAX_dest;
     goto <done>;
 <equal>
     m64 = (zext(ECX) << 32) | zext(EBX);
@@ -1245,7 +1247,7 @@
    UNLOCK();
 }
 
-:XCHG^xacq_xrel_prefx^alwaysLock  m32,Reg32   is vexMode=0 & xacq_xrel_prefx & alwaysLock & opsize=1 & byte=0x87; m32 & Reg32 ...        
+:XCHG^xacq_xrel_prefx^alwaysLock  m32,Reg32   is vexMode=0 & xacq_xrel_prefx & alwaysLock & opsize=1 & byte=0x87; m32 & Reg32 ... & check_Reg32_dest ...
 { 
   build xacq_xrel_prefx;
   build alwaysLock;


### PR DESCRIPTION
The `CMPXCHG8B` and `XCHG mem` constructors (with `opsize=1`) are missing `check_Reg` constructors to zero the upper 32-bits when the destination registers are 64-bit.

e.g.

* 0fc70c2500000000 `CMPXCHG8B qword ptr [0x0]` with RAX=0xaaaaaaaaaaaaaaaa, RDX=0xdddddddddddddddd, mem[0x0]=0011223344556677
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0x00000000_33221100, RDX=0x00000000_77665544 }
    - `x86:LE:64:default` (Existing): "CMPXCHG8B qword ptr [0x0]" { RAX=0xaaaaaaaa_33221100, RDX=0xdddddddd_77665544 }
    - `x86:LE:64:default` (This patch): "CMPXCHG8B qword ptr [0x0]" { RAX=0x00000000_33221100, RDX=0x00000000_77665544 }

* 8701 `XCHG dword ptr [RCX],EAX` with RAX=0xaaaaaaaaaaaaaaaa, RCX=0, mem[0x0]=00112233
    - Hardware Reference (AMD CPU & Intel CPU): { RAX=0x00000000_33221100 }
    - `x86:LE:64:default` (Existing): XCHG dword ptr [RCX],EAX" { RAX=0xaaaaaaaa_33221100 }
    - `x86:LE:64:default` (This patch): XCHG dword ptr [RCX],EAX" { RAX=0x00000000_33221100 }

(Note: this is already handled correctly in the `XCHG reg,reg` form).