### PR TITLE
AArch32: STR/STRT had missing offset when rt/rd is PC

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -639,6 +639,9 @@ rm: Rm is Rm				{ export Rm; }
 rs: pc is pc & Rs=15        { tmp:4 = inst_start+8; export tmp; }
 rs: Rs is Rs				{ export Rs; }
 
+rd: pc is pc & Rd=15        { tmp:4 = inst_start+8; export tmp; }
+rd: Rd is Rd				{ export Rd; }
+
 cc: "eq" is cond=0          { export ZR; }
 cc: "ne" is cond=1          { tmp:1 = !ZR; export tmp; }
 cc: "cs" is cond=2          { export CY; }
@@ -5458,11 +5461,11 @@ armEndianNess: "BE" is c0031=0xf1010200 { export 1:1; }
 #}
 
 # The following form of str assumes alignment checking is on
-:str^COND Rd,addrmode2 		is $(AMODE) & ARMcond=1 & COND & c2627=1 & B22=0 & L20=0 & Rd & (I25=0 | (I25=1 & c0404=0)) & addrmode2
+:str^COND rd,addrmode2 		is $(AMODE) & ARMcond=1 & COND & c2627=1 & B22=0 & L20=0 & rd & (I25=0 | (I25=1 & c0404=0)) & addrmode2
 {
   build COND;
   build addrmode2;
-  *addrmode2 = Rd;
+  *addrmode2 = rd;
 }
 
 :strb^COND Rd,addrmode2 	is $(AMODE) & ARMcond=1 & COND & c2627=1 & B22=1 & L20=0 & Rd & (I25=0 | (I25=1 & c0404=0)) & addrmode2
@@ -5576,11 +5579,11 @@ armEndianNess: "BE" is c0031=0xf1010200 { export 1:1; }
 #}
 
 # The following form of str assumes alignment checking is on
-:strt^COND Rd,addrmode2 	is $(AMODE) & ARMcond=1 & COND & c2627=1 & B22=0 & L20=0 & P24=0 & W21=1 & Rd & (I25=0 | (I25=1 & c0404=0)) & addrmode2
+:strt^COND rd,addrmode2 	is $(AMODE) & ARMcond=1 & COND & c2627=1 & B22=0 & L20=0 & P24=0 & W21=1 & rd & (I25=0 | (I25=1 & c0404=0)) & addrmode2
 {
   build COND;
   build addrmode2;
-  *addrmode2 = Rd;
+  *addrmode2 = rd;
 }
 
 :sub^COND^SBIT_CZNO Rd,rn,shift1	is $(AMODE) & ARMcond=1 & COND & c2124=2 & SBIT_CZNO & rn & Rd & c2627=0 & shift1


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `STR` and `STRT` instructions for AArch32 (`ARM:LE:32:v8`).

According to the manual,
 
`STR (immediate)`: Calculates an address from a base register value and an immediate offset, and stores a word from a register to memory.

`STRT`: Store Register Unprivileged stores a word from a register to memory.

However, we noticed the output was incorrect when rd/rt is PC. 

-----
e.g, for AArch32 with,

Instruction:         `0xffff0ed4, strle pc,[lr],#-0xfff`
initial_registers: `{ "lr": 0x1ad1f844, "pc": 0x10000000, "NG": 0x1, "OV": 0x0 }`

We get:

Hardware:         `{ "lr": 0x1ad1e845, 0x1AD1F844: 0x8, 0x1AD1F845: 0x0, 0x1AD1F846: 0x0, 0x1AD1F847: 0x10 }`
Patched Spec: `{ "lr": 0x1ad1e845, 0x1AD1F844: 0x8, 0x1AD1F845: 0x0, 0x1AD1F846: 0x0, 0x1AD1F847: 0x10 }`
Existing Spec:  `{ "lr": 0x1ad1e845, 0x1AD1F844: 0x0, 0x1AD1F845: 0x0, 0x1AD1F846: 0x0, 0x1AD1F847: 0x10 }`

and, 

Instruction:         `0xffff2ed4, strtle pc,[lr],#-0xfff`
initial_registers: `{ "lr": 0x4122325b, "pc": 0x10000000, "NG": 0x1, "OV": 0x0 }`

We get:

Hardware:         `{ "lr": 0x4122225c, 0x4122325B: 0x8, 0x4122325C: 0x0, 0x4122325D: 0x0, 0x4122325E: 0x10 }`
Patched Spec: `{ "lr": 0x4122225c, 0x4122325B: 0x8, 0x4122325C: 0x0, 0x4122325D: 0x0, 0x4122325E: 0x10 }`
Existing Spec:  `{ "lr": 0x4122225c, 0x4122325B: 0x0, 0x4122325C: 0x0, 0x4122325D: 0x0, 0x4122325E: 0x10 }`

-----

In Thumb mode (`ARM:LE:32:v8T`), if rd/rt is PC, it results in `UNPREDICTABLE` behaviour and so is the case for other variants like `STRB`. However, in the cases above this is permissible. 

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._