### PR TITLE
Encode SlaSpace wordsize as an unsigned integer

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleighbase.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleighbase.cc
@@ -199,7 +199,7 @@ void SleighBase::encodeSlaSpace(Encoder &encoder,AddrSpace *spc) const
 //    encoder.writeSignedInteger(sla::ATTRIB_DEADCODEDELAY, spc->getDeadcodeDelay());
   encoder.writeSignedInteger(sla::ATTRIB_SIZE, spc->getAddrSize());
   if (spc->getWordSize() > 1)
-    encoder.writeSignedInteger(sla::ATTRIB_WORDSIZE, spc->getWordSize());
+    encoder.writeUnsignedInteger(sla::ATTRIB_WORDSIZE, spc->getWordSize());
   encoder.writeBool(sla::ATTRIB_PHYSICAL, spc->hasPhysical());
   if (spc->getType() == IPTR_INTERNAL)
     encoder.closeElement(sla::ELEM_SPACE_UNIQUE);


### PR DESCRIPTION
This patch corrects a mismatch between the encoder and decoder in wordsize signedness. `AddrSpace::getWordSize()` returns an unsigned integer, so use unsigned here for consistency.

Fixes loading SLA files for:
- Toy:BE:32:wordSize2
- Toy:LE:32:wordSize2
- avr8:LE:16:default
- avr8:LE:16:extended
- avr8:LE:16:atmega256
- avr8:LE:24:xmega
- PIC-24E:LE:24:default
- PIC-24F:LE:24:default
- PIC-24H:LE:24:default
- dsPIC30F:LE:24:default
- dsPIC33F:LE:24:default
- dsPIC33E:LE:24:default
- dsPIC33C:LE:24:default
- PIC-16:LE:16:PIC-16C5x
- PIC-12:LE:16:PIC-12C5xx
- PIC-17:LE:16:PIC-17C7xx
- PIC-16:LE:16:PIC-16
- PIC-16:LE:16:PIC-16F
- CP1600:BE:16:default