### PR TITLE
Docs: Add instruction for MacOS to avoid unverified developer error

### DIFF
--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -112,6 +112,10 @@ Ghidra team if you have a specific need.</p></blockquote>
 <h2><a name="Install"></a>Installing Ghidra</h2>
 <p>To install Ghidra, simply extract the Ghidra distribution file to the desired filesystem
 destination using any unzip program (built-in OS utilities, 7-Zip, WinZip, WinRAR, etc)</p>
+
+<p>On MacOS, if you downloaded the distribution file with a browser, you should run 
+<i>xattr -d com.apple.quarantine ghidra_&lt;version&gt;_&lt;date&gt;.zip</i> before unzipping.</p>
+
 <h3><a name="InstallationNotes"></a>Installation Notes</h3>
 <ul>
   <li>


### PR DESCRIPTION
If MacOS users run this one line before installation, they can avoid the whole "unverified binaries" error. 

The following situation exists for MacOS users:
- download Ghidra zip file from GitHub using Safari or Chrome
- use unzip or the MacOS archive to unpack the zip file
- later, when Ghidra runs the demangler, decompiler or other prebuilt binaries, they get an error like:
"demangler_gnu_v2_24" cannot be opened because the developer cannot be verified"

MacOS is doing what it should. Browsers (like Safari/Chrome) mark downloaded zip files with the "com.apple.quarantine" extended attribute. On unpacking, programs like unzip or MacOS archive (but not tar) then mark all files within with that flag.  MacOS blocks running those binaries, causing decompilation, etc to block.

Yes, the user can go to Preferences->Security & Privacy and allow the override. This is awkward because you need to go through this process for each time a new binary is encountered.

Removing the com.apple.quarantine attribute on the zip file before unpacking solves all of this.

![error](https://github.com/NationalSecurityAgency/ghidra/assets/47580386/3aa674c0-8950-4c86-ae4d-27fc6e08d512)