### PR TITLE
AArch32: vpush (sreg variant) had faulty address ordering

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -4651,7 +4651,7 @@ define pcodeop FloatVectorNeg;
 @if defined(VFPv2) || defined(VFPv3) || defined(SIMD)
 
 buildVpushSdList: Sreg					is counter=0 & Sreg			[ regNum=regNum+1; ] { * mult_addr = Sreg; mult_addr = mult_addr + 4; }
-buildVpushSdList: Sreg,buildVpushSdList	is Sreg & buildVpushSdList	[ counter=counter-1; regNum=regNum+1; ] { * mult_addr = Sreg; mult_addr = mult_addr + 4; }
+buildVpushSdList: Sreg,buildVpushSdList	is Sreg & buildVpushSdList	[ counter=counter-1; regNum=regNum+1; ] { * mult_addr = Sreg; mult_addr = mult_addr + 4; build buildVpushSdList; }
 
 vpushSdList: "{"^buildVpushSdList^"}"	is TMode=0 & D22 & c1215 & c0007 & buildVpushSdList [ regNum=(c1215<<1)+D22-1; counter=c0007-1; ] { sp = sp - c0007 * 4; mult_addr = sp; build buildVpushSdList; }
 vpushSdList: "{"^buildVpushSdList^"}"	is TMode=1 & thv_D22 & thv_c1215 & thv_c0007 & buildVpushSdList [ regNum=(thv_c1215<<1)+thv_D22-1; counter=thv_c0007-1; ] { sp = sp - thv_c0007 * 4; mult_addr = sp; build buildVpushSdList; }


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `vpush` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, it stores multiple consecutive registers from the Advanced SIMD and floating-point register file to the stack. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0x020a2d4d, vpushmi {s0,s1}`
initial_registers: `{ "q0": 0xc8d5e62f63a868ba6d6b3be579e0577d, "sp": 0x96ea0a94, "NG": 0x1 }`

We get:

Hardware:         `{ "sp": 0x96ea0a8c, 0x96EA0A8C: 0x7d, 0x96EA0A8D: 0x57, 0x96EA0A8E: 0xe0, 0x96EA0A8F: 0x79, 0x96EA0A90: 0xe5, 0x96EA0A91: 0x3b, 0x96EA0A92: 0x6b, 0x96EA0A93: 0x6d }`

Patched Spec: `{ "sp": 0x96ea0a8c, 0x96EA0A8C: 0x7d, 0x96EA0A8D: 0x57, 0x96EA0A8E: 0xe0, 0x96EA0A8F: 0x79, 0x96EA0A90: 0xe5, 0x96EA0A91: 0x3b, 0x96EA0A92: 0x6b, 0x96EA0A93: 0x6d }`

Existing Spec:  `{ "sp": 0x96ea0a8c, 0x96EA0A8C: 0xe5, 0x96EA0A8D: 0x3b, 0x96EA0A8E: 0x6b, 0x96EA0A8F: 0x6d, 0x96EA0A90: 0x7d, 0x96EA0A91: 0x57, 0x96EA0A92: 0xe0, 0x96EA0A93: 0x79 }`

-----
e.g, for Thumb with,

Instruction:         `0x2ded020a, vpush {s0,s1}`
initial_registers: `{ "q0": 0xc8d5e62f63a868ba6d6b3be579e0577d, "sp": 0x96ea0a94 }`

We get:

Hardware:         `{ "sp": 0x96ea0a8c, 0x96EA0A8C: 0x7d, 0x96EA0A8D: 0x57, 0x96EA0A8E: 0xe0, 0x96EA0A8F: 0x79, 0x96EA0A90: 0xe5, 0x96EA0A91: 0x3b, 0x96EA0A92: 0x6b, 0x96EA0A93: 0x6d }`

Patched Spec: `{ "sp": 0x96ea0a8c, 0x96EA0A8C: 0x7d, 0x96EA0A8D: 0x57, 0x96EA0A8E: 0xe0, 0x96EA0A8F: 0x79, 0x96EA0A90: 0xe5, 0x96EA0A91: 0x3b, 0x96EA0A92: 0x6b, 0x96EA0A93: 0x6d }`

Existing Spec:  `{ "sp": 0x96ea0a8c, 0x96EA0A8C: 0xe5, 0x96EA0A8D: 0x3b, 0x96EA0A8E: 0x6b, 0x96EA0A8F: 0x6d, 0x96EA0A90: 0x7d, 0x96EA0A91: 0x57, 0x96EA0A92: 0xe0, 0x96EA0A93: 0x79 }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
