### PR TITLE
Decompiler: Simplify comparisons between `INT_OR` and zero.

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -5518,6 +5518,7 @@ void ActionDatabase::universalAction(Architecture *conf)
 	actprop->addRule( new RuleOrMultiBool("analysis") );
 	actprop->addRule( new RuleXorSwap("analysis") );
 	actprop->addRule( new RuleLzcountShiftBool("analysis") );
+	actprop->addRule( new RuleOrCompare("analysis") );
 	actprop->addRule( new RuleSubvarAnd("subvar") );
 	actprop->addRule( new RuleSubvarSubpiece("subvar") );
 	actprop->addRule( new RuleSplitFlow("subvar") );

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
@@ -1643,5 +1643,16 @@ public:
   virtual int4 applyOp(PcodeOp *op,Funcdata &data);
 };
 
+class RuleOrCompare : public Rule {
+public:
+  RuleOrCompare(const string &g) : Rule( g, 0, "ruleorcompare") {}	///< Constructor
+  virtual Rule *clone(const ActionGroupList &grouplist) const {
+    if (!grouplist.contains(getGroup())) return (Rule *)0;
+    return new RuleOrCompare(getGroup());
+  }
+  virtual void getOpList(vector<uint4> &oplist) const;
+  virtual int4 applyOp(PcodeOp *op,Funcdata &data);
+};
+
 } // End namespace ghidra
 #endif


### PR DESCRIPTION
At optimisation level `-O1`, gcc combines several values that all need to be compared against zero by combining them using `INT_OR` and only comparing the combined result against zero. With this rule, the decompiler is able to break these `INT_OR` chains apart and simplify the individual links.

**Example**

As an example, let's compile the below source code with `gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0` (or follow along on [godbolt]). Make sure to pass `-O1`.

```c
#include <stdio.h>

int a = 0;
int b = 0;

int main() {
    if ((a == 0) && (b == 0)) {
        printf("zero!\n");
    }
    return 0;
}
```

If using godbolt, you can notice that an `or` instruction is used and only one jump instruction. If you're compiling locally, you can load the resulting binary in ghidra and let auto analysis run. I tested with Github release 11.0.3. The decompiler gives the following output:

```c
undefined8 main(void)

{
  if ((a | b) != 0) {
    return 0;
  }
  puts("zero!");
  return 0;
}
```

Here, you can also see the binary or operator (`|`) being used. Together with the `!= 0` condition, it's not obvious at first glance that this tests if either `a` or `b` is nonzero. Additionally, in this case `a` and `b` are variables that cannot be simplified further. The expressions being or-red together might be more complex, and this structure hinders further simplification.

We can test this PR by compiling `decomp_dbg` and using [this xml] that I generated using the "Debug function decompilation" menu item. Then, we can use the command line interface `decomp_dbg` to see what the decompiled code would look like with this patch:

```
[decomp]> restore /path/to/int_or_zero.xml                          
/path/to/int_or_zero.xml successfully loaded: Intel/AMD 64-bit x86
[decomp]> load function main
Function main: 0x00101149
[decomp]> decompile
Decompiling main
Decompilation complete
[decomp]> print C

undefined8 main(void)

{
  if (a != 0 || b != 0) {
    return 0;
  }
  puts("zero!");
  return 0;
}
```

[this xml]: https://github.com/NationalSecurityAgency/ghidra/files/15442768/int_or_zero.xml.txt
[godbolt]: https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,selection:(endColumn:1,endLineNumber:12,positionColumn:1,positionLineNumber:12,selectionStartColumn:1,selectionStartLineNumber:12,startColumn:1,startLineNumber:12),source:'%23include+%3Cstdio.h%3E%0A%0Aint+a+%3D+0%3B%0Aint+b+%3D+0%3B%0A%0Aint+main()+%7B%0A++++if+((a+%3D%3D+0)+%26%26+(b+%3D%3D+0))+%7B%0A++++++++printf(%22zero!!%5Cn%22)%3B%0A++++%7D%0A++++return+0%3B%0A%7D%0A'),l:'5',n:'1',o:'C+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:cg114,filters:(b:'1',binary:'1',binaryObject:'0',commentOnly:'1',debugCalls:'1',demangle:'1',directives:'1',execute:'1',intel:'1',libraryCode:'1',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,libs:!(),options:'-O1',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+gcc+11.4+(Editor+%231)',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4