### PR TITLE
fix functions that return double in decompiler

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_translate.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_translate.cc
@@ -156,4 +156,16 @@ void GhidraTranslate::decode(Decoder &decoder)
   decoder.closeElement(elemId);
 }
 
+void GhidraTranslate::renormalizeJoinAddress(Address &addr,int4 size) {
+  glb->renormalizeJoinAddress(addr,size);
+}
+
+JoinRecord* GhidraTranslate::findAddJoin(const vector<VarnodeData> &pieces,uint4 logicalsize) {
+  return glb->findAddJoin(pieces,logicalsize);
+}
+
+JoinRecord* GhidraTranslate::findJoin(uintb offset) const {
+  return glb->findJoin(offset);
+}
+
 } // End namespace ghidra

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_translate.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ghidra_translate.hh
@@ -53,6 +53,11 @@ public:
     throw LowlevelError("Cannot currently get instruction length through this interface"); }
   virtual int4 printAssembly(AssemblyEmit &emit,const Address &baseaddr) const {
     throw LowlevelError("Cannot dump assembly through this interface"); }
+  virtual JoinRecord *findAddJoin(const vector<VarnodeData> &pieces,uint4 logicalsize); ///< Get (or create) JoinRecord for \e pieces
+  virtual JoinRecord *findJoin(uintb offset) const; ///< Find JoinRecord for \e offset in the join space
+
+  /// \brief Make sure a possibly offset \e join address has a proper JoinRecord
+  virtual void renormalizeJoinAddress(Address &addr,int4 size);
 };
 
 } // End namespace ghidra

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/translate.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/translate.hh
@@ -266,8 +266,8 @@ public:
   int4 numSpaces(void) const; ///< Get the number of address spaces for this processor
   AddrSpace *getSpace(int4 i) const; ///< Get an address space via its index
   AddrSpace *getNextSpaceInOrder(AddrSpace *spc) const; ///< Get the next \e contiguous address space
-  JoinRecord *findAddJoin(const vector<VarnodeData> &pieces,uint4 logicalsize); ///< Get (or create) JoinRecord for \e pieces
-  JoinRecord *findJoin(uintb offset) const; ///< Find JoinRecord for \e offset in the join space
+  virtual JoinRecord *findAddJoin(const vector<VarnodeData> &pieces,uint4 logicalsize); ///< Get (or create) JoinRecord for \e pieces
+  virtual JoinRecord *findJoin(uintb offset) const; ///< Find JoinRecord for \e offset in the join space
   void setDeadcodeDelay(AddrSpace *spc,int4 delaydelta); ///< Set the deadcodedelay for a specific space
   void truncateSpace(const TruncationTag &tag);	///< Mark a space as truncated from its original size
 
@@ -278,7 +278,7 @@ public:
   Address constructJoinAddress(const Translate *translate,const Address &hiaddr,int4 hisz,const Address &loaddr,int4 losz);
 
   /// \brief Make sure a possibly offset \e join address has a proper JoinRecord
-  void renormalizeJoinAddress(Address &addr,int4 size);
+  virtual void renormalizeJoinAddress(Address &addr,int4 size);
 
   /// \brief Parse a string with just an \e address \e space name and a hex offset
   Address parseAddressSimple(const string &val);


### PR DESCRIPTION
Ghidra Decompiler is having issues decompiling function calls whose return value is of type "double".
For example, our types are defined like this:
```
// A Function Definition entry in Data Type Manager
double __thiscall MyFunction(MyObjectType * this, int param2);

struct MyObjectVtable {
	void* notNeeded[15];
	MyFunction* MyFunction;
};


struct MyObject {
	MyObjectVtable* vtable;
};
```

, given the following x86 32-bit program to decompile:
```
// MyObjectPointer is a global of type MyObject*

        00487c41 8b 0d 3c        MOV        ECX,dword ptr [MyObjectPointer]
                 1d a1 01
        00487c47 8b 01           MOV        EAX,dword ptr [ECX]
        00487c49 8b 50 3c        MOV        EDX,dword ptr [EAX + 0x3c]
        00487c4c 56              PUSH       ESI
        00487c4d ff d2           CALL       EDX
        00487c4f dd 5c 24 20     FSTP       qword ptr [ESP + 0x20]
```

, Ghidra decompiler will produce output:
```cpp
    (*MyObjectPointer->vtable->MyFunction)(MyObjectPointer,pwVar4);
    FStack_89c = (double)extraout_ST0;
// extraout_ST0 is of type float10 (determined automatically)
// FStack_89c is of type double (set manually by the user)
```

In short, it won't show the assignment operator ('=') from the function into the variable that the return value is stored in.

The issue is caused by a constructFloatExtensionAddress call in ParamEntry::getAddrBySlot (file Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc). That function makes use of the findAddJoin function which in turn creates join entries inside an AddrSpaceManager. Problem is that there are two distinct AddrSpaceManagers - one is GhidraArchitecture, and the other is GhidraTranslate. They're separate, and ParamEntry has its spaceid->manage set to the GhidraTranslate one, so its created join entries get stored in GhidraTranslate. Later, when GhidraArchitecture or anyone else tries to find those join entries they probably go to GhidraArchitecture and they do find some join entries there at the provided offsets, but they're different, and they point to different collections of pieces and ultimately to different registers. In this particular case, ParamEntry would load the function definition for MyFunction through the MyObjectPointer symbol's type, through its vtable, and it would create the JoinEntry with 1 piece that specifies that the return value points to register ST0 (IPTR_PROCESSOR, offset 0x1106), and that JoinEntry would point into the joinspace (IPTR_JOIN) at offset 0, and it would be stored inside GhidraTranslate's splitlist/splitset. Then, when ActionLinkFunction would eventually link that function definition to the CPUI_CALLIND that calls it, it would look up the offset 0 in the joinspace that belongs to GhidraArchitecture, and it would actually find a JoinEntry, but it would contain 2 pieces and it would say that it's a EAX:EDX or EDX:EAX, I don't exactly remember. So the function would end up returning double into EAX:EDX that don't get used or get clobbered down the line and ActionDeadCode would kill off the return value varnode and in the final result in the decompiler it would show that the function return is not being used and some random ST0 register shows up.

This Pull Request fixes the following:
1) In the decompiler, force GhidraTranslate to delegate JoinEntry lookup and creation-related calls towards GhidraArchitecture, thus fixing display of return values of type "double" from indirect function calls.