### PR TITLE
x86: Zero upper bits of 64-bit registers on repeat/loop/string instructions

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -2999,7 +2999,7 @@ define pcodeop LocalDescriptorTableRegister;
 
 :LODSB^rep^reptail dseSI1   is vexMode=0 & rep & reptail & byte=0xAC & dseSI1           { build rep; build dseSI1; AL=dseSI1; build reptail; }
 :LODSW^rep^reptail dseSI2   is vexMode=0 & rep & reptail & opsize=0 & byte=0xAD & dseSI2    { build rep; build dseSI2; AX=dseSI2; build reptail; }
-:LODSD^rep^reptail dseSI4   is vexMode=0 & rep & reptail & opsize=1 & byte=0xAD & dseSI4    { build rep; build dseSI4; EAX=dseSI4; build reptail; }
+:LODSD^rep^reptail dseSI4   is vexMode=0 & rep & reptail & opsize=1 & byte=0xAD & dseSI4 & check_EAX_dest { build rep; build dseSI4; EAX=dseSI4; build check_EAX_dest; build reptail; }
 @ifdef IA64
 :LODSQ^rep^reptail dseSI8   is $(LONGMODE_ON) & vexMode=0 & rep & reptail & opsize=2 & byte=0xAD & dseSI8    { build rep; build dseSI8; RAX=dseSI8; build reptail; }
 @endif

--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -3004,20 +3004,20 @@ define pcodeop LocalDescriptorTableRegister;
 :LODSQ^rep^reptail dseSI8   is $(LONGMODE_ON) & vexMode=0 & rep & reptail & opsize=2 & byte=0xAD & dseSI8    { build rep; build dseSI8; RAX=dseSI8; build reptail; }
 @endif
 
-:LOOP   rel8        is vexMode=0 & addrsize=0 & byte=0xE2; rel8             { CX = CX -1; if (CX!=0) goto rel8; }
-:LOOP   rel8        is vexMode=0 & addrsize=1 & byte=0xE2; rel8             { ECX = ECX -1; if (ECX!=0) goto rel8; }
+:LOOP   rel8        is vexMode=0 & addrsize=0 & byte=0xE2; rel8                  { CX = CX -1; if (CX!=0) goto rel8; }
+:LOOP   rel8        is vexMode=0 & addrsize=1 & byte=0xE2; rel8 & check_ECX_dest { ECX = ECX -1; build check_ECX_dest; if (ECX!=0) goto rel8; }
 @ifdef IA64
 :LOOP   rel8        is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & byte=0xE2; rel8             { RCX = RCX -1; if (RCX!=0) goto rel8; }
 @endif
 
-:LOOPZ  rel8        is vexMode=0 & addrsize=0 & byte=0xE1; rel8             { CX = CX -1; if (CX!=0 && ZF!=0) goto rel8; }
-:LOOPZ  rel8        is vexMode=0 & addrsize=1 & byte=0xE1; rel8             { ECX = ECX -1; if (ECX!=0 && ZF!=0) goto rel8; }
+:LOOPZ  rel8        is vexMode=0 & addrsize=0 & byte=0xE1; rel8                  { CX = CX -1; if (CX!=0 && ZF!=0) goto rel8; }
+:LOOPZ  rel8        is vexMode=0 & addrsize=1 & byte=0xE1; rel8 & check_ECX_dest { ECX = ECX -1; build check_ECX_dest; if (ECX!=0 && ZF!=0) goto rel8; }
 @ifdef IA64
 :LOOPZ  rel8        is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & byte=0xE1; rel8             { RCX = RCX -1; if (RCX!=0 && ZF!=0) goto rel8; }
 @endif
 
-:LOOPNZ rel8        is vexMode=0 & addrsize=0 & byte=0xE0; rel8             { CX = CX -1; if (CX!=0 && ZF==0) goto rel8; }
-:LOOPNZ rel8        is vexMode=0 & addrsize=1 & byte=0xE0; rel8             { ECX = ECX -1; if (ECX!=0 && ZF==0) goto rel8; }
+:LOOPNZ rel8        is vexMode=0 & addrsize=0 & byte=0xE0; rel8                  { CX = CX -1; if (CX!=0 && ZF==0) goto rel8; }
+:LOOPNZ rel8        is vexMode=0 & addrsize=1 & byte=0xE0; rel8 & check_ECX_dest { ECX = ECX -1; build check_ECX_dest; if (ECX!=0 && ZF==0) goto rel8; }
 @ifdef IA64
 :LOOPNZ rel8        is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & byte=0xE0; rel8             { RCX = RCX -1; if (RCX!=0 && ZF==0) goto rel8; }
 @endif

--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -1067,7 +1067,7 @@ cc: "G" is cond=15          { local tmp = !ZF && (OF == SF); export tmp; }
 
 # repeat prefixes
 rep: ".REP" is ((repprefx=1 & repneprefx=0)|(repprefx=0 & repneprefx=1)) & addrsize=0  { if (CX==0) goto inst_next; CX=CX-1; }
-rep: ".REP" is ((repprefx=1 & repneprefx=0)|(repprefx=0 & repneprefx=1)) & addrsize=1  { if (ECX==0) goto inst_next; ECX=ECX-1; }
+rep: ".REP" is ((repprefx=1 & repneprefx=0)|(repprefx=0 & repneprefx=1)) & addrsize=1 & check_ECX_dest  { if (ECX==0) goto inst_next; ECX=ECX-1; build check_ECX_dest; }
 @ifdef IA64
 rep: ".REP" is ((repprefx=1 & repneprefx=0)|(repprefx=0 & repneprefx=1)) & addrsize=2  { if (RCX==0) goto inst_next; RCX=RCX-1; }
 @endif
@@ -1077,12 +1077,12 @@ reptail:	is ((repprefx=1 & repneprefx=0)|(repprefx=0 & repneprefx=1))			{ goto i
 reptail:	is repprefx=0 & repneprefx=0			{ }
 
 repe: ".REPE"   is repprefx=1 & repneprefx=0 & addrsize=0  { if (CX==0) goto inst_next; CX=CX-1; }
-repe: ".REPE"   is repprefx=1 & repneprefx=0 & addrsize=1  { if (ECX==0) goto inst_next; ECX=ECX-1; }
+repe: ".REPE"   is repprefx=1 & repneprefx=0 & addrsize=1 & check_ECX_dest { if (ECX==0) goto inst_next; ECX=ECX-1; build check_ECX_dest; }
 @ifdef IA64
 repe: ".REPE"   is repprefx=1 & repneprefx=0 & addrsize=2  { if (RCX==0) goto inst_next; RCX=RCX-1; }
 @endif
 repe: ".REPNE"  is repneprefx=1 & repprefx=0 & addrsize=0    { if (CX==0) goto inst_next; CX=CX-1; }
-repe: ".REPNE"  is repneprefx=1 & repprefx=0 & addrsize=1    { if (ECX==0) goto inst_next; ECX=ECX-1; }
+repe: ".REPNE"  is repneprefx=1 & repprefx=0 & addrsize=1 & check_ECX_dest { if (ECX==0) goto inst_next; ECX=ECX-1; build check_ECX_dest; }
 @ifdef IA64
 repe: ".REPNE"  is repneprefx=1 & repprefx=0 & addrsize=2    { if (RCX==0) goto inst_next; RCX=RCX-1; }
 @endif

--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -954,26 +954,35 @@ moffs64: segWide^[imm32]  is addrsize=1 & highseg=1 & segWide & imm32   { tmp:8 
 @endif
 # TODO: segment register offset in 64bit might not be right
 
+@ifdef IA64
+check_EDI_dest: is $(LONGMODE_ON)	{ RDI = zext(EDI); }
+check_ESI_dest: is $(LONGMODE_ON)	{ RSI = zext(ESI); }
+check_ECX_dest: is $(LONGMODE_ON)	{ RCX = zext(ECX); }
+@endif
+check_EDI_dest:	is epsilon  		{ }
+check_ESI_dest:	is epsilon  		{ }
+check_ECX_dest:	is epsilon  		{ }
+
 # String memory access
 dseSI1: seg16^SI    is addrsize=0 & seg16 & SI  { tmp:4 = segment(seg16,SI); SI = SI + 1-2*zext(DF); export *:1 tmp; }
-dseSI1: segWide^ESI   is addrsize=1 & segWide & ESI { tmp:4 = ESI; ESI = ESI + 1-2*zext(DF); export *:1 tmp; }
+dseSI1: segWide^ESI   is addrsize=1 & segWide & ESI & check_ESI_dest { tmp:4 = ESI; ESI = ESI + 1-2*zext(DF); build check_ESI_dest; export *:1 tmp; }
 dseSI2: seg16^SI    is addrsize=0 & seg16 & SI  { tmp:4 = segment(seg16,SI); SI = SI + 2-4*zext(DF); export *:2 tmp; }
-dseSI2: segWide^ESI   is addrsize=1 & segWide & ESI { tmp:4 = ESI; ESI = ESI + 2-4*zext(DF); export *:2 tmp; }
+dseSI2: segWide^ESI   is addrsize=1 & segWide & ESI & check_ESI_dest { tmp:4 = ESI; ESI = ESI + 2-4*zext(DF); build check_ESI_dest; export *:2 tmp; }
 dseSI4: seg16^SI    is addrsize=0 & seg16 & SI  { tmp:4 = segment(seg16,SI); SI = SI + 4-8*zext(DF); export *:4 tmp; }
-dseSI4: segWide^ESI   is addrsize=1 & segWide & ESI { tmp:4 = ESI; ESI = ESI + 4-8*zext(DF); export *:4 tmp; }
+dseSI4: segWide^ESI   is addrsize=1 & segWide & ESI & check_ESI_dest { tmp:4 = ESI; ESI = ESI + 4-8*zext(DF); build check_ESI_dest; export *:4 tmp; }
 eseDI1: ES:DI       is addrsize=0 & ES & DI     { tmp:4 = segment(ES,DI); DI = DI + 1-2*zext(DF); export *:1 tmp; }
-eseDI1: ES:EDI      is addrsize=1 & ES & EDI    { tmp:4 = EDI; EDI=EDI+1-2*zext(DF); export *:1 tmp; }
+eseDI1: ES:EDI      is addrsize=1 & ES & EDI & check_EDI_dest { tmp:4 = EDI; EDI=EDI+1-2*zext(DF); build check_EDI_dest; export *:1 tmp; }
 eseDI2: ES:DI       is addrsize=0 & ES & DI     { tmp:4 = segment(ES,DI); DI = DI + 2-4*zext(DF); export *:2 tmp; }
-eseDI2: ES:EDI      is addrsize=1 & ES & EDI    { tmp:4 = EDI; EDI=EDI+2-4*zext(DF); export *:2 tmp; }
+eseDI2: ES:EDI      is addrsize=1 & ES & EDI & check_EDI_dest { tmp:4 = EDI; EDI=EDI+2-4*zext(DF); build check_EDI_dest; export *:2 tmp; }
 eseDI4: ES:DI       is addrsize=0 & ES & DI     { tmp:4 = segment(ES,DI); DI = DI + 4-8*zext(DF); export *:4 tmp; }
-eseDI4: ES:EDI      is addrsize=1 & ES & EDI    { tmp:4 = EDI; EDI=EDI+4-8*zext(DF); export *:4 tmp; }
+eseDI4: ES:EDI      is addrsize=1 & ES & EDI & check_EDI_dest { tmp:4 = EDI; EDI=EDI+4-8*zext(DF); build check_EDI_dest; export *:4 tmp; }
 
 @ifdef IA64
 # quadword string functions
 dseSI8: seg16^SI    is addrsize=0 & seg16 & SI  { tmp:4 = segment(seg16,SI); SI = SI + 8-16*zext(DF); export *:8 tmp; }
-dseSI8: segWide^ESI   is addrsize=1 & segWide & ESI { tmp:4 = ESI; ESI = ESI + 8-16*zext(DF); export *:8 tmp; }
+dseSI8: segWide^ESI   is addrsize=1 & segWide & ESI & check_ESI_dest { tmp:4 = ESI; ESI = ESI + 8-16*zext(DF); build check_ESI_dest; export *:8 tmp; }
 eseDI8: ES:DI       is addrsize=0 & ES & DI     { tmp:4 = segment(ES,DI); DI = DI + 8-16*zext(DF); export *:8 tmp; }
-eseDI8: ES:EDI      is addrsize=1 & ES & EDI    { tmp:4 = EDI; EDI=EDI+8-16*zext(DF); export *:8 tmp; }
+eseDI8: ES:EDI      is addrsize=1 & ES & EDI & check_EDI_dest { tmp:4 = EDI; EDI=EDI+8-16*zext(DF); build check_EDI_dest; export *:8 tmp; }
 
 dseSI1: RSI   is addrsize=2 & RSI { local tmp = RSI; RSI = RSI + 1-2*zext(DF); export *:1 tmp; }
 dseSI2: RSI   is addrsize=2 & RSI { local tmp = RSI; RSI = RSI + 2-4*zext(DF); export *:2 tmp; }


### PR DESCRIPTION
Several instructions involving loop semantics are missing `check_Reg` operations when 32-bit registers are modified in long mode. This PR adds an appropriate `check_Reg` to all the places where 32-bits register are modified. (Here several commits have been merged into a single PR, because the fix is essentially the same for each issue).

For string operations, `EDI` and `ESI` need to be zeroed when the address size prefix (67) is set:

* `67a5` `MOVSD ES:EDI,ESI` with `RDI=0xaaaaaaaa00000000`, `RSI=0xaaaaaaaa00001000`, `mem[0x1000]=44332211`
    - Hardware Reference (AMD CPU & Intel CPU): { `RDI=0x4`, `RSI=0x1004`, `mem[0x0]=44332211`}
    - `x86:LE:64:default` (Existing): `"MOVSD ES:EDI,ESI"` { `RDI=0xaaaaaaaa00000004`, `RSI=0xaaaaaaaa00001004`, `mem[0x0]=44332211`}
    - `x86:LE:64:default` (This patch): `"MOVSD ES:EDI,ESI"` { `RDI=0x4`, `RSI=0x1004`, `mem[0x0]=44332211`}


For `REP` instructions, `ECX` is used when the address size prefix (67) is set and needs to be zeroed:

* `67f3af` `SCASD.REPE ES:EDI` with `RDI=0xaaaaaaaa_00000000`, `RCX=0xaaaaaaaa_00000001`
    - Hardware Reference (AMD CPU & Intel CPU): { `CF=0x1`, `RCX=0x0`, `RDI=0x4` }
    - `x86:LE:64:default` (Existing): `"SCASD.REPE ES:EDI"` { `CF=0x1`, `RCX=0xaaaaaaaa00000000`, `RDI=0xaaaaaaaa00000004` }
    - `x86:LE:64:default` (This patch): `"SCASD.REPE ES:EDI"` { `CF=0x1`, `RCX=0x0`, `RDI=0x4` }

Essentially, identical differences apply to all string instructions with repeat ops, e.g.:

- `67f3ac` `"LODSB.REP ESI"`
- `67f3ad` `"LODSD.REP ESI"`
- `67f3a6` `"CMPSB.REPE ES:EDI,ESI"`

A similar change is needed when the 67 prefix is present on `LOOP` instructions:

- `67e2xx` `"LOOP [addr]"`

Also includes conditional `LOOP` instructions:

- `67e1xx` `"LOOPZ [addr]"`
- `67e0xx` `"LOOPNZ [addr]"`


The `LODSD` instruction (no prefix required), writes to `EAX` and also requires a fix:

* `ad` `LODSD RSI` with `RSI=0x1000`, `mem[0x1000]=44332211`,`RAX=0xaaaaaaaa00000000`
    - Hardware Reference (AMD CPU & Intel CPU): { `RAX=0x11223344`, `RSI=0x1004` }
    - `x86:LE:64:default` (Existing): `"LODSD RSI"` { `RAX=0xaaaaaaaa11223344`, `RSI=0x1004` }
    - `x86:LE:64:default` (This patch): `"LODSD RSI"` { `RAX=0x11223344`, `RSI=0x1004` }

---

After the PR, there is still a minor discrepancy with Intel CPUs. Even when `ECX=0` (no loop iterations), the test Intel CPU zeroes the upper bits of `RAX`. AMD's behavior makes more logical sense, for other instructions in long mode, zeroing the upper bits only occur when the register is used as a destination of an operation, and according to the pseudocode listed for REP instructions† `RCX` is not written to if it is zero, however this is what is observed running the instruction on real hardware:

* 67f3af `SCASD.REPE ES:EDI` with `RDI=0xaaaaaaaa_00000000`, `RCX=0xaaaaaaaa_00000000`
    - AMD CPU: { `RDI=0xaaaaaaaa_00000000`, `RCX=0xaaaaaaaa_00000000` } (AMD CPUs behave the same as the PR)
    - Intel CPU: { `RDI=0xaaaaaaaa_00000000`, `RCX=0x00000000_00000000` }
    - `x86:LE:64:default` (unchanged): `"SCASD.REPE ES:EDI"` { `RDI=0xaaaaaaaa_00000000`, `RCX=0xaaaaaaaa_00000000` }

<sub>†Intel SDM Vol.2B "REP/REPE/REPZ/REPNE/REPNZ—Repeat String Operation Prefix"</sub>

