### PR TITLE
Fix bugs in logging statement

### DIFF
--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/Repository.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/Repository.java
@@ -424,7 +424,7 @@ public class Repository implements FileSystemListener, RepositoryLogger {
 		synchronized (fileSystem) {
 			if (userMap.remove(username) != null) {
 				writeUserList(userMap, anonymousAccessAllowed);
-				log.info("User access d from repository '" + name + "': " + username);
+				log.info("User access removed from repository '" + name + "': " + username);
 				return true;
 			}
 			return false;


### PR DESCRIPTION
**Description:**

This pull request fixes a typo in the logging statement within the `removeUser` method. The typo "User access d" has been corrected to "User access removed" to provide a clear and accurate log message when a user is removed from the repository.

**Changes:**

- Corrected the typo in the log message from "User access d" to "User access removed".

**Before:**

```java
log.info("User access d from repository '" + name + "': " + username);
```

**After:**

```java
log.info("User access removed from repository '" + name + "': " + username);
```

**Testing:**

1. Removed a user from the repository and verified that the correct log message is displayed.
2. Ensured no additional warnings or errors are introduced by this change.

**Additional Notes:**

This change ensures that the log messages are clear and accurate, helping in better tracking and debugging user-related actions in the system.

---

**Checklist:**

- [x] Fix typo in log message
- [x] Verify log message correctness after user removal
- [x] Ensure no new warnings or errors introduced
