### PR TITLE
Update InstallationGuide.html to remove instructions for Windows 7

### DIFF
--- a/GhidraDocs/InstallationGuide.html
+++ b/GhidraDocs/InstallationGuide.html
@@ -176,11 +176,7 @@ destination using any unzip program (built-in OS utilities, 7-Zip, WinZip, WinRA
             <ol>
               <li>
                 <p>
-                  <i>Windows 10:</i> Right-click on Windows start button, and click <b>System</b>
-                </p>
-                <p>
-                  <i>Windows 7:</i> Click Windows start button, right-click on Computer, and click 
-                  <b>Properties</b>
+                  <i>Windows 10, 11:</i> Right-click on Windows start button, and click <b>System</b>
                 </p>
               </li>
               <li>Click <b>Advanced system settings</b></li>


### PR DESCRIPTION
Since Windows 7 is not supported, there's no need to keep the instructions about how to set Environment Variables on Windows 7.