### PR TITLE
AArch32: vmov had incorrect vmask & missing position shift of vector element being copied.

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -4084,8 +4084,8 @@ dNvmovIndex: Dn^"["^vmovIndex^"]"   is Dn & vmovIndex     { }
                                    ($(TMODE_E) &         thv_c2327=0x1c & thv_c2222=1 & thv_c2020=0 & thv_c0811=11 & thv_c0404=1 & thv_c0003=0 ) ) & COND & Dn & VRd & vmovIndex & dNvmovIndex
 {
 	el:1 = VRd(0);
-	vmask:8 = 0xf << (vmovIndex*8);
-	Dn = (Dn & ~vmask) | (zext(el) & vmask);
+	vmask:8 = 0xff << (vmovIndex*8);
+	Dn = (Dn & ~vmask) | (zext(el) << (vmovIndex*8));
 	#VectorSetElement(VRd,Dn,vmovIndex);
 }
 
@@ -4093,8 +4093,8 @@ dNvmovIndex: Dn^"["^vmovIndex^"]"   is Dn & vmovIndex     { }
                                        ($(TMODE_E) &         thv_c2327=0x1c & thv_c2222=0 & thv_c2020=0 & thv_c0811=11 & thv_c0505=1 & thv_c0404=1 & thv_c0003=0 ) ) & COND & Dn & VRd & vmovIndex & dNvmovIndex
 {
 	el:2 = VRd(0);
-	vmask:8 = 0xff << (vmovIndex*16);
-	Dn = (Dn & ~vmask) | (zext(el) & vmask);
+	vmask:8 = 0xffff << (vmovIndex*16);
+	Dn = (Dn & ~vmask) | (zext(el) << (vmovIndex*16));
 	#VectorSetElement(VRd,Dn,vmovIndex,vmovSize);
 }
 
@@ -4103,8 +4103,8 @@ dNvmovIndex: Dn^"["^vmovIndex^"]"   is Dn & vmovIndex     { }
                                        ($(TMODE_E) &         thv_c2327=0x1c & thv_c2222=0 & thv_c2020=0 & thv_c0811=11 & thv_c0506=0 & thv_c0404=1 & thv_c0003=0 ) ) & COND & Dn & VRd & vmovIndex & dNvmovIndex
 {
 	el:4 = VRd;
-	vmask:8 = 0xffff << (vmovIndex*32);
-	Dn = (Dn & ~vmask) | (zext(el) & vmask);
+	vmask:8 = 0xffffffff << (vmovIndex*32);
+	Dn = (Dn & ~vmask) | (zext(el) << (vmovIndex*32));
 	#VectorSetElement(VRd,Dn,vmovIndex,vmovSize);
 }
 


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `vmov` (general-purpose register to scalar) instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, it copies a byte, halfword, or word from a general-purpose register into an Advanced SIMD scalar. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0xd05b4cde, vmovle.8 d28[0x2],r5`
initial_registers: `{ "r5": 0x7403198e, "q14": 0x26e05cadfd8460f219a07034b1518d01, "OV": 0x1 }`

We get:

Hardware:         `{ "q14": 0x26e05cadfd8460f219a07034b18e8d01 }`
Patched Spec: `{ "q14": 0x26e05cadfd8460f219a07034b18e8d01 }`
Existing Spec:  `{ "q14": 0x26e05cadfd8460f219a07034b1508d01 }`

and,

Instruction:         `0x900b20de, vmovle.32 d16[0x1],r0`
initial_registers: `{ "r0": 0xee797648, "q8": 0x5b4bba95c30dd82b0bb19dddeec0bed0, "NG": 0x1 }`

We get:

Hardware:         `{ "q8": 0x5b4bba95c30dd82bee797648eec0bed0 }`
Patched Spec: `{ "q8": 0x5b4bba95c30dd82bee797648eec0bed0 }`
Existing Spec:  `{ "q8": 0x5b4bba95c30dd82b0bb10000eec0bed0 }`

-----
e.g, for Thumb with,

Instruction:         `0x2ceeb05b, vmov.16 d28[0x2],r5`
initial_registers: `{ "r5": 0x8648c9d4, "q14": 0xc03538d2a3494060b9db010d20562c0a }`

We get:

Hardware:         `{ "q14": 0xc03538d2a3494060b9dbc9d420562c0a }`
Patched Spec: `{ "q14": 0xc03538d2a3494060b9dbc9d420562c0a }`
Existing Spec:  `{ "q14": 0xc03538d2a3494060b9db010020562c0a }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
