### PR TITLE
Parallel decompiler/disassembler performance

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/ContextCache.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/ContextCache.java
@@ -26,9 +26,6 @@ public class ContextCache {
 	private int context_size = 0;
 	private Register contextBaseRegister = null;
 
-	private BigInteger lastContextValue;
-	private int[] lastContextWords;
-
 	public ContextCache() {
 	}
 
@@ -57,10 +54,7 @@ public class ContextCache {
 		}
 	}
 
-	private synchronized int[] getWords(BigInteger value) {
-		if (value.equals(lastContextValue)) {
-			return lastContextWords;
-		}
+	private int[] getWords(BigInteger value) {
 
 		int[] words = new int[context_size];
 		byte[] bytes = value.toByteArray();
@@ -73,8 +67,6 @@ public class ContextCache {
 			}
 			words[i] = word;
 		}
-		lastContextValue = value;
-		lastContextWords = words;
 		return words;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighFunction.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighFunction.java
@@ -50,6 +50,8 @@ public class HighFunction extends PcodeSyntaxTree {
 	private GlobalSymbolMap globalSymbols;
 	private List<JumpTable> jumpTables;
 	private List<DataTypeSymbol> protoOverrides;
+	private Address entryPoint;
+	private AddressSpace entryAddrSpace;
 
 	/**
 	 * @param function  function associated with the higher level function abstraction.
@@ -64,6 +66,8 @@ public class HighFunction extends PcodeSyntaxTree {
 		this.language = language;
 		this.compilerSpec = compilerSpec;
 		AddressSpace stackSpace = function.getProgram().getAddressFactory().getStackSpace();
+		entryPoint = function.getEntryPoint();
+		entryAddrSpace = entryPoint.getAddressSpace();
 		localSymbols = new LocalSymbolMap(this, stackSpace);
 		globalSymbols = new GlobalSymbolMap(this);
 		proto = new FunctionPrototype(localSymbols, function);
@@ -87,7 +91,7 @@ public class HighFunction extends PcodeSyntaxTree {
 		if (func instanceof FunctionDB) {
 			return func.getSymbol().getID();
 		}
-		return func.getProgram().getSymbolTable().getDynamicSymbolID(func.getEntryPoint());
+		return func.getProgram().getSymbolTable().getDynamicSymbolID(entryPoint);
 	}
 
 	/**
@@ -255,7 +259,7 @@ public class HighFunction extends PcodeSyntaxTree {
 			}
 			if (subel == ELEM_ADDR.id()) {
 				Address addr = AddressXML.decode(decoder);
-				if (!func.getEntryPoint().equals(addr)) {
+				if (!entryPoint.equals(addr)) {
 					throw new DecoderException("Mismatched address in function tag");
 				}
 			}
@@ -300,7 +304,7 @@ public class HighFunction extends PcodeSyntaxTree {
 	private void decodeJumpTableList(Decoder decoder) throws DecoderException {
 		int el = decoder.openElement(ELEM_JUMPTABLELIST);
 		while (decoder.peekElement() != 0) {
-			JumpTable table = new JumpTable(func.getEntryPoint().getAddressSpace());
+			JumpTable table = new JumpTable(entryAddrSpace);
 			table.decode(decoder);
 			if (!table.isEmpty()) {
 				if (jumpTables == null) {
@@ -318,10 +322,10 @@ public class HighFunction extends PcodeSyntaxTree {
 			pcaddr = rep.getPCAddress();
 			if (pcaddr == Address.NO_ADDRESS) {
 				try {
-					pcaddr = func.getEntryPoint().add(-1);
+					pcaddr = entryPoint.add(-1);
 				}
 				catch (AddressOutOfBoundsException e) {
-					pcaddr = func.getEntryPoint();
+					pcaddr = entryPoint;
 				}
 			}
 		}
@@ -446,7 +450,7 @@ public class HighFunction extends PcodeSyntaxTree {
 			encoder.writeBool(ATTRIB_NORETURN, true);
 		}
 		if (entryPoint == null) {
-			AddressXML.encode(encoder, func.getEntryPoint());
+			AddressXML.encode(encoder, this.entryPoint);
 		}
 		else {
 			AddressXML.encode(encoder, entryPoint);		// Address is forced on XML


### PR DESCRIPTION
This p/r has 3 commits which do the following:

1.) Remove ``synchronized`` bottlenecks in ``ContextCache`` and ``SleighLanguage``
2.) store ``HighFunction.func.getEntryPoint()`` and ``HighFunction.func.getEntryPoint().getAddressSpace()`` to avoid expensive hits to the database lock.

