### PR TITLE
add support for Arm stack limit register instructions

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -2859,6 +2859,45 @@ control: "control" 			is epsilon {}
 }
 
 @endif
+@if defined(CORTEX)
+
+define pcodeop setMainStackPointerLimit;
+
+msplim: "msplim" 		    is epsilon {}
+
+:msr^ItCond msplim,Rn0003 		is TMode=1 & ItCond & op4=0xf38 & Rn0003; op12=0x8 & th_psrmask=8 & sysm=10 & msplim
+{
+  build ItCond;
+  setMainStackPointerLimit(Rn0003);
+}
+
+define pcodeop setProcStackPointerLimit;
+
+psplim: "psplim" 		is epsilon {}
+
+:msr^ItCond psplim,Rn0003 		is TMode=1 & ItCond & op4=0xf38 & Rn0003; op12=0x8 & th_psrmask=8 & sysm=11 & psplim
+{
+  build ItCond;
+  setProcStackPointerLimit(Rn0003);
+}
+
+define pcodeop getMainStackPointerLimit;
+
+:mrs^ItCond Rd0811,msplim 		is TMode=1 & ItCond & op0=0xf3ff; op12=0x8 & Rd0811 & sysm=10 & msplim
+{
+  build ItCond;
+  Rd0811 = getMainStackPointerLimit();
+}
+
+define pcodeop getProcessStackPointerLimit;
+
+:mrs^ItCond Rd0811,psplim 		is TMode=1 & ItCond & op0=0xf3ff; op12=0x8 & Rd0811 & sysm=11 & psplim
+{
+  build ItCond;
+  Rd0811 = getProcessStackPointerLimit();
+}
+
+@endif
 
 :mrs^ItCond Rd0811,cpsr 		is TMode=1 & ItCond & op0=0xf3ef; op12=0x8 & Rd0811 & sysm=0 & cpsr
 {


### PR DESCRIPTION
This is a current rebase of the diff from #5256 (credit to @befoulad ) which has been minimally tested and decompiles the new Armv8-M stack limit register arguments (_msplim_ and _psplim_ as arguments for _msr_ and _mrs_)