### PR TITLE
AArch32: vld1 had incorrect post indexed increment

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMneon.sinc
@@ -2962,7 +2962,7 @@ RnAligned3: "["^Rn^vld1Align3^"]" 	is Rn & vld1Align3	{ export Rn; }
 {
 	mult_dat8 = vld1RnReplicate;
 	build vld1DdList3;
-	RnAligned3 = RnAligned3 + vld1DdList3;
+	RnAligned3 = RnAligned3 + esize0607;
 }
 
 :vld1.^esize0607 vld1DdList3,RnAligned3,VRm	is $(AMODE) & ARMcond=0 & cond=15 & c2327=9 & c2021=2 & RnAligned3 & vld1RnReplicate & vld1DdList3 & c0811=12 & esize0607 & VRm & $(vld1Constrain)
@@ -3012,7 +3012,7 @@ VRnAligned3: "["^VRn^thv_vld1Align3^"]" 	is VRn & thv_vld1Align3	{ export VRn; }
 {
 	mult_dat8 = thv_vld1RnReplicate;
 	build thv_vld1DdList3;
-	VRnAligned3 = VRnAligned3 + thv_vld1DdList3;
+	VRnAligned3 = VRnAligned3 + esize0607;
 }
 
 :vld1.^esize0607 thv_vld1DdList3,VRnAligned3,VRm	is $(TMODE_F)  &thv_c2327=19 & thv_c2021=2 & VRnAligned3 & thv_vld1RnReplicate & thv_vld1DdList3 & thv_c0811=12 & esize0607 & VRm & $(T_vld1Constrain)


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed an unexpected behaviour in the `vld1` instruction for both, AArch32 (`ARM:LE:32:v8`) & Thumb (`ARM:LE:32:v8T`). 

According to the manual, the post-indexed behaviour uses the ebytes for write back. However, we noticed the output was incorrect. 

-----
e.g, for AArch32 with,

Instruction:         `0x4d0ca0f4, vld1.16 {d0[]},[r0]!`
initial_memory: `{ "0x0": [ 0xbb, 0xda] }` 

We get:

Hardware:         `{ "q0": 0xdabbdabbdabbdabb, "r0": 0x2 }`
Patched Spec: `{ "q0": 0xdabbdabbdabbdabb, "r0": 0x2 }`
Existing Spec:  `{ "q0": 0xdabbdabbdabbdabb, "r0": 0x1 }`

-----
e.g, for Thumb with,

Instruction:         `0xebf95dfc, vld1.16 {d31[]},[r11@16]!`
initial_memory: `{ "0x0": [ 0xbb, 0xda] }` 

We get:

Hardware:         `{ "q15": 0xdabbdabbdabbdabb0000000000000000, "r11": 0x2 }`
Patched Spec: `{ "q15": 0xdabbdabbdabbdabb0000000000000000, "r11": 0x2 }`
Existing Spec:  `{ "q15": 0xdabbdabbdabbdabb0000000000000000, "r11": 0x1 }`

-----

_Note: The patched spec does not introduce any disassembly changes to the best of our knowledge._