### PR TITLE
AArch32: addrmode3 incorrectly had load in address pointer export

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -997,13 +997,13 @@ addrmode2: [rn],-addr2shift is I25=1 & P24=0 & U23=0 & W21=1 & rn & addr2shift	{
 addrmode3: [reloff]		is P24=1 & U23=1 & c2122=2 & c1619=15 & immedH & immedL
   [ reloff=inst_start+8+((immedH<<4) | immedL);]
 {
-  export *:4 reloff;
+  export reloff;
 }
 
 addrmode3: [reloff]		is P24=1 & U23=0 & c2122=2 & c1619=15 & immedH & immedL
   [ reloff=inst_start+8-((immedH<<4) | immedL);]
 {
-  export *:4 reloff;
+  export reloff;
 }
 
 addrmode3: [rn,"#"^off8]		is P24=1 & U23=1 & c2122=2 & rn & immedH & immedL


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed unexpected behaviours in a few instructions that used  `addrmode3` constructor for AArch32 (`ARM:LE:32:v8`). 

According to the manual, the instructions in the example must store double registers at the specified address. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0xf000cfb1, strdlt r0,r1,[0x10000008]`
initial_registers: `{ "r5": 0x7403198e, "q14": 0x26e05cadfd8460f219a07034b1518d01, "OV": 0x1 }`

We get:

Hardware:         `{ "q14": 0x26e05cadfd8460f219a07034b18e8d01 }`
Patched Spec: `{ "q14": 0x26e05cadfd8460f219a07034b18e8d01 }`
Existing Spec:  `{ "q14": 0x26e05cadfd8460f219a07034b1508d01 }`

and,

Instruction:         `0x900b20de, vmovle.32 d16[0x1],r0`
initial_registers: `{ "r0": 0xee797648, "q8": 0x5b4bba95c30dd82b0bb19dddeec0bed0, "NG": 0x1 }`

We get:

Hardware:         `{ "q8": 0x5b4bba95c30dd82bee797648eec0bed0 }`
Patched Spec: `{ "q8": 0x5b4bba95c30dd82bee797648eec0bed0 }`
Existing Spec:  `{ "q8": 0x5b4bba95c30dd82b0bb10000eec0bed0 }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._
