### PR TITLE
AArch32: vpop (sreg variant) had faulty mult_addr ordering

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -4676,14 +4676,14 @@ vpushSd64List: "{"^buildVpushSd64List^"}"	is TMode=1 & thv_D22 & thv_c1215 & thv
 }
 
 buildVpopSdList: Sreg					is counter=0 & Sreg			[ regNum=regNum+1; ]
-   { tmp:4 = *mult_addr; Sreg = zext(tmp); mult_addr = mult_addr + 4; }
+   { tmp:4 = *mult_addr; Sreg = zext(tmp); mult_addr = mult_addr - 4; }
 buildVpopSdList: Sreg,buildVpopSdList	is Sreg & buildVpopSdList	[ counter=counter-1; regNum=regNum+1; ]
-   { tmp:4 = *mult_addr; Sreg = zext(tmp); mult_addr = mult_addr + 4; }
+   { tmp:4 = *mult_addr; Sreg = zext(tmp); mult_addr = mult_addr - 4; }
 
 vpopSdList: "{"^buildVpopSdList^"}"	is TMode=0 & D22 & c1215 & c0007 & buildVpopSdList [ regNum=(c1215<<1)+D22-1; counter=c0007-1; ]
-   { mult_addr = sp; sp = sp + c0007 * 4; build buildVpopSdList; }
+   { mult_addr = sp + ((c0007 - 1) * 4); sp = sp + c0007 * 4; build buildVpopSdList; }
 vpopSdList: "{"^buildVpopSdList^"}"	is TMode=1 & thv_D22 & thv_c1215 & thv_c0007 & buildVpopSdList [ regNum=(thv_c1215<<1)+thv_D22-1; counter=thv_c0007-1; ]
-   { mult_addr = sp; sp = sp + thv_c0007 * 4; build buildVpopSdList; }
+   { mult_addr = sp + ((thv_c0007 - 1) * 4); sp = sp + thv_c0007 * 4; build buildVpopSdList; }
 
 buildVpopSd64List: Dreg					is counter=0 & Dreg			[ regNum=regNum+1; ]
    { Dreg = *mult_addr; mult_addr = mult_addr + 8; }


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `vpop` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, it loads multiple consecutive Advanced SIMD and floating-point register file registers from the stack. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0x020abd7c, vpopvc {s0,s1}`
initial_memory: `{ "0x0": [ 0xbb, 0xda, 0x60, 0xca, 0xe8, 0x7c, 0x26, 0xcf ] }`

We get:

Hardware:         `{ "q0": 0xcf267ce8ca60dabb, "sp": 0x8 }`
Patched Spec: `{ "q0": 0xcf267ce8ca60dabb, "sp": 0x8 }`
Existing Spec:  `{ "q0": 0xca60dabbcf267ce8, "sp": 0x8 }`

-----
e.g, for Thumb with,

Instruction:         `0xbdec020a, vpop {s0,s1}`
initial_memory: `{ "0x0": [ 0xbb, 0xda, 0x60, 0xca, 0xe8, 0x7c, 0x26, 0xcf ] }`

We get:

Hardware:         `{ "q0": 0xcf267ce8ca60dabb, "sp": 0x8 }`
Patched Spec: `{ "q0": 0xcf267ce8ca60dabb, "sp": 0x8 }`
Existing Spec:  `{ "q0": 0xca60dabbcf267ce8, "sp": 0x8 }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
