### PR TITLE
x86: PUSH FS/GS long mode improvements.

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -1194,9 +1194,9 @@ macro push88(x) {
 }
 
 macro pushseg88(x) {
-  mysave:2 = x;
+  mysave:8 = zext(x);
   $(STACKPTR) = $(STACKPTR) - 8;
-  *:2 $(STACKPTR) = mysave;
+  *:8 $(STACKPTR) = mysave;
 }
 @endif
 
@@ -3433,12 +3433,14 @@ define pcodeop ptwrite;
 :PUSH FS        is $(LONGMODE_OFF) & vexMode=0 & addrsize=0 & byte=0xf; byte=0xa0 & FS        { push22(FS); }
 :PUSH FS        is $(LONGMODE_OFF) & vexMode=0 & addrsize=1 & byte=0xf; byte=0xa0 & FS        { pushseg44(FS); }
 @ifdef IA64
-:PUSH FS        is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & byte=0xf; byte=0xa0 & FS        { pushseg88(FS); }
+:PUSH FS        is $(LONGMODE_ON) & vexMode=0 & opsize=0 & byte=0xf; byte=0xa0 & FS        { push82(FS); }
+:PUSH FS        is $(LONGMODE_ON) & vexMode=0 &            byte=0xf; byte=0xa0 & FS        { pushseg88(FS); }
 @endif
 :PUSH GS        is $(LONGMODE_OFF) & vexMode=0 & addrsize=0 & byte=0xf; byte=0xa8 & GS        { push22(GS); }
 :PUSH GS        is $(LONGMODE_OFF) & vexMode=0 & addrsize=1 & byte=0xf; byte=0xa8 & GS        { pushseg44(GS); }
 @ifdef IA64
-:PUSH GS        is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & byte=0xf; byte=0xa8 & GS        { pushseg88(GS); }
+:PUSH GS        is $(LONGMODE_ON) & vexMode=0 & opsize=0 & byte=0xf; byte=0xa8 & GS        { push82(GS); }
+:PUSH GS        is $(LONGMODE_ON) & vexMode=0 &            byte=0xf; byte=0xa8 & GS        { pushseg88(GS); }
 @endif
 
 :PUSHA          is $(LONGMODE_OFF) & vexMode=0 & addrsize=0 & opsize=0 & byte=0x60            { local tmp=SP; push22(AX); push22(CX); push22(DX); push22(BX); push22(tmp); push22(BP); push22(SI); push22(DI); }


### PR DESCRIPTION
In long-mode, `PUSH` instructions default to a 64-bit operand size, and the manual states: "If the source operand is a segment register (16 bits) and the operand size is 64-bits, a zero-extended value is pushed on the stack". Currently the SLEIGH spec adjusts RSP correctly but performs a 16-bit store leaving the upper bits unmodified.

Additionally, for segment register pushes the address size prefix should be ignored, but the operand override prefix needs to be accounted for.

This PR changes the `pushseg88` macro to zero extend the input operand (the same macro is used in the `CALLF` which should also the upper 48-bits), and also fixes prefix handling.


* `0fa0` `PUSH FS` with `RSP=0x1008`, `mem[0x1000]=aaaaaaaaaaaaaaaa`
    - Hardware Reference (AMD CPU & Intel CPU): { `RSP=0x1000`, `mem[0x1000]=0000000000000000` }
    - `x86:LE:64:default` (Existing): `"PUSH FS"` { `RSP=0x1000`, `mem[0x1000]=0000aaaaaaaaaaaa` }
    - `x86:LE:64:default` (This patch): `"PUSH FS"` { `RSP=0x1000`, `mem[0x1000]=0000000000000000` }

* `67660fa0` `PUSH FS` with `RSP=0x1008`, `mem[0x1000]=aaaaaaaaaaaaaaaa`
    - Hardware Reference (AMD CPU & Intel CPU): { `RSP=0x1006`, `mem[0x1000]=aaaaaaaaaaaa0000` }
    - `x86:LE:64:default` (Existing): Invalid instruction
    - `x86:LE:64:default` (This patch): `"PUSH FS"` { `RSP=0x1006`, `mem[0x1000]=aaaaaaaaaaaa0000` }


(Note: The 32-bit variants use `addrsize` to choose whether to use the `segment` pcodeop, which is technically incorrect, see: #6601, but not included in this PR.)
