### PR TITLE
Improve ClassSearcher.search performance

### DIFF
--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/classfinder/ClassDir.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/classfinder/ClassDir.java
@@ -21,20 +21,24 @@ import java.util.List;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
 
-class ClassDir {
+class ClassDir extends ClassLocation {
 
 	private String dirPath;
 	private File dir;
 	private ClassPackage classPackage;
 
-	ClassDir(String dirPath, TaskMonitor monitor) throws CancelledException {
+	ClassDir(String dirPath, List<ClassFileInfo> dest, TaskMonitor monitor) {
+		super(dest);
 		this.dirPath = dirPath;
 		this.dir = new File(dirPath);
-		classPackage = new ClassPackage(dir, "", monitor);
+		this.classPackage = new ClassPackage(dir, "", dest, monitor);
+		start(monitor);
 	}
 
-	void getClasses(List<ClassFileInfo> list, TaskMonitor monitor) throws CancelledException {
-		classPackage.getClasses(list, monitor);
+	@Override
+	protected void scan(TaskMonitor monitor) throws CancelledException {
+		classPackage.start(monitor);
+		classPackage.join(monitor);
 	}
 
 	String getDirPath() {


### PR DESCRIPTION
This improves the ClassSearcher search performance by about 50% by using virtual threads to do the file IO in parallel. You can read/write multiple files at the same time as well as read/write to different parts of the same file at the same time. The JVM will schedule the file IO accordingly and you can process other data while the virtual threads waiting for file IO are blocked.