### PR TITLE
win pdb: don't override PlatformToolset

### DIFF
--- a/GPL/vsconfig.gradle
+++ b/GPL/vsconfig.gradle
@@ -60,8 +60,6 @@ def configureVisualStudio() {
 		def vcvarsPath = "${vsInstallDir}\\VC\\Auxiliary\\Build\\vcvarsall.bat"
 		def vcvarsCmd = "\"${vcvarsPath}\" x86_amd64"
 		def vcvarsEnvCmd = "cmd /v:ON /c ${vcvarsCmd} > nul && cmd /c echo"
-		def toolsVersion = "${vcvarsEnvCmd} !VCToolsVersion!".execute().text.trim()
-		println "  -> VCTools Version (default): ${toolsVersion}"
 		def sdkDir = "${vcvarsEnvCmd} !WindowsSdkDir!".execute().text.trim()
 		println "  -> SDK Directory (default): ${sdkDir}"
 		def sdkVersion = "${vcvarsEnvCmd} !WindowsSDKVersion!".execute().text.trim().replace('\\', '')
@@ -73,7 +71,6 @@ def configureVisualStudio() {
 		
 		// Save Visual Studio information so other projects can access it
 		rootProject.ext.VISUAL_STUDIO_INSTALL_DIR = vsInstallDir
-		rootProject.ext.VISUAL_STUDIO_TOOLS_VERSION_DEFAULT = toolsVersion
 		rootProject.ext.VISUAL_STUDIO_SDK_DIR_DEFAULT = sdkDir
 		rootProject.ext.VISUAL_STUDIO_SDK_VERSION_DEFAULT = sdkVersion
 		rootProject.ext.VISUAL_STUDIO_SDK_VERSION_OVERRIDE = windowsTargetPlatformVersion

--- a/Ghidra/Features/PDB/buildNatives.gradle
+++ b/Ghidra/Features/PDB/buildNatives.gradle
@@ -35,9 +35,8 @@ if ("win_x86_64".equals(getCurrentPlatformName())) {
 		doFirst {
 			file("build/os/win_x86_64").mkdirs()
 			
-			def platformToolset = 'v' + VISUAL_STUDIO_TOOLS_VERSION_DEFAULT.substring(0, 4).replace('.', '');
 			def windowsTargetPlatformVersion = VISUAL_STUDIO_SDK_VERSION_OVERRIDE ?: VISUAL_STUDIO_SDK_VERSION_DEFAULT		
-			def msbuildCmd = "msbuild ${solutionPathWindows} /p:Configuration=Release /p:PlatformToolset=${platformToolset} /p:WindowsTargetPlatformVersion=${windowsTargetPlatformVersion}"
+			def msbuildCmd = "msbuild ${solutionPathWindows} /p:Configuration=Release /p:WindowsTargetPlatformVersion=${windowsTargetPlatformVersion}"
 			
 			println "Executing: " + msbuildCmd
 			


### PR DESCRIPTION
The msvc toolset version recently bumped to 14.40.x.
See https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/
Ghidra was assuming the msvc toolset version would match the PlatformToolset version (which indicates binary compatibility), which is not correct. 
PlatformToolset specified on msbuild commandline was overriding the value in the vcxproj, and not acting as a "default" value.
Just remove the explicit passing, it's handled by the vcxproj already.

fixes windows build