### PR TITLE
Fix:debugger-agent-gdb:remote make sure `brk.commands` is not none

### DIFF
--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/hooks.py
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/hooks.py
@@ -312,6 +312,8 @@ def check_for_continue(event):
             return True
         for brk in event.breakpoints:
             if hasattr(brk, 'commands'):
+                if brk.commands is None:
+                    return False
                 for cmd in brk.commands:
                     if cmd == 'c' or cmd.startswith('cont'):
                         HOOK_STATE.in_break_w_cont = True


### PR DESCRIPTION
When debugging in gdb remote, `brk.commands` would be `None` thus a python `Exception` would be thrown which then hang the Ghidra debugger