### PR TITLE
AArch64: Add missing load to ldapr

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
@@ -2690,7 +2690,7 @@ is b_3031=0b10 & b_2129=0b111000101 & b_1015=0b110000 & Rn_GPR64xsp & aa_Wt & ls
 # size == 11 64-bit variant
 
 :ldapr aa_Xt, [Rn_GPR64xsp]
-is b_3031=0b11 & b_2129=0b111000101 & b_1015=0b110000 & Rn_GPR64xsp & aa_Xt
+is b_3031=0b11 & b_2129=0b111000101 & b_1015=0b110000 & Rn_GPR64xsp & aa_Xt & ls_data8
 {
 	aa_Xt = tmp_ldXn;
 }


### PR DESCRIPTION
As part of a research project testing the accuracy of the sleigh specifications compared to real hardware, we observed an unexpected behaviour in the ldapr instruction for AARCH64. According to Section C6.2.136, the expected behaviour is to load a value based on address from the second operand. While the current behaviour instead performs no memory loads for the 64 bit variant of the instruction, and uses an uninitialised value.

e.g.:
`0xdfc3bff8` "ldapr xzr, [x30]" with x30 = 0

Hardware Reference: Loaded Pages = 0x0
Existing Spec: Loaded Pages = None
Patched Spec: Loaded Pages - 0x0