### PR TITLE
x86: PUSHF/POPF address size fixes (64-bit mode)

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -3368,8 +3368,8 @@ define pcodeop swap_bytes;
 :POPFD          is $(LONGMODE_OFF) & vexMode=0 & addrsize=0 & opsize=1 & byte=0x9d            { pop24(eflags); unpackflags(eflags); unpackeflags(eflags); }
 :POPFD          is $(LONGMODE_OFF) & vexMode=0 & addrsize=1 & opsize=1 & byte=0x9d            { pop44(eflags); unpackflags(eflags); unpackeflags(eflags); }
 @ifdef IA64
-:POPF           is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & opsize=0 & byte=0x9d            { pop82(flags); unpackflags(flags); }
-:POPFQ          is $(LONGMODE_ON) & vexMode=0 & addrsize=2 &            byte=0x9d            { pop88(rflags); unpackflags(rflags); unpackeflags(rflags); }
+:POPF           is $(LONGMODE_ON) & vexMode=0 & opsize=0 & byte=0x9d            { pop82(flags); unpackflags(flags); }
+:POPFQ          is $(LONGMODE_ON) & vexMode=0 &            byte=0x9d            { pop88(rflags); unpackflags(rflags); unpackeflags(rflags); }
 @endif
 
 :PREFETCH     m8  is vexMode=0 & byte=0x0f; byte=0x0d; m8 & reg_opcode=0 ... { }
@@ -3451,8 +3451,8 @@ define pcodeop ptwrite;
 :PUSHFD         is $(LONGMODE_OFF) & vexMode=0 & addrsize=0 & opsize=1 & byte=0x9c            { packflags(eflags); packeflags(eflags); push24(eflags); }
 :PUSHFD         is $(LONGMODE_OFF) & vexMode=0 & addrsize=1 & opsize=1 & byte=0x9c            { packflags(eflags); packeflags(eflags); push44(eflags); }
 @ifdef IA64
-:PUSHF          is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & opsize=0 & byte=0x9c            { packflags(flags); push82(flags); }
-:PUSHFQ         is $(LONGMODE_ON) & vexMode=0 &                         byte=0x9c            { packflags(rflags); packeflags(rflags); push88(rflags); }
+:PUSHF          is $(LONGMODE_ON) & vexMode=0 & opsize=0 & byte=0x9c            { packflags(flags); push82(flags); }
+:PUSHFQ         is $(LONGMODE_ON) & vexMode=0 &            byte=0x9c            { packflags(rflags); packeflags(rflags); push88(rflags); }
 @endif
 
 :RCL  rm8,n1        is vexMode=0 & byte=0xD0; rm8 & n1 & reg_opcode=2 ...           { local tmpCF = CF; CF = rm8 s< 0; rm8 = (rm8 << 1) | tmpCF; OF = CF ^ (rm8 s< 0); }


### PR DESCRIPTION
The `addrsize` should be ignored for PUSHF/POPF instructions. This was potentially used before the `LONGMODE_ON` context bit was introduced to distinguish the 64-bit behavior from the 32-bit behavior. Since `addrsize` can be manipulated using the address size override prefix, it can cause the wrong PUSHF/POPF size to be decoded. The `LONGMODE_ON` constraint is now sufficient, so this PR simply removes the unnecessary `addrsize` constraint.

e.g.,


* 67669c `PUSHF` with `RSP=0x1002`, `ZF=1`
    - Hardware Reference (AMD CPU & Intel CPU): { `mem[0x1000] = 4201`, `RSP=0x1000` }
    - `x86:LE:64:default` (Existing): `"PUSHFQ"` { `mem[0xffa] = 4000000000000000`, `RSP=0x0ffa` }
    - `x86:LE:64:default` (This patch): `"PUSHF"` { `mem[0x1000] = 4000`, `RSP=0x1000` }

(Note: on the hardware reference, extra bits that are set correspond to `EFLAGS.res1` (bit 1) and `EFLAGS.TF` (bit 8))

* 67669d `POPF` with `RSP=0x1000`, `mem[0x1000] = 4000`
    - Hardware Reference (AMD CPU & Intel CPU): { `ZF=1`, `RSP=0x1002` }
    - `x86:LE:64:default` (Existing): Invalid Instruction
    - `x86:LE:64:default` (This patch): `"PUSHF"` { `ZF=1`, `RSP=0x1002`  }

---

The `LONGMODE_OFF` constructors have been left alone in this PR, although they technically should also ignore address size overrides. With `LONGMODE_OFF`, the address size is used to determine whether the `segment` pcodeop is applied during address translation, however segmentation should still be applied in 32-bit protected mode, but since most users are likely to be working with 32-bit programs where segment bases are all zero, the current behavior probably behaves better than injecting `segment` ops everywhere.

(It could make sense to introduce pseudo registers like `CS.base`/`DS.base`/etc... that are assumed to be zero but are user overridable, like the way the direction flag is handled)