### PR TITLE
68000: Update condition flags for `ext` instruction

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -1529,9 +1529,9 @@ subdiv: regdr:regdq		is regdq & regdr & divsz=1 & divsgn=1 {
 :exg reg9an,regan		is op=12 & reg9an & op8=1 & op37=9 & regan			{ local tmp = reg9an; reg9an=regan; regan=tmp; }
 :exg reg9dn,regan		is op=12 & reg9dn & op8=1 & op37=17 & regan			{ local tmp = reg9dn; reg9dn=regan; regan=tmp; }
 
-:ext.w regdnw			is op=4 & reg9dn=4 & op68=2 & op35=0 & regdnw		{ local tmp = regdnw:1; regdnw = sext(tmp); }
-:ext.l regdn			is op=4 & reg9dn=4 & op68=3 & op35=0 & regdn		{ local tmp = regdn:2; regdn = sext(tmp); }
-:extb.l regdn			is op=4 & reg9dn=4 & op68=7 & op35=0 & regdn		{ local tmp = regdn:1; regdn = sext(tmp); }
+:ext.w regdnw			is op=4 & reg9dn=4 & op68=2 & op35=0 & regdnw		{ local tmp = regdnw:1; regdnw = sext(tmp); resflags(regdnw); logflags(); }
+:ext.l regdn			is op=4 & reg9dn=4 & op68=3 & op35=0 & regdn		{ local tmp = regdn:2; regdn = sext(tmp); resflags(regdn); logflags(); }
+:extb.l regdn			is op=4 & reg9dn=4 & op68=7 & op35=0 & regdn		{ local tmp = regdn:1; regdn = sext(tmp); resflags(regdn); logflags(); }
 
 @ifdef COLDFIRE
 :halt			is d16=0x4ac8							unimpl


### PR DESCRIPTION
As discussed in #6679, [the 68000 manual](https://www.nxp.com/docs/en/reference-manual/M68000PRM.pdf) states that for the `ext` instruction, the condition flags should be updated. Currently, this is not done, leading to issues in the decompilation (and presumably also emulation) of 68k code that uses this instruction and relies on the condition flags being updated. This commit adds the updates to the condition flags to the sleigh definition of this instruction.

Fixes #6679.