### PR TITLE
Fix null pointer exception in createGot method

### DIFF
--- a/Ghidra/Processors/x86/src/main/java/ghidra/app/util/bin/format/elf/relocation/X86_64_ElfRelocationContext.java
+++ b/Ghidra/Processors/x86/src/main/java/ghidra/app/util/bin/format/elf/relocation/X86_64_ElfRelocationContext.java
@@ -260,6 +260,9 @@ class X86_64_ElfRelocationContext extends ElfRelocationContext<X86_64_ElfRelocat
 				"NOTE: This block is artificial and allows ELF Relocations to work correctly",
 				"Elf Loader", true, false, false, loadHelper.getLog());
 
+			if (block == null) {
+				return;
+			}
 			// Mark block as an artificial fabrication
 			block.setArtificial(true);
 


### PR DESCRIPTION
Add a null check before accessing 'block' in the createGot method to prevent a potential NullPointerException. The check ensures that the method returns early if 'block' is null, which can occur if MemoryBlock creation fails or is not initialized.