### PR TITLE
Decompiler: `RuleIgnoreNan`: Don't descend if NAN flow has been removed

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -9503,6 +9503,8 @@ Varnode *RuleIgnoreNan::testForComparison(Varnode *floatVar,PcodeOp *op,int4 slo
       data.opRemoveInput(op, 1);
       data.opSetInput(op, vn, 0);
       count += 1;
+      // NaN flow has been removed - don't descend further
+      return (Varnode *)0;
     }
     return op->getOut();
   }


### PR DESCRIPTION
Sometimes, when `RuleIgnoreNan` tries to remove `NAN`-branches from conditionals, it is too aggressive and also removes other branches, leading to incorrect decompiler output. By returning a null pointer if the `NAN` flow has been removed by replacing the boolean operation such as `BOOL_AND` or `BOOL_OR` by a `COPY` operation, we avoid descending down further and removing too much of the tree.

Fixes #6580 