### PR TITLE
Add ARM32 coprocessor symbolic names for decompilation view (for mcr,mrc,mcrr,mrrc instructions)

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -110,8 +110,9 @@ define token instrThumb (16)
   thcond=(8,11)
   thcpn=(8,11)
   thcop=(8,10)
-  thopcode1=(4,7)
+  thopcode1_rr=(4,7)
   thop1=(4,6)
+  thopcode1_r=(5,7)
   thopcode2=(5,7)
   thop2=(7,7)
   thopcode3=(0,5)
@@ -1628,20 +1629,20 @@ bxns: "ns" is thc0002=0b100 { }
 @if defined(VERSION_6T2) || defined(VERSION_7)
 
 @ifndef CDE
-:cdp^ItCond thcpn,thopcode1,thCRd,thCRn,thCRm,thopcode2 is TMode=1 & ItCond & op8=0xee & thopcode1 & thCRn; thCRd & thcpn & thopcode2 & thc0404=0 & thCRm
+:cdp^ItCond thcpn,thopcode1_rr,thCRd,thCRn,thCRm,thopcode2 is TMode=1 & ItCond & op8=0xee & thopcode1_rr & thCRn; thCRd & thcpn & thopcode2 & thc0404=0 & thCRm
 {
   build ItCond;
   t_cpn:4 = thcpn;
-  t_op1:4 = thopcode1;
+  t_op1:4 = thopcode1_rr;
   t_op2:4 = thopcode2;
   coprocessor_function(t_cpn,t_op1,t_op2,thCRd,thCRn,thCRm);
 }
 
-:cdp2^ItCond thcpn,thopcode1,thCRd,thCRn,thCRm,thopcode2 is TMode=1 & ItCond & op8=0xfe & thopcode1 & thCRn; thCRd & thcpn & thopcode2 & thc0404=0 & thCRm
+:cdp2^ItCond thcpn,thopcode1_rr,thCRd,thCRn,thCRm,thopcode2 is TMode=1 & ItCond & op8=0xfe & thopcode1_rr & thCRn; thCRd & thcpn & thopcode2 & thc0404=0 & thCRm
 {
   build ItCond;
   t_cpn:4 = thcpn;
-  t_op1:4 = thopcode1;
+  t_op1:4 = thopcode1_rr;
   t_op2:4 = thopcode2;
   coprocessor_function2(t_cpn,t_op1,t_op2,thCRd,thCRn,thCRm);
 }
@@ -2583,11 +2584,6032 @@ macro th_set_carry_for_lsr(op1,shift_count) {
 
 @endif # VERSION_6T2 || VERSION_7
 @ifndef CDE
-:mcr^ItCond thcpn,thc0507,Rt1215,thCRn,thCRm,thopcode2 is TMode=1 & ItCond & op8=0xee & thc0507 & thc0404=0 & thCRn; Rt1215 & thcpn & thopcode2 & thc0404=1 & thCRm
+
+mcrThumbOperands: thcpn,thopcode1_r,Rt1215,thCRn,thCRm,thopcode2 is thopcode1_r & thCRn; Rt1215 & thcpn & thopcode2 & thCRm {}
+mcrrThumbOperands: thcpn,thopcode1_rr,Rt1215,Rn0003,thCRm is Rn0003; Rt1215 & thcpn & thopcode1_rr & thCRm {}
+
+# ===== Start mrc
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDTRRXext();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDSCRint();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDCCINT();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDSCRext();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDTRTXext();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDTRRXint();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWFAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGOSECCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGVCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBVR7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBCR7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWVR7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGWCR7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDRAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGOSLAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGOSLSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGOSDLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGPRCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGBXVR7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDSAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDEVID2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDEVID1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGDEVID();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGCLAIMSET();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGCLAIMCLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DBGAUTHSTATUS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b111 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_JIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b111 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_JOSCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b111 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_JMCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_MIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TCMTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_MPIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_REVIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_PFR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_PFR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_DFR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_AFR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_MMFR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_MMFR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_MMFR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_MMFR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_ISAR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_ISAR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_ISAR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_ISAR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_ISAR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_ISAR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_MMFR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_ISAR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_PFR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_DFR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ID_MMFR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_SCTLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ACTLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CPACR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ACTLR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_SCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_SDER();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_NSACR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TRFCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_SDCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0011; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DACR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_PMR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DFSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_IFSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ADFSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AIFSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERRIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERRSELR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXFR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXCTLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXSTATUS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXADDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXFR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXCTLR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXADDR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ERXMISC7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DFAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_IFAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICIALLUIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_BPIALLIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CFPRCTX();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DVPRCTX();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CPPRCTX();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICIALLU();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICIMVAU();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CP15ISB();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_BPIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_BPIMVA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCIMVAC();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCISW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1CPR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1CPW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1CUR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1CUW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS12NSOPR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS12NSOPW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS12NSOUR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS12NSOUW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1CPRP();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1CPWP();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCCMVAC();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCCSW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CP15DSB();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CP15DMB();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCCMVAU();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCCIMVAC();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCCISW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIALLIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIASIDIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAAIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVALIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAALIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ITLBIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ITLBIMVA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ITLBIASID();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DTLBIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DTLBIMVA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DTLBIASID();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIASID();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAAL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCNTENSET();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCNTENCLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMOVSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMSWINC();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMSELR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCEID0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCEID1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCCNTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMXEVTYPER();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMXEVCNTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMUSERENR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMINTENSET();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMINTENCLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMOVSSET();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCEID2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCEID3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMMIR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMAIR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMAIR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_VBAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_RMR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ISR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DISR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_IAR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_EOIR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_HPPIR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_BPR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_AP0R0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_AP0R1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_AP1R0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_AP1R1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_DIR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_RPR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_IAR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_EOIR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_HPPIR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_BPR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_CTLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_SRE();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_IGRPEN0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_IGRPEN1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_FCSEIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CONTEXTIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TPIDRURW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TPIDRURO();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TPIDRPRW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMCFGR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMCGCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMUSERENR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMCNTENCLR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMCNTENSET0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMCNTENCLR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMCNTENSET1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER00();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER01();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER02();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER03();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER04();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER05();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER06();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER07();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER10();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER11();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER12();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER13();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER14();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER15();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER16();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AMEVTYPER17();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTFRQ();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTKCTL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTP_TVAL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTP_CTL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTV_TVAL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTV_CTL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR8();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR9();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR10();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR11();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR12();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR13();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR14();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVCNTR15();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMCCFILTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER8();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER9();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER10();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER11();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER12();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER13();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER14();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PMEVTYPER15();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CCSIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CLIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CCSIDR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_AIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b010 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CSSELR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b011 & thCRn=0b0100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DSPSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b011 & thCRn=0b0100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_VPIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_VMPIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HSCTLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HACTLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HACTLR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HDCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HCPTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HSTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HCR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HACR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HTRFCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HTCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_VTCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HADFSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HAIFSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_VDFSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HDFAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HIFAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HPFAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1HR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ATS1HW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIIPAS2IS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIIPAS2LIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIALLHIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAHIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIALLNSNHIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVALHIS();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIIPAS2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIIPAS2L();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIALLH();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVAH();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIALLNSNH();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TLBIMVALH();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HMAIR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HMAIR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HAMAIR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HAMAIR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HVBAR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HRMR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_VDISR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_AP0R0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_AP0R1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_AP1R0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_AP1R1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_HSRE();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_HCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_VTR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_MISR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_EISR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_ELRSR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_VMCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LR7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC2();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC3();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC4();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC5();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC6();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICH_LRC7();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HTPIDR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTHCTL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTHP_TVAL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b100 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CNTHP_CTL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b110 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_MCTLR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b110 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_MSRE();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b110 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICC_MGRPEN1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TTBR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TTBR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TTBCR();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TTBR0H();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_TTBR1H();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_HTTBRH();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_VTTBRH();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_WFI();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_ICISW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CIMVA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CISW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCCALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CCALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CCSW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_PFIMVA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_DCCIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CCIALL();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CCIMVA();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_CCISW();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_MAIR0();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_MAIR1();
+}
+
+
+:mrc^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=1 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom_MVBAR();
+}
+
+# ===== End mrc
+# ===== Start mcr
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDTRRXext(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDSCRint(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDCCINT(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDSCRext(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDTRTXext(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDTRTXint(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWFAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGOSECCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGVCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBVR7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b101 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBCR7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWVR7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGWCR7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDRAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGOSLAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGOSLSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGOSDLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b100 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGPRCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGBXVR7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDSAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDEVID2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDEVID1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b111 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGDEVID(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGCLAIMSET(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGCLAIMCLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DBGAUTHSTATUS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b111 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_JIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b111 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_JOSCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b111 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1110 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_JMCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_MIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TCMTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_MPIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_REVIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_PFR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_PFR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_DFR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_AFR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_MMFR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_MMFR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_MMFR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_MMFR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_ISAR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_ISAR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_ISAR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_ISAR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_ISAR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_ISAR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_MMFR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_ISAR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_PFR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_DFR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ID_MMFR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_SCTLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ACTLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CPACR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ACTLR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_SCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_SDER(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_NSACR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TRFCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_SDCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0011; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DACR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_PMR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DFSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_IFSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ADFSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AIFSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERRIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERRSELR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXFR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXCTLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXSTATUS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXADDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXFR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXCTLR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXADDR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ERXMISC7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DFAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_IFAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICIALLUIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_BPIALLIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CFPRCTX(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DVPRCTX(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CPPRCTX(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CP15ISB(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_BPIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_BPIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCISW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1CPR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1CPW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1CUR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1CUW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS12NSOPR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS12NSOPW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS12NSOUR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS12NSOUW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1CPRP(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1CPWP(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCCSW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CP15DSB(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CP15DMB(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCCISW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIALLIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIASIDIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAAIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVALIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAALIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ITLBIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ITLBIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ITLBIASID(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DTLBIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DTLBIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DTLBIASID(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIASID(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAAL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCNTENSET(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCNTENCLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMOVSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMSWINC(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMSELR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCEID0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCEID1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCCNTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMXEVTYPER(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMXEVCNTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMUSERENR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMINTENSET(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMINTENCLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMOVSSET(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCEID2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCEID3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMMIR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMAIR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMAIR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_VBAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_RMR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ISR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DISR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_IAR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_EOIR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_HPPIR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_BPR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_AP0R0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_AP0R1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_AP1R0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_AP1R1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_DIR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_RPR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_IAR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_EOIR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_HPPIR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_BPR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_CTLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_SRE(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_IGRPEN0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_IGRPEN1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_FCSEIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CONTEXTIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TPIDRURW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TPIDRURO(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TPIDRPRW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMCFGR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMCGCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMUSERENR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMCNTENCLR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMCNTENSET0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMCNTENCLR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMCNTENSET1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER00(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER01(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER02(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER03(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER04(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER05(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER06(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER07(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER10(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER11(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER12(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER13(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER14(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER15(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER16(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AMEVTYPER17(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTFRQ(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTKCTL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTP_TVAL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTP_CTL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTV_TVAL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTV_CTL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR8(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR9(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR10(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR11(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR12(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR13(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR14(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVCNTR15(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMCCFILTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER8(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER9(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER10(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER11(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER12(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER13(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER14(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PMEVTYPER15(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCSIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CLIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCSIDR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b001 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_AIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b010 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CSSELR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b011 & thCRn=0b0100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DSPSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b011 & thCRn=0b0100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_VPIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_VMPIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HSCTLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HACTLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HACTLR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HDCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HCPTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HSTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HCR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HACR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0001; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HTRFCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HTCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_VTCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HADFSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HAIFSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_VDFSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HDFAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HIFAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HPFAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1HR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ATS1HW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIIPAS2IS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIIPAS2LIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIALLHIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAHIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIALLNSNHIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVALHIS(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIIPAS2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIIPAS2L(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIALLH(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVAH(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIALLNSNH(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1000; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TLBIMVALH(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HMAIR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HMAIR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HAMAIR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HAMAIR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HVBAR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HRMR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_VDISR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_AP0R0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_AP0R1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_AP1R0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_AP1R1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_HSRE(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_HCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_VTR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_MISR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_EISR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_ELRSR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_VMCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LR7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC2(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b011 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC3(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC4(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC5(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC6(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICH_LRC7(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1101; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HTPIDR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0001) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTHCTL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTHP_TVAL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b100 & thCRn=0b1110; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CNTHP_CTL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b110 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_MCTLR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b110 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b101 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_MSRE(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b110 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b111 & thCRm=0b1100) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICC_MGRPEN1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TTBR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TTBR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TTBCR(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TTBR0H(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_TTBR1H(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_HTTBRH(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b110 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_VTTBRH(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b100 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_WFI(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_ICISW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b0111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CISW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCCALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCCMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1011) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCSW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1101) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_PFIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCCIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1110) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_DCCIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCIALL(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCIMVA(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b0111; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b010 & thCRm=0b1111) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_CCISW(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b000 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_MAIR0(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1010; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0010) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_MAIR1(Rt1215);
+}
+
+
+:mcr^ItCond mcrThumbOperands is (TMode=1 & ItCond & op8=0xee & thc0404=0 & thopcode1_r=0b000 & thCRn=0b1100; thc0404=1 & Rt1215 & thcpn=0b1111 & thopcode2=0b001 & thCRm=0b0000) & mcrThumbOperands
+{
+  build ItCond;
+  coproc_moveto_MVBAR(Rt1215);
+}
+
+# ===== End mcr
+
+# ===== Start mrrc
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1110 & thopcode1_rr=0b0000 & thCRm=0b0001) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_DBGDRAR();
+  Rn0003 = coproc_movefrom2_upper_DBGDRAR();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1110 & thopcode1_rr=0b0000 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_DBGDSAR();
+  Rn0003 = coproc_movefrom2_upper_DBGDSAR();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR00();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR00();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR01();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR01();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR02();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR02();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0011 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR03();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR03();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR04();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR04();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0101 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR05();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR05();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR06();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR06();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0111 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR07();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR07();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_TTBR0();
+  Rn0003 = coproc_movefrom2_upper_TTBR0();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_TTBR1();
+  Rn0003 = coproc_movefrom2_upper_TTBR1();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_HTTBR();
+  Rn0003 = coproc_movefrom2_upper_HTTBR();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_VTTBR();
+  Rn0003 = coproc_movefrom2_upper_VTTBR();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR10();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR10();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR11();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR11();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR12();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR12();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0011 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR13();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR13();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR14();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR14();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0101 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR15();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR15();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR16();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR16();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0111 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_AMEVCNTR17();
+  Rn0003 = coproc_movefrom2_upper_AMEVCNTR17();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0111) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_PAR();
+  Rn0003 = coproc_movefrom2_upper_PAR();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b1001) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_PMCCNTR();
+  Rn0003 = coproc_movefrom2_upper_PMCCNTR();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b1100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_ICC_SGI1R();
+  Rn0003 = coproc_movefrom2_upper_ICC_SGI1R();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b1100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_ICC_ASGI1R();
+  Rn0003 = coproc_movefrom2_upper_ICC_ASGI1R();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b1100) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_ICC_SGI0R();
+  Rn0003 = coproc_movefrom2_upper_ICC_SGI0R();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTPCT();
+  Rn0003 = coproc_movefrom2_upper_CNTPCT();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTVCT();
+  Rn0003 = coproc_movefrom2_upper_CNTVCT();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTP_CVAL();
+  Rn0003 = coproc_movefrom2_upper_CNTP_CVAL();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0011 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTV_CVAL();
+  Rn0003 = coproc_movefrom2_upper_CNTV_CVAL();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTVOFF();
+  Rn0003 = coproc_movefrom2_upper_CNTVOFF();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTHP_CVAL();
+  Rn0003 = coproc_movefrom2_upper_CNTHP_CVAL();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b1000 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTPCTSS();
+  Rn0003 = coproc_movefrom2_upper_CNTPCTSS();
+}
+
+
+:mrrc^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b1001 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  Rt1215 = coproc_movefrom2_lower_CNTVCTSS();
+  Rn0003 = coproc_movefrom2_upper_CNTVCTSS();
+}
+
+# ===== End mrrc
+# ===== Start mcrr
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1110 & thopcode1_rr=0b0000 & thCRm=0b0001) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_DBGDRAR(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1110 & thopcode1_rr=0b0000 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_DBGDSAR(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR00(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR01(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR02(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0011 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR03(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR04(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0101 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR05(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR06(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0111 & thCRm=0b0000) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR07(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_TTBR0(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_TTBR1(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_HTTBR(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b0010) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_VTTBR(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR10(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR11(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR12(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0011 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR13(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR14(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0101 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR15(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR16(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0111 & thCRm=0b0100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_AMEVCNTR17(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b0111) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_PAR(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b1001) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_PMCCNTR(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b1100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_ICC_SGI1R(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b1100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_ICC_ASGI1R(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b1100) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_ICC_SGI0R(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0000 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTPCT(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0001 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTVCT(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0010 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTP_CVAL(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0011 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTV_CVAL(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0100 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTVOFF(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b0110 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTHP_CVAL(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b1000 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTPCTSS(t_val);
+}
+
+
+:mcrr^ItCond mcrrThumbOperands is (TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn=0b1111 & thopcode1_rr=0b1001 & thCRm=0b1110) & mcrrThumbOperands
+{
+  build ItCond;
+  t_val:8 = zext(Rt1215) | (zext(Rn0003)<<32);
+  coproc_moveto2_CNTVCTSS(t_val);
+}
+
+# ===== End mcrr
+
+
+:mcr^ItCond thcpn,thopcode1_r,Rt1215,thCRn,thCRm,thopcode2 is TMode=1 & ItCond & op8=0xee & thopcode1_r & thc0404=0 & thCRn; Rt1215 & thcpn & thopcode2 & thc0404=1 & thCRm
 {
   build ItCond;
   t_cpn:4 = thcpn;
-  t_op1:4 = thc0507;
+  t_op1:4 = thopcode1_r;
   t_op2:4 = thopcode2;
   coprocessor_moveto(t_cpn,t_op1,t_op2,Rt1215,thCRn,thCRm);
 }
@@ -2601,19 +8623,19 @@ macro th_set_carry_for_lsr(op1,shift_count) {
   coprocessor_moveto(t_cpn,t_op1,t_op2,Rt1215,thCRn,thCRm);
 }
 
-:mcrr^ItCond thcpn,thopcode1,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn & thopcode1 & thCRm
+:mcrr^ItCond thcpn,thopcode1_rr,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xec4 & Rn0003; Rt1215 & thcpn & thopcode1_rr & thCRm
 {
   build ItCond;
   t_cpn:4 = thcpn;
-  t_op:4 = thopcode1;
+  t_op:4 = thopcode1_rr;
   coprocessor_moveto2(t_cpn,t_op,Rt1215,Rn0003,thCRm);
 }
 
-:mcrr^ItCond thcpn,thopcode1,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xfc4 & Rn0003; Rt1215 & thcpn & thopcode1 & thCRm
+:mcrr^ItCond thcpn,thopcode1_rr,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xfc4 & Rn0003; Rt1215 & thcpn & thopcode1_rr & thCRm
 {
   build ItCond;
   t_cpn:4 = thcpn;
-  t_op:4 = thopcode1;
+  t_op:4 = thopcode1_rr;
   coprocessor_moveto2(t_cpn,t_op,Rt1215,Rn0003,thCRm);
 }
 @endif # CDE
@@ -2730,20 +8752,20 @@ macro th_set_carry_for_lsr(op1,shift_count) {
   writeAPSR_nzcv(tmp);
 }
 
-:mrrc^ItCond thcpn,thopcode1,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn & thopcode1 & thCRm
+:mrrc^ItCond thcpn,thopcode1_rr,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xec5 & Rn0003; Rt1215 & thcpn & thopcode1_rr & thCRm
 {
   build ItCond;
   t_cpn:4 = thcpn;
-  t_op:4 = thopcode1;
+  t_op:4 = thopcode1_rr;
   Rt1215 = coprocessor_movefromRt(t_cpn,t_op,thCRm);
   Rn0003 = coprocessor_movefromRt2(t_cpn,t_op,thCRm);
 }
 
-:mrrc2^ItCond thcpn,thopcode1,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xfc5 & Rn0003; Rt1215 & thcpn & thopcode1 & thCRm
+:mrrc2^ItCond thcpn,thopcode1_rr,Rt1215,Rn0003,thCRm   is TMode=1 & ItCond & op4=0xfc5 & Rn0003; Rt1215 & thcpn & thopcode1_rr & thCRm
 {
   build ItCond;
   t_cpn:4 = thcpn;
-  t_op:4 = thopcode1;
+  t_op:4 = thopcode1_rr;
   Rt1215 = coprocessor_movefromRt(t_cpn,t_op,thCRm);
   Rn0003 = coprocessor_movefromRt2(t_cpn,t_op,thCRm);
 }

--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -701,113 +701,897 @@ shift1: "#"^value 		is I25=1 & immed & rotate
 }
 
 ####################
-define pcodeop coproc_moveto_Main_ID;
-define pcodeop coproc_moveto_Cache_Type;
-define pcodeop coproc_moveto_TCM_Status;
-define pcodeop coproc_moveto_TLB_Type;
-define pcodeop coproc_moveto_Control;
-define pcodeop coproc_moveto_Auxiliary_Control;
-define pcodeop coproc_moveto_Coprocessor_Access_Control;
-define pcodeop coproc_moveto_Secure_Configuration;
-define pcodeop coproc_moveto_Secure_Debug_Enable;
-define pcodeop coproc_moveto_NonSecure_Access_Control;
-define pcodeop coproc_moveto_Translation_table_base_0;
-define pcodeop coproc_moveto_Translation_table_base_1;
-define pcodeop coproc_moveto_Translation_table_control;
-define pcodeop coproc_moveto_Domain_Access_Control;
-define pcodeop coproc_moveto_Data_Fault_Status;
-define pcodeop coproc_moveto_Instruction_Fault_Status;
-define pcodeop coproc_moveto_Instruction_Fault_Address;
-define pcodeop coproc_moveto_Fault_Address;
-define pcodeop coproc_moveto_Instruction_Fault;
-define pcodeop coproc_moveto_Wait_for_interrupt;
-define pcodeop coproc_moveto_Invalidate_Entire_Instruction;
-define pcodeop coproc_moveto_Invalidate_Instruction_Cache_by_MVA;
-define pcodeop coproc_moveto_Flush_Prefetch_Buffer;
-define pcodeop coproc_moveto_Invalidate_Entire_Data_cache;
-define pcodeop coproc_moveto_Invalidate_Entire_Data_by_MVA;
-define pcodeop coproc_moveto_Invalidate_Entire_Data_by_Index;
-define pcodeop coproc_moveto_Clean_Entire_Data_Cache;
-define pcodeop coproc_moveto_Clean_Data_Cache_by_MVA;
-define pcodeop coproc_moveto_Clean_Data_Cache_by_Index;
-define pcodeop coproc_moveto_Data_Synchronization;
-define pcodeop coproc_moveto_Data_Memory_Barrier;
-define pcodeop coproc_moveto_Invalidate_Entire_Data_Cache;
-define pcodeop coproc_moveto_Invalidate_Data_Cache_by_MVA;
-define pcodeop coproc_moveto_Invalidate_unified_TLB_unlocked;
-define pcodeop coproc_moveto_Invalidate_unified_TLB_by_MVA;
-define pcodeop coproc_moveto_Invalidate_unified_TLB_by_ASID_match;
-define pcodeop coproc_moveto_FCSE_PID;
-define pcodeop coproc_moveto_Context_ID;
-define pcodeop coproc_moveto_User_RW_Thread_and_Process_ID;
-define pcodeop coproc_moveto_User_R_Thread_and_Process_ID;
-define pcodeop coproc_moveto_Privileged_only_Thread_and_Process_ID;
-define pcodeop coproc_moveto_Peripherial_Port_Memory_Remap;
-define pcodeop coproc_moveto_Feature_Identification;
-define pcodeop coproc_moveto_ISA_Feature_Identification;
-define pcodeop coproc_moveto_Peripheral_Port_Memory_Remap;
-define pcodeop coproc_moveto_Control_registers;
-define pcodeop coproc_moveto_Security_world_control;
-define pcodeop coproc_moveto_Translation_table;
-define pcodeop coproc_moveto_Instruction_cache;
-define pcodeop coproc_moveto_Data_cache_operations;
-define pcodeop coproc_moveto_Identification_registers;
-define pcodeop coproc_moveto_Peripheral_System;
 
-define pcodeop coproc_movefrom_Main_ID;
-define pcodeop coproc_movefrom_Cache_Type;
-define pcodeop coproc_movefrom_TCM_Status;
-define pcodeop coproc_movefrom_TLB_Type;
-define pcodeop coproc_movefrom_Control;
-define pcodeop coproc_movefrom_Auxiliary_Control;
-define pcodeop coproc_movefrom_Coprocessor_Access_Control;
-define pcodeop coproc_movefrom_Secure_Configuration;
-define pcodeop coproc_movefrom_Secure_Debug_Enable;
-define pcodeop coproc_movefrom_NonSecure_Access_Control;
-define pcodeop coproc_movefrom_Translation_table_base_0;
-define pcodeop coproc_movefrom_Translation_table_base_1;
-define pcodeop coproc_movefrom_Translation_table_control;
-define pcodeop coproc_movefrom_Domain_Access_Control;
-define pcodeop coproc_movefrom_Data_Fault_Status;
-define pcodeop coproc_movefrom_Instruction_Fault;
-define pcodeop coproc_movefrom_Fault_Address;
-define pcodeop coproc_movefrom_Instruction_Fault_Status;
-define pcodeop coproc_movefrom_Instruction_Fault_Address;
-define pcodeop coproc_movefrom_Wait_for_interrupt;
-define pcodeop coproc_movefrom_Invalidate_Entire_Instruction;
-define pcodeop coproc_movefrom_Invalidate_Instruction_Cache_by_MVA;
-define pcodeop coproc_movefrom_Flush_Prefetch_Buffer;
-define pcodeop coproc_movefrom_Invalidate_Entire_Data_cache;
-define pcodeop coproc_movefrom_Invalidate_Entire_Data_by_MVA;
-define pcodeop coproc_movefrom_Invalidate_Entire_Data_by_Index;
-define pcodeop coproc_movefrom_Clean_Entire_Data_Cache;
-define pcodeop coproc_movefrom_Clean_Data_Cache_by_MVA;
-define pcodeop coproc_movefrom_Clean_Data_Cache_by_Index;
-define pcodeop coproc_movefrom_Data_Synchronization;
-define pcodeop coproc_movefrom_Data_Memory_Barrier;
-define pcodeop coproc_movefrom_Invalidate_Entire_Data_Cache;
-define pcodeop coproc_movefrom_Invalidate_Data_Cache_by_MVA;
-define pcodeop coproc_movefrom_Invalidate_unified_TLB_unlocked;
-define pcodeop coproc_movefrom_Invalidate_unified_TLB_by_MVA;
-define pcodeop coproc_movefrom_Invalidate_unified_TLB_by_ASID_match;
-define pcodeop coproc_movefrom_FCSE_PID;
-define pcodeop coproc_movefrom_Context_ID;
-define pcodeop coproc_movefrom_User_RW_Thread_and_Process_ID;
-define pcodeop coproc_movefrom_User_R_Thread_and_Process_ID;
-define pcodeop coproc_movefrom_Privileged_only_Thread_and_Process_ID;
-define pcodeop coproc_movefrom_Peripherial_Port_Memory_Remap;
-define pcodeop coproc_movefrom_Feature_Identification;
-define pcodeop coproc_movefrom_ISA_Feature_Identification;
-define pcodeop coproc_movefrom_Peripheral_Port_Memory_Remap;
-define pcodeop coproc_movefrom_Control_registers;
-define pcodeop coproc_movefrom_Security_world_control;
-define pcodeop coproc_movefrom_Translation_table;
-define pcodeop coproc_movefrom_Instruction_cache;
-define pcodeop coproc_movefrom_Data_cache_operations;
-define pcodeop coproc_movefrom_Identification_registers;
-define pcodeop coproc_movefrom_Peripheral_System;
+#put mcr defines here
+
+define pcodeop coproc_movefrom_DBGDIDR;
+define pcodeop coproc_movefrom_DBGDTRRXext;
+define pcodeop coproc_movefrom_DBGDSCRint;
+define pcodeop coproc_movefrom_DBGDCCINT;
+define pcodeop coproc_movefrom_DBGDSCRext;
+define pcodeop coproc_movefrom_DBGDTRTXext;
+define pcodeop coproc_movefrom_DBGDTRRXint;
+define pcodeop coproc_movefrom_DBGWFAR;
+define pcodeop coproc_movefrom_DBGOSECCR;
+define pcodeop coproc_movefrom_DBGVCR;
+define pcodeop coproc_movefrom_DBGBVR0;
+define pcodeop coproc_movefrom_DBGBVR1;
+define pcodeop coproc_movefrom_DBGBVR2;
+define pcodeop coproc_movefrom_DBGBVR3;
+define pcodeop coproc_movefrom_DBGBVR4;
+define pcodeop coproc_movefrom_DBGBVR5;
+define pcodeop coproc_movefrom_DBGBVR6;
+define pcodeop coproc_movefrom_DBGBVR7;
+define pcodeop coproc_movefrom_DBGBCR0;
+define pcodeop coproc_movefrom_DBGBCR1;
+define pcodeop coproc_movefrom_DBGBCR2;
+define pcodeop coproc_movefrom_DBGBCR3;
+define pcodeop coproc_movefrom_DBGBCR4;
+define pcodeop coproc_movefrom_DBGBCR5;
+define pcodeop coproc_movefrom_DBGBCR6;
+define pcodeop coproc_movefrom_DBGBCR7;
+define pcodeop coproc_movefrom_DBGWVR0;
+define pcodeop coproc_movefrom_DBGWVR1;
+define pcodeop coproc_movefrom_DBGWVR2;
+define pcodeop coproc_movefrom_DBGWVR3;
+define pcodeop coproc_movefrom_DBGWVR4;
+define pcodeop coproc_movefrom_DBGWVR5;
+define pcodeop coproc_movefrom_DBGWVR6;
+define pcodeop coproc_movefrom_DBGWVR7;
+define pcodeop coproc_movefrom_DBGWCR0;
+define pcodeop coproc_movefrom_DBGWCR1;
+define pcodeop coproc_movefrom_DBGWCR2;
+define pcodeop coproc_movefrom_DBGWCR3;
+define pcodeop coproc_movefrom_DBGWCR4;
+define pcodeop coproc_movefrom_DBGWCR5;
+define pcodeop coproc_movefrom_DBGWCR6;
+define pcodeop coproc_movefrom_DBGWCR7;
+define pcodeop coproc_movefrom_DBGDRAR;
+define pcodeop coproc_movefrom_DBGOSLAR;
+define pcodeop coproc_movefrom_DBGOSLSR;
+define pcodeop coproc_movefrom_DBGOSDLR;
+define pcodeop coproc_movefrom_DBGPRCR;
+define pcodeop coproc_movefrom_DBGBXVR0;
+define pcodeop coproc_movefrom_DBGBXVR1;
+define pcodeop coproc_movefrom_DBGBXVR2;
+define pcodeop coproc_movefrom_DBGBXVR3;
+define pcodeop coproc_movefrom_DBGBXVR4;
+define pcodeop coproc_movefrom_DBGBXVR5;
+define pcodeop coproc_movefrom_DBGBXVR6;
+define pcodeop coproc_movefrom_DBGBXVR7;
+define pcodeop coproc_movefrom_DBGDSAR;
+define pcodeop coproc_movefrom_DBGDEVID2;
+define pcodeop coproc_movefrom_DBGDEVID1;
+define pcodeop coproc_movefrom_DBGDEVID;
+define pcodeop coproc_movefrom_DBGCLAIMSET;
+define pcodeop coproc_movefrom_DBGCLAIMCLR;
+define pcodeop coproc_movefrom_DBGAUTHSTATUS;
+define pcodeop coproc_movefrom_JIDR;
+define pcodeop coproc_movefrom_JOSCR;
+define pcodeop coproc_movefrom_JMCR;
+define pcodeop coproc_movefrom_MIDR;
+define pcodeop coproc_movefrom_CTR;
+define pcodeop coproc_movefrom_TCMTR;
+define pcodeop coproc_movefrom_TLBTR;
+define pcodeop coproc_movefrom_MPIDR;
+define pcodeop coproc_movefrom_REVIDR;
+define pcodeop coproc_movefrom_ID_PFR0;
+define pcodeop coproc_movefrom_ID_PFR1;
+define pcodeop coproc_movefrom_ID_DFR0;
+define pcodeop coproc_movefrom_ID_AFR0;
+define pcodeop coproc_movefrom_ID_MMFR0;
+define pcodeop coproc_movefrom_ID_MMFR1;
+define pcodeop coproc_movefrom_ID_MMFR2;
+define pcodeop coproc_movefrom_ID_MMFR3;
+define pcodeop coproc_movefrom_ID_ISAR0;
+define pcodeop coproc_movefrom_ID_ISAR1;
+define pcodeop coproc_movefrom_ID_ISAR2;
+define pcodeop coproc_movefrom_ID_ISAR3;
+define pcodeop coproc_movefrom_ID_ISAR4;
+define pcodeop coproc_movefrom_ID_ISAR5;
+define pcodeop coproc_movefrom_ID_MMFR4;
+define pcodeop coproc_movefrom_ID_ISAR6;
+define pcodeop coproc_movefrom_ID_PFR2;
+define pcodeop coproc_movefrom_ID_DFR1;
+define pcodeop coproc_movefrom_ID_MMFR5;
+define pcodeop coproc_movefrom_SCTLR;
+define pcodeop coproc_movefrom_ACTLR;
+define pcodeop coproc_movefrom_CPACR;
+define pcodeop coproc_movefrom_ACTLR2;
+define pcodeop coproc_movefrom_SCR;
+define pcodeop coproc_movefrom_SDER;
+define pcodeop coproc_movefrom_NSACR;
+define pcodeop coproc_movefrom_TRFCR;
+define pcodeop coproc_movefrom_SDCR;
+define pcodeop coproc_movefrom_DACR;
+define pcodeop coproc_movefrom_ICC_PMR;
+define pcodeop coproc_movefrom_DFSR;
+define pcodeop coproc_movefrom_IFSR;
+define pcodeop coproc_movefrom_ADFSR;
+define pcodeop coproc_movefrom_AIFSR;
+define pcodeop coproc_movefrom_ERRIDR;
+define pcodeop coproc_movefrom_ERRSELR;
+define pcodeop coproc_movefrom_ERXFR;
+define pcodeop coproc_movefrom_ERXCTLR;
+define pcodeop coproc_movefrom_ERXSTATUS;
+define pcodeop coproc_movefrom_ERXADDR;
+define pcodeop coproc_movefrom_ERXFR2;
+define pcodeop coproc_movefrom_ERXCTLR2;
+define pcodeop coproc_movefrom_ERXADDR2;
+define pcodeop coproc_movefrom_ERXMISC0;
+define pcodeop coproc_movefrom_ERXMISC1;
+define pcodeop coproc_movefrom_ERXMISC4;
+define pcodeop coproc_movefrom_ERXMISC5;
+define pcodeop coproc_movefrom_ERXMISC2;
+define pcodeop coproc_movefrom_ERXMISC3;
+define pcodeop coproc_movefrom_ERXMISC6;
+define pcodeop coproc_movefrom_ERXMISC7;
+define pcodeop coproc_movefrom_DFAR;
+define pcodeop coproc_movefrom_IFAR;
+define pcodeop coproc_movefrom_ICIALLUIS;
+define pcodeop coproc_movefrom_BPIALLIS;
+define pcodeop coproc_movefrom_CFPRCTX;
+define pcodeop coproc_movefrom_DVPRCTX;
+define pcodeop coproc_movefrom_CPPRCTX;
+define pcodeop coproc_movefrom_PAR;
+define pcodeop coproc_movefrom_ICIALLU;
+define pcodeop coproc_movefrom_ICIMVAU;
+define pcodeop coproc_movefrom_CP15ISB;
+define pcodeop coproc_movefrom_BPIALL;
+define pcodeop coproc_movefrom_BPIMVA;
+define pcodeop coproc_movefrom_DCIMVAC;
+define pcodeop coproc_movefrom_DCISW;
+define pcodeop coproc_movefrom_ATS1CPR;
+define pcodeop coproc_movefrom_ATS1CPW;
+define pcodeop coproc_movefrom_ATS1CUR;
+define pcodeop coproc_movefrom_ATS1CUW;
+define pcodeop coproc_movefrom_ATS12NSOPR;
+define pcodeop coproc_movefrom_ATS12NSOPW;
+define pcodeop coproc_movefrom_ATS12NSOUR;
+define pcodeop coproc_movefrom_ATS12NSOUW;
+define pcodeop coproc_movefrom_ATS1CPRP;
+define pcodeop coproc_movefrom_ATS1CPWP;
+define pcodeop coproc_movefrom_DCCMVAC;
+define pcodeop coproc_movefrom_DCCSW;
+define pcodeop coproc_movefrom_CP15DSB;
+define pcodeop coproc_movefrom_CP15DMB;
+define pcodeop coproc_movefrom_DCCMVAU;
+define pcodeop coproc_movefrom_DCCIMVAC;
+define pcodeop coproc_movefrom_DCCISW;
+define pcodeop coproc_movefrom_TLBIALLIS;
+define pcodeop coproc_movefrom_TLBIMVAIS;
+define pcodeop coproc_movefrom_TLBIASIDIS;
+define pcodeop coproc_movefrom_TLBIMVAAIS;
+define pcodeop coproc_movefrom_TLBIMVALIS;
+define pcodeop coproc_movefrom_TLBIMVAALIS;
+define pcodeop coproc_movefrom_ITLBIALL;
+define pcodeop coproc_movefrom_ITLBIMVA;
+define pcodeop coproc_movefrom_ITLBIASID;
+define pcodeop coproc_movefrom_DTLBIALL;
+define pcodeop coproc_movefrom_DTLBIMVA;
+define pcodeop coproc_movefrom_DTLBIASID;
+define pcodeop coproc_movefrom_TLBIALL;
+define pcodeop coproc_movefrom_TLBIMVA;
+define pcodeop coproc_movefrom_TLBIASID;
+define pcodeop coproc_movefrom_TLBIMVAA;
+define pcodeop coproc_movefrom_TLBIMVAL;
+define pcodeop coproc_movefrom_TLBIMVAAL;
+define pcodeop coproc_movefrom_PMCR;
+define pcodeop coproc_movefrom_PMCNTENSET;
+define pcodeop coproc_movefrom_PMCNTENCLR;
+define pcodeop coproc_movefrom_PMOVSR;
+define pcodeop coproc_movefrom_PMSWINC;
+define pcodeop coproc_movefrom_PMSELR;
+define pcodeop coproc_movefrom_PMCEID0;
+define pcodeop coproc_movefrom_PMCEID1;
+define pcodeop coproc_movefrom_PMCCNTR;
+define pcodeop coproc_movefrom_PMXEVTYPER;
+define pcodeop coproc_movefrom_PMXEVCNTR;
+define pcodeop coproc_movefrom_PMUSERENR;
+define pcodeop coproc_movefrom_PMINTENSET;
+define pcodeop coproc_movefrom_PMINTENCLR;
+define pcodeop coproc_movefrom_PMOVSSET;
+define pcodeop coproc_movefrom_PMCEID2;
+define pcodeop coproc_movefrom_PMCEID3;
+define pcodeop coproc_movefrom_PMMIR;
+define pcodeop coproc_movefrom_AMAIR0;
+define pcodeop coproc_movefrom_AMAIR1;
+define pcodeop coproc_movefrom_VBAR;
+define pcodeop coproc_movefrom_RMR;
+define pcodeop coproc_movefrom_ISR;
+define pcodeop coproc_movefrom_DISR;
+define pcodeop coproc_movefrom_ICC_IAR0;
+define pcodeop coproc_movefrom_ICC_EOIR0;
+define pcodeop coproc_movefrom_ICC_HPPIR0;
+define pcodeop coproc_movefrom_ICC_BPR0;
+define pcodeop coproc_movefrom_ICC_AP0R0;
+define pcodeop coproc_movefrom_ICC_AP0R1;
+define pcodeop coproc_movefrom_ICC_AP1R0;
+define pcodeop coproc_movefrom_ICC_AP1R1;
+define pcodeop coproc_movefrom_ICC_DIR;
+define pcodeop coproc_movefrom_ICC_RPR;
+define pcodeop coproc_movefrom_ICC_IAR1;
+define pcodeop coproc_movefrom_ICC_EOIR1;
+define pcodeop coproc_movefrom_ICC_HPPIR1;
+define pcodeop coproc_movefrom_ICC_BPR1;
+define pcodeop coproc_movefrom_ICC_CTLR;
+define pcodeop coproc_movefrom_ICC_SRE;
+define pcodeop coproc_movefrom_ICC_IGRPEN0;
+define pcodeop coproc_movefrom_ICC_IGRPEN1;
+define pcodeop coproc_movefrom_FCSEIDR;
+define pcodeop coproc_movefrom_CONTEXTIDR;
+define pcodeop coproc_movefrom_TPIDRURW;
+define pcodeop coproc_movefrom_TPIDRURO;
+define pcodeop coproc_movefrom_TPIDRPRW;
+define pcodeop coproc_movefrom_AMCR;
+define pcodeop coproc_movefrom_AMCFGR;
+define pcodeop coproc_movefrom_AMCGCR;
+define pcodeop coproc_movefrom_AMUSERENR;
+define pcodeop coproc_movefrom_AMCNTENCLR0;
+define pcodeop coproc_movefrom_AMCNTENSET0;
+define pcodeop coproc_movefrom_AMCNTENCLR1;
+define pcodeop coproc_movefrom_AMCNTENSET1;
+define pcodeop coproc_movefrom_AMEVTYPER00;
+define pcodeop coproc_movefrom_AMEVTYPER01;
+define pcodeop coproc_movefrom_AMEVTYPER02;
+define pcodeop coproc_movefrom_AMEVTYPER03;
+define pcodeop coproc_movefrom_AMEVTYPER04;
+define pcodeop coproc_movefrom_AMEVTYPER05;
+define pcodeop coproc_movefrom_AMEVTYPER06;
+define pcodeop coproc_movefrom_AMEVTYPER07;
+define pcodeop coproc_movefrom_AMEVTYPER10;
+define pcodeop coproc_movefrom_AMEVTYPER11;
+define pcodeop coproc_movefrom_AMEVTYPER12;
+define pcodeop coproc_movefrom_AMEVTYPER13;
+define pcodeop coproc_movefrom_AMEVTYPER14;
+define pcodeop coproc_movefrom_AMEVTYPER15;
+define pcodeop coproc_movefrom_AMEVTYPER16;
+define pcodeop coproc_movefrom_AMEVTYPER17;
+define pcodeop coproc_movefrom_CNTFRQ;
+define pcodeop coproc_movefrom_CNTKCTL;
+define pcodeop coproc_movefrom_CNTP_TVAL;
+define pcodeop coproc_movefrom_CNTP_CTL;
+define pcodeop coproc_movefrom_CNTV_TVAL;
+define pcodeop coproc_movefrom_CNTV_CTL;
+define pcodeop coproc_movefrom_PMEVCNTR0;
+define pcodeop coproc_movefrom_PMEVCNTR1;
+define pcodeop coproc_movefrom_PMEVCNTR2;
+define pcodeop coproc_movefrom_PMEVCNTR3;
+define pcodeop coproc_movefrom_PMEVCNTR4;
+define pcodeop coproc_movefrom_PMEVCNTR5;
+define pcodeop coproc_movefrom_PMEVCNTR6;
+define pcodeop coproc_movefrom_PMEVCNTR7;
+define pcodeop coproc_movefrom_PMEVCNTR8;
+define pcodeop coproc_movefrom_PMEVCNTR9;
+define pcodeop coproc_movefrom_PMEVCNTR10;
+define pcodeop coproc_movefrom_PMEVCNTR11;
+define pcodeop coproc_movefrom_PMEVCNTR12;
+define pcodeop coproc_movefrom_PMEVCNTR13;
+define pcodeop coproc_movefrom_PMEVCNTR14;
+define pcodeop coproc_movefrom_PMEVCNTR15;
+define pcodeop coproc_movefrom_PMCCFILTR;
+define pcodeop coproc_movefrom_PMEVTYPER0;
+define pcodeop coproc_movefrom_PMEVTYPER1;
+define pcodeop coproc_movefrom_PMEVTYPER2;
+define pcodeop coproc_movefrom_PMEVTYPER3;
+define pcodeop coproc_movefrom_PMEVTYPER4;
+define pcodeop coproc_movefrom_PMEVTYPER5;
+define pcodeop coproc_movefrom_PMEVTYPER6;
+define pcodeop coproc_movefrom_PMEVTYPER7;
+define pcodeop coproc_movefrom_PMEVTYPER8;
+define pcodeop coproc_movefrom_PMEVTYPER9;
+define pcodeop coproc_movefrom_PMEVTYPER10;
+define pcodeop coproc_movefrom_PMEVTYPER11;
+define pcodeop coproc_movefrom_PMEVTYPER12;
+define pcodeop coproc_movefrom_PMEVTYPER13;
+define pcodeop coproc_movefrom_PMEVTYPER14;
+define pcodeop coproc_movefrom_PMEVTYPER15;
+define pcodeop coproc_movefrom_CCSIDR;
+define pcodeop coproc_movefrom_CLIDR;
+define pcodeop coproc_movefrom_CCSIDR2;
+define pcodeop coproc_movefrom_AIDR;
+define pcodeop coproc_movefrom_CSSELR;
+define pcodeop coproc_movefrom_DSPSR;
+define pcodeop coproc_movefrom_DLR;
+define pcodeop coproc_movefrom_VPIDR;
+define pcodeop coproc_movefrom_VMPIDR;
+define pcodeop coproc_movefrom_HSCTLR;
+define pcodeop coproc_movefrom_HACTLR;
+define pcodeop coproc_movefrom_HACTLR2;
+define pcodeop coproc_movefrom_HCR;
+define pcodeop coproc_movefrom_HDCR;
+define pcodeop coproc_movefrom_HCPTR;
+define pcodeop coproc_movefrom_HSTR;
+define pcodeop coproc_movefrom_HCR2;
+define pcodeop coproc_movefrom_HACR;
+define pcodeop coproc_movefrom_HTRFCR;
+define pcodeop coproc_movefrom_HTCR;
+define pcodeop coproc_movefrom_VTCR;
+define pcodeop coproc_movefrom_HADFSR;
+define pcodeop coproc_movefrom_HAIFSR;
+define pcodeop coproc_movefrom_HSR;
+define pcodeop coproc_movefrom_VDFSR;
+define pcodeop coproc_movefrom_HDFAR;
+define pcodeop coproc_movefrom_HIFAR;
+define pcodeop coproc_movefrom_HPFAR;
+define pcodeop coproc_movefrom_ATS1HR;
+define pcodeop coproc_movefrom_ATS1HW;
+define pcodeop coproc_movefrom_TLBIIPAS2IS;
+define pcodeop coproc_movefrom_TLBIIPAS2LIS;
+define pcodeop coproc_movefrom_TLBIALLHIS;
+define pcodeop coproc_movefrom_TLBIMVAHIS;
+define pcodeop coproc_movefrom_TLBIALLNSNHIS;
+define pcodeop coproc_movefrom_TLBIMVALHIS;
+define pcodeop coproc_movefrom_TLBIIPAS2;
+define pcodeop coproc_movefrom_TLBIIPAS2L;
+define pcodeop coproc_movefrom_TLBIALLH;
+define pcodeop coproc_movefrom_TLBIMVAH;
+define pcodeop coproc_movefrom_TLBIALLNSNH;
+define pcodeop coproc_movefrom_TLBIMVALH;
+define pcodeop coproc_movefrom_HMAIR0;
+define pcodeop coproc_movefrom_HMAIR1;
+define pcodeop coproc_movefrom_HAMAIR0;
+define pcodeop coproc_movefrom_HAMAIR1;
+define pcodeop coproc_movefrom_HVBAR;
+define pcodeop coproc_movefrom_HRMR;
+define pcodeop coproc_movefrom_VDISR;
+define pcodeop coproc_movefrom_ICH_AP0R0;
+define pcodeop coproc_movefrom_ICH_AP0R1;
+define pcodeop coproc_movefrom_ICH_AP1R0;
+define pcodeop coproc_movefrom_ICH_AP1R1;
+define pcodeop coproc_movefrom_ICC_HSRE;
+define pcodeop coproc_movefrom_ICH_HCR;
+define pcodeop coproc_movefrom_ICH_VTR;
+define pcodeop coproc_movefrom_ICH_MISR;
+define pcodeop coproc_movefrom_ICH_EISR;
+define pcodeop coproc_movefrom_ICH_ELRSR;
+define pcodeop coproc_movefrom_ICH_VMCR;
+define pcodeop coproc_movefrom_ICH_LR0;
+define pcodeop coproc_movefrom_ICH_LR1;
+define pcodeop coproc_movefrom_ICH_LR2;
+define pcodeop coproc_movefrom_ICH_LR3;
+define pcodeop coproc_movefrom_ICH_LR4;
+define pcodeop coproc_movefrom_ICH_LR5;
+define pcodeop coproc_movefrom_ICH_LR6;
+define pcodeop coproc_movefrom_ICH_LR7;
+define pcodeop coproc_movefrom_ICH_LRC0;
+define pcodeop coproc_movefrom_ICH_LRC1;
+define pcodeop coproc_movefrom_ICH_LRC2;
+define pcodeop coproc_movefrom_ICH_LRC3;
+define pcodeop coproc_movefrom_ICH_LRC4;
+define pcodeop coproc_movefrom_ICH_LRC5;
+define pcodeop coproc_movefrom_ICH_LRC6;
+define pcodeop coproc_movefrom_ICH_LRC7;
+define pcodeop coproc_movefrom_HTPIDR;
+define pcodeop coproc_movefrom_CNTHCTL;
+define pcodeop coproc_movefrom_CNTHP_TVAL;
+define pcodeop coproc_movefrom_CNTHP_CTL;
+define pcodeop coproc_movefrom_ICC_MCTLR;
+define pcodeop coproc_movefrom_ICC_MSRE;
+define pcodeop coproc_movefrom_ICC_MGRPEN1;
+define pcodeop coproc_movefrom_TTBR0;
+define pcodeop coproc_movefrom_TTBR1;
+define pcodeop coproc_movefrom_TTBCR;
+define pcodeop coproc_movefrom_TTBR0H;
+define pcodeop coproc_movefrom_TTBR1H;
+define pcodeop coproc_movefrom_HTTBRH;
+define pcodeop coproc_movefrom_VTTBRH;
+define pcodeop coproc_movefrom_WFI;
+define pcodeop coproc_movefrom_ICISW;
+define pcodeop coproc_movefrom_DCIALL;
+define pcodeop coproc_movefrom_CIALL;
+define pcodeop coproc_movefrom_CIMVA;
+define pcodeop coproc_movefrom_CISW;
+define pcodeop coproc_movefrom_DCCALL;
+define pcodeop coproc_movefrom_CCALL;
+define pcodeop coproc_movefrom_CCSW;
+define pcodeop coproc_movefrom_PFIMVA;
+define pcodeop coproc_movefrom_DCCIALL;
+define pcodeop coproc_movefrom_CCIALL;
+define pcodeop coproc_movefrom_CCIMVA;
+define pcodeop coproc_movefrom_CCISW;
+define pcodeop coproc_movefrom_MAIR0;
+define pcodeop coproc_movefrom_MAIR1;
+define pcodeop coproc_movefrom_MVBAR;
+define pcodeop coproc_moveto_DBGDIDR;
+define pcodeop coproc_moveto_DBGDTRRXext;
+define pcodeop coproc_moveto_DBGDSCRint;
+define pcodeop coproc_moveto_DBGDCCINT;
+define pcodeop coproc_moveto_DBGDSCRext;
+define pcodeop coproc_moveto_DBGDTRTXext;
+define pcodeop coproc_moveto_DBGDTRTXint;
+define pcodeop coproc_moveto_DBGWFAR;
+define pcodeop coproc_moveto_DBGOSECCR;
+define pcodeop coproc_moveto_DBGVCR;
+define pcodeop coproc_moveto_DBGBVR0;
+define pcodeop coproc_moveto_DBGBVR1;
+define pcodeop coproc_moveto_DBGBVR2;
+define pcodeop coproc_moveto_DBGBVR3;
+define pcodeop coproc_moveto_DBGBVR4;
+define pcodeop coproc_moveto_DBGBVR5;
+define pcodeop coproc_moveto_DBGBVR6;
+define pcodeop coproc_moveto_DBGBVR7;
+define pcodeop coproc_moveto_DBGBCR0;
+define pcodeop coproc_moveto_DBGBCR1;
+define pcodeop coproc_moveto_DBGBCR2;
+define pcodeop coproc_moveto_DBGBCR3;
+define pcodeop coproc_moveto_DBGBCR4;
+define pcodeop coproc_moveto_DBGBCR5;
+define pcodeop coproc_moveto_DBGBCR6;
+define pcodeop coproc_moveto_DBGBCR7;
+define pcodeop coproc_moveto_DBGWVR0;
+define pcodeop coproc_moveto_DBGWVR1;
+define pcodeop coproc_moveto_DBGWVR2;
+define pcodeop coproc_moveto_DBGWVR3;
+define pcodeop coproc_moveto_DBGWVR4;
+define pcodeop coproc_moveto_DBGWVR5;
+define pcodeop coproc_moveto_DBGWVR6;
+define pcodeop coproc_moveto_DBGWVR7;
+define pcodeop coproc_moveto_DBGWCR0;
+define pcodeop coproc_moveto_DBGWCR1;
+define pcodeop coproc_moveto_DBGWCR2;
+define pcodeop coproc_moveto_DBGWCR3;
+define pcodeop coproc_moveto_DBGWCR4;
+define pcodeop coproc_moveto_DBGWCR5;
+define pcodeop coproc_moveto_DBGWCR6;
+define pcodeop coproc_moveto_DBGWCR7;
+define pcodeop coproc_moveto_DBGDRAR;
+define pcodeop coproc_moveto_DBGOSLAR;
+define pcodeop coproc_moveto_DBGOSLSR;
+define pcodeop coproc_moveto_DBGOSDLR;
+define pcodeop coproc_moveto_DBGPRCR;
+define pcodeop coproc_moveto_DBGBXVR0;
+define pcodeop coproc_moveto_DBGBXVR1;
+define pcodeop coproc_moveto_DBGBXVR2;
+define pcodeop coproc_moveto_DBGBXVR3;
+define pcodeop coproc_moveto_DBGBXVR4;
+define pcodeop coproc_moveto_DBGBXVR5;
+define pcodeop coproc_moveto_DBGBXVR6;
+define pcodeop coproc_moveto_DBGBXVR7;
+define pcodeop coproc_moveto_DBGDSAR;
+define pcodeop coproc_moveto_DBGDEVID2;
+define pcodeop coproc_moveto_DBGDEVID1;
+define pcodeop coproc_moveto_DBGDEVID;
+define pcodeop coproc_moveto_DBGCLAIMSET;
+define pcodeop coproc_moveto_DBGCLAIMCLR;
+define pcodeop coproc_moveto_DBGAUTHSTATUS;
+define pcodeop coproc_moveto_JIDR;
+define pcodeop coproc_moveto_JOSCR;
+define pcodeop coproc_moveto_JMCR;
+define pcodeop coproc_moveto_MIDR;
+define pcodeop coproc_moveto_CTR;
+define pcodeop coproc_moveto_TCMTR;
+define pcodeop coproc_moveto_TLBTR;
+define pcodeop coproc_moveto_MPIDR;
+define pcodeop coproc_moveto_REVIDR;
+define pcodeop coproc_moveto_ID_PFR0;
+define pcodeop coproc_moveto_ID_PFR1;
+define pcodeop coproc_moveto_ID_DFR0;
+define pcodeop coproc_moveto_ID_AFR0;
+define pcodeop coproc_moveto_ID_MMFR0;
+define pcodeop coproc_moveto_ID_MMFR1;
+define pcodeop coproc_moveto_ID_MMFR2;
+define pcodeop coproc_moveto_ID_MMFR3;
+define pcodeop coproc_moveto_ID_ISAR0;
+define pcodeop coproc_moveto_ID_ISAR1;
+define pcodeop coproc_moveto_ID_ISAR2;
+define pcodeop coproc_moveto_ID_ISAR3;
+define pcodeop coproc_moveto_ID_ISAR4;
+define pcodeop coproc_moveto_ID_ISAR5;
+define pcodeop coproc_moveto_ID_MMFR4;
+define pcodeop coproc_moveto_ID_ISAR6;
+define pcodeop coproc_moveto_ID_PFR2;
+define pcodeop coproc_moveto_ID_DFR1;
+define pcodeop coproc_moveto_ID_MMFR5;
+define pcodeop coproc_moveto_SCTLR;
+define pcodeop coproc_moveto_ACTLR;
+define pcodeop coproc_moveto_CPACR;
+define pcodeop coproc_moveto_ACTLR2;
+define pcodeop coproc_moveto_SCR;
+define pcodeop coproc_moveto_SDER;
+define pcodeop coproc_moveto_NSACR;
+define pcodeop coproc_moveto_TRFCR;
+define pcodeop coproc_moveto_SDCR;
+define pcodeop coproc_moveto_DACR;
+define pcodeop coproc_moveto_ICC_PMR;
+define pcodeop coproc_moveto_DFSR;
+define pcodeop coproc_moveto_IFSR;
+define pcodeop coproc_moveto_ADFSR;
+define pcodeop coproc_moveto_AIFSR;
+define pcodeop coproc_moveto_ERRIDR;
+define pcodeop coproc_moveto_ERRSELR;
+define pcodeop coproc_moveto_ERXFR;
+define pcodeop coproc_moveto_ERXCTLR;
+define pcodeop coproc_moveto_ERXSTATUS;
+define pcodeop coproc_moveto_ERXADDR;
+define pcodeop coproc_moveto_ERXFR2;
+define pcodeop coproc_moveto_ERXCTLR2;
+define pcodeop coproc_moveto_ERXADDR2;
+define pcodeop coproc_moveto_ERXMISC0;
+define pcodeop coproc_moveto_ERXMISC1;
+define pcodeop coproc_moveto_ERXMISC4;
+define pcodeop coproc_moveto_ERXMISC5;
+define pcodeop coproc_moveto_ERXMISC2;
+define pcodeop coproc_moveto_ERXMISC3;
+define pcodeop coproc_moveto_ERXMISC6;
+define pcodeop coproc_moveto_ERXMISC7;
+define pcodeop coproc_moveto_DFAR;
+define pcodeop coproc_moveto_IFAR;
+define pcodeop coproc_moveto_ICIALLUIS;
+define pcodeop coproc_moveto_BPIALLIS;
+define pcodeop coproc_moveto_CFPRCTX;
+define pcodeop coproc_moveto_DVPRCTX;
+define pcodeop coproc_moveto_CPPRCTX;
+define pcodeop coproc_moveto_PAR;
+define pcodeop coproc_moveto_CP15ISB;
+define pcodeop coproc_moveto_BPIALL;
+define pcodeop coproc_moveto_BPIMVA;
+define pcodeop coproc_moveto_DCISW;
+define pcodeop coproc_moveto_ATS1CPR;
+define pcodeop coproc_moveto_ATS1CPW;
+define pcodeop coproc_moveto_ATS1CUR;
+define pcodeop coproc_moveto_ATS1CUW;
+define pcodeop coproc_moveto_ATS12NSOPR;
+define pcodeop coproc_moveto_ATS12NSOPW;
+define pcodeop coproc_moveto_ATS12NSOUR;
+define pcodeop coproc_moveto_ATS12NSOUW;
+define pcodeop coproc_moveto_ATS1CPRP;
+define pcodeop coproc_moveto_ATS1CPWP;
+define pcodeop coproc_moveto_DCCSW;
+define pcodeop coproc_moveto_CP15DSB;
+define pcodeop coproc_moveto_CP15DMB;
+define pcodeop coproc_moveto_DCCISW;
+define pcodeop coproc_moveto_TLBIALLIS;
+define pcodeop coproc_moveto_TLBIMVAIS;
+define pcodeop coproc_moveto_TLBIASIDIS;
+define pcodeop coproc_moveto_TLBIMVAAIS;
+define pcodeop coproc_moveto_TLBIMVALIS;
+define pcodeop coproc_moveto_TLBIMVAALIS;
+define pcodeop coproc_moveto_ITLBIALL;
+define pcodeop coproc_moveto_ITLBIMVA;
+define pcodeop coproc_moveto_ITLBIASID;
+define pcodeop coproc_moveto_DTLBIALL;
+define pcodeop coproc_moveto_DTLBIMVA;
+define pcodeop coproc_moveto_DTLBIASID;
+define pcodeop coproc_moveto_TLBIALL;
+define pcodeop coproc_moveto_TLBIMVA;
+define pcodeop coproc_moveto_TLBIASID;
+define pcodeop coproc_moveto_TLBIMVAA;
+define pcodeop coproc_moveto_TLBIMVAL;
+define pcodeop coproc_moveto_TLBIMVAAL;
+define pcodeop coproc_moveto_PMCR;
+define pcodeop coproc_moveto_PMCNTENSET;
+define pcodeop coproc_moveto_PMCNTENCLR;
+define pcodeop coproc_moveto_PMOVSR;
+define pcodeop coproc_moveto_PMSWINC;
+define pcodeop coproc_moveto_PMSELR;
+define pcodeop coproc_moveto_PMCEID0;
+define pcodeop coproc_moveto_PMCEID1;
+define pcodeop coproc_moveto_PMCCNTR;
+define pcodeop coproc_moveto_PMXEVTYPER;
+define pcodeop coproc_moveto_PMXEVCNTR;
+define pcodeop coproc_moveto_PMUSERENR;
+define pcodeop coproc_moveto_PMINTENSET;
+define pcodeop coproc_moveto_PMINTENCLR;
+define pcodeop coproc_moveto_PMOVSSET;
+define pcodeop coproc_moveto_PMCEID2;
+define pcodeop coproc_moveto_PMCEID3;
+define pcodeop coproc_moveto_PMMIR;
+define pcodeop coproc_moveto_AMAIR0;
+define pcodeop coproc_moveto_AMAIR1;
+define pcodeop coproc_moveto_VBAR;
+define pcodeop coproc_moveto_RMR;
+define pcodeop coproc_moveto_ISR;
+define pcodeop coproc_moveto_DISR;
+define pcodeop coproc_moveto_ICC_IAR0;
+define pcodeop coproc_moveto_ICC_EOIR0;
+define pcodeop coproc_moveto_ICC_HPPIR0;
+define pcodeop coproc_moveto_ICC_BPR0;
+define pcodeop coproc_moveto_ICC_AP0R0;
+define pcodeop coproc_moveto_ICC_AP0R1;
+define pcodeop coproc_moveto_ICC_AP1R0;
+define pcodeop coproc_moveto_ICC_AP1R1;
+define pcodeop coproc_moveto_ICC_DIR;
+define pcodeop coproc_moveto_ICC_RPR;
+define pcodeop coproc_moveto_ICC_IAR1;
+define pcodeop coproc_moveto_ICC_EOIR1;
+define pcodeop coproc_moveto_ICC_HPPIR1;
+define pcodeop coproc_moveto_ICC_BPR1;
+define pcodeop coproc_moveto_ICC_CTLR;
+define pcodeop coproc_moveto_ICC_SRE;
+define pcodeop coproc_moveto_ICC_IGRPEN0;
+define pcodeop coproc_moveto_ICC_IGRPEN1;
+define pcodeop coproc_moveto_FCSEIDR;
+define pcodeop coproc_moveto_CONTEXTIDR;
+define pcodeop coproc_moveto_TPIDRURW;
+define pcodeop coproc_moveto_TPIDRURO;
+define pcodeop coproc_moveto_TPIDRPRW;
+define pcodeop coproc_moveto_AMCR;
+define pcodeop coproc_moveto_AMCFGR;
+define pcodeop coproc_moveto_AMCGCR;
+define pcodeop coproc_moveto_AMUSERENR;
+define pcodeop coproc_moveto_AMCNTENCLR0;
+define pcodeop coproc_moveto_AMCNTENSET0;
+define pcodeop coproc_moveto_AMCNTENCLR1;
+define pcodeop coproc_moveto_AMCNTENSET1;
+define pcodeop coproc_moveto_AMEVTYPER00;
+define pcodeop coproc_moveto_AMEVTYPER01;
+define pcodeop coproc_moveto_AMEVTYPER02;
+define pcodeop coproc_moveto_AMEVTYPER03;
+define pcodeop coproc_moveto_AMEVTYPER04;
+define pcodeop coproc_moveto_AMEVTYPER05;
+define pcodeop coproc_moveto_AMEVTYPER06;
+define pcodeop coproc_moveto_AMEVTYPER07;
+define pcodeop coproc_moveto_AMEVTYPER10;
+define pcodeop coproc_moveto_AMEVTYPER11;
+define pcodeop coproc_moveto_AMEVTYPER12;
+define pcodeop coproc_moveto_AMEVTYPER13;
+define pcodeop coproc_moveto_AMEVTYPER14;
+define pcodeop coproc_moveto_AMEVTYPER15;
+define pcodeop coproc_moveto_AMEVTYPER16;
+define pcodeop coproc_moveto_AMEVTYPER17;
+define pcodeop coproc_moveto_CNTFRQ;
+define pcodeop coproc_moveto_CNTKCTL;
+define pcodeop coproc_moveto_CNTP_TVAL;
+define pcodeop coproc_moveto_CNTP_CTL;
+define pcodeop coproc_moveto_CNTV_TVAL;
+define pcodeop coproc_moveto_CNTV_CTL;
+define pcodeop coproc_moveto_PMEVCNTR0;
+define pcodeop coproc_moveto_PMEVCNTR1;
+define pcodeop coproc_moveto_PMEVCNTR2;
+define pcodeop coproc_moveto_PMEVCNTR3;
+define pcodeop coproc_moveto_PMEVCNTR4;
+define pcodeop coproc_moveto_PMEVCNTR5;
+define pcodeop coproc_moveto_PMEVCNTR6;
+define pcodeop coproc_moveto_PMEVCNTR7;
+define pcodeop coproc_moveto_PMEVCNTR8;
+define pcodeop coproc_moveto_PMEVCNTR9;
+define pcodeop coproc_moveto_PMEVCNTR10;
+define pcodeop coproc_moveto_PMEVCNTR11;
+define pcodeop coproc_moveto_PMEVCNTR12;
+define pcodeop coproc_moveto_PMEVCNTR13;
+define pcodeop coproc_moveto_PMEVCNTR14;
+define pcodeop coproc_moveto_PMEVCNTR15;
+define pcodeop coproc_moveto_PMCCFILTR;
+define pcodeop coproc_moveto_PMEVTYPER0;
+define pcodeop coproc_moveto_PMEVTYPER1;
+define pcodeop coproc_moveto_PMEVTYPER2;
+define pcodeop coproc_moveto_PMEVTYPER3;
+define pcodeop coproc_moveto_PMEVTYPER4;
+define pcodeop coproc_moveto_PMEVTYPER5;
+define pcodeop coproc_moveto_PMEVTYPER6;
+define pcodeop coproc_moveto_PMEVTYPER7;
+define pcodeop coproc_moveto_PMEVTYPER8;
+define pcodeop coproc_moveto_PMEVTYPER9;
+define pcodeop coproc_moveto_PMEVTYPER10;
+define pcodeop coproc_moveto_PMEVTYPER11;
+define pcodeop coproc_moveto_PMEVTYPER12;
+define pcodeop coproc_moveto_PMEVTYPER13;
+define pcodeop coproc_moveto_PMEVTYPER14;
+define pcodeop coproc_moveto_PMEVTYPER15;
+define pcodeop coproc_moveto_CCSIDR;
+define pcodeop coproc_moveto_CLIDR;
+define pcodeop coproc_moveto_CCSIDR2;
+define pcodeop coproc_moveto_AIDR;
+define pcodeop coproc_moveto_CSSELR;
+define pcodeop coproc_moveto_DSPSR;
+define pcodeop coproc_moveto_DLR;
+define pcodeop coproc_moveto_VPIDR;
+define pcodeop coproc_moveto_VMPIDR;
+define pcodeop coproc_moveto_HSCTLR;
+define pcodeop coproc_moveto_HACTLR;
+define pcodeop coproc_moveto_HACTLR2;
+define pcodeop coproc_moveto_HCR;
+define pcodeop coproc_moveto_HDCR;
+define pcodeop coproc_moveto_HCPTR;
+define pcodeop coproc_moveto_HSTR;
+define pcodeop coproc_moveto_HCR2;
+define pcodeop coproc_moveto_HACR;
+define pcodeop coproc_moveto_HTRFCR;
+define pcodeop coproc_moveto_HTCR;
+define pcodeop coproc_moveto_VTCR;
+define pcodeop coproc_moveto_HADFSR;
+define pcodeop coproc_moveto_HAIFSR;
+define pcodeop coproc_moveto_HSR;
+define pcodeop coproc_moveto_VDFSR;
+define pcodeop coproc_moveto_HDFAR;
+define pcodeop coproc_moveto_HIFAR;
+define pcodeop coproc_moveto_HPFAR;
+define pcodeop coproc_moveto_ATS1HR;
+define pcodeop coproc_moveto_ATS1HW;
+define pcodeop coproc_moveto_TLBIIPAS2IS;
+define pcodeop coproc_moveto_TLBIIPAS2LIS;
+define pcodeop coproc_moveto_TLBIALLHIS;
+define pcodeop coproc_moveto_TLBIMVAHIS;
+define pcodeop coproc_moveto_TLBIALLNSNHIS;
+define pcodeop coproc_moveto_TLBIMVALHIS;
+define pcodeop coproc_moveto_TLBIIPAS2;
+define pcodeop coproc_moveto_TLBIIPAS2L;
+define pcodeop coproc_moveto_TLBIALLH;
+define pcodeop coproc_moveto_TLBIMVAH;
+define pcodeop coproc_moveto_TLBIALLNSNH;
+define pcodeop coproc_moveto_TLBIMVALH;
+define pcodeop coproc_moveto_HMAIR0;
+define pcodeop coproc_moveto_HMAIR1;
+define pcodeop coproc_moveto_HAMAIR0;
+define pcodeop coproc_moveto_HAMAIR1;
+define pcodeop coproc_moveto_HVBAR;
+define pcodeop coproc_moveto_HRMR;
+define pcodeop coproc_moveto_VDISR;
+define pcodeop coproc_moveto_ICH_AP0R0;
+define pcodeop coproc_moveto_ICH_AP0R1;
+define pcodeop coproc_moveto_ICH_AP1R0;
+define pcodeop coproc_moveto_ICH_AP1R1;
+define pcodeop coproc_moveto_ICC_HSRE;
+define pcodeop coproc_moveto_ICH_HCR;
+define pcodeop coproc_moveto_ICH_VTR;
+define pcodeop coproc_moveto_ICH_MISR;
+define pcodeop coproc_moveto_ICH_EISR;
+define pcodeop coproc_moveto_ICH_ELRSR;
+define pcodeop coproc_moveto_ICH_VMCR;
+define pcodeop coproc_moveto_ICH_LR0;
+define pcodeop coproc_moveto_ICH_LR1;
+define pcodeop coproc_moveto_ICH_LR2;
+define pcodeop coproc_moveto_ICH_LR3;
+define pcodeop coproc_moveto_ICH_LR4;
+define pcodeop coproc_moveto_ICH_LR5;
+define pcodeop coproc_moveto_ICH_LR6;
+define pcodeop coproc_moveto_ICH_LR7;
+define pcodeop coproc_moveto_ICH_LRC0;
+define pcodeop coproc_moveto_ICH_LRC1;
+define pcodeop coproc_moveto_ICH_LRC2;
+define pcodeop coproc_moveto_ICH_LRC3;
+define pcodeop coproc_moveto_ICH_LRC4;
+define pcodeop coproc_moveto_ICH_LRC5;
+define pcodeop coproc_moveto_ICH_LRC6;
+define pcodeop coproc_moveto_ICH_LRC7;
+define pcodeop coproc_moveto_HTPIDR;
+define pcodeop coproc_moveto_CNTHCTL;
+define pcodeop coproc_moveto_CNTHP_TVAL;
+define pcodeop coproc_moveto_CNTHP_CTL;
+define pcodeop coproc_moveto_ICC_MCTLR;
+define pcodeop coproc_moveto_ICC_MSRE;
+define pcodeop coproc_moveto_ICC_MGRPEN1;
+define pcodeop coproc_moveto_TTBR0;
+define pcodeop coproc_moveto_TTBR1;
+define pcodeop coproc_moveto_TTBCR;
+define pcodeop coproc_moveto_TTBR0H;
+define pcodeop coproc_moveto_TTBR1H;
+define pcodeop coproc_moveto_HTTBRH;
+define pcodeop coproc_moveto_VTTBRH;
+define pcodeop coproc_moveto_WFI;
+define pcodeop coproc_moveto_ICIALL;
+define pcodeop coproc_moveto_ICIMVA;
+define pcodeop coproc_moveto_ICISW;
+define pcodeop coproc_moveto_DCIALL;
+define pcodeop coproc_moveto_DCIMVA;
+define pcodeop coproc_moveto_CIALL;
+define pcodeop coproc_moveto_CIMVA;
+define pcodeop coproc_moveto_CISW;
+define pcodeop coproc_moveto_DCCALL;
+define pcodeop coproc_moveto_DCCMVA;
+define pcodeop coproc_moveto_CCALL;
+define pcodeop coproc_moveto_CCMVA;
+define pcodeop coproc_moveto_CCSW;
+define pcodeop coproc_moveto_PFIMVA;
+define pcodeop coproc_moveto_DCCIALL;
+define pcodeop coproc_moveto_DCCIMVA;
+define pcodeop coproc_moveto_CCIALL;
+define pcodeop coproc_moveto_CCIMVA;
+define pcodeop coproc_moveto_CCISW;
+define pcodeop coproc_moveto_MAIR0;
+define pcodeop coproc_moveto_MAIR1;
+define pcodeop coproc_moveto_MVBAR;
+
+define pcodeop coproc_movefrom2_lower_DBGDRAR;
+define pcodeop coproc_movefrom2_upper_DBGDRAR;
+define pcodeop coproc_movefrom2_lower_DBGDSAR;
+define pcodeop coproc_movefrom2_upper_DBGDSAR;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR00;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR00;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR01;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR01;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR02;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR02;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR03;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR03;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR04;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR04;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR05;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR05;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR06;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR06;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR07;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR07;
+define pcodeop coproc_movefrom2_lower_TTBR0;
+define pcodeop coproc_movefrom2_upper_TTBR0;
+define pcodeop coproc_movefrom2_lower_TTBR1;
+define pcodeop coproc_movefrom2_upper_TTBR1;
+define pcodeop coproc_movefrom2_lower_HTTBR;
+define pcodeop coproc_movefrom2_upper_HTTBR;
+define pcodeop coproc_movefrom2_lower_VTTBR;
+define pcodeop coproc_movefrom2_upper_VTTBR;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR10;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR10;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR11;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR11;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR12;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR12;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR13;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR13;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR14;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR14;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR15;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR15;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR16;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR16;
+define pcodeop coproc_movefrom2_lower_AMEVCNTR17;
+define pcodeop coproc_movefrom2_upper_AMEVCNTR17;
+define pcodeop coproc_movefrom2_lower_PAR;
+define pcodeop coproc_movefrom2_upper_PAR;
+define pcodeop coproc_movefrom2_lower_PMCCNTR;
+define pcodeop coproc_movefrom2_upper_PMCCNTR;
+define pcodeop coproc_movefrom2_lower_ICC_SGI1R;
+define pcodeop coproc_movefrom2_upper_ICC_SGI1R;
+define pcodeop coproc_movefrom2_lower_ICC_ASGI1R;
+define pcodeop coproc_movefrom2_upper_ICC_ASGI1R;
+define pcodeop coproc_movefrom2_lower_ICC_SGI0R;
+define pcodeop coproc_movefrom2_upper_ICC_SGI0R;
+define pcodeop coproc_movefrom2_lower_CNTPCT;
+define pcodeop coproc_movefrom2_upper_CNTPCT;
+define pcodeop coproc_movefrom2_lower_CNTVCT;
+define pcodeop coproc_movefrom2_upper_CNTVCT;
+define pcodeop coproc_movefrom2_lower_CNTP_CVAL;
+define pcodeop coproc_movefrom2_upper_CNTP_CVAL;
+define pcodeop coproc_movefrom2_lower_CNTV_CVAL;
+define pcodeop coproc_movefrom2_upper_CNTV_CVAL;
+define pcodeop coproc_movefrom2_lower_CNTVOFF;
+define pcodeop coproc_movefrom2_upper_CNTVOFF;
+define pcodeop coproc_movefrom2_lower_CNTHP_CVAL;
+define pcodeop coproc_movefrom2_upper_CNTHP_CVAL;
+define pcodeop coproc_movefrom2_lower_CNTPCTSS;
+define pcodeop coproc_movefrom2_upper_CNTPCTSS;
+define pcodeop coproc_movefrom2_lower_CNTVCTSS;
+define pcodeop coproc_movefrom2_upper_CNTVCTSS;
+define pcodeop coproc_moveto2_DBGDRAR;
+define pcodeop coproc_moveto2_DBGDSAR;
+define pcodeop coproc_moveto2_AMEVCNTR00;
+define pcodeop coproc_moveto2_AMEVCNTR01;
+define pcodeop coproc_moveto2_AMEVCNTR02;
+define pcodeop coproc_moveto2_AMEVCNTR03;
+define pcodeop coproc_moveto2_AMEVCNTR04;
+define pcodeop coproc_moveto2_AMEVCNTR05;
+define pcodeop coproc_moveto2_AMEVCNTR06;
+define pcodeop coproc_moveto2_AMEVCNTR07;
+define pcodeop coproc_moveto2_TTBR0;
+define pcodeop coproc_moveto2_TTBR1;
+define pcodeop coproc_moveto2_HTTBR;
+define pcodeop coproc_moveto2_VTTBR;
+define pcodeop coproc_moveto2_AMEVCNTR10;
+define pcodeop coproc_moveto2_AMEVCNTR11;
+define pcodeop coproc_moveto2_AMEVCNTR12;
+define pcodeop coproc_moveto2_AMEVCNTR13;
+define pcodeop coproc_moveto2_AMEVCNTR14;
+define pcodeop coproc_moveto2_AMEVCNTR15;
+define pcodeop coproc_moveto2_AMEVCNTR16;
+define pcodeop coproc_moveto2_AMEVCNTR17;
+define pcodeop coproc_moveto2_PAR;
+define pcodeop coproc_moveto2_PMCCNTR;
+define pcodeop coproc_moveto2_ICC_SGI1R;
+define pcodeop coproc_moveto2_ICC_ASGI1R;
+define pcodeop coproc_moveto2_ICC_SGI0R;
+define pcodeop coproc_moveto2_CNTPCT;
+define pcodeop coproc_moveto2_CNTVCT;
+define pcodeop coproc_moveto2_CNTP_CVAL;
+define pcodeop coproc_moveto2_CNTV_CVAL;
+define pcodeop coproc_moveto2_CNTVOFF;
+define pcodeop coproc_moveto2_CNTHP_CVAL;
+define pcodeop coproc_moveto2_CNTPCTSS;
+define pcodeop coproc_moveto2_CNTVCTSS;
+
 
 mcrOperands: cpn,opc1,Rd,CRn,CRm,opc2 is CRm & opc2 & cpn & CRn & opc1 & Rd { }
+mcrrOperands: cpn,opcode3,Rd,Rn,CRm is cpn & opcode3 & Rd & Rn & CRm { }
 
 #####################
 ######  shift2 ######
@@ -2938,478 +3722,7648 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
 ###### must come first cond=15
 
 
-# ===== START mcr
+# ===== Start mrc
 
-:mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Main_ID(Rd);
+  Rd = coproc_movefrom_DBGDIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDTRRXext();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDSCRint();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDCCINT();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDSCRext();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDTRTXext();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDTRRXint();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWFAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGOSECCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGVCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBVR7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBCR7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWVR7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGWCR7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDRAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGOSLAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGOSLSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGOSDLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGPRCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGBXVR7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDSAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDEVID2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDEVID1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGDEVID();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGCLAIMSET();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGCLAIMCLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DBGAUTHSTATUS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=1 & opc1=0b111 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_JIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=1 & opc1=0b111 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_JOSCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0010 & c2020=1 & opc1=0b111 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_JMCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_MIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TCMTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_MPIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_REVIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_PFR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_PFR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_DFR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_AFR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_MMFR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_MMFR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_MMFR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_MMFR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_ISAR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_ISAR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_ISAR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_ISAR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_ISAR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_ISAR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_MMFR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_ISAR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_PFR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_DFR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ID_MMFR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_SCTLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ACTLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CPACR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ACTLR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_SCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_SDER();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_NSACR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TRFCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_SDCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0011 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DACR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_PMR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DFSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_IFSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ADFSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AIFSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERRIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERRSELR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXFR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXCTLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXSTATUS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXADDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXFR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXCTLR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXADDR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ERXMISC7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DFAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_IFAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICIALLUIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_BPIALLIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CFPRCTX();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DVPRCTX();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CPPRCTX();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICIALLU();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICIMVAU();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CP15ISB();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_BPIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_BPIMVA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCIMVAC();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCISW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1CPR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1CPW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1CUR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1CUW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS12NSOPR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS12NSOPW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS12NSOUR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS12NSOUW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1CPRP();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1CPWP();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCCMVAC();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCCSW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CP15DSB();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CP15DMB();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCCMVAU();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCCIMVAC();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCCISW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIALLIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIASIDIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAAIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVALIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAALIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ITLBIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ITLBIMVA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ITLBIASID();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DTLBIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DTLBIMVA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DTLBIASID();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIASID();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAAL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCNTENSET();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCNTENCLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMOVSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMSWINC();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMSELR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCEID0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCEID1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCCNTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMXEVTYPER();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMXEVCNTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMUSERENR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMINTENSET();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMINTENCLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMOVSSET();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCEID2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCEID3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMMIR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMAIR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMAIR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_VBAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_RMR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ISR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DISR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_IAR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_EOIR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_HPPIR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_BPR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_AP0R0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_AP0R1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_AP1R0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_AP1R1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_DIR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_RPR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_IAR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_EOIR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_HPPIR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_BPR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_CTLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_SRE();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_IGRPEN0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_IGRPEN1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_FCSEIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CONTEXTIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TPIDRURW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TPIDRURO();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TPIDRPRW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMCFGR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMCGCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMUSERENR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMCNTENCLR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMCNTENSET0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMCNTENCLR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMCNTENSET1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER00();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER01();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER02();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER03();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER04();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER05();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER06();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER07();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER10();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER11();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER12();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER13();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER14();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER15();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER16();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AMEVTYPER17();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTFRQ();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTKCTL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTP_TVAL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTP_CTL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTV_TVAL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTV_CTL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR8();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR9();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR10();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR11();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR12();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR13();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR14();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVCNTR15();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMCCFILTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER8();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER9();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER10();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER11();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER12();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER13();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER14();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PMEVTYPER15();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CCSIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CLIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CCSIDR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_AIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b010 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CSSELR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0100 & c2020=1 & opc1=0b011 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DSPSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0100 & c2020=1 & opc1=0b011 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_VPIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_VMPIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HSCTLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HACTLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HACTLR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HDCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HCPTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HSTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HCR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HACR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HTRFCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HTCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_VTCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HADFSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HAIFSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_VDFSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HDFAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HIFAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HPFAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1HR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ATS1HW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIIPAS2IS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIIPAS2LIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIALLHIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAHIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIALLNSNHIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVALHIS();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIIPAS2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIIPAS2L();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIALLH();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVAH();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIALLNSNH();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TLBIMVALH();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HMAIR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HMAIR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HAMAIR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HAMAIR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HVBAR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HRMR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_VDISR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_AP0R0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_AP0R1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_AP1R0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_AP1R1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_HSRE();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_HCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_VTR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_MISR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_EISR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_ELRSR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_VMCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LR7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC2();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC3();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC4();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC5();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC6();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICH_LRC7();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HTPIDR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTHCTL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTHP_TVAL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=1 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CNTHP_CTL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b110 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_MCTLR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b110 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_MSRE();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b110 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICC_MGRPEN1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TTBR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TTBR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TTBCR();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TTBR0H();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_TTBR1H();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_HTTBRH();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_VTTBRH();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_WFI();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_ICISW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CIMVA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CISW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCCALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CCALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CCSW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_PFIMVA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_DCCIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CCIALL();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CCIMVA();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_CCISW();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_MAIR0();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_MAIR1();
+}
+
+
+:mrc^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=1 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  Rd = coproc_movefrom_MVBAR();
+}
+
+# ===== End mrc
+# ===== Start mcr
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGDIDR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Cache_Type(Rd);
+  coproc_moveto_DBGDTRRXext(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_TCM_Status(Rd);
+  coproc_moveto_DBGDSCRint(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=3 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_TLB_Type(Rd);
+  coproc_moveto_DBGDCCINT(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Control(Rd);
+  coproc_moveto_DBGDSCRext(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Auxiliary_Control(Rd);
+  coproc_moveto_DBGDTRTXext(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Coprocessor_Access_Control(Rd);
+  coproc_moveto_DBGDTRTXint(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Secure_Configuration(Rd);
+  coproc_moveto_DBGWFAR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Secure_Debug_Enable(Rd);
+  coproc_moveto_DBGOSECCR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_NonSecure_Access_Control(Rd);
+  coproc_moveto_DBGVCR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=2 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Translation_table_base_0(Rd);
+  coproc_moveto_DBGBVR0(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=2 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Translation_table_base_1(Rd);
+  coproc_moveto_DBGBVR1(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=2 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Translation_table_control(Rd);
+  coproc_moveto_DBGBVR2(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=3 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Domain_Access_Control(Rd);
+  coproc_moveto_DBGBVR3(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=5 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Data_Fault_Status(Rd);
+  coproc_moveto_DBGBVR4(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=5 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Instruction_Fault(Rd);
+  coproc_moveto_DBGBVR5(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=6 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Fault_Address(Rd);
+  coproc_moveto_DBGBVR6(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=6 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Instruction_Fault(Rd);
+  coproc_moveto_DBGBVR7(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Wait_for_interrupt(Rd);
+  coproc_moveto_DBGBCR0(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_Entire_Instruction(Rd);
+  coproc_moveto_DBGBCR1(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_Instruction_Cache_by_MVA(Rd);
+  coproc_moveto_DBGBCR2(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Flush_Prefetch_Buffer(Rd);
+  coproc_moveto_DBGBCR3(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=6 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_Entire_Data_cache(Rd);
+  coproc_moveto_DBGBCR4(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=6 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_Entire_Data_by_MVA(Rd);
+  coproc_moveto_DBGBCR5(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=6 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_Entire_Data_by_Index(Rd);
+  coproc_moveto_DBGBCR6(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b101 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Clean_Entire_Data_Cache(Rd);
+  coproc_moveto_DBGBCR7(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Clean_Data_Cache_by_MVA(Rd);
+  coproc_moveto_DBGWVR0(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Clean_Data_Cache_by_Index(Rd);
+  coproc_moveto_DBGWVR1(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Data_Synchronization(Rd);
+  coproc_moveto_DBGWVR2(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=5 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Data_Memory_Barrier(Rd);
+  coproc_moveto_DBGWVR3(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=14 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_Entire_Data_Cache(Rd);
+  coproc_moveto_DBGWVR4(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=14 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_Data_Cache_by_MVA(Rd);
+  coproc_moveto_DBGWVR5(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=7 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=8 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_unified_TLB_unlocked(Rd);
+  coproc_moveto_DBGWVR6(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=7 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=8 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_unified_TLB_by_MVA(Rd);
+  coproc_moveto_DBGWVR7(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=7 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=8 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Invalidate_unified_TLB_by_ASID_match(Rd);
+  coproc_moveto_DBGWCR0(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=13 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_FCSE_PID(Rd);
+  coproc_moveto_DBGWCR1(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=13 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Context_ID(Rd);
+  coproc_moveto_DBGWCR2(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=13 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_User_RW_Thread_and_Process_ID(Rd);
+  coproc_moveto_DBGWCR3(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=3 & cpn=15 & Rd & CRn=13 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_User_R_Thread_and_Process_ID(Rd);
+  coproc_moveto_DBGWCR4(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=13 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Privileged_only_Thread_and_Process_ID(Rd);
+  coproc_moveto_DBGWCR5(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=2 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=15 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  coproc_moveto_Peripherial_Port_Memory_Remap(Rd);
+  coproc_moveto_DBGWCR6(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opt2:4=opc2;
-  coproc_moveto_Feature_Identification(Rd,t_opt2);
+  coproc_moveto_DBGWCR7(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=2 & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opt2:4=opc2;
-  coproc_moveto_ISA_Feature_Identification(Rd,t_opt2);
+  coproc_moveto_DBGDRAR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=4 & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=2 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2;
-  coproc_moveto_Peripheral_Port_Memory_Remap(Rd,t_opc2);
+  coproc_moveto_DBGOSLAR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2;
-  coproc_moveto_Control_registers(Rd, t_opc2);
+  coproc_moveto_DBGOSLSR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2 & cpn=15 & Rd & CRn=1 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2;
-  coproc_moveto_Security_world_control(Rd, t_opc2);
+  coproc_moveto_DBGOSDLR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2 & cpn=15 & Rd & CRn=2 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b100 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2;
-  coproc_moveto_Translation_table(Rd,t_opc2);
+  coproc_moveto_DBGPRCR(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2;
-  coproc_moveto_Instruction_cache(Rd,t_opc2);
+  coproc_moveto_DBGBXVR0(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2 & cpn=15 & Rd & CRn=7 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2;
-  coproc_moveto_Data_cache_operations(Rd,t_opc2);
+  coproc_moveto_DBGBXVR1(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=0 & opc1=0 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2; t_crm:4 = CRm;
-  coproc_moveto_Identification_registers(Rd,t_opc2,t_crm);
+  coproc_moveto_DBGBXVR2(Rd);
 }
 
 
 :mcr^COND mcrOperands  is 
-    $(AMODE) &  CRm & c0404=1 & opc2 & cpn=15 & Rd & CRn=15 & c2020=0 & opc1 & c2427=14 & COND & ARMcond=1 &
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
         mcrOperands
 {
   build COND;
-  t_opc2:4 = opc2; t_crm:4 = CRm; t_op1:4 = opc1;
-  coproc_moveto_Peripheral_System(Rd,t_opc2,t_crm,t_op1);
+  coproc_moveto_DBGBXVR3(Rd);
 }
 
 
-# ===== END mcr 
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGBXVR4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGBXVR5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGBXVR6(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGBXVR7(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGDSAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGDEVID2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGDEVID1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b111 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGDEVID(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGCLAIMSET(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGCLAIMCLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1110 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DBGAUTHSTATUS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0000 & c2020=0 & opc1=0b111 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_JIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0001 & c2020=0 & opc1=0b111 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_JOSCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1110 & Rd & CRn=0b0010 & c2020=0 & opc1=0b111 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_JMCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_MIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TCMTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_MPIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_REVIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_PFR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_PFR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_DFR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_AFR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_MMFR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_MMFR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_MMFR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_MMFR3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_ISAR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_ISAR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_ISAR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_ISAR3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_ISAR4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_ISAR5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_MMFR4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_ISAR6(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_PFR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_DFR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ID_MMFR5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_SCTLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ACTLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CPACR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ACTLR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_SCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_SDER(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_NSACR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TRFCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_SDCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0011 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DACR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_PMR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DFSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_IFSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ADFSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AIFSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERRIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERRSELR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXFR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXCTLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXSTATUS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXADDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXFR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXCTLR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXADDR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC6(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ERXMISC7(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DFAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_IFAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICIALLUIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_BPIALLIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CFPRCTX(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DVPRCTX(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CPPRCTX(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CP15ISB(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_BPIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_BPIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCISW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1CPR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1CPW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1CUR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1CUW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS12NSOPR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS12NSOPW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS12NSOUR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS12NSOUW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1CPRP(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1CPWP(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCCSW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CP15DSB(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CP15DMB(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCCISW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIALLIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIASIDIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAAIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVALIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAALIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ITLBIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ITLBIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ITLBIASID(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DTLBIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DTLBIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DTLBIASID(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIASID(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAAL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCNTENSET(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCNTENCLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMOVSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMSWINC(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMSELR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCEID0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCEID1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCCNTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMXEVTYPER(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMXEVCNTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMUSERENR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMINTENSET(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMINTENCLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMOVSSET(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCEID2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCEID3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1001 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMMIR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMAIR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMAIR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_VBAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_RMR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ISR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DISR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_IAR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_EOIR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_HPPIR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_BPR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_AP0R0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_AP0R1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_AP1R0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_AP1R1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_DIR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_RPR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_IAR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_EOIR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_HPPIR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_BPR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_CTLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_SRE(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_IGRPEN0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_IGRPEN1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_FCSEIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CONTEXTIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TPIDRURW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TPIDRURO(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TPIDRPRW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMCFGR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMCGCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMUSERENR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMCNTENCLR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMCNTENSET0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMCNTENCLR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMCNTENSET1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER00(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER01(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER02(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER03(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER04(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER05(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER06(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER07(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER10(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER11(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER12(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER13(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER14(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER15(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER16(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AMEVTYPER17(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTFRQ(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTKCTL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTP_TVAL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTP_CTL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTV_TVAL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTV_CTL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR6(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR7(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR8(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR9(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR10(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR11(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR12(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR13(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR14(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVCNTR15(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMCCFILTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER6(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER7(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER8(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER9(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER10(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER11(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER12(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER13(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER14(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PMEVTYPER15(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCSIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CLIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCSIDR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b001 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_AIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b010 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CSSELR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0100 & c2020=0 & opc1=0b011 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DSPSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0100 & c2020=0 & opc1=0b011 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_VPIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b0000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_VMPIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HSCTLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HACTLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HACTLR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HDCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HCPTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HSTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HCR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HACR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0001 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HTRFCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HTCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_VTCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HADFSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HAIFSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b0101 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_VDFSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HDFAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HIFAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0110 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HPFAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1HR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ATS1HW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIIPAS2IS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIIPAS2LIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIALLHIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAHIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIALLNSNHIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVALHIS(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIIPAS2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIIPAS2L(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIALLH(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVAH(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIALLNSNH(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1000 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TLBIMVALH(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HMAIR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HMAIR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HAMAIR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HAMAIR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HVBAR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HRMR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_VDISR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_AP0R0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_AP0R1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_AP1R0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_AP1R1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1001 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_HSRE(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_HCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_VTR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_MISR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_EISR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_ELRSR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_VMCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR6(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LR7(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC2(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b011 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC3(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC4(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC5(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC6(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICH_LRC7(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b1101 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HTPIDR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0001 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTHCTL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTHP_TVAL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1110 & c2020=0 & opc1=0b100 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CNTHP_CTL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b110 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_MCTLR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b101 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b110 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_MSRE(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1100 & c0404=1 & opc2=0b111 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b110 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICC_MGRPEN1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TTBR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TTBR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TTBCR(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TTBR0H(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_TTBR1H(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_HTTBRH(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b110 & cpn=0b1111 & Rd & CRn=0b0010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_VTTBRH(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b100 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_WFI(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0101 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_ICISW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0111 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CISW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCCALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCCMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1011 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCSW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1101 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_PFIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCCIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1110 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_DCCIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCIALL(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCIMVA(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b1111 & c0404=1 & opc2=0b010 & cpn=0b1111 & Rd & CRn=0b0111 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_CCISW(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b000 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_MAIR0(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0010 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1010 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_MAIR1(Rd);
+}
+
+
+:mcr^COND mcrOperands  is 
+    $(AMODE) &  CRm=0b0000 & c0404=1 & opc2=0b001 & cpn=0b1111 & Rd & CRn=0b1100 & c2020=0 & opc1=0b000 & c2427=14 & COND & ARMcond=1 &
+        mcrOperands
+{
+  build COND;
+  coproc_moveto_MVBAR(Rd);
+}
+
+# ===== End mcr
+
+# ===== Start mrrc
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1110 & opcode3=0b0000 & Rd & Rn & CRm=0b0001 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_DBGDRAR();
+  Rn = coproc_movefrom2_upper_DBGDRAR();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1110 & opcode3=0b0000 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_DBGDSAR();
+  Rn = coproc_movefrom2_upper_DBGDSAR();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR00();
+  Rn = coproc_movefrom2_upper_AMEVCNTR00();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR01();
+  Rn = coproc_movefrom2_upper_AMEVCNTR01();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR02();
+  Rn = coproc_movefrom2_upper_AMEVCNTR02();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0011 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR03();
+  Rn = coproc_movefrom2_upper_AMEVCNTR03();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR04();
+  Rn = coproc_movefrom2_upper_AMEVCNTR04();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0101 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR05();
+  Rn = coproc_movefrom2_upper_AMEVCNTR05();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR06();
+  Rn = coproc_movefrom2_upper_AMEVCNTR06();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0111 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR07();
+  Rn = coproc_movefrom2_upper_AMEVCNTR07();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_TTBR0();
+  Rn = coproc_movefrom2_upper_TTBR0();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_TTBR1();
+  Rn = coproc_movefrom2_upper_TTBR1();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_HTTBR();
+  Rn = coproc_movefrom2_upper_HTTBR();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_VTTBR();
+  Rn = coproc_movefrom2_upper_VTTBR();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR10();
+  Rn = coproc_movefrom2_upper_AMEVCNTR10();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR11();
+  Rn = coproc_movefrom2_upper_AMEVCNTR11();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR12();
+  Rn = coproc_movefrom2_upper_AMEVCNTR12();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0011 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR13();
+  Rn = coproc_movefrom2_upper_AMEVCNTR13();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR14();
+  Rn = coproc_movefrom2_upper_AMEVCNTR14();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0101 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR15();
+  Rn = coproc_movefrom2_upper_AMEVCNTR15();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR16();
+  Rn = coproc_movefrom2_upper_AMEVCNTR16();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0111 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_AMEVCNTR17();
+  Rn = coproc_movefrom2_upper_AMEVCNTR17();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0111 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_PAR();
+  Rn = coproc_movefrom2_upper_PAR();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b1001 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_PMCCNTR();
+  Rn = coproc_movefrom2_upper_PMCCNTR();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b1100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_ICC_SGI1R();
+  Rn = coproc_movefrom2_upper_ICC_SGI1R();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b1100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_ICC_ASGI1R();
+  Rn = coproc_movefrom2_upper_ICC_ASGI1R();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b1100 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_ICC_SGI0R();
+  Rn = coproc_movefrom2_upper_ICC_SGI0R();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTPCT();
+  Rn = coproc_movefrom2_upper_CNTPCT();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTVCT();
+  Rn = coproc_movefrom2_upper_CNTVCT();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTP_CVAL();
+  Rn = coproc_movefrom2_upper_CNTP_CVAL();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0011 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTV_CVAL();
+  Rn = coproc_movefrom2_upper_CNTV_CVAL();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTVOFF();
+  Rn = coproc_movefrom2_upper_CNTVOFF();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTHP_CVAL();
+  Rn = coproc_movefrom2_upper_CNTHP_CVAL();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b1000 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTPCTSS();
+  Rn = coproc_movefrom2_upper_CNTPCTSS();
+}
+
+
+:mrrc^COND mcrrOperands is
+    $(AMODE) & c2027=0xc5 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b1001 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  Rd = coproc_movefrom2_lower_CNTVCTSS();
+  Rn = coproc_movefrom2_upper_CNTVCTSS();
+}
+
+# ===== End mrrc
+# ===== Start mcrr
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1110 & opcode3=0b0000 & Rd & Rn & CRm=0b0001 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_DBGDRAR(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1110 & opcode3=0b0000 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_DBGDSAR(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR00(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR01(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR02(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0011 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR03(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR04(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0101 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR05(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR06(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0111 & Rd & Rn & CRm=0b0000 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR07(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_TTBR0(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_TTBR1(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_HTTBR(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b0010 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_VTTBR(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR10(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR11(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR12(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0011 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR13(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR14(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0101 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR15(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR16(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0111 & Rd & Rn & CRm=0b0100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_AMEVCNTR17(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b0111 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_PAR(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b1001 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_PMCCNTR(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b1100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_ICC_SGI1R(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b1100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_ICC_ASGI1R(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b1100 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_ICC_SGI0R(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0000 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTPCT(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0001 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTVCT(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0010 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTP_CVAL(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0011 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTV_CVAL(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0100 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTVOFF(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b0110 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTHP_CVAL(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b1000 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTPCTSS(t_val);
+}
+
+
+:mcrr^COND mcrrOperands is 
+    $(AMODE) & c2027=0xc4 & COND & ARMcond=1 & cpn=0b1111 & opcode3=0b1001 & Rd & Rn & CRm=0b1110 & mcrrOperands
+{
+  build COND;
+  t_val:8 = zext(Rd) | (zext(Rn)<<32);
+  coproc_moveto2_CNTVCTSS(t_val);
+}
+
+# ===== End mcrr
+
 
 :mcr^COND cpn,opc1,Rd,CRn,CRm,opc2 is $(AMODE) & ARMcond=1 & COND & c2427=14 & opc1 & c2020=0 & CRn & Rd & cpn & opc2 & c0404=1 & CRm
 {
@@ -3608,530 +11562,6 @@ ArmPCRelImmed12: reloff		is U23=0 & immed & rotate
 }
 @endif # VERSION_5
 
-# ===== Start mrc
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Main_ID();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Cache_Type();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_TCM_Status();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=3 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_TLB_Type();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Control();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Auxiliary_Control();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Coprocessor_Access_Control();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Secure_Configuration();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Secure_Debug_Enable();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_NonSecure_Access_Control();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=2 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Translation_table_base_0();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=2 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Translation_table_base_1();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=2 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Translation_table_control();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=3 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Domain_Access_Control();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=5 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Instruction_Fault_Status();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=5 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Data_Fault_Status();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=6 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Fault_Address();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=6 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Instruction_Fault_Address();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Wait_for_interrupt();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_Entire_Instruction();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_Instruction_Cache_by_MVA();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Flush_Prefetch_Buffer();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=6 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_Entire_Data_cache();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=6 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_Entire_Data_by_MVA();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=6 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_Entire_Data_by_Index();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Clean_Entire_Data_Cache();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Clean_Data_Cache_by_MVA();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Clean_Data_Cache_by_Index();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Data_Synchronization();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2=5 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Data_Memory_Barrier();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=14 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_Entire_Data_Cache();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=14 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_Data_Cache_by_MVA();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=7 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=8 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_unified_TLB_unlocked();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=7 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=8 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_unified_TLB_by_MVA();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=7 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=8 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Invalidate_unified_TLB_by_ASID_match();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=0 & cpn=15 & Rd & CRn=13 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_FCSE_PID();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=1 & cpn=15 & Rd & CRn=13 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Context_ID();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=2 & cpn=15 & Rd & CRn=13 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_User_RW_Thread_and_Process_ID();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=3 & cpn=15 & Rd & CRn=13 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_User_R_Thread_and_Process_ID();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=13 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Privileged_only_Thread_and_Process_ID();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=2 & c0404=1 & opc2=4 & cpn=15 & Rd & CRn=15 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  Rd = coproc_movefrom_Peripherial_Port_Memory_Remap();
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opt2:4=opc2;
-  Rd = coproc_movefrom_Feature_Identification(t_opt2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=2 & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2;
-  Rd = coproc_movefrom_ISA_Feature_Identification(t_opc2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=4 & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=2 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2;
-  Rd = coproc_movefrom_Peripheral_Port_Memory_Remap(t_opc2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2;
-  Rd = coproc_movefrom_Control_registers(t_opc2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=1 & c0404=1 & opc2 & cpn=15 & Rd & CRn=1 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2;
-  Rd = coproc_movefrom_Security_world_control(t_opc2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=0 & c0404=1 & opc2 & cpn=15 & Rd & CRn=2 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2;
-  Rd = coproc_movefrom_Translation_table(t_opc2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=5 & c0404=1 & opc2 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2;
-  Rd = coproc_movefrom_Instruction_cache(t_opc2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm=10 & c0404=1 & opc2 & cpn=15 & Rd & CRn=7 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2;
-  Rd = coproc_movefrom_Data_cache_operations(t_opc2);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm & c0404=1 & opc2 & cpn=15 & Rd & CRn=0 & c2020=1 & opc1=0 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2; t_crm:4 = CRm;
-  Rd = coproc_movefrom_Identification_registers(t_opc2,t_crm);
-}
-
-
-
-:mrc^COND mcrOperands  is 
-    $(AMODE) &  CRm & c0404=1 & opc2 & cpn=15 & Rd & CRn=15 & c2020=1 & opc1 & c2427=14 & COND & ARMcond=1 &
-        mcrOperands
-{
-  build COND;
-  t_opc2:4 = opc2; t_crm:4 = CRm; t_op1:4 = opc1;
-  Rd = coproc_movefrom_Peripheral_System(t_opc2,t_crm,t_op1);
-}
-
-
-
-# ===== End mrc
 
 :mrc^COND cpn,opc1,Rd,CRn,CRm,opc2 is $(AMODE) & ARMcond=1 & COND & c2427=14 & opc1 & c2020=1 & CRn & Rd & cpn & opc2 & c0404=1 & CRm
 {


### PR DESCRIPTION
I added names for arm coprocessor the read/write instructions `mrc`, `mcr`, `mrrc` and `mcrr` for the reserved coprocessors (cp15 and cp14).
That makes reversing bare metal arm code much more pleasant.

Side by side before and after comparison:
<img width="50%" alt="before" src="https://github.com/NationalSecurityAgency/ghidra/assets/1363935/37637461-02fd-43f7-b352-4bf8909b0362"><img width="50%" alt="after" src="https://github.com/NationalSecurityAgency/ghidra/assets/1363935/45d4d292-4ab7-4dfb-ba7a-9e53edaea346">

I compiled a list of as many register names for usage with mcr/mrc and mcrr/mrrc as i could and wrote a few python scripts to generate sleigh code from it.

[input_32.txt](https://github.com/NationalSecurityAgency/ghidra/files/15434102/input_32.txt)
[input_64.txt](https://github.com/NationalSecurityAgency/ghidra/files/15434103/input_64.txt)
[scripts.zip](https://github.com/NationalSecurityAgency/ghidra/files/15434111/scripts.zip)


PS:
This does work perfectly well for but, since i have no idea what i'm doing, please someone come up with a clean solution for this and integrate it into the build process.
I.e. cleanup the list to remove duplicates and make the script pretty and readable or replace it altogether