### PR TITLE
AArch64: Change rmif bit shift to rotate

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
@@ -4971,7 +4971,7 @@ is b_1230=0b1011010110000000000 & b_31=1 & b_1011=0b10 & Rn_GPR64 & Rd_GPR64
 :rmif Rn_GPR64, UImm6, NZCVImm_uimm4
 is b_2131=0b10111010000 & b_1014=0b00001 & b_04=0b0 & Rn_GPR64 & UImm6 & NZCVImm_uimm4
 {
-	tmp:8 = Rn_GPR64 >> UImm6;
+	tmp:8 = Rn_GPR64 >> UImm6 | (Rn_GPR64 << (64 - UImm6));
 	condMask:1 = NZCVImm_uimm4;
 	set_NZCV(tmp,condMask);
 }


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the rmif instruction for AARCH64. According to Section C6.2.260, the expected behaviour is to rotate right the value in the operand register, and the lower bits are copied into the NZCV flags. While the current behaviour instead performs a right shift, clearing some bits when the shift immediate is greater than 60.

e.g.:
`0xcf871fba` "rmif x30, #0x3f, #0xf" with x30 = 0x5f6d9d6c85ec78e5

Hardware Reference: NZCV = 0xa
Existing Spec: NZCV = 0x0
Patched Spec: NZCV = 0xa