### PR TITLE
MSP430 and MSP430X fixes

### DIFF
--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -519,35 +519,19 @@ postIncrement:  			 is as=0x3 & ctx_haveext=0 & src16_8_4=1 & bow=0x1 & ctx_al=0
 postIncrement:               is as & src16_8_4 & bow
 {  }
 
-
 #
-# Zero Extends if the store is byte oriented, and a register is being stored to
-zeroExtend: is dest_Direct_lo & dest_Direct16_0_4
-{ dest_Direct16_0_4 = zext(dest_Direct_lo); }
-
+# Post processing when destination is the PC
 #
-# Post processing when destination is the PC - for byte operations
-#
-postIncrementStore:  			 is postIncrement & ad=0x0 & src_InDirect16_8_4 & as=0x3 & src16_8_4=1 & dest_Direct16_0_4=0x0 & bow=0x1 & ctx_al=1 & zeroExtend
-{ build zeroExtend; build postIncrement; return [PC]; }
-postIncrementStore:  			 is postIncrement & ad=0x0 & dest_Direct16_0_4=0x0 & bow=0x1 & ctx_al=1 & zeroExtend
-{ build zeroExtend; build postIncrement; PC = PC & 0xFFFFFE; goto [PC];} # Writes to PC are rounded to alignment
-postIncrementStore:              is postIncrement & ad=0x0 & bow=0x1 & ctx_al=1 & zeroExtend
-{ build zeroExtend; build postIncrement; }
 
-postIncrementStore:  			 is postIncrement & ctx_haveext=0 & ad=0x0 & src_InDirect16_8_4 & as=0x3 & src16_8_4=1 & dest_Direct16_0_4=0x0 & bow=0x1 & zeroExtend 
-{ build zeroExtend; build postIncrement; return [PC]; }
-postIncrementStore:  			 is postIncrement & ctx_haveext=0 & ad=0x0 & dest_Direct16_0_4=0x0 & bow=0x1 & zeroExtend # MOV.B any,PC
-{ build zeroExtend; build postIncrement; PC = PC & 0xFE; goto [PC];} # Writes to PC are rounded to alignment
-postIncrementStore:              is postIncrement & ctx_haveext=0 & ad=0x0 & bow=0x1 & zeroExtend
-{ build zeroExtend; build postIncrement; }
+postStorePC:  			is ad=0x0 & as=0x3 & dest_Direct16_0_4=0x0 & src16_8_4=0x1
+{ PC = PC & ~1; return [PC]; }
+postStorePC:  			is ad=0x0 & dest_Direct16_0_4=0x0
+{ PC = PC & ~1; goto [PC];}
+postStorePC:			is epsilon
+{  }
 
-postIncrementStore:  			 is postIncrement & ad=0x0 & src_InDirect16_8_4 & as=0x3 & src16_8_4=1 & dest_Direct16_0_4=0x0
-{ build postIncrement; return [PC]; }
-postIncrementStore:  			 is postIncrement & ad=0x0 & dest_Direct16_0_4=0x0
-{ build postIncrement; PC = PC & 0xFFFE; goto [PC];} # Writes to PC are rounded to alignment
-postIncrementStore:              is postIncrement & ad & bow
-{ build postIncrement; }
+postIncrementStore: is postIncrement & postStorePC
+{ build postIncrement; build postStorePC; }
 
 #-----------------------------------------------
 #
@@ -764,7 +748,7 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 	tmp:$(REG_SIZE) = zext(*:2 SP);
 	SR = zext(tmp[0,12]);
 	SP = SP + 0x2;
-	PC = zext(*:2 SP) | ((tmp & 0xF000) << 4);
+	PC = zext(*:2 SP) | ((tmp & 0xF000) << 4) & ~1;
 @endif	
 	SP = SP + 0x2;
 	return [PC];
@@ -822,7 +806,7 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 #-----------------------
 # Branch
 :BR SRC_W_AS   is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x0 & ad=0x0 & dest_Direct16_0_4=0x0 & postIncrement) ... & SRC_W_AS ... {
-	PC = zext(SRC_W_AS) & 0xFFFFFFFE:$(REG_SIZE);
+	PC = zext(SRC_W_AS) & ~1;
 	build postIncrement; # needed before branch
 	goto [PC];
 	#Status bits are not affected
@@ -830,9 +814,8 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 
 # Branch to an immediate value
 :BR DirectAddr       is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x0 & ad=0x0 & dest_Direct16_0_4=0x0 & src_Direct16_8_4=0x0 & as=0x3); DirectAddr {
-	PC = &DirectAddr;
-    goto DirectAddr;
-    #Status bits are not affected
+	goto DirectAddr;
+	#Status bits are not affected
 }
 
 # No operation

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -571,7 +571,7 @@ JCND: "MP"	is condition=0x7 {cndTst:1 = 0x1; export cndTst;}                    
 #-----------------------------------------------
 
 OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
-	{ export *:2 offset10;}
+	{ export *:$(REG_SIZE) offset10;}
 	
 	
 ###################################################################################

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -94,7 +94,6 @@ define context contextreg
 # use the repeat feature.
 # NOTE: The POPM/PUSM have a starting register & # of register to pop/push. We need to track
 # that info in context for the subtables that do the work.
-  ctx_isHi=(0,0) noflow					# Used in pspec to flag msp430 instruction > 64k
   ctx_al=(1,1) noflow					# extension word al field
   ctx_ctregdest=(2,5) noflow			# extension word dest register/immediate field
   ctx_ctregdests=(2,5) signed noflow	# signed version of above
@@ -243,11 +242,22 @@ DST8_0_4: reg_Direct16_0_4		is reg_Direct16_0_4 & dest_Direct_lo {export dest_Di
 #-----------------------------------------------
 
 @if REG_SIZE == "4"
-AMASK: val	is ctx_isHi=1 [ val = 0xFFFF; ]  { export *[const]:4 val; }
-AMASK: val	is ctx_isHi=0 [ val = 0xFFFFF; ] { export *[const]:4 val; }
+AMASK: val	is bow=0 [ val = 0xFFFFE; ] { export *[const]:4 val; }
+AMASK: val	is bow=1 [ val = 0xFFFFF; ] { export *[const]:4 val; }
+
+macro computeIndexedAddr(ptr, reg, index, input_mask) {
+	local isHi = (reg & 0xF0000) != 0;
+	local mask = 0xFFFF | (zext(isHi) * 0xF0000);
+	ptr = (reg + index) & mask & input_mask;
+}
 @else
 AMASK: val	is bow=0 [ val = 0xFFFE; ]  { export *[const]:2 val; } # Memory accesses for unaligned (odd) word addresses round down for alignment.
 AMASK: val	is bow=1 [ val = 0xFFFF; ]  { export *[const]:2 val; }
+AMASK: val	is epsilon [ val = 0xFFFF; ]  { export *[const]:2 val; }
+
+macro computeIndexedAddr(ptr, reg, index, mask) {
+	ptr = (reg + index) & mask;
+}
 @endif
 
 #-----------------------------------------------
@@ -259,11 +269,11 @@ AMASK: val	is bow=1 [ val = 0xFFFF; ]  { export *[const]:2 val; }
 #-----------------------------------------------
 REG_W_AS: DST16_0_4 			 		 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
 REG_W_AS: DST16_0_4 			 		 is DST16_0_4 & reg16_0_4=0 & as=0x0 & bow=0x0  {DST16_0_4 = inst_next & 0xFFFE; export DST16_0_4;} # PC register accesses point to next instruction
-REG_W_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + indexExtWord16_0_16s) & AMASK; export *:2 tmp;}
-REG_W_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK & reg_Indexed16_0_4=1 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + indexExtWord16_0_16s - 0x2) & AMASK; export *:2 tmp;} # PUSH, CALL X(SP) - addressing includes SP decrement
+REG_W_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:2 tmp;}
+REG_W_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK & reg_Indexed16_0_4=1 ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s - 0x2, AMASK); export *:2 tmp;} # PUSH, CALL X(SP) - addressing includes SP decrement
 REG_W_AS: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect (@Rn):
 REG_W_AS: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-REG_W_AS: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = labelCalc & AMASK; export *:2 tmp; } # Symbolic
+REG_W_AS: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:2 tmp; } # Symbolic
 REG_W_AS: "#"^indexExtWord16_0_16 	 is reg16_0_4=0x0 & as=0x3 & bow=0x0 ; indexExtWord16_0_16 {export *[const]:2 indexExtWord16_0_16; } # Immediate
 REG_W_AS: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 & AMASK; indexExtWord16_0_16 {tmp:$(REG_SIZE) = indexExtWord16_0_16 & AMASK; export *:2 tmp; } # Absolute
 REG_W_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x0  { export 4:2;}		# Constant
@@ -275,18 +285,18 @@ REG_W_AS: "#-1" 					 is	reg16_0_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2;} 	
 
 REG_W_AS_DEST: DST16_0_4 			 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
 REG_W_AS_DEST: DST16_0_4 			 is DST16_0_4 & reg16_0_4=0 & as=0x0 & bow=0x0  {DST16_0_4 = inst_next & 0xFFFE; export DST16_0_4;} # PC register accesses point to next instruction
-REG_W_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + indexExtWord16_0_16s) & AMASK; export *:2 tmp;}
+REG_W_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:2 tmp;}
 REG_W_AS_DEST: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect (@Rn):
 REG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-REG_W_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = labelCalc & AMASK; export *:2 tmp; } # Symbolic
+REG_W_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:2 tmp; } # Symbolic
 REG_W_AS_DEST: "#"^indexExtWord16_0_16 	 is reg16_0_4=0x0 & as=0x3 & bow=0x0 & AMASK ; indexExtWord16_0_16 {export *:2 inst_next; } # Immediate - Undocumented behaviour
 REG_W_AS_DEST: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 {tmp:$(REG_SIZE) = indexExtWord16_0_16 & AMASK; export *:2 tmp; } # Absolute
 
 #-----------------------------------------------
 REG_B_AS: DST8_0_4 			 		 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
 REG_B_AS: DST8_0_4 			 		 is DST8_0_4 & reg16_0_4=0 & as=0x0 & bow=0x1  {tmp:$(REG_SIZE) = inst_next; DST8_0_4 = tmp:1 & 0xFF; export DST8_0_4;} # PC register accesses point to next instruction - must return register for resulting stores
-REG_B_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + indexExtWord16_0_16s) & AMASK; export *:1 tmp;}
-REG_B_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK & reg_Indexed16_0_4=1 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + indexExtWord16_0_16s - 0x2) & AMASK; export *:1 tmp;} # PUSH.B X(SP) - includes SP decrement
+REG_B_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:1 tmp;}
+REG_B_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK & reg_Indexed16_0_4=1 ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s - 0x2, AMASK); export *:1 tmp;} # PUSH.B X(SP) - includes SP decrement
 REG_B_AS: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 REG_B_AS: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
 REG_B_AS: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = labelCalc & AMASK;export *:1 tmp; } # Symbolic
@@ -301,10 +311,10 @@ REG_B_AS: "#-1" 					 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1;} 	# 
 
 REG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
 REG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & reg16_0_4=0 & as=0x0 & bow=0x1  {tmp:$(REG_SIZE) = inst_next; DST8_0_4 = tmp:1 & 0xFF; export DST8_0_4;} # PC register accesses point to next instruction
-REG_B_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + indexExtWord16_0_16s) & AMASK; export *:1 tmp;}
+REG_B_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:1 tmp;}
 REG_B_AS_DEST: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-REG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-REG_B_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = labelCalc & AMASK;export *:1 tmp; } # Symbolic
+REG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
+REG_B_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:1 tmp; } # Symbolic
 REG_B_AS_DEST: "#"^indexExtWord16_0_16 	 is reg16_0_4=0x0 & as=0x3 & bow=0x1 & AMASK ; indexExtWord16_0_16 {export *:1 inst_next; } # Undocumented behaviour
 REG_B_AS_DEST: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
 
@@ -315,10 +325,10 @@ REG_B_AS_DEST: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; i
 #-----------------------------------------------
 SRC_W_AS: SRC16_8_4 			 		 is SRC16_8_4 & as=0x0 & bow=0x0  {export SRC16_8_4;} # Word/Register Direct (Rn):
 SRC_W_AS: SRC16_8_4 			 		 is SRC16_8_4 & src16_8_4=0 & as=0x0 & bow=0x0 {tmp:2 = inst_next; export tmp;} # PC register accesses point to next instruction (PC-relative addresses already covered by Immediate/Symbolic modes)
-SRC_W_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (src_Indexed16_8_4 + indexExtWord16_0_16s) & AMASK; export *:2 tmp;}
+SRC_W_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, src_Indexed16_8_4, indexExtWord16_0_16s, AMASK); export *:2 tmp;}
 SRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = src_InDirect16_8_4 & AMASK; export *:2 tmp;} # Word/Register Indirect (@Rn):
 SRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = src_InDirect16_8_4 & AMASK; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-SRC_W_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = labelCalc & AMASK; export *:2 tmp; } # Symbolic
+SRC_W_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:2 tmp; } # Symbolic
 SRC_W_AS: "#"^indexExtWord16_0_16 	 is src16_8_4=0x0 & as=0x3 & bow=0x0 ; indexExtWord16_0_16 {export *[const]:2 indexExtWord16_0_16; } # Immediate
 SRC_W_AS: "&"^indexExtWord16_0_16 	 is src16_8_4=0x2 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 {tmp:$(REG_SIZE) = indexExtWord16_0_16 & AMASK; export *:2 tmp; } # Absolute
 SRC_W_AS: "#4" 						 is src16_8_4=0x2 & as=0x2 & bow=0x0  { export 4:2; }		# Constant
@@ -330,10 +340,10 @@ SRC_W_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2; } 
 #-----------------------------------------------
 SRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & as=0x0 & bow=0x1  { export SRC8_8_4;} # Word/Register Direct (Rn):
 SRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & src16_8_4=0 & as=0x0 & bow=0x1  {tmp:$(REG_SIZE) = inst_next; tmp2:1 = tmp:1; export tmp2;} # PC register accesses point to next instruction.
-SRC_B_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = (src_Indexed16_8_4 + indexExtWord16_0_16s) & AMASK; export *:1 tmp;}
+SRC_B_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, src_Indexed16_8_4, indexExtWord16_0_16s, AMASK); export *:1 tmp;}
 SRC_B_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
 SRC_B_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-SRC_B_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = labelCalc & AMASK;export *:1 tmp; } # Symbolic
+SRC_B_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:1 tmp; } # Symbolic
 SRC_B_AS: "#"^indexExtWord16_0_16 	 is src16_8_4=0x0 & as=0x3 & bow=0x1 ; indexExtWord16_0_16 {export *[const]:1 indexExtWord16_0_16;} # Immediate
 SRC_B_AS: "&"^indexExtWord16_0_16 	 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
 SRC_B_AS: "#4" 						 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:1; }		# Constant
@@ -354,27 +364,27 @@ DEST_W_AD: DST16_0_4 			 		 is DST16_0_4 & dest_0_4=0 & ad=0x0 & bow=0x0  {DST16
 
 # Register relative destinations for R1, R4-R15
 DEST_W_AD: indexExtWord16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s
-     {tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + indexExtWord16_0_16s) & AMASK; export *:2 tmp;}
+     {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:2 tmp;}
 #---Depends on SRC ---#
 # Source is register-relative and involves 'embedded' immediate
 DEST_W_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & AMASK & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     {tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + indexExt2Word16_0_16s) & AMASK; export *:2 tmp;}
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4, indexExt2Word16_0_16s, AMASK); export *:2 tmp;}
 # Source is an 'embedded' immediate implemented by @PC+
 DEST_W_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & AMASK & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     {tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + indexExt2Word16_0_16s) & AMASK; export *:2 tmp;}
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4, indexExt2Word16_0_16s, AMASK); export *:2 tmp;}
 # Source is involves a register increment (@reg+) that applies to the destination (of same register, but not PC, SR, R3)
 DEST_W_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & AMASK & as=0x3 & src16_8_4=dest_0_4 & (src16_8_4 = 1 | src16_8_4 >= 4) ; indexExt2Word16_0_16s
-     {tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + 2 + indexExt2Word16_0_16s) & AMASK; export *:2 tmp;}
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4 + 2, indexExt2Word16_0_16s, AMASK); export *:2 tmp;}
 #---End of Depend ----#
 
 # PC-relative destinations
 DEST_W_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ]
-     {tmp:$(REG_SIZE) = labelCalc & AMASK; export *:2 tmp; } # Symbolic
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16s, AMASK); export *:2 tmp; } # Symbolic
 #---Depends on SRC ---#
 DEST_W_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x0 & AMASK & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 4 + indexExt2Word16_0_16s; ]
-     {tmp:$(REG_SIZE) = labelCalc & AMASK; export *:2 tmp; } # Symbolic
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 4, indexExt2Word16_0_16s, AMASK); export *:2 tmp; } # Symbolic
 DEST_W_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x0 & AMASK & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 4 + indexExt2Word16_0_16s; ]
-     {tmp:$(REG_SIZE) = labelCalc & AMASK; export *:2 tmp; } # Symbolic
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 4, indexExt2Word16_0_16s, AMASK); export *:2 tmp; } # Symbolic
 #---End of Depend ----#
 
 # SR-relative (absolute value) destinations
@@ -393,24 +403,24 @@ DEST_B_AD: DST8_0_4 		  			 is DST8_0_4 & dest_Direct_lo & ad=0x0 & bow=0x1
 DEST_B_AD: DST8_0_4 			 		 is DST8_0_4 & dest_Direct_lo & dest_0_4=0 & ad=0x0 & bow=0x1  {tmp:$(REG_SIZE) = inst_next; DST8_0_4 = tmp:1 & 0xFF; export DST8_0_4;} # PC register accesses point to next instruction
 
 DEST_B_AD: indexExtWord16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s
-     { tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + indexExtWord16_0_16s) & AMASK; export *:1 tmp;}
+     {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:1 tmp;}
 #---Depends on SRC ---#
 DEST_B_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & AMASK & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     { tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + indexExt2Word16_0_16s) & AMASK; export *:1 tmp;}
+     {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4, indexExt2Word16_0_16s, AMASK); export *:1 tmp;}
 DEST_B_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & AMASK & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     { tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + indexExt2Word16_0_16s) & AMASK; export *:1 tmp;}
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4, indexExt2Word16_0_16s, AMASK); export *:1 tmp;}
 # Source includes a register increment (@reg+) that applies to the destination (use of same register in source and dest, but not PC, SR, R3)
 DEST_B_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & AMASK & as=0x3 & src16_8_4=dest_0_4 & (src16_8_4 = 1 | src16_8_4 >= 4) ; indexExt2Word16_0_16s
-     {tmp:$(REG_SIZE) = (dest_Indexed16_0_4 + 2 + indexExt2Word16_0_16s) & AMASK; export *:1 tmp;}
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, dest_Indexed16_0_4 + 2, indexExt2Word16_0_16s, AMASK); export *:1 tmp;}
 #---End of Depend ----#
 
 DEST_B_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ]
-     {tmp:$(REG_SIZE) = labelCalc & AMASK; export *:1 tmp; } # Symbolic
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16s, AMASK); export *:1 tmp; } # Symbolic
 #---Depends on SRC ---#
 DEST_B_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 & AMASK & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 4 + indexExt2Word16_0_16s; ]
-     {tmp:$(REG_SIZE) = labelCalc & AMASK;export *:1 tmp; } # Symbolic
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 4, indexExt2Word16_0_16s, AMASK); export *:1 tmp; } # Symbolic
 DEST_B_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 & AMASK & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 4 + indexExt2Word16_0_16s; ]
-     {tmp:$(REG_SIZE) = labelCalc & AMASK;export *:1 tmp; } # Symbolic
+     { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 4, indexExt2Word16_0_16s, AMASK); export *:1 tmp; } # Symbolic
 #---End of Depend ----#
 
 DEST_B_AD: "&"^indexExtWord16_0_16 	  is dest=0x2 & ad=0x1 & bow=0x1 ; indexExtWord16_0_16

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -537,6 +537,8 @@ postStorePC:  			is ad=0x0 & as=0x3 & dest_Direct16_0_4=0x0 & src16_8_4=0x1
 { PC = PC & ~1; return [PC]; }
 postStorePC:  			is ad=0x0 & dest_Direct16_0_4=0x0
 { PC = PC & ~1; goto [PC];}
+postStorePC:  			is op16_12_4=0 & dest_0_4=0x0
+{ PC = PC & ~1; goto [PC]; }
 postStorePC:			is epsilon
 {  }
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -833,17 +833,21 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 
 # Pop word from stack
 :POP^".W" DEST_W_AD is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x0 & (ad=0x1 | dest_Direct16_0_4) & as=0x3 & src_Direct16_8_4=0x1 & tbl_wzero & AMASK) ... & DEST_W_AD ... {
-	DEST_W_AD = *:2 (SP & AMASK);
+	local tmp:2 = *:2 (SP & AMASK);
 	build tbl_wzero;
 	SP = SP + 0x2;
+	build DEST_W_AD;
+	DEST_W_AD = tmp;
 	#Status bits are not affected
 }
 
 # Pop byte from stack
 :POP^".B" DEST_B_AD is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x1 & (ad=0x1 | dest_Direct16_0_4) & as=0x3 & src_Direct16_8_4=0x1 & tbl_bzero) ... & DEST_B_AD ... {
-	DEST_B_AD = *:1 SP;
+	local tmp:1 = *:1 SP;
 	build tbl_bzero;
 	SP = SP + 0x2;
+	build DEST_B_AD;
+	DEST_B_AD = tmp;
 	#Status bits are not affected
 }
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -886,22 +886,26 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 #------------------
 #	SRC Word
 #------------------
-:MOV^".W" SRC_W_AS, DEST_W_AD is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x0 & tbl_wzero & postIncrementStore) ... & SRC_W_AS ... & DEST_W_AD ... {
-	DEST_W_AD = SRC_W_AS;
+:MOV^".W" SRC_W_AS, DEST_W_AD is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x0 & tbl_wzero & postIncrement & postStorePC) ... & SRC_W_AS ... & DEST_W_AD ... {
+	local tmp:2 = SRC_W_AS;
+	build postIncrement;
+	DEST_W_AD = tmp;
 	build tbl_wzero;
 	#Status bits are not affected
-	build postIncrementStore;
+	build postStorePC;
 }
 
 
 #------------------
 #   SRC Byte
 #------------------
-:MOV^".B" SRC_B_AS, DEST_B_AD is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x1 & tbl_bzero & postIncrementStore) ... & SRC_B_AS ... & DEST_B_AD ... {
-	DEST_B_AD = SRC_B_AS;
+:MOV^".B" SRC_B_AS, DEST_B_AD is ctx_haveext=0 & (op16_12_4=0x4 & bow=0x1 & tbl_bzero & postIncrement & postStorePC) ... & SRC_B_AS ... & DEST_B_AD ... {
+	local tmp:1 = SRC_B_AS;
+	build postIncrement;
+	DEST_B_AD = tmp;
 	build tbl_bzero;
 	#Status bits are not affected
-	build postIncrementStore;
+	build postStorePC;
 }
 
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -450,6 +450,11 @@ tbl_wzero:			is ad=0 & reg_Direct16_0_4 & reg_Direct16_0_4W {ztmp:2 = reg_Direct
 @endif
 tbl_wzero:			is epsilon {}
 
+@if REG_SIZE == "4"
+tbl_wzero_singleop:		is as=0 & reg_Direct16_0_4 & reg_Direct16_0_4W {ztmp:2 = reg_Direct16_0_4W; reg_Direct16_0_4 = 0; reg_Direct16_0_4W = ztmp; }
+@endif
+tbl_wzero_singleop:		is epsilon {}
+
 #
 # Post Processing
 #    does correct increment of source register
@@ -587,14 +592,14 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 #	| 15 | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7  |  6  | 5  | 4  | 3 | 2 | 1 |  0  |
 #	------------------------------------------------------------------------------
 #	| 0  | 0  | 0  | 1  | 0  | 0  |     000    | B/W |   As    |     register    | 
-:RRC^".W" REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x0 & tbl_wzero & postRegIncrement) ... & REG_W_AS_DEST {
+:RRC^".W" REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x0 & tbl_wzero_singleop & postRegIncrement) ... & REG_W_AS_DEST {
 	# Operation Flags...
 	$(OVERFLOW) = 0;	# V Flag is reset
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = REG_W_AS_DEST[0,1];
 	REG_W_AS_DEST = ((zext(tmp) << 0xF) | (REG_W_AS_DEST >> 0x1));
-	build tbl_wzero;
+	build tbl_wzero_singleop;
 	# Result Flags...
 	$(SIGN) = (REG_W_AS_DEST s< 0x0);			# S Flag
 	$(ZERO) = (REG_W_AS_DEST == 0x0);			# Z Flag
@@ -624,11 +629,11 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 #	| 15 | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7  |  6  | 5  | 4  | 3 | 2 | 1 |  0  |
 #	------------------------------------------------------------------------------
 #	| 0  | 0  | 0  | 1  | 0  | 0  |     001    |  0  |   As    |     register    | 
-:SWPB REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x1 & bow=0x0 & tbl_wzero & postRegIncrement) ... & REG_W_AS_DEST {
+:SWPB REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x1 & bow=0x0 & tbl_wzero_singleop & postRegIncrement) ... & REG_W_AS_DEST {
 	lowByte:1 = REG_W_AS_DEST[0,8];
 	highByte:1 = REG_W_AS_DEST[8,8];
 	REG_W_AS_DEST = (((zext(lowByte)) << 0x8) | zext(highByte));
-	build tbl_wzero;
+	build tbl_wzero_singleop;
 	#Status bits are not affected
 	build postRegIncrement;
 }
@@ -642,14 +647,14 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 #	| 15 | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7  |  6  | 5  | 4  | 3 | 2 | 1 |  0  |
 #	------------------------------------------------------------------------------
 #	| 0  | 0  | 0  | 1  | 0  | 0  |     010    | B/W |   As    |     register    | 
-:RRA^".W" REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x0 & bow=0x0 & tbl_wzero & postRegIncrement) ... & REG_W_AS_DEST {
+:RRA^".W" REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x0 & bow=0x0 & tbl_wzero_singleop & postRegIncrement) ... & REG_W_AS_DEST {
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;					# V Flag (reset)
 	# Operation...
 	$(CARRY) = REG_W_AS_DEST[0,1];
 	MSB:2 = REG_W_AS_DEST >> 0xF;
 	REG_W_AS_DEST = ((MSB << 0xF) | (REG_W_AS_DEST >> 0x1));
-	build tbl_wzero;
+	build tbl_wzero_singleop;
 	# Result Flags...
 	$(SIGN) = (REG_W_AS_DEST s< 0x0);			# S Flag
 	$(ZERO) = (REG_W_AS_DEST == 0x0);			# Z Flag
@@ -679,13 +684,13 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 #	| 15 | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7  |  6  | 5  | 4  | 3 | 2 | 1 |  0  |
 #	------------------------------------------------------------------------------
 #	| 0  | 0  | 0  | 1  | 0  | 0  |     011    |  0  |   As    |     register    | 
-:SXT REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x1 & bow=0x0 & tbl_wzero & postRegIncrement) ... & REG_W_AS_DEST {
+:SXT REG_W_AS_DEST is ctx_haveext=0 & (op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x1 & bow=0x0 & tbl_wzero_singleop & postRegIncrement) ... & REG_W_AS_DEST {
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;						# V Flag
 	# Operation...	
 	byteVal:1 = REG_W_AS_DEST[0,8];
 	REG_W_AS_DEST = sext(byteVal);
-	build tbl_wzero;
+	build tbl_wzero_singleop;
 	# Result Flags...
 	$(SIGN) = (REG_W_AS_DEST s< 0x0);			# S Flag
 	$(ZERO) = (REG_W_AS_DEST == 0x0);			# Z Flag

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -689,6 +689,19 @@ OFFSET_10BIT: offset10 is off16   [offset10 = inst_start + 2 + off16 * 2; ]
 	build postRegIncrement;
 }
 
+@if REG_SIZE == "4"
+:SXT DST20_0_4 is ctx_haveext=0 & as=0 & (op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x1 & bow=0x0 & postRegIncrement) & DST20_0_4 {
+	# Operation...
+	DST20_0_4 = sext(DST20_0_4:1) & 0xfffff;
+	# Result Flags...
+	$(SIGN) = (DST20_0_4[19,1] == 0x1);		# S Flag
+	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
+	$(CARRY) = (DST20_0_4 != 0x0);			# C Flag
+	$(OVERFLOW) = 0x0;				# V Flag
+	build postRegIncrement;
+}
+@endif
+
 
 ###################################################################################
 #

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -180,8 +180,8 @@ define token instr16(16)
 #
 #	Attach(s)
 #
-attach variables [ 	src_8_4
-					dest_0_4
+attach variables [ src_8_4 dest_0_4 ] [ PC SP SR _ R4 R5 R6 R7 R8 R9 R10 R11 R12 R13 R14 R15 ];
+attach variables [
 					reg_Direct16_0_4 
 					src_Direct16_8_4 
 					dest_Direct16_0_4
@@ -210,6 +210,13 @@ SRC16_8_4: src_Direct16_8_4		is src_Direct16_8_4 & reg_Direct16_8_4W {export reg
 DST16_0_4: dest_Direct16_0_4		is dest_Direct16_0_4 & reg_Direct16_0_4W {export reg_Direct16_0_4W;}
 SRC8_8_4: src_Direct16_8_4		is src_Direct16_8_4 & src_Direct_lo {export src_Direct_lo;}
 DST8_0_4: reg_Direct16_0_4		is reg_Direct16_0_4 & dest_Direct_lo {export dest_Direct_lo;}
+
+@if REG_SIZE == "4"
+SRC20_8_4: src_8_4			is src_8_4 { export src_8_4; }
+SRC20_8_4: PC				is src_8_4=0 & PC { PC = inst_next; export PC; }
+DST20_0_4: dest_0_4			is dest_0_4  { export dest_0_4; }
+DST20_0_4: PC				is dest_0_4=0 & PC { PC = inst_next; export PC; }
+@endif
 
 ####################################
 # Status Register (SR) Map

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -467,6 +467,7 @@ tbl_wzero_singleop:		is epsilon {}
 #    does correct increment of source register
 #    Also catches when PC is being stored to and does the correct branching
 #
+postRegIncrement:   is as=0x3 & dest_0_4   & ctx_al=0x0 & reg_InDirect16_0_4	 { reg_InDirect16_0_4 = reg_InDirect16_0_4 + 4; }
 postRegIncrement:   is as=0x3 & dest_0_4   & bow=0x0 & reg_InDirect16_0_4                { reg_InDirect16_0_4 = reg_InDirect16_0_4 + 2; }
 postRegIncrement:   is as=0x3 & dest_0_4=1 & bow=0x0 & reg_InDirect16_0_4 & (op16_12_4=0x1 & op16_8_4=0x2 & op16_7_1=0x0)               { } # PUSH.W SP, SP modification covered by PUSH
 postRegIncrement:   is as=0x3 & dest_0_4   & bow=0x1 & reg_InDirect16_0_4                 { reg_InDirect16_0_4 = reg_InDirect16_0_4 + 1; }
@@ -474,12 +475,14 @@ postRegIncrement:  	is as=0x3 & dest_0_4=1 & bow=0x1 & reg_InDirect16_0_4 { reg_
 postRegIncrement:  	is as=0x3 & dest_0_4=1 & bow=0x1 & reg_InDirect16_0_4 & (op16_12_4=0x1 & op16_8_4=0x2 & op16_7_1=0x0) { } # PUSH.B @SP+, SP modification covered by PUSH
 postRegIncrement:   is as=0x3 & dest_0_4=0 & bow=0x0 & reg_InDirect16_0_4   { }     # PC is incremented by 2, but that is just to skip over the value
 postRegIncrement:   is as=0x3 & dest_0_4=0 & bow=0x1 & reg_InDirect16_0_4   { }     # PC is incremented by 2, but that is just to skip over the value
+postRegIncrement:   is as=0x3 & (dest_0_4=2 | dest_0_4=3) & ctx_al=0x0 & (bow=0x1 | bow=0x0) { }
 postRegIncrement:   is as=0x3 & dest_0_4=2 & bow=0x1     { }
 postRegIncrement:   is as=0x3 & dest_0_4=3 & bow=0x1     { }
 postRegIncrement:   is as=0x3 & dest_0_4=2 & bow=0x0     { }
 postRegIncrement:   is as=0x3 & dest_0_4=3 & bow=0x0     { }
-postRegIncrement:   is as=0x0 & dest_0_4=0 & bow=0x0 & (op16_12_4!=0x1 | op16_8_4!=0x2 | op16_7_1!=0x0) { PC = PC & 0xFFFE; goto [PC]; } # If PC is modified, alter flow (except for PUSH instructions)
-postRegIncrement:   is as=0x0 & dest_0_4=0 & bow=0x1 & (op16_12_4!=0x1 | op16_8_4!=0x2 | op16_7_1!=0x0) { PC = PC & 0xFE; goto [PC]; } # If PC is modified, alter flow (except for PUSH instructions)
+postRegIncrement:   is as=0x0 & dest_0_4=0 & ctx_al=1 & bow=0x0 & (op16_12_4!=0x1 | op16_8_4!=0x2 | op16_7_1!=0x0) { PC = PC & 0xFFFE; goto [PC]; } # If PC is modified, alter flow (except for PUSH instructions)
+postRegIncrement:   is as=0x0 & dest_0_4=0 & ctx_al=1 & bow=0x1 & (op16_12_4!=0x1 | op16_8_4!=0x2 | op16_7_1!=0x0) { PC = PC & 0xFE; goto [PC]; } # If PC is modified, alter flow (except for PUSH instructions)
+postRegIncrement:   is as=0x0 & dest_0_4=0 & ctx_al=0 { PC = PC & 0xFFFFE; goto [PC]; }
 postRegIncrement:   is as     & bow                       { }
 
 # R2 and R3 are constant generators - post-increment not supported

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430Common.sinc
@@ -273,7 +273,7 @@ REG_W_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & 
 REG_W_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK & reg_Indexed16_0_4=1 ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s - 0x2, AMASK); export *:2 tmp;} # PUSH, CALL X(SP) - addressing includes SP decrement
 REG_W_AS: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect (@Rn):
 REG_W_AS: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-REG_W_AS: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:2 tmp; } # Symbolic
+REG_W_AS: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16s, AMASK); export *:2 tmp; } # Symbolic
 REG_W_AS: "#"^indexExtWord16_0_16 	 is reg16_0_4=0x0 & as=0x3 & bow=0x0 ; indexExtWord16_0_16 {export *[const]:2 indexExtWord16_0_16; } # Immediate
 REG_W_AS: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 & AMASK; indexExtWord16_0_16 {tmp:$(REG_SIZE) = indexExtWord16_0_16 & AMASK; export *:2 tmp; } # Absolute
 REG_W_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x0  { export 4:2;}		# Constant
@@ -288,7 +288,7 @@ REG_W_AS_DEST: DST16_0_4 			 is DST16_0_4 & reg16_0_4=0 & as=0x0 & bow=0x0  {DST
 REG_W_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:2 tmp;}
 REG_W_AS_DEST: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect (@Rn):
 REG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = reg_InDirect16_0_4 & AMASK; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-REG_W_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:2 tmp; } # Symbolic
+REG_W_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16s, AMASK); export *:2 tmp; } # Symbolic
 REG_W_AS_DEST: "#"^indexExtWord16_0_16 	 is reg16_0_4=0x0 & as=0x3 & bow=0x0 & AMASK ; indexExtWord16_0_16 {export *:2 inst_next; } # Immediate - Undocumented behaviour
 REG_W_AS_DEST: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 {tmp:$(REG_SIZE) = indexExtWord16_0_16 & AMASK; export *:2 tmp; } # Absolute
 
@@ -299,7 +299,7 @@ REG_B_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & 
 REG_B_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK & reg_Indexed16_0_4=1 ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s - 0x2, AMASK); export *:1 tmp;} # PUSH.B X(SP) - includes SP decrement
 REG_B_AS: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 REG_B_AS: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-REG_B_AS: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = labelCalc & AMASK;export *:1 tmp; } # Symbolic
+REG_B_AS: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ] {tmp:$(REG_SIZE) = labelCalc & AMASK;export *:1 tmp; } # Symbolic
 REG_B_AS: "#"^indexExtWord16_0_16 	 is reg16_0_4=0x0 & as=0x3 & bow=0x1 ; indexExtWord16_0_16 { export *[const]:1 indexExtWord16_0_16; } # Immediate
 REG_B_AS: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
 REG_B_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:1;}		# Constant
@@ -314,7 +314,7 @@ REG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & reg16_0_4=0 & as=0x0 & bow=0x1  {tmp
 REG_B_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, reg_Indexed16_0_4, indexExtWord16_0_16s, AMASK); export *:1 tmp;}
 REG_B_AS_DEST: "@"^reg_InDirect16_0_4 	 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 REG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+" is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
-REG_B_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:1 tmp; } # Symbolic
+REG_B_AS_DEST: labelCalc 				 is reg16_0_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16s, AMASK); export *:1 tmp; } # Symbolic
 REG_B_AS_DEST: "#"^indexExtWord16_0_16 	 is reg16_0_4=0x0 & as=0x3 & bow=0x1 & AMASK ; indexExtWord16_0_16 {export *:1 inst_next; } # Undocumented behaviour
 REG_B_AS_DEST: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
 
@@ -328,7 +328,7 @@ SRC_W_AS: SRC16_8_4 			 		 is SRC16_8_4 & src16_8_4=0 & as=0x0 & bow=0x0 {tmp:2 
 SRC_W_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s {local tmp:$(REG_SIZE); computeIndexedAddr(tmp, src_Indexed16_8_4, indexExtWord16_0_16s, AMASK); export *:2 tmp;}
 SRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = src_InDirect16_8_4 & AMASK; export *:2 tmp;} # Word/Register Indirect (@Rn):
 SRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0 & AMASK {tmp:$(REG_SIZE) = src_InDirect16_8_4 & AMASK; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-SRC_W_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:2 tmp; } # Symbolic
+SRC_W_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16s, AMASK); export *:2 tmp; } # Symbolic
 SRC_W_AS: "#"^indexExtWord16_0_16 	 is src16_8_4=0x0 & as=0x3 & bow=0x0 ; indexExtWord16_0_16 {export *[const]:2 indexExtWord16_0_16; } # Immediate
 SRC_W_AS: "&"^indexExtWord16_0_16 	 is src16_8_4=0x2 & as=0x1 & bow=0x0 & AMASK ; indexExtWord16_0_16 {tmp:$(REG_SIZE) = indexExtWord16_0_16 & AMASK; export *:2 tmp; } # Absolute
 SRC_W_AS: "#4" 						 is src16_8_4=0x2 & as=0x2 & bow=0x0  { export 4:2; }		# Constant
@@ -343,7 +343,7 @@ SRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & src16_8_4=0 & as=0x0 & bow=0x1  {tmp:$(R
 SRC_B_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, src_Indexed16_8_4, indexExtWord16_0_16s, AMASK); export *:1 tmp;}
 SRC_B_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
 SRC_B_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-SRC_B_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16 [labelCalc = inst_start + 2 + indexExtWord16_0_16; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16, AMASK); export *:1 tmp; } # Symbolic
+SRC_B_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 & AMASK ; indexExtWord16_0_16s [labelCalc = inst_start + 2 + indexExtWord16_0_16s; ] { local tmp:$(REG_SIZE); computeIndexedAddr(tmp, inst_start + 2, indexExtWord16_0_16s, AMASK); export *:1 tmp; } # Symbolic
 SRC_B_AS: "#"^indexExtWord16_0_16 	 is src16_8_4=0x0 & as=0x3 & bow=0x1 ; indexExtWord16_0_16 {export *[const]:1 indexExtWord16_0_16;} # Immediate
 SRC_B_AS: "&"^indexExtWord16_0_16 	 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
 SRC_B_AS: "#4" 						 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:1; }		# Constant

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -3240,7 +3240,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }	
 
-:RRAX.B XRREG_B_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x1 & bow=0x1 & postRegIncrement & XRREG_B_AS_DEST {
+:RRAX.B XRREG_B_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x0 & bow=0x1 & postRegIncrement & XRREG_B_AS_DEST {
 	<top>
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;					# V Flag (reset)
@@ -3256,7 +3256,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RRAX.W XRREG_W_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x1 & bow=0x0 & postRegIncrement & XRREG_W_AS_DEST {
+:RRAX.W XRREG_W_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x0 & bow=0x0 & postRegIncrement & XRREG_W_AS_DEST {
 	<top>
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;					# V Flag (reset)
@@ -3272,7 +3272,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RRAX.A XRREG_A_AS_DEST 		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x1 & bow=0x1 & postRegIncrement & XRREG_A_AS_DEST {
+:RRAX.A XRREG_A_AS_DEST 		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x0 & bow=0x1 & postRegIncrement & XRREG_A_AS_DEST {
 	<top>
 	$(CARRY) = XRREG_A_AS_DEST[0,1];
 	XRREG_A_AS_DEST = (XRREG_A_AS_DEST << 12 s>> 13) & 0xfffff;
@@ -3285,7 +3285,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RRCX.B XRREG_B_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & ctx_zc & op16_12_4=0x1 & op16_8_4=0x0 & bow=0x1 & postRegIncrement & XRREG_B_AS_DEST & repeat_carry {
+:RRCX.B XRREG_B_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & ctx_zc & op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x1 & postRegIncrement & XRREG_B_AS_DEST & repeat_carry {
 	<top>
 	# Operation Flags...
 	build repeat_carry;
@@ -3320,7 +3320,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RRCX.W XRREG_W_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x0 & bow=0x0 & postRegIncrement & XRREG_W_AS_DEST & repeat_carry {
+:RRCX.W XRREG_W_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x0 & postRegIncrement & XRREG_W_AS_DEST & repeat_carry {
 	<top>
 	build repeat_carry;
 	# Operation Flags...
@@ -3355,7 +3355,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RRCX.A XRREG_A_AS_DEST 		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x0 & bow=0x1 & postRegIncrement & XRREG_A_AS_DEST & repeat_carry {
+:RRCX.A XRREG_A_AS_DEST 		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x1 & postRegIncrement & XRREG_A_AS_DEST & repeat_carry {
 	<top>
 	build repeat_carry;
 	# Operation Flags...

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -54,7 +54,7 @@ NUM2: val					is rrn [ val = rrn+1;] {export *[const]:1 val;}
 XREG_B_AS: DST8_0_4 			 		 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
 XREG_B_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src; export *:1 tmp;}
 XREG_B_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XREG_B_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XREG_B_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
 XREG_B_AS: Label20Src 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Src {export *:1 Label20Src; } # Symbolic
 XREG_B_AS: "#"^ImmS20Dst 		 is reg16_0_4=0x0 & as=0x3 & bow=0x1 ; ImmS20Dst {export *[const]:1 ImmS20Dst; } # Immediate
 XREG_B_AS: "&"^Imm20Dst 		 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:1 Imm20Dst; } # Absolute
@@ -67,7 +67,7 @@ XREG_B_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1;} 	
 
 XRREG_B_AS: DST8_0_4 			 		 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
 XRREG_B_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_B_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRREG_B_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
 XRREG_B_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:1;}		# Constant
 XRREG_B_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x1  { export 8:1;}		# Constant
 XRREG_B_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:1;}		# Constant
@@ -76,10 +76,10 @@ XRREG_B_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:1;}		# C
 XRREG_B_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1;} 	# Constant	
 
 XREG_W_AS: DST16_0_4 			 		 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
-XREG_W_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src; export *:2 tmp;}
-XREG_W_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XREG_W_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_W_AS: Label20Src 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Src {export *:2 Label20Src; } # Symbolic
+XREG_W_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src & ~1; export *:2 tmp;}
+XREG_W_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
+XREG_W_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
+XREG_W_AS: Label20Src 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Src {local tmp:$(REG_SIZE) = Label20Src & ~1; export *:2 tmp; } # Symbolic
 XREG_W_AS: "#"^ImmS20Dst 		 is reg16_0_4=0x0 & as=0x3 & bow=0x0 ; ImmS20Dst {export *[const]:2 ImmS20Dst; } # Immediate
 XREG_W_AS: "&"^Imm20Dst 		 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {export *:2 Imm20Dst; } # Absolute
 XREG_W_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x0  { export 4:2;}		# Constant
@@ -90,8 +90,8 @@ XREG_W_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x0  { export 2:2;}		# Co
 XREG_W_AS: "#-1" 					 	 is	reg16_0_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2;} 	    # Constant
 
 XRREG_W_AS: DST16_0_4 			 		 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
-XRREG_W_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_W_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRREG_W_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
+XRREG_W_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XRREG_W_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x0  { export 4:2;}		# Constant
 XRREG_W_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x0  { export 8:2;}		# Constant
 XRREG_W_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x0  { export 0:2;}		# Constant
@@ -100,12 +100,12 @@ XRREG_W_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x0  { export 2:2;}		# C
 XRREG_W_AS: "#-1" 					 	 is	reg16_0_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2;} 	    # Constant
 
 XREG_A_AS: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
-XREG_A_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src; export *:$(REG_SIZE) tmp;}
-XREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XREG_A_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src & ~1; export *:$(REG_SIZE) tmp;}
+XREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XREG_A_AS: Label20Src 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Src  {export *:$(REG_SIZE) Label20Src; } # Symbolic
 XREG_A_AS: "#"^ImmS20Dst 						 is reg16_0_4=0x0 & as=0x3 & bow=0x1 ; ImmS20Dst {export *[const]:$(REG_SIZE) ImmS20Dst; } # Immediate
-XREG_A_AS: "&"^Imm20Dst 						 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
+XREG_A_AS: "&"^Imm20Dst 						 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 XREG_A_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE);}		# Constant
 XREG_A_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE);}		# Constant
 XREG_A_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE);}		# Constant
@@ -114,8 +114,8 @@ XREG_A_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZ
 XREG_A_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE);} 	# Constant	
 
 XRREG_A_AS: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
-XRREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XRREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XRREG_A_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE);}		# Constant
 XRREG_A_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE);}		# Constant
 XRREG_A_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE);}		# Constant
@@ -126,43 +126,43 @@ XRREG_A_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xfffffff
 XREG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
 XREG_B_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst; export *:1 tmp;}
 XREG_B_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
 XREG_B_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Dst {export *:1 Label20Dst; } # Symbolic
 XREG_B_AS_DEST: "&"^Imm20Dst 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:1 Imm20Dst; } # Absolute
 
 XRREG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x1  { ztmp:1 = DST8_0_4; reg_Direct16_0_4=0; DST8_0_4 = ztmp; export DST8_0_4;} # Word/Register Direct (Rn):
 XRREG_B_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
 
-XREG_W_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
-XREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_W_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {export *:2 Label20Dst; } # Symbolic
-XREG_W_AS_DEST: "&"^Imm20Dst 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {export *:2 Imm20Dst; } # Absolute
+XREG_W_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK ; ImmS20Dst {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + ImmS20Dst) & AMASK; export *:2 tmp;}
+XREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
+XREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
+XREG_W_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {local tmp:$(REG_SIZE) = Label20Dst & ~1; export *:2 tmp; } # Symbolic
+XREG_W_AS_DEST: "&"^Imm20Dst 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:2 tmp; } # Absolute
 
 XRREG_W_AS_DEST: DST16_0_4 			 is DST16_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x0  {ztmp:2 = DST16_0_4; reg_Direct16_0_4=0; DST16_0_4 = ztmp;export DST16_0_4;} # Word/Register Direct (Rn):
-XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
+XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 
-XREG_A_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
-XREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XREG_A_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst & ~1; export *:$(REG_SIZE) tmp;}
+XREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XREG_A_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
 XREG_A_AS_DEST: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
 
 XRREG_A_AS_DEST: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
-XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 
-XREG_A_AS_DEST2: Imm20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; Imm20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + Imm20Dst; export *:$(REG_SIZE) tmp;}
-XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XREG_A_AS_DEST2: Imm20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; Imm20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + Imm20Dst & ~1; export *:$(REG_SIZE) tmp;}
+XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XREG_A_AS_DEST2: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
-XREG_A_AS_DEST2: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
+XREG_A_AS_DEST2: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 
 XRREG_A_AS_DEST2: dest_0_4						 is dest_0_4 & as=0 & bow=0x0 {export dest_0_4;}
-XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 
 XSRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & as=0x0 & bow=0x1 { export SRC8_8_4;} # Word/Register Direct (Rn):
 XSRC_B_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:1 tmp;}
@@ -180,7 +180,7 @@ XSRC_B_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1; } 	
 
 XRSRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & as=0x0 & bow=0x1 { export SRC8_8_4;} # Word/Register Direct (Rn):
 XRSRC_B_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
-XRSRC_B_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRSRC_B_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):
 XRSRC_B_AS: "#4" 						 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:1; }		# Constant
 XRSRC_B_AS: "#8" 						 is src16_8_4=0x2 & as=0x3 & bow=0x1  { export 8:1; }		# Constant
 XRSRC_B_AS: "#0" 						 is src16_8_4=0x3 & as=0x0 & bow=0x1  { export 0:1; }		# Constant
@@ -191,11 +191,11 @@ XRSRC_B_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1; } 
 
 XSRC_W_AS: SRC16_8_4 			 	 is SRC16_8_4 & as=0x0 & bow=0x0 {export SRC16_8_4;} # Word/Register Direct (Rn):
 XSRC_W_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x0 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:2 tmp;}
-XSRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0  {export *:2 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
-XSRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0  {export *:2 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XSRC_W_AS: Label20Src 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 ; Label20Src {export *:2 Label20Src; } # Symbolic
+XSRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
+XSRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
+XSRC_W_AS: Label20Src 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 ; Label20Src {local tmp:$(REG_SIZE) = Label20Src & ~1; export *:2 tmp; } # Symbolic
 XSRC_W_AS: "#"^ImmS20Src 	 is src16_8_4=0x0 & as=0x3 & bow=0x0 ; ImmS20Src {export *[const]:2 ImmS20Src; } # Immediate
-XSRC_W_AS: "&"^Imm20Src 	 is src16_8_4=0x2 & as=0x1 & bow=0x0 ; Imm20Src {export *:2 Imm20Src; } # Absolute
+XSRC_W_AS: "&"^Imm20Src 	 is src16_8_4=0x2 & as=0x1 & bow=0x0 ; Imm20Src {local tmp:$(REG_SIZE) = Imm20Src & ~1; export *:2 tmp; } # Absolute
 XSRC_W_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x0  { export 4:2; }		# Constant
 XSRC_W_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x0  { export 8:2; }		# Constant
 XSRC_W_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x0  { export 0:2; }		# Constant
@@ -204,8 +204,8 @@ XSRC_W_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x0  { export 2:2; }		# Co
 XSRC_W_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2; } 	# Constant	
 
 XRSRC_W_AS: SRC16_8_4 			 	 is SRC16_8_4 & as=0x0 & bow=0x0 {export SRC16_8_4;} # Word/Register Direct (Rn):
-XRSRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0  {export *:2 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
-XRSRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0  {export *:2 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRSRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
+XRSRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XRSRC_W_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x0  { export 4:2; }		# Constant
 XRSRC_W_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x0  { export 8:2; }		# Constant
 XRSRC_W_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x0  { export 0:2; }		# Constant
@@ -214,12 +214,12 @@ XRSRC_W_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x0  { export 2:2; }		# C
 XRSRC_W_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2; } 	# Constant	
 
 XSRC_A_AS: src_8_4 			 		 is src_8_4 & as=0x0 & bow=0x1 { export src_8_4;} # Word/Register Direct (Rn):
-XSRC_A_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:$(REG_SIZE) tmp;}
-XSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
-XSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XSRC_A_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src & ~1; export *:$(REG_SIZE) tmp;}
+XSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XSRC_A_AS: Label20Src 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 ; Label20Src {export *:$(REG_SIZE) Label20Src; } # Symbolic
 XSRC_A_AS: "#"^ImmS20Src 	 				 is src16_8_4=0x0 & as=0x3 & bow=0x1 ; ImmS20Src {export *[const]:$(REG_SIZE) ImmS20Src; } # Immediate
-XSRC_A_AS: "&"^Imm20Src 	 				 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; Imm20Src {export *:$(REG_SIZE) Imm20Src; } # Absolute
+XSRC_A_AS: "&"^Imm20Src 	 				 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; Imm20Src {local tmp:$(REG_SIZE) = Imm20Src & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 XSRC_A_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE); }		# Constant
 XSRC_A_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE); }		# Constant
 XSRC_A_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE); }		# Constant
@@ -228,8 +228,8 @@ XSRC_A_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZE
 XSRC_A_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE); } 	# Constant	
 
 XRSRC_A_AS: src_8_4 			 		 is src_8_4 & as=0x0 & bow=0x1 { export src_8_4;} # Word/Register Direct (Rn):
-XRSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
-XRSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
+XRSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
+XRSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XRSRC_A_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE); }		# Constant
 XRSRC_A_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE); }		# Constant
 XRSRC_A_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE); }		# Constant
@@ -262,44 +262,44 @@ XDEST_B_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0
 XDEST_W_AD: DST16_0_4 		  		 is DST16_0_4 & ad=0x0 & bow=0x0
      {export DST16_0_4;} # Word/Register Direct (Rn):
 XDEST_W_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 ; ImmS20Dst
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst & ~1; export *:2 tmp;}
 XDEST_W_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; ImmS20Dst
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst & ~1; export *:2 tmp;}
 XDEST_W_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; ImmS20Dst
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst & ~1; export *:2 tmp;}
 XDEST_W_AD: Label20Dst 				  is dest=0x0 & ad=0x1 & bow=0x0 ; Label20Dst
-     {export *:2 Label20Dst; } # Symbolic
+     {local tmp:$(REG_SIZE) = Label20Dst & ~1; export *:2 tmp; } # Symbolic
 XDEST_W_AD: Label20DstExt 				  is dest=0x0 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Label20DstExt
-     {export *:2 Label20DstExt; } # Symbolic
+     {local tmp:$(REG_SIZE) = Label20DstExt & ~1; export *:2 tmp; } # Symbolic
 XDEST_W_AD: Label20DstExt 				  is dest=0x0 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Label20DstExt
-     {export *:2 Label20DstExt; } # Symbolic
+     {local tmp:$(REG_SIZE) = Label20DstExt & ~1; export *:2 tmp; } # Symbolic
 XDEST_W_AD: "&"^Imm20Dst 	  is dest=0x2 & ad=0x1 & bow=0x0 ; Imm20Dst
-     {export *:2 Imm20Dst; } # Absolute
+     {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:2 tmp; } # Absolute
 XDEST_W_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Imm20Dst
-     {export *:2 Imm20Dst; } # Absolute
+     {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:2 tmp; } # Absolute
 XDEST_W_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Imm20Dst
-     {export *:2 Imm20Dst; } # Absolute
+     {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:2 tmp; } # Absolute
 
 XDEST_A_AD: dest_0_4 		  		 is dest_0_4 & ad=0x0 & bow=0x1
      { export dest_0_4; }        # Word/Register Direct (Rn):
 XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 ; ImmS20Dst
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst & ~1; export *:$(REG_SIZE) tmp;}
 XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; ImmS20Dst
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst & ~1; export *:$(REG_SIZE) tmp;}
 XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; ImmS20Dst
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst & ~1; export *:$(REG_SIZE) tmp;}
 XDEST_A_AD: Label20Dst 				  is dest=0x0 & ad=0x1 & bow=0x1 ; Label20Dst
-     {export *:$(REG_SIZE) Label20Dst; } # Symbolic
+     {local tmp:$(REG_SIZE) = Label20Dst & ~1; export *:$(REG_SIZE) tmp; } # Symbolic
 XDEST_A_AD: Label20DstExt			  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ;Label20DstExt
-     {export *:$(REG_SIZE) Label20DstExt; } # Symbolic
+     {local tmp:$(REG_SIZE) = Label20DstExt & ~1; export *:$(REG_SIZE) tmp; } # Symbolic
 XDEST_A_AD: Label20DstExt			  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Label20DstExt
-     {export *:$(REG_SIZE) Label20DstExt; } # Symbolic
+     {local tmp:$(REG_SIZE) = Label20DstExt & ~1; export *:$(REG_SIZE) tmp; } # Symbolic
 XDEST_A_AD: "&"^Imm20Dst 			  is dest=0x2 & ad=0x1 & bow=0x1 ; Imm20Dst
-     {export *:$(REG_SIZE) Imm20Dst; } # Absolute
+     {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 XDEST_A_AD: "&"^Imm20Dst			  is dest=0x2 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Imm20Dst
-     {export *:$(REG_SIZE) Imm20Dst; } # Absolute
+     {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 XDEST_A_AD: "&"^Imm20Dst			  is dest=0x2 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Imm20Dst
-     {export *:$(REG_SIZE) Imm20Dst; } # Absolute
+     {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 
 #Use repeat_carry with a build directive at the beginning of a RPT loop
 
@@ -928,35 +928,35 @@ macro adda(dst, src) {
 }
 
 :MOVA "@"^src_8_4, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & src_8_4 & dest_0_4 {
-	dest_0_4 = *[RAM]:$(REG_SIZE) src_8_4;
+	dest_0_4 = *[RAM]:$(REG_SIZE) src_8_4 & ~1;
 	dest_0_4 = sext(dest_0_4[0,20]);
 }
 
 :MOVA "@"^src_8_4^"+", dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & src_8_4 & dest_0_4 {
-	dest_0_4 = *[RAM]:$(REG_SIZE) src_8_4;
+	dest_0_4 = *[RAM]:$(REG_SIZE) src_8_4 & ~1;
 	dest_0_4 = sext(dest_0_4[0,20]);
 	src_8_4 = src_8_4 + 4;
 }
 
 :MOVA "&"^Abs20, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x2 & imm_8_4 & dest_0_4 ; Abs20 [ctx_ctregdest=imm_8_4;] {
-	tmp:$(REG_SIZE) = zext(Abs20);
+	tmp:$(REG_SIZE) = zext(Abs20) & ~1;
 	dest_0_4 = *[RAM]:$(REG_SIZE) tmp;
 	dest_0_4 = sext(dest_0_4[0,20]);
 }
 
 :MOVA imms_0_16^"("^src_8_4^")", dest_0_4		is ctx_haveext=0 & op16_12_4=0 & insid=0x3 & src_8_4 & dest_0_4 ; imms_0_16 {
-	tmp:$(REG_SIZE) = src_8_4 + sext(imms_0_16:2);
+	tmp:$(REG_SIZE) = src_8_4 + sext(imms_0_16:2) & ~1;
 	dest_0_4 = *[RAM]:$(REG_SIZE) tmp;
 	dest_0_4 = sext(dest_0_4[0,20]);
 }
 
 :MOVA src_8_4, "&"^Abs20				is ctx_haveext=0 & op16_12_4=0 & insid=0x6 & imm_0_4 & src_8_4 ; Abs20 [ctx_ctregdest=imm_0_4;] {
-	tmp:$(REG_SIZE) = zext(Abs20);
+	tmp:$(REG_SIZE) = zext(Abs20) & ~1;
 	*[RAM]:$(REG_SIZE) tmp = src_8_4 & 0xFFFFF;
 }
 
 :MOVA src_8_4, imms_0_16^"("^dest_0_4^")"		is ctx_haveext=0 & op16_12_4=0 & insid=0x7 & src_8_4 & dest_0_4 ; imms_0_16 {
-	tmp:$(REG_SIZE) = dest_0_4 + sext(imms_0_16:2);
+	tmp:$(REG_SIZE) = dest_0_4 + sext(imms_0_16:2) & ~1;
 	*[RAM]:$(REG_SIZE) tmp = src_8_4 & 0xFFFFF;
 }
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -809,17 +809,9 @@ macro adda(dst, src) {
 	setaddflags(dst,tmps,tmpd);
 }
 
-:ADDA SRC20_8_4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & SRC20_8_4 & DST20_0_4 {
+:ADDA SRC20_8_4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & SRC20_8_4 & DST20_0_4 & postStorePC {
 	adda(DST20_0_4,SRC20_8_4);
-}
-
-:ADDA SRC20_8_4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & SRC20_8_4 & DST20_0_4 & dest_0_4=0x0 {
-	tmpd:$(REG_SIZE) = DST20_0_4;
-	tmp:$(REG_SIZE) = SRC20_8_4 + tmpd;
-	PC = tmp & 0xFFFFE;
-	
-	setaddflags(DST20_0_4,SRC20_8_4,tmpd);
-	goto [PC];
+	build postStorePC;
 }
 
 # `ADDA SR, <dst>`, verified with hardware but not in spec.
@@ -827,27 +819,19 @@ macro adda(dst, src) {
 	adda(DST20_0_4, 4:$(REG_SIZE));
 }
 
-:INCDA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x3 & DST20_0_4 {
+:INCDA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x3 & DST20_0_4 & postStorePC {
 	adda(DST20_0_4, 2:$(REG_SIZE));
+	build postStorePC;
 }
 
-:ADDA "#"^Abs20s, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & DST20_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
+:ADDA "#"^Abs20s, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & DST20_0_4 & postStorePC ; Abs20s [ctx_ctregdest=imm_8_4;] {
 	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = sext(Abs20s);
 	tmp:$(REG_SIZE) = tmpd + tmps;
 	DST20_0_4 = sext(tmp[0,20]);
 	
 	setaddflags(DST20_0_4,tmps,tmpd);
-}
-
-:ADDA "#"^Abs20s, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & DST20_0_4 & dest_0_4=0x0; Abs20s [ctx_ctregdest=imm_8_4;] {
-	tmpd:$(REG_SIZE) = DST20_0_4;
-	tmps:$(REG_SIZE) = sext(Abs20s);
-	tmp:$(REG_SIZE) = tmpd + tmps;
-	PC = tmp & 0xFFFFE;
-	
-	setaddflags(PC,tmps,tmpd);
-	goto [PC];
+	build postStorePC;
 }
 
 :CMPA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xD & SRC20_8_4 & DST20_0_4 {
@@ -910,8 +894,9 @@ macro adda(dst, src) {
 	DST20_0_4 = SRC20_8_4;
 }
 
-:CLRA DST20_0_4						is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4=0x3 & DST20_0_4 {
+:CLRA DST20_0_4						is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4=0x3 & DST20_0_4 & postStorePC {
 	DST20_0_4 = 0:$(REG_SIZE);
+	build postStorePC;
 }
 
 macro suba(dst, src) {
@@ -923,45 +908,19 @@ macro suba(dst, src) {
 	setsubflags(dst,tmps,tmpd);
 }
 
-:SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & DST20_0_4 {
+:SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & DST20_0_4 & postStorePC {
 	suba(DST20_0_4, SRC20_8_4);
+	build postStorePC;
 }
 
-:SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & DST20_0_4 & dest_0_4=0x0 {
-	tmpd:$(REG_SIZE) = DST20_0_4;
-	tmp:$(REG_SIZE) = tmpd - SRC20_8_4;
-	PC = tmp & 0xffffe;
-	
-	setsubflags(DST20_0_4,SRC20_8_4,tmpd);
-	goto [PC];
-}
-
-:SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & src_8_4=0x0 & DST20_0_4 {
-	tmpd:$(REG_SIZE) = DST20_0_4;
-	tmps:$(REG_SIZE) = SRC20_8_4;
-	tmp:$(REG_SIZE) = DST20_0_4 - tmps;
-	DST20_0_4 = sext(tmp[0,20]);
-	
-	setsubflags(DST20_0_4,tmps,tmpd);
-}
-
-:SUBA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4 & DST20_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
+:SUBA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4 & DST20_0_4 & postStorePC ; Abs20s [ctx_ctregdest=imm_8_4;] {
 	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = sext(Abs20s);
 	tmp:$(REG_SIZE) = DST20_0_4 - tmps;
 	DST20_0_4 = sext(tmp[0,20]);
 	
 	setsubflags(DST20_0_4,tmps,tmpd);
-}
-
-:SUBA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4 & DST20_0_4 & dest_0_4=0x0; Abs20s [ctx_ctregdest=imm_8_4;] {
-	tmpd:$(REG_SIZE) = DST20_0_4;
-	tmps:$(REG_SIZE) = sext(Abs20s);
-	tmp:$(REG_SIZE) = tmpd - tmps;
-	PC = tmp & 0xffffe;
-	
-	setsubflags(PC,tmps,tmpd);
-	goto [PC];
+	build postStorePC;
 }
 
 ##################

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -1309,14 +1309,6 @@ macro wzero(full, word)
 # double and single operand. The double operand ones come
 # first. A lot of the singles are covered under the address
 # extensions as they don't have the extension word.
-#
-# The manual talks about RRUX extended instructions.  However,
-# I've determined they don't really exist. First off, the base
-# RRU is not mentioned in the manual and is not in the toolchain.
-# The toolchain does take rrux instructions, but what I've figured
-# out is that for the W and A versions, it substitutes RRUM with 
-# the 'n' argument being 1. For the B version, it uses rra.b
-# followed by a bic.b instruction.
 #############################
 #
 # Double Operand
@@ -3311,6 +3303,23 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
+:RRUX.B XRREG_B_AS_DEST 		is ctx_haveext=4 & ctx_zc=1 & ctx_al=1 & ctx_zc & op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x1 & postRegIncrement & XRREG_B_AS_DEST & repeat_carry {
+	<top>
+	# Operation Flags...
+	# build repeat_carry;
+	$(OVERFLOW) = 0x0;					# V Flag
+	# Operation...
+	$(CARRY) = (XRREG_B_AS_DEST & 0x1);
+	XRREG_B_AS_DEST = XRREG_B_AS_DEST >> 0x1;
+	# Result Flags...
+	$(SIGN) = (XRREG_B_AS_DEST s< 0x0);			# S Flag
+	$(ZERO) = (XRREG_B_AS_DEST == 0x0);			# Z Flag
+	build postRegIncrement;
+	if (CNT == 0) goto inst_next;
+	CNT = CNT - 1;
+	goto <top>;
+}
+
 :RRCX.W XRREG_W_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x0 & bow=0x0 & postRegIncrement & XRREG_W_AS_DEST & repeat_carry {
 	<top>
 	build repeat_carry;
@@ -3320,6 +3329,23 @@ define pcodeop bcd_add;
 	tmp:1 = $(CARRY);
 	$(CARRY) = XRREG_W_AS_DEST[0,1];
 	XRREG_W_AS_DEST = ((zext(tmp) << 0xF) | (XRREG_W_AS_DEST >> 0x1));
+	# Result Flags...
+	$(SIGN) = (XRREG_W_AS_DEST s< 0x0);			# S Flag
+	$(ZERO) = (XRREG_W_AS_DEST == 0x0);			# Z Flag
+	build postRegIncrement;
+	if (CNT == 0) goto inst_next;
+	CNT = CNT - 1;
+	goto <top>;
+}
+
+:RRUX.W XRREG_W_AS_DEST 		is ctx_haveext=4 & ctx_zc=1 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x0 & postRegIncrement & XRREG_W_AS_DEST & repeat_carry {
+	<top>
+	build repeat_carry;
+	# Operation Flags...
+	$(OVERFLOW) = 0;					# V Flag
+	# Operation...
+	$(CARRY) = XRREG_W_AS_DEST[0,1];
+	XRREG_W_AS_DEST = XRREG_W_AS_DEST >> 0x1;
 	# Result Flags...
 	$(SIGN) = (XRREG_W_AS_DEST s< 0x0);			# S Flag
 	$(ZERO) = (XRREG_W_AS_DEST == 0x0);			# Z Flag
@@ -3341,6 +3367,23 @@ define pcodeop bcd_add;
 	XRREG_A_AS_DEST = sext(XRREG_A_AS_DEST[0,20]);
 	# Result Flags...
 	$(SIGN) = (XRREG_A_AS_DEST s< 0x0);			# S Flag
+	$(ZERO) = (XRREG_A_AS_DEST == 0x0);			# Z Flag
+	build postRegIncrement;
+	if (CNT == 0) goto inst_next;
+	CNT = CNT - 1;
+	goto <top>;
+}
+
+:RRUX.A XRREG_A_AS_DEST 		is ctx_haveext=4 & ctx_zc=1 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x1 & postRegIncrement & XRREG_A_AS_DEST & repeat_carry {
+	<top>
+	build repeat_carry;
+	# Operation Flags...
+	$(OVERFLOW) = 0x0;					# V Flag
+	# Operation...
+	$(CARRY) = XRREG_A_AS_DEST[0,1];
+	XRREG_A_AS_DEST = (XRREG_A_AS_DEST >> 0x1) & 0x7FFFF;
+	# Result Flags...
+	$(SIGN) = XRREG_A_AS_DEST[19, 1] == 1;			# S Flag
 	$(ZERO) = (XRREG_A_AS_DEST == 0x0);			# Z Flag
 	build postRegIncrement;
 	if (CNT == 0) goto inst_next;

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -724,7 +724,7 @@ POPAR1:						is ctx_mreg=0x1 & POPAR2 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 POPAR0:						is  POPAR1 {build POPAR1;}
 POPAR0:						is ctx_mreg=0x0 & POPAR1 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+1;] {
 	PC = *[RAM]:4 SP;
-	PC = sext(PC[0,20]);
+	PC = PC & 0xffffe;
 	SP = SP + 4;
 	build POPAR1;
 	goto [PC];
@@ -850,7 +850,7 @@ POPWR1:						is ctx_mreg=0x1 & POPWR2 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 
 POPWR0:						is  POPWR1 {build POPWR1;}
 POPWR0:						is ctx_mreg=0x0 & POPWR1 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+1;] {
-	PC = zext(*[RAM]:2 SP);
+	PC = zext(*[RAM]:2 SP) & ~1;
 	SP = SP + 2;
 	build POPWR1;
 	goto [PC];
@@ -871,7 +871,7 @@ macro adda(dst, src) {
 :ADDA src_8_4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4 & dest_0_4 & dest_0_4=0x0 {
 	tmpd:$(REG_SIZE) = inst_start + 2;
 	tmp:$(REG_SIZE) = src_8_4 + tmpd;
-	PC = sext(tmp[0,20]);
+	PC = tmp & 0xFFFFE;
 	
 	setaddflags(dest_0_4,src_8_4,tmpd);
 	goto [PC];
@@ -908,7 +908,7 @@ macro adda(dst, src) {
 	tmpd:$(REG_SIZE) = inst_start + 2;
 	tmps:$(REG_SIZE) = sext(Abs20s);
 	tmp:$(REG_SIZE) = tmpd + tmps;
-	PC = sext(tmp[0,20]);
+	PC = tmp & 0xFFFFE;
 	
 	setaddflags(PC,tmps,tmpd);
 	goto [PC];
@@ -987,7 +987,7 @@ macro suba(dst, src) {
 :SUBA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4 & dest_0_4 & dest_0_4=0x0 {
 	tmpd:$(REG_SIZE) = inst_start + 2;
 	tmp:$(REG_SIZE) = tmpd - src_8_4;
-	PC = sext(tmp[0,20]);
+	PC = tmp & 0xffffe;
 	
 	setsubflags(dest_0_4,src_8_4,tmpd);
 	goto [PC];
@@ -1015,7 +1015,7 @@ macro suba(dst, src) {
 	tmpd:$(REG_SIZE) = inst_start + 2;
 	tmps:$(REG_SIZE) = sext(Abs20s);
 	tmp:$(REG_SIZE) = tmpd - tmps;
-	PC = sext(tmp[0,20]);
+	PC = tmp & 0xffffe;
 	
 	setsubflags(PC,tmps,tmpd);
 	goto [PC];
@@ -1035,45 +1035,40 @@ macro suba(dst, src) {
 }
 
 :BRA "@"^src_8_4 					is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & src_8_4 & dest_0_4=0x0 {
-	PC = *[RAM]:$(REG_SIZE) src_8_4;
-	PC = sext(PC[0,20]);
+	PC = *[RAM]:$(REG_SIZE) src_8_4 & 0xffffe;
 	goto [PC];
 }
 
 :BRA "@"^src_8_4^"+" 				is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & src_8_4 & dest_0_4=0x0 {
-	PC = *[RAM]:$(REG_SIZE) src_8_4;
-	PC = sext(PC[0,20]);
+	PC = *[RAM]:$(REG_SIZE) src_8_4 & 0xffffe;
 	src_8_4 = src_8_4 + 4;
 	goto [PC];
 }
 
 :BRA "&"^Abs20						is ctx_haveext=0 & op16_12_4=0 & insid=0x2 & imm_8_4 & dest_0_4=0x0; Abs20 [ctx_ctregdest=imm_8_4;] {
 	tmp:$(REG_SIZE) = zext(Abs20);
-	PC = *[RAM]:$(REG_SIZE) tmp;
-	PC = sext(PC[0,20]);
+	PC = *[RAM]:$(REG_SIZE) tmp & 0xffffe;
 	goto [PC];
 }
 
 :BRA imms_0_16^"("^src_8_4^")"		is ctx_haveext=0 & op16_12_4=0 & insid=0x3 & src_8_4 & dest_0_4=0x0; imms_0_16 {
 	tmp:$(REG_SIZE) = src_8_4 + sext(imms_0_16:2);
-	PC = *[RAM]:$(REG_SIZE) tmp;
-	PC = sext(PC[0,20]);
+	PC = *[RAM]:$(REG_SIZE) tmp & 0xffffe;
 	goto [PC];
 }
 
 :BRA "#"^Abs20add					is ctx_haveext=0 & op16_12_4=0 & insid=0x8 & imm_8_4 & dest_0_4=0x0; Abs20add [ctx_ctregdest=imm_8_4;] {
-#	PC = Abs20add;
+#	PC = Abs20add & 0xffffe;
 	goto Abs20add;
 }
 
 :BRA src_8_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4 & dest_0_4=0x0 {
-	PC = src_8_4;
+	PC = src_8_4 & 0xffffe;
 	goto [PC];
 }
 
 :RETA "@"^src_8_4^"+"			is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & src_8_4 & src_8_4=0x1 & dest_0_4=0x0 {
-	PC = *[RAM]:$(REG_SIZE) src_8_4;
-	PC = sext(PC[0,20]);
+	PC = *[RAM]:$(REG_SIZE) src_8_4 & 0xffffe;
 	SP = SP + 4;
 	return [PC];
 }
@@ -1124,7 +1119,7 @@ macro suba(dst, src) {
 :CALLA dest_0_4							is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x4 & dest_0_4 {
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
-	PC = dest_0_4;
+	PC = dest_0_4 & ~1;
 	call [PC];
 }
 
@@ -1133,7 +1128,7 @@ macro suba(dst, src) {
 	*:4 SP = inst_next;
 	tmp:$(REG_SIZE) = dest_0_4 + sext(imms_0_16:2);
 	PC = *[RAM]:$(REG_SIZE) tmp;
-	PC = sext(PC[0,20]);
+	PC = PC & 0xffffe;
 	call [PC];
 }
 
@@ -1141,7 +1136,7 @@ macro suba(dst, src) {
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
 	PC = *[RAM]:$(REG_SIZE) dest_0_4;
-	PC = sext(PC[0,20]);
+	PC = PC & 0xffffe;
 	call [PC];
 }
 
@@ -1149,7 +1144,7 @@ macro suba(dst, src) {
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
 	PC = *[RAM]:$(REG_SIZE) dest_0_4;
-	PC = sext(PC[0,20]);
+	PC = PC & 0xffffe;
 	dest_0_4 = dest_0_4 + 4;
 	call [PC];
 }
@@ -1159,7 +1154,7 @@ macro suba(dst, src) {
 	*:4 SP = inst_next;
 	tmp:$(REG_SIZE) = zext(Abs20);
 	PC = *[RAM]:$(REG_SIZE) tmp;
-	PC = sext(PC[0,20]);
+	PC = PC & 0xffffe;
 	call [PC];
 }
 
@@ -1168,7 +1163,7 @@ macro suba(dst, src) {
 	*:4 SP = inst_next;
 	tmp:$(REG_SIZE) = inst_start + sext(imms_0_16:2);
 	PC = *[RAM]:$(REG_SIZE) tmp;
-	PC = sext(PC[0,20]);
+	PC = PC & 0xffffe;
 	call [PC];
 }
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -698,8 +698,6 @@ POPAR4:						is ctx_mreg=0x4 & POPAR5 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 POPAR3:						is ctx_count=0 {}
 POPAR3:						is  POPAR4 {build POPAR4;}
 POPAR3:						is ctx_mreg=0x3 & POPAR4 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+1;] {
-	R3 = *[RAM]:4 SP;
-	R3 = sext(R3[0,20]);
 	SP = SP + 4;
 	build POPAR4;
 }
@@ -715,8 +713,6 @@ POPAR2:						is ctx_mreg=0x2 & POPAR3 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 POPAR1:						is ctx_count=0 {}
 POPAR1:						is  POPAR2 {build POPAR2;}
 POPAR1:						is ctx_mreg=0x1 & POPAR2 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+1;] {
-	SP = *[RAM]:4 SP;
-	SP = sext(SP[0,20]);
 	SP = SP + 4;
 	build POPAR2;
 }
@@ -827,7 +823,6 @@ POPWR4:						is ctx_mreg=0x4 & POPWR5 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 POPWR3:						is ctx_count=0 {}
 POPWR3:						is  POPWR4 {build POPWR4;}
 POPWR3:						is ctx_mreg=0x3 & POPWR4 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+1;] {
-	R3 = zext(*[RAM]:2 SP);
 	SP = SP + 2;
 	build POPWR4;
 }
@@ -843,7 +838,6 @@ POPWR2:						is ctx_mreg=0x2 & POPWR3 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 POPWR1:						is ctx_count=0 {}
 POPWR1:						is  POPWR2 {build POPWR2;}
 POPWR1:						is ctx_mreg=0x1 & POPWR2 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+1;] {
-	SP = zext(*[RAM]:2 SP);
 	SP = SP + 2;
 	build POPWR2;
 }

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -1243,7 +1243,7 @@ macro suba(dst, src) {
 	DST20_0_4 = zext(tmpr s>> NUM2);
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
-	$(SIGN) = (DST20_0_4[19,1] != 0);
+	$(SIGN) = (DST20_0_4[15,1] != 0);
 	$(ZERO) = (DST20_0_4 == 0);
 }
 
@@ -1252,7 +1252,7 @@ macro suba(dst, src) {
 	DST20_0_4 = (DST20_0_4 << NUM2);
 	DST20_0_4 = zext(DST20_0_4:2);
 	$(CARRY) = (tmph != 0);
-	$(SIGN) = (DST20_0_4[19,1] != 0);
+	$(SIGN) = (DST20_0_4[15,1] != 0);
 	$(ZERO) = (DST20_0_4 == 0);
 }
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -3206,10 +3206,11 @@ define pcodeop bcd_add;
 # Note: The manual says PUSHX doesn't use extension word. The manual is *WRONG*
 :PUSHX.B XRREG_B_AS 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x2 & bow=0x1 & postRegIncrement & XRREG_B_AS {
 	<top>
-	SP = SP - 0x2;
-	*:1 SP = XRREG_B_AS;
+	local tmp = SP - 0x2;
+	*:1 tmp = XRREG_B_AS;
 	#Status bits are not affected
 	build postRegIncrement;
+	SP = tmp;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
@@ -3217,10 +3218,11 @@ define pcodeop bcd_add;
 
 :PUSHX.W XRREG_W_AS 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x2 & bow=0x0 & postRegIncrement & XRREG_W_AS {
 	<top>
-	SP = SP - 0x2;
-	*:2 SP = XRREG_W_AS;
+	local tmp = SP - 0x2;
+	*:2 tmp = XRREG_W_AS;
 	#Status bits are not affected
 	build postRegIncrement;
+	SP = tmp;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
@@ -3228,10 +3230,11 @@ define pcodeop bcd_add;
 
 :PUSHX.A XRREG_A_AS 		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x2 & bow=0x1 & postRegIncrement & XRREG_A_AS {
 	<top>
-	SP = SP - 0x4;
-	*:$(REG_SIZE) SP = XRREG_A_AS & 0xfffff;
+	local tmp = SP - 0x4;
+	*:4 tmp = XRREG_A_AS & 0xfffff;
 	#Status bits are not affected
 	build postRegIncrement;
+	SP = tmp;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
@@ -3448,23 +3451,26 @@ define pcodeop bcd_add;
 #############################
 # No Repeat
 :PUSHX.B XREG_B_AS 		is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x1 & op16_8_4=0x2 & op16_7_1=0x0 & bow=0x1 & postRegIncrement) ... & XREG_B_AS {
-	SP = SP - 0x2;
-	*:1 SP = XREG_B_AS;
+	local tmp = SP - 2;
+	*:1 tmp = XREG_B_AS;
 	#Status bits are not affected
 	build postRegIncrement;
+	SP = tmp;
 }	
 
 :PUSHX.W XREG_W_AS 		is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x1 & op16_8_4=0x2 & op16_7_1=0x0 & bow=0x0 & postRegIncrement) ... & XREG_W_AS {
-	SP = SP - 0x2;
-	*:2 SP = XREG_W_AS;
+	local tmp = SP - 2;
+	*:2 tmp = XREG_W_AS;
 	#Status bits are not affected
 	build postRegIncrement;
+	SP = tmp;
 }
 
 :PUSHX.A XREG_A_AS 		is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x1 & op16_8_4=0x2 & op16_7_1=0x0 & bow=0x1 & postRegIncrement) ... & XREG_A_AS {
-	SP = SP - 0x4;
-	*:$(REG_SIZE) SP = XREG_A_AS & 0xfffff;
+	local tmp_sp = SP - 4;
+	*:$(REG_SIZE) tmp_sp = XREG_A_AS & 0xfffff;
 	build postRegIncrement;
+	SP = tmp_sp;
 }	
 
 :RRAX.B XREG_B_AS_DEST 	is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x0 & bow=0x1 & postRegIncrement) ... & XREG_B_AS_DEST {

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -318,7 +318,7 @@ macro setsubflags(ans, in1, in2)
 {
 	tmp1:$(REG_SIZE) = zext(in1[0,20]);
 	tmp2:$(REG_SIZE) = zext(in2[0,20]);
-	$(CARRY) = tmp1 > tmp2;
+	$(CARRY) = tmp1 <= tmp2;
 	$(OVERFLOW) = ((in1 s< 0) & (in2 s>= 0) & (ans s< 0)) | ((in1 s>= 0) & (in2 s< 0) & (ans s>= 0));
 	$(SIGN) = (ans s< 0);
 	$(ZERO) = (ans == 0);

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -290,14 +290,15 @@ macro setsubflags(ans, in1, in2)
 PUSHAR0:					is ctx_count=0 {}
 PUSHAR0:					is ctx_mreg=0x0 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg-1;] {
 	SP = SP - 4;
-	*[RAM]:4 SP = inst_start & 0xFFFFF;
+	*[RAM]:4 SP = inst_next;
 }
 
 PUSHAR1:					is ctx_count=0 {}
 PUSHAR1:					is PUSHAR0 {build PUSHAR0;}
 PUSHAR1:					is ctx_mreg=0x1 & PUSHAR0 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg-1;] {
+	local tmp:4 = SP;
 	SP = SP - 4;
-	*[RAM]:4 SP = SP & 0xFFFF;
+	*[RAM]:4 SP = tmp & 0xFFFFE;
 	build PUSHAR0;
 }
 
@@ -415,14 +416,15 @@ PUSHAR15:					is ctx_mreg=0xF & PUSHAR14 [ctx_count=ctx_count-1; ctx_mreg=ctx_mr
 PUSHWR0:					is ctx_count=0 {}
 PUSHWR0:					is ctx_mreg=0x0 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg-1;] {
 	SP = SP - 2;
-	*[RAM]:2 SP = inst_start & 0xFFFF;
+	*[RAM]:2 SP = inst_next & 0xFFFF;
 }
 
 PUSHWR1:					is ctx_count=0 {}
 PUSHWR1:					is PUSHWR0 {build PUSHWR0;}
 PUSHWR1:					is ctx_mreg=0x1 & PUSHWR0 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg-1;] {
+	local tmp:2 = SP:2;
 	SP = SP - 2;
-	*[RAM]:2 SP = SP:2;
+	*[RAM]:2 SP = tmp;
 	build PUSHWR0;
 }
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -33,7 +33,6 @@
 :"RPT #"^val^" { "^instruction			is ctx_haveext=3 & instruction & ctx_num=0 & ctx_ctregdest [ctx_haveext=4; val = ctx_ctregdest+1;] { CNT = ctx_ctregdest;build instruction;}
 :"RPT "^ctx_repreg^" { "^instruction	is ctx_haveext=3 & instruction & ctx_num=1 & ctx_repreg [ctx_haveext=4;] { CNT = zext(ctx_repreg[0,4]); build instruction;}
 
-
 # 20bit address mode sub tables
 Abs20: val						is ctx_ctregdest & imm_0_16 [ val=(ctx_ctregdest << 16) | imm_0_16;] {export *[const]:3 val;}
 Abs20s: val						is ctx_ctregdests & imm_0_16 [ val=(ctx_ctregdests << 16) | imm_0_16;] {export *[const]:3 val;}
@@ -99,7 +98,7 @@ XRREG_W_AS: "#1" 						 is reg16_0_4=0x3 & as=0x1 & bow=0x0  { export 1:2;}		# C
 XRREG_W_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x0  { export 2:2;}		# Constant
 XRREG_W_AS: "#-1" 					 	 is	reg16_0_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2;} 	    # Constant
 
-XREG_A_AS: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
+XREG_A_AS: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x1 {export DST20_0_4;}
 XREG_A_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src & ~1; export *:$(REG_SIZE) tmp;}
 XREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
 XREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
@@ -113,7 +112,7 @@ XREG_A_AS: "#1" 						 is reg16_0_4=0x3 & as=0x1 & bow=0x1  { export 1:$(REG_SIZ
 XREG_A_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZE);}		# Constant
 XREG_A_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE);} 	# Constant	
 
-XRREG_A_AS: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
+XRREG_A_AS: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x1 {export DST20_0_4;}
 XRREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
 XRREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XRREG_A_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE);}		# Constant
@@ -150,7 +149,7 @@ XREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow
 XREG_A_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
 XREG_A_AS_DEST: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
 
-XRREG_A_AS_DEST: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
+XRREG_A_AS_DEST: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x1 {export DST20_0_4;}
 XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
 XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 
@@ -160,7 +159,7 @@ XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bo
 XREG_A_AS_DEST2: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
 XREG_A_AS_DEST2: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 
-XRREG_A_AS_DEST2: dest_0_4						 is dest_0_4 & as=0 & bow=0x0 {export dest_0_4;}
+XRREG_A_AS_DEST2: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x0 {export DST20_0_4;}
 XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
 XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 
@@ -213,7 +212,7 @@ XRSRC_W_AS: "#1" 					 is src16_8_4=0x3 & as=0x1 & bow=0x0  { export 1:2; }		# C
 XRSRC_W_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x0  { export 2:2; }		# Constant
 XRSRC_W_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2; } 	# Constant	
 
-XSRC_A_AS: src_8_4 			 		 is src_8_4 & as=0x0 & bow=0x1 { export src_8_4;} # Word/Register Direct (Rn):
+XSRC_A_AS: SRC20_8_4 			 		 is SRC20_8_4 & as=0x0 & bow=0x1 { export SRC20_8_4;} # Word/Register Direct (Rn):
 XSRC_A_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src & ~1; export *:$(REG_SIZE) tmp;}
 XSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
 XSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
@@ -227,7 +226,7 @@ XSRC_A_AS: "#1" 					 is src16_8_4=0x3 & as=0x1 & bow=0x1  { export 1:$(REG_SIZE
 XSRC_A_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZE); }		# Constant
 XSRC_A_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE); } 	# Constant	
 
-XRSRC_A_AS: src_8_4 			 		 is src_8_4 & as=0x0 & bow=0x1 { export src_8_4;} # Word/Register Direct (Rn):
+XRSRC_A_AS: SRC20_8_4 			 		 is SRC20_8_4 & as=0x0 & bow=0x1 { export SRC20_8_4;} # Word/Register Direct (Rn):
 XRSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
 XRSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
 XRSRC_A_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE); }		# Constant
@@ -280,8 +279,8 @@ XDEST_W_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4
 XDEST_W_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Imm20Dst
      {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:2 tmp; } # Absolute
 
-XDEST_A_AD: dest_0_4 		  		 is dest_0_4 & ad=0x0 & bow=0x1
-     { export dest_0_4; }        # Word/Register Direct (Rn):
+XDEST_A_AD: DST20_0_4 		  		 is DST20_0_4 & ad=0x0 & bow=0x1
+     { export DST20_0_4; }        # Word/Register Direct (Rn):
 XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 ; ImmS20Dst
      {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst & ~1; export *:$(REG_SIZE) tmp;}
 XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; ImmS20Dst
@@ -858,48 +857,39 @@ macro adda(dst, src) {
 	setaddflags(dst,src,tmpd);
 }
 
-:ADDA src_8_4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4 & dest_0_4 {
-	adda(dest_0_4,src_8_4);
+:ADDA SRC20_8_4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & SRC20_8_4 & DST20_0_4 {
+	adda(DST20_0_4,SRC20_8_4);
 }
 
-:ADDA src_8_4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4 & dest_0_4 & dest_0_4=0x0 {
-	tmpd:$(REG_SIZE) = inst_start + 2;
-	tmp:$(REG_SIZE) = src_8_4 + tmpd;
+:ADDA SRC20_8_4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & SRC20_8_4 & DST20_0_4 & dest_0_4=0x0 {
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = SRC20_8_4 + tmpd;
 	PC = tmp & 0xFFFFE;
 	
-	setaddflags(dest_0_4,src_8_4,tmpd);
+	setaddflags(DST20_0_4,SRC20_8_4,tmpd);
 	goto [PC];
 }
 
-:ADDA src_8_4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4 & src_8_4=0x0 & dest_0_4 {
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmps:$(REG_SIZE) = inst_start + 2;
-	tmp:$(REG_SIZE) = tmps + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
-	
-	setaddflags(dest_0_4,tmps,tmpd);
-}
-
 # `ADDA SR, <dst>`, verified with hardware but not in spec.
-:ADDA "#"^4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x2 & dest_0_4 {
-	adda(dest_0_4, 4:$(REG_SIZE));
+:ADDA "#"^4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x2 & DST20_0_4 {
+	adda(DST20_0_4, 4:$(REG_SIZE));
 }
 
-:INCDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x3 & dest_0_4 {
-	adda(dest_0_4, 2:$(REG_SIZE));
+:INCDA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x3 & DST20_0_4 {
+	adda(DST20_0_4, 2:$(REG_SIZE));
 }
 
-:ADDA "#"^Abs20s, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & dest_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
-	tmpd:$(REG_SIZE) = dest_0_4;
+:ADDA "#"^Abs20s, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & DST20_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
+	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = sext(Abs20s);
 	tmp:$(REG_SIZE) = tmpd + tmps;
-	dest_0_4 = sext(tmp[0,20]);
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,tmps,tmpd);
+	setaddflags(DST20_0_4,tmps,tmpd);
 }
 
-:ADDA "#"^Abs20s, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & dest_0_4 & dest_0_4=0x0; Abs20s [ctx_ctregdest=imm_8_4;] {
-	tmpd:$(REG_SIZE) = inst_start + 2;
+:ADDA "#"^Abs20s, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & DST20_0_4 & dest_0_4=0x0; Abs20s [ctx_ctregdest=imm_8_4;] {
+	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = sext(Abs20s);
 	tmp:$(REG_SIZE) = tmpd + tmps;
 	PC = tmp & 0xFFFFE;
@@ -908,62 +898,62 @@ macro adda(dst, src) {
 	goto [PC];
 }
 
-:CMPA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xD & src_8_4 & dest_0_4 {
-	tmp:$(REG_SIZE) = dest_0_4 - src_8_4;
+:CMPA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xD & SRC20_8_4 & DST20_0_4 {
+	tmp:$(REG_SIZE) = DST20_0_4 - SRC20_8_4;
 	tmpd:$(REG_SIZE) = sext(tmp[0,20]);
-	setsubflags(tmpd,src_8_4,dest_0_4);
+	setsubflags(tmpd,SRC20_8_4,DST20_0_4);
 }
 
-:CMPA "#"^Abs20s, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x9 & imm_8_4 & dest_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
+:CMPA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x9 & imm_8_4 & DST20_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
 	tmps:$(REG_SIZE) = sext(Abs20s);
-	tmp:$(REG_SIZE) = dest_0_4 - tmps;
+	tmp:$(REG_SIZE) = DST20_0_4 - tmps;
 	tmpd:$(REG_SIZE) = sext(tmp[0,20]);
-	setsubflags(tmpd,tmps,dest_0_4);
+	setsubflags(tmpd,tmps,DST20_0_4);
 }
 
-:MOVA "@"^src_8_4, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & src_8_4 & dest_0_4 {
-	dest_0_4 = *[RAM]:$(REG_SIZE) src_8_4 & ~1;
-	dest_0_4 = sext(dest_0_4[0,20]);
+:MOVA "@"^SRC20_8_4, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & SRC20_8_4 & DST20_0_4 {
+	DST20_0_4 = *[RAM]:$(REG_SIZE) SRC20_8_4 & ~1;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 }
 
-:MOVA "@"^src_8_4^"+", dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & src_8_4 & dest_0_4 {
-	dest_0_4 = *[RAM]:$(REG_SIZE) src_8_4 & ~1;
-	dest_0_4 = sext(dest_0_4[0,20]);
-	src_8_4 = src_8_4 + 4;
+:MOVA "@"^SRC20_8_4^"+", DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & SRC20_8_4 & DST20_0_4 {
+	DST20_0_4 = *[RAM]:$(REG_SIZE) SRC20_8_4 & ~1;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
+	SRC20_8_4 = SRC20_8_4 + 4;
 }
 
-:MOVA "&"^Abs20, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x2 & imm_8_4 & dest_0_4 ; Abs20 [ctx_ctregdest=imm_8_4;] {
+:MOVA "&"^Abs20, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x2 & imm_8_4 & DST20_0_4 ; Abs20 [ctx_ctregdest=imm_8_4;] {
 	tmp:$(REG_SIZE) = zext(Abs20) & ~1;
-	dest_0_4 = *[RAM]:$(REG_SIZE) tmp;
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = *[RAM]:$(REG_SIZE) tmp;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 }
 
-:MOVA imms_0_16^"("^src_8_4^")", dest_0_4		is ctx_haveext=0 & op16_12_4=0 & insid=0x3 & src_8_4 & dest_0_4 ; imms_0_16 {
-	tmp:$(REG_SIZE) = src_8_4 + sext(imms_0_16:2) & ~1;
-	dest_0_4 = *[RAM]:$(REG_SIZE) tmp;
-	dest_0_4 = sext(dest_0_4[0,20]);
+:MOVA imms_0_16^"("^SRC20_8_4^")", DST20_0_4		is ctx_haveext=0 & op16_12_4=0 & insid=0x3 & SRC20_8_4 & DST20_0_4 ; imms_0_16 {
+	tmp:$(REG_SIZE) = SRC20_8_4 + sext(imms_0_16:2) & ~1;
+	DST20_0_4 = *[RAM]:$(REG_SIZE) tmp;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 }
 
-:MOVA src_8_4, "&"^Abs20				is ctx_haveext=0 & op16_12_4=0 & insid=0x6 & imm_0_4 & src_8_4 ; Abs20 [ctx_ctregdest=imm_0_4;] {
+:MOVA SRC20_8_4, "&"^Abs20				is ctx_haveext=0 & op16_12_4=0 & insid=0x6 & imm_0_4 & SRC20_8_4 ; Abs20 [ctx_ctregdest=imm_0_4;] {
 	tmp:$(REG_SIZE) = zext(Abs20) & ~1;
-	*[RAM]:$(REG_SIZE) tmp = src_8_4 & 0xFFFFF;
+	*[RAM]:$(REG_SIZE) tmp = SRC20_8_4 & 0xFFFFF;
 }
 
-:MOVA src_8_4, imms_0_16^"("^dest_0_4^")"		is ctx_haveext=0 & op16_12_4=0 & insid=0x7 & src_8_4 & dest_0_4 ; imms_0_16 {
-	tmp:$(REG_SIZE) = dest_0_4 + sext(imms_0_16:2) & ~1;
-	*[RAM]:$(REG_SIZE) tmp = src_8_4 & 0xFFFFF;
+:MOVA SRC20_8_4, imms_0_16^"("^DST20_0_4^")"		is ctx_haveext=0 & op16_12_4=0 & insid=0x7 & SRC20_8_4 & DST20_0_4 ; imms_0_16 {
+	tmp:$(REG_SIZE) = DST20_0_4 + sext(imms_0_16:2) & ~1;
+	*[RAM]:$(REG_SIZE) tmp = SRC20_8_4 & 0xFFFFF;
 }
 
-:MOVA "#"^Abs20s, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x8 & imm_8_4 & dest_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
-	dest_0_4 = sext(Abs20s);
+:MOVA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x8 & imm_8_4 & DST20_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
+	DST20_0_4 = sext(Abs20s);
 }
 
-:MOVA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4 & dest_0_4 {
-	dest_0_4 = src_8_4;
+:MOVA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xC & SRC20_8_4 & DST20_0_4 {
+	DST20_0_4 = SRC20_8_4;
 }
 
-:CLRA dest_0_4						is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4=0x3 & dest_0_4 {
-	dest_0_4 = 0:$(REG_SIZE);
+:CLRA DST20_0_4						is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4=0x3 & DST20_0_4 {
+	DST20_0_4 = 0:$(REG_SIZE);
 }
 
 macro suba(dst, src) {
@@ -974,39 +964,39 @@ macro suba(dst, src) {
 	setsubflags(dst,src,tmpd);
 }
 
-:SUBA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4 & dest_0_4 {
-	suba(dest_0_4, src_8_4);
+:SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & DST20_0_4 {
+	suba(DST20_0_4, SRC20_8_4);
 }
 
-:SUBA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4 & dest_0_4 & dest_0_4=0x0 {
-	tmpd:$(REG_SIZE) = inst_start + 2;
-	tmp:$(REG_SIZE) = tmpd - src_8_4;
+:SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & DST20_0_4 & dest_0_4=0x0 {
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = tmpd - SRC20_8_4;
 	PC = tmp & 0xffffe;
 	
-	setsubflags(dest_0_4,src_8_4,tmpd);
+	setsubflags(DST20_0_4,SRC20_8_4,tmpd);
 	goto [PC];
 }
 
-:SUBA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4 & src_8_4=0x0 & dest_0_4 {
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmps:$(REG_SIZE) = inst_start + 2;
-	tmp:$(REG_SIZE) = dest_0_4 - tmps;
-	dest_0_4 = sext(tmp[0,20]);
+:SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & src_8_4=0x0 & DST20_0_4 {
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmps:$(REG_SIZE) = SRC20_8_4;
+	tmp:$(REG_SIZE) = DST20_0_4 - tmps;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,tmps,tmpd);
+	setsubflags(DST20_0_4,tmps,tmpd);
 }
 
-:SUBA "#"^Abs20s, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4 & dest_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
-	tmpd:$(REG_SIZE) = dest_0_4;
+:SUBA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4 & DST20_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
+	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = sext(Abs20s);
-	tmp:$(REG_SIZE) = dest_0_4 - tmps;
-	dest_0_4 = sext(tmp[0,20]);
+	tmp:$(REG_SIZE) = DST20_0_4 - tmps;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,tmps,tmpd);
+	setsubflags(DST20_0_4,tmps,tmpd);
 }
 
-:SUBA "#"^Abs20s, dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4 & dest_0_4 & dest_0_4=0x0; Abs20s [ctx_ctregdest=imm_8_4;] {
-	tmpd:$(REG_SIZE) = inst_start + 2;
+:SUBA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4 & DST20_0_4 & dest_0_4=0x0; Abs20s [ctx_ctregdest=imm_8_4;] {
+	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = sext(Abs20s);
 	tmp:$(REG_SIZE) = tmpd - tmps;
 	PC = tmp & 0xffffe;
@@ -1025,17 +1015,17 @@ macro suba(dst, src) {
 # assembler extension regarding @rN being treated as 0(rN) and vice versa. That would effectively turn
 # this into a branch to following instruction. What I think may be happening is a compiler bug where in
 # some cases an immediate gets output even though the constant generator is used.
-:BRA "@"^src_8_4 					is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & src_8_4 & src_8_4=0 & dest_0_4=0x0 {
+:BRA "@"^SRC20_8_4 					is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & SRC20_8_4 & src_8_4=0 & dest_0_4=0x0 {
 }
 
-:BRA "@"^src_8_4 					is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & src_8_4 & dest_0_4=0x0 {
-	PC = *[RAM]:$(REG_SIZE) src_8_4 & 0xffffe;
+:BRA "@"^SRC20_8_4 					is ctx_haveext=0 & op16_12_4=0 & insid=0x0 & SRC20_8_4 & dest_0_4=0x0 {
+	PC = *[RAM]:$(REG_SIZE) SRC20_8_4 & 0xffffe;
 	goto [PC];
 }
 
-:BRA "@"^src_8_4^"+" 				is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & src_8_4 & dest_0_4=0x0 {
-	PC = *[RAM]:$(REG_SIZE) src_8_4 & 0xffffe;
-	src_8_4 = src_8_4 + 4;
+:BRA "@"^SRC20_8_4^"+" 				is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & SRC20_8_4 & dest_0_4=0x0 {
+	PC = *[RAM]:$(REG_SIZE) SRC20_8_4 & 0xffffe;
+	SRC20_8_4 = SRC20_8_4 + 4;
 	goto [PC];
 }
 
@@ -1045,8 +1035,8 @@ macro suba(dst, src) {
 	goto [PC];
 }
 
-:BRA imms_0_16^"("^src_8_4^")"		is ctx_haveext=0 & op16_12_4=0 & insid=0x3 & src_8_4 & dest_0_4=0x0; imms_0_16 {
-	tmp:$(REG_SIZE) = src_8_4 + sext(imms_0_16:2);
+:BRA imms_0_16^"("^SRC20_8_4^")"		is ctx_haveext=0 & op16_12_4=0 & insid=0x3 & SRC20_8_4 & dest_0_4=0x0; imms_0_16 {
+	tmp:$(REG_SIZE) = SRC20_8_4 + sext(imms_0_16:2);
 	PC = *[RAM]:$(REG_SIZE) tmp & 0xffffe;
 	goto [PC];
 }
@@ -1056,13 +1046,13 @@ macro suba(dst, src) {
 	goto Abs20add;
 }
 
-:BRA src_8_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4 & dest_0_4=0x0 {
-	PC = src_8_4 & 0xffffe;
+:BRA SRC20_8_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xC & SRC20_8_4 & dest_0_4=0x0 {
+	PC = SRC20_8_4 & 0xffffe;
 	goto [PC];
 }
 
-:RETA "@"^src_8_4^"+"			is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & src_8_4 & src_8_4=0x1 & dest_0_4=0x0 {
-	PC = *[RAM]:$(REG_SIZE) src_8_4 & 0xffffe;
+:RETA "@"^SRC20_8_4^"+"			is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & SRC20_8_4 & src_8_4=0x1 & dest_0_4=0x0 {
+	PC = *[RAM]:$(REG_SIZE) SRC20_8_4 & 0xffffe;
 	SP = SP + 4;
 	return [PC];
 }
@@ -1072,74 +1062,74 @@ macro suba(dst, src) {
 # Special cases of SUBA/ADDA/CMPA/MOVA
 
 # `SUBA SR, <dst>`, verified with hardware but not in spec.
-:SUBA "#"^4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4=0x2 & dest_0_4 {
-	suba(dest_0_4, 4:$(REG_SIZE));
+:SUBA "#"^4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4=0x2 & DST20_0_4 {
+	suba(DST20_0_4, 4:$(REG_SIZE));
 }
 
-:DECDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4=0x3 & dest_0_4 {
-	suba(dest_0_4, 2:$(REG_SIZE));
+:DECDA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4=0x3 & DST20_0_4 {
+	suba(DST20_0_4, 2:$(REG_SIZE));
 }
 
-:DECDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4=0x0 & dest_0_4 ; imm_0_16=0x0002  {
-	suba(dest_0_4, 2:$(REG_SIZE));
+:DECDA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4=0x0 & DST20_0_4 ; imm_0_16=0x0002  {
+	suba(DST20_0_4, 2:$(REG_SIZE));
 }
 
-:INCDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4=0x0 & dest_0_4 ; imm_0_16=0x0002  {
-	adda(dest_0_4, 2:$(REG_SIZE));
+:INCDA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4=0x0 & DST20_0_4 ; imm_0_16=0x0002  {
+	adda(DST20_0_4, 2:$(REG_SIZE));
 }
 
-:TSTA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xD & src_8_4=0x3 & dest_0_4 {
+:TSTA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xD & src_8_4=0x3 & DST20_0_4 {
 	$(CARRY) = 1;
 	$(OVERFLOW) = 0;
-	$(SIGN) = (dest_0_4 s< 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4 s< 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:TSTA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x9 & imm_8_4=0x0 & dest_0_4 ; imm_0_16=0x0000 {
+:TSTA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x9 & imm_8_4=0x0 & DST20_0_4 ; imm_0_16=0x0000 {
 	$(CARRY) = 1;
 	$(OVERFLOW) = 0;
-	$(SIGN) = (dest_0_4 s< 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4 s< 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:CLRA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x8 & imm_8_4=0 & dest_0_4 ; imm_0_16=0  {
-	dest_0_4 = 0;
+:CLRA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x8 & imm_8_4=0 & DST20_0_4 ; imm_0_16=0  {
+	DST20_0_4 = 0;
 }
 
 #
 ################
 #
 # Other 20 bit address instructions
-:CALLA dest_0_4							is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x4 & dest_0_4 {
+:CALLA DST20_0_4							is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x4 & DST20_0_4 {
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
-	PC = dest_0_4 & ~1;
+	PC = DST20_0_4 & ~1;
 	call [PC];
 }
 
-:CALLA imms_0_16^"("^dest_0_4^")"		is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x5 & dest_0_4 ; imms_0_16 {
+:CALLA imms_0_16^"("^DST20_0_4^")"		is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x5 & DST20_0_4 ; imms_0_16 {
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
-	tmp:$(REG_SIZE) = dest_0_4 + sext(imms_0_16:2);
+	tmp:$(REG_SIZE) = DST20_0_4 + sext(imms_0_16:2);
 	PC = *[RAM]:$(REG_SIZE) tmp;
 	PC = PC & 0xffffe;
 	call [PC];
 }
 
-:CALLA "@"^dest_0_4						is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x6 & dest_0_4 {
+:CALLA "@"^DST20_0_4						is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x6 & DST20_0_4 {
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
-	PC = *[RAM]:$(REG_SIZE) dest_0_4;
+	PC = *[RAM]:$(REG_SIZE) DST20_0_4;
 	PC = PC & 0xffffe;
 	call [PC];
 }
 
-:CALLA "@"^dest_0_4^"+"					is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x7 & dest_0_4 {
+:CALLA "@"^DST20_0_4^"+"					is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x7 & DST20_0_4 {
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
-	PC = *[RAM]:$(REG_SIZE) dest_0_4;
+	PC = *[RAM]:$(REG_SIZE) DST20_0_4;
 	PC = PC & 0xffffe;
-	dest_0_4 = dest_0_4 + 4;
+	DST20_0_4 = DST20_0_4 + 4;
 	call [PC];
 }
 
@@ -1189,85 +1179,85 @@ macro suba(dst, src) {
 	build POPWR0;
 }
 
-:RRCM.A	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x04 & NUM2 & dest_0_4 & rrn {
-	tmph:$(REG_SIZE) = (dest_0_4 >> rrn) & 0x1;
+:RRCM.A	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x04 & NUM2 & DST20_0_4 & rrn {
+	tmph:$(REG_SIZE) = (DST20_0_4 >> rrn) & 0x1;
 	tmpc:$(REG_SIZE) = zext($(CARRY));
 	tmpc = tmpc << (20-NUM2);
-	dest_0_4 = (dest_0_4 >> NUM2) | (dest_0_4 << (20-rrn));
-	dest_0_4 = ((dest_0_4 & (~tmpc)) | tmpc) & 0xFFFFF;
+	DST20_0_4 = (DST20_0_4 >> NUM2) | (DST20_0_4 << (20-rrn));
+	DST20_0_4 = ((DST20_0_4 & (~tmpc)) | tmpc) & 0xFFFFF;
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
-	$(SIGN) = (dest_0_4[19,1] != 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4[19,1] != 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:RRAM.A	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x14 & NUM2 & dest_0_4 & rrn {
-	tmph:$(REG_SIZE) = (dest_0_4 >> rrn) & 0x1;
-	dest_0_4 = (dest_0_4 s>> NUM2);
+:RRAM.A	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x14 & NUM2 & DST20_0_4 & rrn {
+	tmph:$(REG_SIZE) = (DST20_0_4 >> rrn) & 0x1;
+	DST20_0_4 = (DST20_0_4 s>> NUM2);
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
-	$(SIGN) = (dest_0_4[19,1] != 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4[19,1] != 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:RLAM.A	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x24 & NUM2 & dest_0_4 {
-	tmph:$(REG_SIZE) = (dest_0_4 >> (20 - NUM2)) & 0x1;
-	dest_0_4 = (dest_0_4 << NUM2);
-	dest_0_4 = sext(dest_0_4[0,20]);
+:RLAM.A	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x24 & NUM2 & DST20_0_4 {
+	tmph:$(REG_SIZE) = (DST20_0_4 >> (20 - NUM2)) & 0x1;
+	DST20_0_4 = (DST20_0_4 << NUM2);
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	$(CARRY) = (tmph != 0);
-	$(SIGN) = (dest_0_4[19,1] != 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4[19,1] != 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:RRUM.A	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x34 & NUM2 & dest_0_4 & rrn {
-	tmph:$(REG_SIZE) = (dest_0_4 >> rrn) & 0x1;
-	dest_0_4 = (dest_0_4 >> NUM2) & 0xFFFFF;
+:RRUM.A	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x34 & NUM2 & DST20_0_4 & rrn {
+	tmph:$(REG_SIZE) = (DST20_0_4 >> rrn) & 0x1;
+	DST20_0_4 = (DST20_0_4 >> NUM2) & 0xFFFFF;
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
 	$(SIGN) = 0;
-	$(ZERO) = (dest_0_4 == 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:RRCM.W	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x05 & NUM2 & dest_0_4 & rrn {
-	tmpr:2 = dest_0_4:2;
+:RRCM.W	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x05 & NUM2 & DST20_0_4 & rrn {
+	tmpr:2 = DST20_0_4:2;
 	tmph:2 = (tmpr >> rrn) & 0x1;
 	tmpc:2 = zext($(CARRY));
 	tmpc = tmpc << (16-NUM2);
 	tmpr = (tmpr >> NUM2) | (tmpr << (16-rrn));
-	dest_0_4 = zext((tmpr & (~tmpc)) | tmpc);
+	DST20_0_4 = zext((tmpr & (~tmpc)) | tmpc);
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
-	$(SIGN) = (dest_0_4[15,1] != 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4[15,1] != 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:RRAM.W	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x15 & NUM2 & dest_0_4 & rrn {
-	tmpr:2 = dest_0_4:2;
-	tmph:$(REG_SIZE) = (dest_0_4 >> rrn) & 0x1;
-	dest_0_4 = zext(tmpr s>> NUM2);
+:RRAM.W	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x15 & NUM2 & DST20_0_4 & rrn {
+	tmpr:2 = DST20_0_4:2;
+	tmph:$(REG_SIZE) = (DST20_0_4 >> rrn) & 0x1;
+	DST20_0_4 = zext(tmpr s>> NUM2);
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
-	$(SIGN) = (dest_0_4[19,1] != 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4[19,1] != 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:RLAM.W	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x25 & NUM2 & dest_0_4 {
-	tmph:$(REG_SIZE) = (dest_0_4 >> (16 - NUM2)) & 0x1;
-	dest_0_4 = (dest_0_4 << NUM2);
-	dest_0_4 = zext(dest_0_4:2);
+:RLAM.W	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x25 & NUM2 & DST20_0_4 {
+	tmph:$(REG_SIZE) = (DST20_0_4 >> (16 - NUM2)) & 0x1;
+	DST20_0_4 = (DST20_0_4 << NUM2);
+	DST20_0_4 = zext(DST20_0_4:2);
 	$(CARRY) = (tmph != 0);
-	$(SIGN) = (dest_0_4[19,1] != 0);
-	$(ZERO) = (dest_0_4 == 0);
+	$(SIGN) = (DST20_0_4[19,1] != 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
-:RRUM.W	NUM2, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x35 & NUM2 & dest_0_4 & rrn {
-	tmpr:2 = dest_0_4:2;
+:RRUM.W	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x35 & NUM2 & DST20_0_4 & rrn {
+	tmpr:2 = DST20_0_4:2;
 	tmph:2 = (tmpr >> rrn) & 0x1;
-	dest_0_4 = zext(tmpr >> NUM2);
+	DST20_0_4 = zext(tmpr >> NUM2);
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
 	$(SIGN) = 0;
-	$(ZERO) = (dest_0_4 == 0);
+	$(ZERO) = (DST20_0_4 == 0);
 }
 
 macro bzero(full, byte)
@@ -1342,15 +1332,15 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:ADCX.A dest_0_4							is ctx_haveext=4 & op16_12_4=0x6 & src16_8_4=0x3 & as=0x0 & bow=1 & ctx_al=0 & postIncrementStore & dest_0_4 & repeat_carry {
+:ADCX.A DST20_0_4							is ctx_haveext=4 & op16_12_4=0x6 & src16_8_4=0x3 & as=0x0 & bow=1 & ctx_al=0 & postIncrementStore & DST20_0_4 & repeat_carry {
 	<top>
 	build repeat_carry;
-	tmpd:$(REG_SIZE) = dest_0_4;
+	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmpc:$(REG_SIZE) = zext($(CARRY));
-	tmp:$(REG_SIZE) = tmpc + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+	tmp:$(REG_SIZE) = tmpc + DST20_0_4;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,tmpc,tmpd);
+	setaddflags(DST20_0_4,tmpc,tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1391,13 +1381,13 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:ADDX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 {
+:ADDX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = XRSRC_A_AS + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = XRSRC_A_AS + DST20_0_4;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,XRSRC_A_AS,tmpd);
+	setaddflags(DST20_0_4,XRSRC_A_AS,tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1442,15 +1432,15 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:ADDCX.A XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0x6 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 & repeat_carry {
+:ADDCX.A XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0x6 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 & repeat_carry {
 	<top>
 	build repeat_carry;
-	tmpd:$(REG_SIZE) = dest_0_4;
+	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = XRSRC_A_AS + zext($(CARRY));
-	tmp:$(REG_SIZE) = tmps + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+	tmp:$(REG_SIZE) = tmps + DST20_0_4;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,tmps,tmpd);
+	setaddflags(DST20_0_4,tmps,tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1491,17 +1481,17 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:ANDX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0xF & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 {
+:ANDX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0xF & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...
-	dest_0_4 = dest_0_4 & XRSRC_A_AS;
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = DST20_0_4 & XRSRC_A_AS;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (dest_0_4 s< 0x0);			# S Flag
-	$(ZERO) = (dest_0_4 == 0x0);			# Z Flag
-	$(CARRY) = (dest_0_4 != 0x0);			# C Flag
+	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
+	$(CARRY) = (DST20_0_4 != 0x0);			# C Flag
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1530,10 +1520,10 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:BICX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0xC & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 {
+:BICX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0xC & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	dest_0_4 = (~XRSRC_A_AS) & dest_0_4;
-	dest_0_4 = zext(dest_0_4[0,20]);
+	DST20_0_4 = (~XRSRC_A_AS) & DST20_0_4;
+	DST20_0_4 = zext(DST20_0_4[0,20]);
 	#Status bits are not affected
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
@@ -1562,11 +1552,11 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:BISX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0xD & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 {
+:BISX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0xD & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	dest_0_4 = XRSRC_A_AS | dest_0_4;
+	DST20_0_4 = XRSRC_A_AS | DST20_0_4;
 	#Status bits are not affected
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1605,12 +1595,12 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:BITX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0xB & bow=1 & ctx_al=0 & postIncrement & XRSRC_A_AS & dest_0_4 {
+:BITX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0xB & bow=1 & ctx_al=0 & postIncrement & XRSRC_A_AS & DST20_0_4 {
 	<top>
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;					# V Flag (reset)
 	# Operation...
-	result:$(REG_SIZE) = dest_0_4 & XRSRC_A_AS;
+	result:$(REG_SIZE) = DST20_0_4 & XRSRC_A_AS;
 	# Result Flags...
 	result = sext(result[0,20]);
 	$(CARRY) = (result != 0x0);			# C Flag
@@ -1644,9 +1634,9 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:CLRX.A	dest_0_4						is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x3 & as=0x0 & bow=1 & ctx_al=0 & postIncrementStore & dest_0_4 {
+:CLRX.A	DST20_0_4						is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x3 & as=0x0 & bow=1 & ctx_al=0 & postIncrementStore & DST20_0_4 {
 	<top>
-	dest_0_4 = 0;
+	DST20_0_4 = 0;
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1685,11 +1675,11 @@ macro wzero(full, word)
 	goto <top>;
 }
 
-:CMPX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0x9 & bow=1 & ctx_al=0 & postIncrement & XRSRC_A_AS & dest_0_4 {
+:CMPX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0x9 & bow=1 & ctx_al=0 & postIncrement & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	tmp:$(REG_SIZE) = dest_0_4 - XRSRC_A_AS;
+	tmp:$(REG_SIZE) = DST20_0_4 - XRSRC_A_AS;
 	tmpd:$(REG_SIZE) = sext(tmp[0,20]);
-	setsubflags(tmpd,XRSRC_A_AS,dest_0_4);
+	setsubflags(tmpd,XRSRC_A_AS,DST20_0_4);
 	build postIncrement;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1730,16 +1720,16 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:DADCX.A dest_0_4						is ctx_haveext=4 & op16_12_4=0xA & src16_8_4=0x3 & as=0x0 & bow=1 & ctx_al=0 & postIncrementStore & dest_0_4 & repeat_carry {
+:DADCX.A DST20_0_4						is ctx_haveext=4 & op16_12_4=0xA & src16_8_4=0x3 & as=0x0 & bow=1 & ctx_al=0 & postIncrementStore & DST20_0_4 & repeat_carry {
 	<top>
 	build repeat_carry;
-	local temp:4 = zext(dest_0_4);
-	dest_0_4 = bcd_add(temp, $(CARRY));
+	local temp:4 = zext(DST20_0_4);
+	DST20_0_4 = bcd_add(temp, $(CARRY));
 	$(CARRY) = temp >= 0x99999;
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (dest_0_4 s< 0x0);			# S Flag
-	$(ZERO) = (dest_0_4 == 0x0);			# Z Flag
+	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1782,17 +1772,17 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:DADDX.A XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0xA & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 & repeat_carry {
+:DADDX.A XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0xA & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 & repeat_carry {
 	<top>
 	build repeat_carry;
 	local temp_src:4 = zext(XRSRC_A_AS);
-	local temp_dest:4 = zext(dest_0_4);
+	local temp_dest:4 = zext(DST20_0_4);
 	local temp_carry:4 = zext($(CARRY));
-	dest_0_4 = bcd_add(temp_src, temp_dest, temp_carry);
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = bcd_add(temp_src, temp_dest, temp_carry);
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (dest_0_4 s< 0x0);			# S Flag
-	$(ZERO) = (dest_0_4 == 0x0);			# Z Flag
+	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
 	$(CARRY) = (temp_src + temp_dest + temp_carry) > 0x99999;
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
@@ -1834,13 +1824,13 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:DECX.A	dest_0_4				is ctx_haveext=4 & op16_12_4=0x8 & src16_8_4=0x3 & as=0x1 & bow=1 & ctx_al=0 & postIncrementStore & dest_0_4 {
+:DECX.A	DST20_0_4				is ctx_haveext=4 & op16_12_4=0x8 & src16_8_4=0x3 & as=0x1 & bow=1 & ctx_al=0 & postIncrementStore & DST20_0_4 {
 	<top>
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = dest_0_4 - 1;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = DST20_0_4 - 1;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,1:$(REG_SIZE),tmpd);
+	setsubflags(DST20_0_4,1:$(REG_SIZE),tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1881,13 +1871,13 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:DECDX.A dest_0_4				is ctx_haveext=4 & op16_12_4=0x8 & src16_8_4=0x3 & as=0x2 & bow=1 & ctx_al=0 & postIncrementStore & dest_0_4 {
+:DECDX.A DST20_0_4				is ctx_haveext=4 & op16_12_4=0x8 & src16_8_4=0x3 & as=0x2 & bow=1 & ctx_al=0 & postIncrementStore & DST20_0_4 {
 	<top>
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = dest_0_4 - 2;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = DST20_0_4 - 2;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,2:$(REG_SIZE),tmpd);
+	setsubflags(DST20_0_4,2:$(REG_SIZE),tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1928,13 +1918,13 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:INCX.A	dest_0_4						is ctx_haveext=4 & op16_12_4=0x5 & src16_8_4=0x3 & as=0x1 & bow=1 & ctx_al=0 & postIncrementStore & dest_0_4 {
+:INCX.A	DST20_0_4						is ctx_haveext=4 & op16_12_4=0x5 & src16_8_4=0x3 & as=0x1 & bow=1 & ctx_al=0 & postIncrementStore & DST20_0_4 {
 	<top>
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = 1 + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = 1 + DST20_0_4;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,1:$(REG_SIZE),tmpd);
+	setaddflags(DST20_0_4,1:$(REG_SIZE),tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -1975,13 +1965,13 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:INCDX.A dest_0_4						is ctx_haveext=4 & op16_12_4=0x5 & src16_8_4=0x3 & as=0x2 & bow=1 & ctx_al=0 & postIncrementStore & dest_0_4 {
+:INCDX.A DST20_0_4						is ctx_haveext=4 & op16_12_4=0x5 & src16_8_4=0x3 & as=0x2 & bow=1 & ctx_al=0 & postIncrementStore & DST20_0_4 {
 	<top>
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = 2 + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = 2 + DST20_0_4;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,2:$(REG_SIZE),tmpd);
+	setaddflags(DST20_0_4,2:$(REG_SIZE),tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2022,17 +2012,17 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:INVX.A	dest_0_4				is ctx_haveext=4 & op16_12_4=0xE & src16_8_4=0x3 & as=0x3 & bow=1 & ctx_al=0 & postIncrementStore &  dest_0_4 {
+:INVX.A	DST20_0_4				is ctx_haveext=4 & op16_12_4=0xE & src16_8_4=0x3 & as=0x3 & bow=1 & ctx_al=0 & postIncrementStore &  DST20_0_4 {
 	<top>
 	# Operation Flags...
-	$(OVERFLOW) = dest_0_4 s< 0x0;	# V Flag
+	$(OVERFLOW) = DST20_0_4 s< 0x0;	# V Flag
 	# Operation...
-	dest_0_4 = dest_0_4 ^ -1;
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = DST20_0_4 ^ -1;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (dest_0_4 s< 0x0);			# S Flag
-	$(ZERO) = (dest_0_4 == 0x0);			# Z Flag
-	$(CARRY) = (dest_0_4 != 0x0);			# C Flag
+	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
+	$(CARRY) = (DST20_0_4 != 0x0);			# C Flag
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2061,9 +2051,9 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:MOVX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0x4 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 {
+:MOVX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0x4 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	dest_0_4 = XRSRC_A_AS;
+	DST20_0_4 = XRSRC_A_AS;
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2092,11 +2082,11 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:POPX.A	dest_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & ctx_al=0 & XRSRC_A_AS & dest_0_4 {
+:POPX.A	DST20_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & ctx_al=0 & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	dest_0_4 = *:4 SP;
+	DST20_0_4 = *:4 SP;
 	SP = SP + 0x4;
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
@@ -2134,13 +2124,13 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RLAX.A	dest_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & src_Direct16_8_4=dest_Direct16_0_4 & ctx_al=0 & dest_0_4 {
+:RLAX.A	DST20_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & src_Direct16_8_4=dest_Direct16_0_4 & ctx_al=0 & DST20_0_4 {
 	<top>
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = dest_0_4 + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = DST20_0_4 + DST20_0_4;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,tmpd,tmpd);
+	setaddflags(DST20_0_4,tmpd,tmpd);
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
@@ -2184,15 +2174,15 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RLCX.A dest_0_4						is ctx_haveext=4 & op16_12_4=0x6 & bow=1 & ctx_al=0 & src_Direct16_8_4=dest_Direct16_0_4 & postIncrementStore & XRSRC_A_AS & dest_0_4 & repeat_carry {
+:RLCX.A DST20_0_4						is ctx_haveext=4 & op16_12_4=0x6 & bow=1 & ctx_al=0 & src_Direct16_8_4=dest_Direct16_0_4 & postIncrementStore & XRSRC_A_AS & DST20_0_4 & repeat_carry {
 	<top>
 	build repeat_carry;
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmps:$(REG_SIZE) = dest_0_4 + zext($(CARRY));
-	tmp:$(REG_SIZE) = tmps + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmps:$(REG_SIZE) = DST20_0_4 + zext($(CARRY));
+	tmp:$(REG_SIZE) = tmps + DST20_0_4;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setaddflags(dest_0_4,tmps,tmpd);
+	setaddflags(DST20_0_4,tmps,tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2237,15 +2227,15 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:SBCX.A dest_0_4				is ctx_haveext=4 & op16_12_4=0x7 & bow=1 & ctx_al=0 & src16_8_4=0x3 & as=0x0 & postIncrementStore & dest_0_4 & repeat_carry {
+:SBCX.A DST20_0_4				is ctx_haveext=4 & op16_12_4=0x7 & bow=1 & ctx_al=0 & src16_8_4=0x3 & as=0x0 & postIncrementStore & DST20_0_4 & repeat_carry {
 	<top>
 	build repeat_carry;
 	brw:$(REG_SIZE) = 1 - zext( $(CARRY) );
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = dest_0_4 - brw;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = DST20_0_4 - brw;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,brw,tmpd);
+	setsubflags(DST20_0_4,brw,tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2290,16 +2280,16 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:SUBCX.A XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0x7 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 & repeat_carry {
+:SUBCX.A XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0x7 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 & repeat_carry {
 	<top>
 	build repeat_carry;
 	brw:$(REG_SIZE) = 1 - zext( $(CARRY) );
-	tmpd:$(REG_SIZE) = dest_0_4;
+	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmps:$(REG_SIZE) = XRSRC_A_AS + brw;
-	tmp:$(REG_SIZE) = dest_0_4 - tmps;
-	dest_0_4 = sext(tmp[0,20]);
+	tmp:$(REG_SIZE) = DST20_0_4 - tmps;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,tmps,tmpd);
+	setsubflags(DST20_0_4,tmps,tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2340,13 +2330,13 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:SUBX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0x8 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 {
+:SUBX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0x8 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = dest_0_4 - XRSRC_A_AS;
-	dest_0_4 = sext(tmp[0,20]);
+	tmpd:$(REG_SIZE) = DST20_0_4;
+	tmp:$(REG_SIZE) = DST20_0_4 - XRSRC_A_AS;
+	DST20_0_4 = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,XRSRC_A_AS,tmpd);
+	setsubflags(DST20_0_4,XRSRC_A_AS,tmpd);
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2379,9 +2369,9 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:TSTX.A	dest_0_4						is ctx_haveext=4 & op16_12_4=0x9 & bow=1 & ctx_al=0 & src16_8_4=0x3 & as=0x0 & dest_0_4 {
+:TSTX.A	DST20_0_4						is ctx_haveext=4 & op16_12_4=0x9 & bow=1 & ctx_al=0 & src16_8_4=0x3 & as=0x0 & DST20_0_4 {
 	<top>
-	setsubflags(dest_0_4,0:$(REG_SIZE),dest_0_4);
+	setsubflags(DST20_0_4,0:$(REG_SIZE),DST20_0_4);
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
@@ -2421,17 +2411,17 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:XORX.A	XRSRC_A_AS, dest_0_4				is ctx_haveext=4 & op16_12_4=0xE & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & dest_0_4 {
+:XORX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0xE & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
 	# Operation Flags...
-	$(OVERFLOW) = ((dest_0_4 s< 0x0) && (XRSRC_A_AS s< 0x0)) ;	# V Flag
+	$(OVERFLOW) = ((DST20_0_4 s< 0x0) && (XRSRC_A_AS s< 0x0)) ;	# V Flag
 	# Operation...
-	dest_0_4 = dest_0_4 ^ XRSRC_A_AS;
-	dest_0_4 = sext(dest_0_4[0,20]);
+	DST20_0_4 = DST20_0_4 ^ XRSRC_A_AS;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (dest_0_4 s< 0x0);			# S Flag
-	$(ZERO) = (dest_0_4 == 0x0);			# Z Flag
-	$(CARRY) = (dest_0_4 != 0x0);			# C Flag
+	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
+	$(CARRY) = (DST20_0_4 != 0x0);			# C Flag
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -847,12 +847,16 @@ POPWR0:						is ctx_mreg=0x0 & POPWR1 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 	goto [PC];
 }
 
-:ADDA src_8_4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4 & dest_0_4 {
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = src_8_4 + dest_0_4;
-	dest_0_4 = sext(tmp[0,20]);
+macro adda(dst, src) {
+	tmpd:$(REG_SIZE) = dst;
+	tmp:$(REG_SIZE) = src + dst;
+	dst = tmp & 0xfffff;
 	
-	setaddflags(dest_0_4,src_8_4,tmpd);
+	setaddflags(dst,src,tmpd);
+}
+
+:ADDA src_8_4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4 & dest_0_4 {
+	adda(dest_0_4,src_8_4);
 }
 
 :ADDA src_8_4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4 & dest_0_4 & dest_0_4=0x0 {
@@ -871,6 +875,15 @@ POPWR0:						is ctx_mreg=0x0 & POPWR1 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 	dest_0_4 = sext(tmp[0,20]);
 	
 	setaddflags(dest_0_4,tmps,tmpd);
+}
+
+# `ADDA SR, <dst>`, verified with hardware but not in spec.
+:ADDA "#"^4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x2 & dest_0_4 {
+	adda(dest_0_4, 4:$(REG_SIZE));
+}
+
+:INCDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xE & src_8_4=0x3 & dest_0_4 {
+	adda(dest_0_4, 2:$(REG_SIZE));
 }
 
 :ADDA "#"^Abs20s, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4 & dest_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
@@ -946,12 +959,20 @@ POPWR0:						is ctx_mreg=0x0 & POPWR1 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 	dest_0_4 = src_8_4;
 }
 
-:SUBA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4 & dest_0_4 {
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmp:$(REG_SIZE) = dest_0_4 - src_8_4;
-	dest_0_4 = sext(tmp[0,20]);
+:CLRA dest_0_4						is ctx_haveext=0 & op16_12_4=0 & insid=0xC & src_8_4=0x3 & dest_0_4 {
+	dest_0_4 = 0:$(REG_SIZE);
+}
+
+macro suba(dst, src) {
+	tmpd:$(REG_SIZE) = dst;
+	tmp:$(REG_SIZE) = dst - src;
+	dst = sext(tmp[0,20]);
 	
-	setsubflags(dest_0_4,src_8_4,tmpd);
+	setsubflags(dst,src,tmpd);
+}
+
+:SUBA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4 & dest_0_4 {
+	suba(dest_0_4, src_8_4);
 }
 
 :SUBA src_8_4, dest_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4 & dest_0_4 & dest_0_4=0x0 {
@@ -1051,22 +1072,29 @@ POPWR0:						is ctx_mreg=0x0 & POPWR1 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 ################
 #
 # Special cases of SUBA/ADDA/CMPA/MOVA
+
+# `SUBA SR, <dst>`, verified with hardware but not in spec.
+:SUBA "#"^4, dest_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4=0x2 & dest_0_4 {
+	suba(dest_0_4, 4:$(REG_SIZE));
+}
+
+:DECDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xF & src_8_4=0x3 & dest_0_4 {
+	suba(dest_0_4, 2:$(REG_SIZE));
+}
+
 :DECDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xB & imm_8_4=0x0 & dest_0_4 ; imm_0_16=0x0002  {
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmps:$(REG_SIZE) = 2;
-	dest_0_4 = dest_0_4 - 2;
-	dest_0_4 = sext(dest_0_4[0,20]);
-	
-	setsubflags(dest_0_4,tmps,tmpd);
+	suba(dest_0_4, 2:$(REG_SIZE));
 }
 
 :INCDA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xA & imm_8_4=0x0 & dest_0_4 ; imm_0_16=0x0002  {
-	tmpd:$(REG_SIZE) = dest_0_4;
-	tmps:$(REG_SIZE) = 2;
-	dest_0_4 = dest_0_4 + 2;
-	dest_0_4 = sext(dest_0_4[0,20]);
-	
-	setaddflags(dest_0_4,tmps,tmpd);
+	adda(dest_0_4, 2:$(REG_SIZE));
+}
+
+:TSTA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xD & src_8_4=0x3 & dest_0_4 {
+	$(CARRY) = 1;
+	$(OVERFLOW) = 0;
+	$(SIGN) = (dest_0_4 s< 0);
+	$(ZERO) = (dest_0_4 == 0);
 }
 
 :TSTA dest_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x9 & imm_8_4=0x0 & dest_0_4 ; imm_0_16=0x0000 {

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -3289,7 +3289,7 @@ define pcodeop bcd_add;
 	<top>
 	# Operation Flags...
 	build repeat_carry;
-	$(OVERFLOW) = ((XRREG_B_AS_DEST != 0x0) && ($(CARRY) == 0x1));	# V Flag
+	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = (XRREG_B_AS_DEST & 0x1);
@@ -3324,7 +3324,7 @@ define pcodeop bcd_add;
 	<top>
 	build repeat_carry;
 	# Operation Flags...
-	$(OVERFLOW) = ((XRREG_W_AS_DEST != 0x0) && ($(CARRY) == 0x1));	# V Flag
+	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = XRREG_W_AS_DEST[0,1];
@@ -3359,7 +3359,7 @@ define pcodeop bcd_add;
 	<top>
 	build repeat_carry;
 	# Operation Flags...
-	$(OVERFLOW) = ((XRREG_A_AS_DEST != 0x0) && ($(CARRY) == 0x1));	# V Flag
+	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = XRREG_A_AS_DEST[0,1];
@@ -3505,7 +3505,7 @@ define pcodeop bcd_add;
 
 :RRCX.B XREG_B_AS_DEST 	is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x1 & postRegIncrement) ... & XREG_B_AS_DEST {
 	# Operation Flags...
-	$(OVERFLOW) = ((XREG_B_AS_DEST != 0x0) && ($(CARRY) == 0x1));	# V Flag
+	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = (XREG_B_AS_DEST & 0x1);
@@ -3518,7 +3518,7 @@ define pcodeop bcd_add;
 
 :RRCX.W XREG_W_AS_DEST	is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x0 & postRegIncrement) ... & XREG_W_AS_DEST {
 	# Operation Flags...
-	$(OVERFLOW) = ((XREG_W_AS_DEST != 0x0) && ($(CARRY) == 0x1));	# V Flag
+	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = XREG_W_AS_DEST[0,1];
@@ -3531,7 +3531,7 @@ define pcodeop bcd_add;
 
 :RRCX.A XREG_A_AS_DEST 	is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x1 & op16_8_4=0x0 & op16_7_1=0x0 & bow=0x1 & postRegIncrement) ... & XREG_A_AS_DEST {
 	# Operation Flags...
-	$(OVERFLOW) = ((XREG_A_AS_DEST != 0x0) && ($(CARRY) == 0x1));	# V Flag
+	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = XREG_A_AS_DEST[0,1];

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -938,6 +938,12 @@ macro adda(dst, src) {
 	DST20_0_4 = sext(DST20_0_4[0,20]);
 }
 
+:MOVA imms_0_16^"(PC)", DST20_0_4		is ctx_haveext=0 & op16_12_4=0 & src_8_4=0 & insid=0x3 & SRC20_8_4 & DST20_0_4 ; imms_0_16 {
+	tmp:$(REG_SIZE) = inst_start + 2 + sext(imms_0_16:2);
+	DST20_0_4 = *[RAM]:$(REG_SIZE) tmp;
+	DST20_0_4 = sext(DST20_0_4[0,20]);
+}
+
 :MOVA SRC20_8_4, "&"^Abs20				is ctx_haveext=0 & op16_12_4=0 & insid=0x6 & imm_0_4 & SRC20_8_4 ; Abs20 [ctx_ctregdest=imm_0_4;] {
 	tmp:$(REG_SIZE) = zext(Abs20) & ~1;
 	*[RAM]:$(REG_SIZE) tmp = SRC20_8_4 & 0xFFFFF;
@@ -1046,6 +1052,12 @@ macro suba(dst, src) {
 	goto [PC];
 }
 
+:BRA imms_0_16^"(PC)"		is ctx_haveext=0 & op16_12_4=0 & src_8_4=0 & insid=0x3 & SRC20_8_4 & dest_0_4=0x0; imms_0_16 {
+	tmp:$(REG_SIZE) = inst_start + 2 + sext(imms_0_16:2);
+	PC = *[RAM]:$(REG_SIZE) tmp & 0xffffe;
+	goto [PC];
+}
+
 :BRA "#"^Abs20add					is ctx_haveext=0 & op16_12_4=0 & insid=0x8 & imm_8_4 & dest_0_4=0x0; Abs20add [ctx_ctregdest=imm_8_4;] {
 #	PC = Abs20add & 0xffffe;
 	goto Abs20add;
@@ -1114,6 +1126,15 @@ macro suba(dst, src) {
 
 :CALLA imms_0_16^"("^DST20_0_4^")"		is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x5 & DST20_0_4 ; imms_0_16 {
 	tmp:$(REG_SIZE) = DST20_0_4 + sext(imms_0_16:2);
+	PC = *[RAM]:$(REG_SIZE) tmp;
+	PC = PC & 0xffffe;
+	SP = SP - 0x4;
+	*:4 SP = inst_next;
+	call [PC];
+}
+
+:CALLA imms_0_16^"(PC)"		is ctx_haveext=0 & op16_8_8=0x13 & dest_0_4=0 & op16_4_4=0x5 & DST20_0_4 ; imms_0_16 {
+	tmp:$(REG_SIZE) = inst_start + 2 + sext(imms_0_16:2);
 	PC = *[RAM]:$(REG_SIZE) tmp;
 	PC = PC & 0xffffe;
 	SP = SP - 0x4;

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -921,9 +921,9 @@ macro adda(dst, src) {
 }
 
 :MOVA "@"^SRC20_8_4^"+", DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & SRC20_8_4 & DST20_0_4 {
-	DST20_0_4 = *[RAM]:$(REG_SIZE) SRC20_8_4 & ~1;
-	DST20_0_4 = sext(DST20_0_4[0,20]);
+	local tmp = *[RAM]:$(REG_SIZE) SRC20_8_4 & ~1;
 	SRC20_8_4 = SRC20_8_4 + 4;
+	DST20_0_4 = zext(tmp[0,20]);
 }
 
 :MOVA "&"^Abs20, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x2 & imm_8_4 & DST20_0_4 ; Abs20 [ctx_ctregdest=imm_8_4;] {
@@ -1029,9 +1029,9 @@ macro suba(dst, src) {
 }
 
 :BRA "@"^SRC20_8_4^"+" 				is ctx_haveext=0 & op16_12_4=0 & insid=0x1 & SRC20_8_4 & dest_0_4=0x0 {
-	PC = *[RAM]:$(REG_SIZE) SRC20_8_4 & 0xffffe;
+	local tmp = *[RAM]:$(REG_SIZE) SRC20_8_4 & 0xffffe;
 	SRC20_8_4 = SRC20_8_4 + 4;
-	goto [PC];
+	goto [tmp];
 }
 
 :BRA "&"^Abs20						is ctx_haveext=0 & op16_12_4=0 & insid=0x2 & imm_8_4 & dest_0_4=0x0; Abs20 [ctx_ctregdest=imm_8_4;] {
@@ -2968,23 +2968,29 @@ define pcodeop bcd_add;
 	build postIncrementStore;
 }
 
-:MOVX.B	XSRC_B_AS, XDEST_B_AD			is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & bow=1 & tbl_bzero & postIncrementStore) ... & XSRC_B_AS ... & XDEST_B_AD ...  {
-	XDEST_B_AD = XSRC_B_AS;
+:MOVX.B	XSRC_B_AS, XDEST_B_AD			is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & bow=1 & tbl_bzero & postIncrement & postStorePC) ... & XSRC_B_AS ... & XDEST_B_AD ...  {
+	local tmp:1 = XSRC_B_AS;
+	build postIncrement;
+	XDEST_B_AD = tmp;
 	build tbl_bzero;
 	#Status bits are not affected
-	build postIncrementStore;
+	build postStorePC;
 }
 
-:MOVX.W	XSRC_W_AS, XDEST_W_AD			is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & bow=0 & tbl_wzero & postIncrementStore) ... & XSRC_W_AS ... & XDEST_W_AD ... {
-	XDEST_W_AD = XSRC_W_AS;
+:MOVX.W	XSRC_W_AS, XDEST_W_AD			is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & bow=0 & tbl_wzero & postIncrement & postStorePC) ... & XSRC_W_AS ... & XDEST_W_AD ... {
+	local tmp:2 = XSRC_W_AS;
+	build postIncrement;
+	XDEST_W_AD = tmp;
 	build tbl_wzero;
 	#Status bits are not affected
-	build postIncrementStore;
+	build postStorePC;
 }
 
-:MOVX.A	XSRC_A_AS, XDEST_A_AD			is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x4 & bow=1 & postIncrementStore) ... & XSRC_A_AS ... & XDEST_A_AD ... {
-	XDEST_A_AD = XSRC_A_AS & 0xfffff;
-	build postIncrementStore;
+:MOVX.A	XSRC_A_AS, XDEST_A_AD			is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x4 & bow=1 & postIncrement & postStorePC) ... & XSRC_A_AS ... & XDEST_A_AD ... {
+	local tmp:$(REG_SIZE) = XSRC_A_AS & 0xfffff;
+	build postIncrement;
+	XDEST_A_AD = tmp;
+	build postStorePC;
 }
 
 :POPX.B	XDEST_B_AD						is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & tbl_bzero) ... & XDEST_B_AD ...  {

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -2119,7 +2119,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:RLAX.B	DST8_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & ctx_al=1 & src_Direct16_8_4=dest_Direct16_0_4 & DST8_0_4 & reg_Direct16_0_4 {
+:RLAX.B	DST8_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & ctx_al=1 & src_Direct16_8_4=dest_Direct16_0_4 & DST8_0_4 & reg_Direct16_0_4 & postStorePC {
 	<top>
 	# Operation Flags...
 	$(CARRY) = carry(DST8_0_4, DST8_0_4); 	 	# C Flag
@@ -2130,12 +2130,13 @@ define pcodeop bcd_add;
 	# Result Flags...
 	$(SIGN) = (DST8_0_4 s< 0x0);			# S Flag
 	$(ZERO) = (DST8_0_4 == 0x0);			# Z Flag
+	build postStorePC;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
 }
 
-:RLAX.W	DST16_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=0 & ctx_al=1 & src_Direct16_8_4=dest_Direct16_0_4 & DST16_0_4 & reg_Direct16_0_4 {
+:RLAX.W	DST16_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=0 & ctx_al=1 & src_Direct16_8_4=dest_Direct16_0_4 & DST16_0_4 & reg_Direct16_0_4 & postStorePC {
 	<top>
 	# Operation Flags...
 	$(CARRY) = carry(DST16_0_4, DST16_0_4); 	 	# C Flag
@@ -2146,18 +2147,20 @@ define pcodeop bcd_add;
 	# Result Flags...
 	$(SIGN) = (DST16_0_4 s< 0x0);			# S Flag
 	$(ZERO) = (DST16_0_4 == 0x0);			# Z Flag
+	build postStorePC;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
 }
 
-:RLAX.A	DST20_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & src_Direct16_8_4=dest_Direct16_0_4 & ctx_al=0 & DST20_0_4 {
+:RLAX.A	DST20_0_4						is ctx_haveext=4 & op16_12_4=0x5 & bow=1 & src_Direct16_8_4=dest_Direct16_0_4 & ctx_al=0 & postStorePC & DST20_0_4 {
 	<top>
 	tmpd:$(REG_SIZE) = DST20_0_4;
 	tmp:$(REG_SIZE) = DST20_0_4 + DST20_0_4;
 	DST20_0_4 = sext(tmp[0,20]);
 	
 	setaddflags(DST20_0_4,tmpd,tmpd);
+	build postStorePC;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -853,11 +853,12 @@ POPWR0:						is ctx_mreg=0x0 & POPWR1 [ctx_count=ctx_count-1; ctx_mreg=ctx_mreg+
 }
 
 macro adda(dst, src) {
+	tmps:$(REG_SIZE) = src;
 	tmpd:$(REG_SIZE) = dst;
 	tmp:$(REG_SIZE) = src + dst;
 	dst = tmp & 0xfffff;
 	
-	setaddflags(dst,src,tmpd);
+	setaddflags(dst,tmps,tmpd);
 }
 
 :ADDA SRC20_8_4, DST20_0_4			is ctx_haveext=0 & op16_12_4=0 & insid=0xE & SRC20_8_4 & DST20_0_4 {
@@ -960,11 +961,12 @@ macro adda(dst, src) {
 }
 
 macro suba(dst, src) {
+	tmps:$(REG_SIZE) = src;
 	tmpd:$(REG_SIZE) = dst;
 	tmp:$(REG_SIZE) = dst - src;
 	dst = sext(tmp[0,20]);
 	
-	setsubflags(dst,src,tmpd);
+	setsubflags(dst,tmps,tmpd);
 }
 
 :SUBA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xF & SRC20_8_4 & DST20_0_4 {

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -1106,34 +1106,34 @@ macro suba(dst, src) {
 #
 # Other 20 bit address instructions
 :CALLA DST20_0_4							is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x4 & DST20_0_4 {
+	PC = DST20_0_4 & ~1;
 	SP = SP - 0x4;
 	*:4 SP = inst_next;
-	PC = DST20_0_4 & ~1;
 	call [PC];
 }
 
 :CALLA imms_0_16^"("^DST20_0_4^")"		is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x5 & DST20_0_4 ; imms_0_16 {
-	SP = SP - 0x4;
-	*:4 SP = inst_next;
 	tmp:$(REG_SIZE) = DST20_0_4 + sext(imms_0_16:2);
 	PC = *[RAM]:$(REG_SIZE) tmp;
 	PC = PC & 0xffffe;
+	SP = SP - 0x4;
+	*:4 SP = inst_next;
 	call [PC];
 }
 
 :CALLA "@"^DST20_0_4						is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x6 & DST20_0_4 {
-	SP = SP - 0x4;
-	*:4 SP = inst_next;
 	PC = *[RAM]:$(REG_SIZE) DST20_0_4;
 	PC = PC & 0xffffe;
+	SP = SP - 0x4;
+	*:4 SP = inst_next;
 	call [PC];
 }
 
 :CALLA "@"^DST20_0_4^"+"					is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x7 & DST20_0_4 {
-	SP = SP - 0x4;
-	*:4 SP = inst_next;
 	PC = *[RAM]:$(REG_SIZE) DST20_0_4;
 	PC = PC & 0xffffe;
+	SP = SP - 0x4;
+	*:4 SP = inst_next;
 	DST20_0_4 = DST20_0_4 + 4;
 	call [PC];
 }
@@ -1148,11 +1148,11 @@ macro suba(dst, src) {
 }
 
 :CALLA imms_0_16^"(PC)"					is ctx_haveext=0 & op16_8_8=0x13 & op16_4_4=0x9 ; imms_0_16 {
-	SP = SP - 0x4;
-	*:4 SP = inst_next;
 	tmp:$(REG_SIZE) = inst_start + sext(imms_0_16:2);
 	PC = *[RAM]:$(REG_SIZE) tmp;
 	PC = PC & 0xffffe;
+	SP = SP - 0x4;
+	*:4 SP = inst_next;
 	call [PC];
 }
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -313,22 +313,25 @@ repeat_carry: is ctx_zc = 1 {$(CARRY) = 0;}
 
 macro setaddflags(ans, in1, in2)
 {
-	tmp1:$(REG_SIZE) = zext(in1[0,20]);
-	tmp2:$(REG_SIZE) = zext(in2[0,20]);
-	tmp1 = tmp1 + tmp2;
-	$(CARRY) = tmp1 > 0xFFFFF;
-	$(OVERFLOW) = ((in1 s>= 0) & (in2 s>= 0) & (ans s< 0)) | ((in1 s< 0) & (in2 s< 0) & (ans s>= 0));
-	$(SIGN) = (ans s< 0);
-	$(ZERO) = (ans == 0);
+	local src_neg:1 = in1[19,1] == 1;
+	local dst_neg:1 = in2[19,1] == 1;
+	local ans_neg:1 = ans[19,1] == 1;
+
+	$(CARRY) = in1[0,20] + in2[0,20] > 0xFFFFF;
+	$(OVERFLOW) = (!src_neg && !dst_neg && ans_neg) || (src_neg && dst_neg && !ans_neg);
+	$(SIGN) = ans_neg;
+	$(ZERO) = (ans[0,20] == 0);
 }
 
 macro setsubflags(ans, in1, in2)
 {
-	tmp1:$(REG_SIZE) = zext(in1[0,20]);
-	tmp2:$(REG_SIZE) = zext(in2[0,20]);
+	tmp1:$(REG_SIZE) = in1 << 12 s>> 12; # Rscr
+	tmp2:$(REG_SIZE) = in2 << 12 s>> 12; # Rdst
+	tmpans:$(REG_SIZE) = ans << 12 s>> 12;
+
 	$(CARRY) = tmp1 <= tmp2;
-	$(OVERFLOW) = ((in1 s< 0) & (in2 s>= 0) & (ans s< 0)) | ((in1 s>= 0) & (in2 s< 0) & (ans s>= 0));
-	$(SIGN) = (ans s< 0);
+	$(OVERFLOW) = ((tmp1 s< 0) && (tmp2 s>= 0) && (tmpans s< 0)) || ((tmp1 s>= 0) && (tmp2 s< 0) && (tmpans s>= 0));
+	$(SIGN) = tmpans s< 0;
 	$(ZERO) = (ans == 0);
 }
 
@@ -1081,14 +1084,14 @@ macro suba(dst, src) {
 :TSTA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0xD & src_8_4=0x3 & DST20_0_4 {
 	$(CARRY) = 1;
 	$(OVERFLOW) = 0;
-	$(SIGN) = (DST20_0_4 s< 0);
+	$(SIGN) = DST20_0_4[19, 1] == 1;
 	$(ZERO) = (DST20_0_4 == 0);
 }
 
 :TSTA DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x9 & imm_8_4=0x0 & DST20_0_4 ; imm_0_16=0x0000 {
 	$(CARRY) = 1;
 	$(OVERFLOW) = 0;
-	$(SIGN) = (DST20_0_4 s< 0);
+	$(SIGN) = DST20_0_4[19, 1] == 1;
 	$(ZERO) = (DST20_0_4 == 0);
 }
 
@@ -1192,8 +1195,9 @@ macro suba(dst, src) {
 }
 
 :RRAM.A	NUM2, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insidbig=0x14 & NUM2 & DST20_0_4 & rrn {
-	tmph:$(REG_SIZE) = (DST20_0_4 >> rrn) & 0x1;
-	DST20_0_4 = (DST20_0_4 s>> NUM2);
+	local tmp:$(REG_SIZE) = DST20_0_4 << 12 s>> 12; # Rscr
+	tmph:$(REG_SIZE) = (tmp >> rrn) & 0x1;
+	DST20_0_4 = (tmp s>> NUM2) & 0xfffff;
 	$(CARRY) = (tmph != 0);
 	$(OVERFLOW) = 0;
 	$(SIGN) = (DST20_0_4[19,1] != 0);
@@ -1489,7 +1493,7 @@ macro wzero(full, word)
 	DST20_0_4 = DST20_0_4 & XRSRC_A_AS;
 	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(SIGN) = DST20_0_4[19, 1] == 1;
 	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
 	$(CARRY) = (DST20_0_4 != 0x0);			# C Flag
 	build postIncrementStore;
@@ -1604,7 +1608,7 @@ macro wzero(full, word)
 	# Result Flags...
 	result = sext(result[0,20]);
 	$(CARRY) = (result != 0x0);			# C Flag
-	$(SIGN) = (result s< 0x0);			# S Flag
+	$(SIGN) = result[19, 1] == 1;
 	$(ZERO) = (result == 0x0);			# Z Flag
 	build postIncrement;
 	if (CNT == 0) goto inst_next;
@@ -1728,7 +1732,7 @@ define pcodeop bcd_add;
 	$(CARRY) = temp >= 0x99999;
 	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(SIGN) = DST20_0_4[19, 1] == 1;
 	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
@@ -1781,7 +1785,7 @@ define pcodeop bcd_add;
 	DST20_0_4 = bcd_add(temp_src, temp_dest, temp_carry);
 	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(SIGN) = DST20_0_4[19, 1] == 1;
 	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
 	$(CARRY) = (temp_src + temp_dest + temp_carry) > 0x99999;
 	build postIncrementStore;
@@ -2020,7 +2024,7 @@ define pcodeop bcd_add;
 	DST20_0_4 = DST20_0_4 ^ -1;
 	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(SIGN) = DST20_0_4[19, 1] == 1;
 	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
 	$(CARRY) = (DST20_0_4 != 0x0);			# C Flag
 	build postIncrementStore;
@@ -2194,7 +2198,7 @@ define pcodeop bcd_add;
 	build repeat_carry;
 	# Operation Flags...
 	brw:1 = 1 - $(CARRY);
-    $(CARRY) = (brw <= DST8_0_4);             # Carry flag is NOT set if there is a borrow
+	$(CARRY) = (brw <= DST8_0_4);             # Carry flag is NOT set if there is a borrow
 	$(OVERFLOW) = sborrow(DST8_0_4, brw);	
 	# Operation...
 	DST8_0_4 = DST8_0_4 - brw;
@@ -2247,7 +2251,7 @@ define pcodeop bcd_add;
 	build repeat_carry;
 	# Operation Flags...
 	brw:1 = 1 - $(CARRY);
-    $(CARRY) = ((brw + XRSRC_B_AS) <= DST8_0_4);             # Carry flag is NOT set if there is a borrow
+	$(CARRY) = ((brw + XRSRC_B_AS) <= DST8_0_4);             # Carry flag is NOT set if there is a borrow
 	$(OVERFLOW) = sborrow(DST8_0_4, XRSRC_B_AS + brw);	
 	# Operation...
 	DST8_0_4 = DST8_0_4 - XRSRC_B_AS - brw;
@@ -2419,7 +2423,7 @@ define pcodeop bcd_add;
 	DST20_0_4 = DST20_0_4 ^ XRSRC_A_AS;
 	DST20_0_4 = sext(DST20_0_4[0,20]);
 	# Result Flags...
-	$(SIGN) = (DST20_0_4 s< 0x0);			# S Flag
+	$(SIGN) = DST20_0_4[19, 1] == 1;
 	$(ZERO) = (DST20_0_4 == 0x0);			# Z Flag
 	$(CARRY) = (DST20_0_4 != 0x0);			# C Flag
 	build postIncrementStore;
@@ -2576,7 +2580,7 @@ define pcodeop bcd_add;
 	XDEST_A_AD = XDEST_A_AD & XSRC_A_AS;
 	XDEST_A_AD = sext(XDEST_A_AD[0,20]);
 	# Result Flags...
-	$(SIGN) = (XDEST_A_AD s< 0x0);			# S Flag
+	$(SIGN) = XDEST_A_AD[19, 1] == 1;
 	$(ZERO) = (XDEST_A_AD == 0x0);			# Z Flag
 	$(CARRY) = (XDEST_A_AD != 0x0);			# C Flag
 	build postIncrementStore;
@@ -2656,7 +2660,7 @@ define pcodeop bcd_add;
 	# Result Flags...
 	result = sext(result[0,20]);
 	$(CARRY) = (result != 0x0);			# C Flag
-	$(SIGN) = (result s< 0x0);			# S Flag
+	$(SIGN) = result[19, 1] == 1;
 	$(ZERO) = (result == 0x0);			# Z Flag
 	build postIncrement;
 }
@@ -2742,7 +2746,7 @@ define pcodeop bcd_add;
 	XDEST_A_AD = bcd_add(XDEST_A_AD);
 	XDEST_A_AD = sext(XDEST_A_AD[0,20]);
 	# Result Flags...
-	$(SIGN) = (XDEST_A_AD s< 0x0);			# S Flag
+	$(SIGN) = XDEST_A_AD[19, 1] == 1;
 	$(ZERO) = (XDEST_A_AD == 0x0);			# Z Flag
 	build postIncrementStore;
 }
@@ -2778,7 +2782,7 @@ define pcodeop bcd_add;
 	XDEST_A_AD = bcd_add(XSRC_A_AS ,XDEST_A_AD);
 	XDEST_A_AD = sext(XDEST_A_AD[0,20]);
 	# Result Flags...
-	$(SIGN) = (XDEST_A_AD s< 0x0);			# S Flag
+	$(SIGN) = XDEST_A_AD[19, 1] == 1;
 	$(ZERO) = (XDEST_A_AD == 0x0);			# Z Flag
 	build postIncrementStore;
 }
@@ -2956,7 +2960,7 @@ define pcodeop bcd_add;
 	XDEST_A_AD = XDEST_A_AD ^ -1;
 	XDEST_A_AD = sext(XDEST_A_AD[0,20]);
 	# Result Flags...
-	$(SIGN) = (XDEST_A_AD s< 0x0);			# S Flag
+	$(SIGN) = XDEST_A_AD[19, 1] == 1;
 	$(ZERO) = (XDEST_A_AD == 0x0);			# Z Flag
 	$(CARRY) = (XDEST_A_AD != 0x0);			# C Flag
 	build postIncrementStore;
@@ -3171,7 +3175,7 @@ define pcodeop bcd_add;
 	XDEST_A_AD = XDEST_A_AD ^ XSRC_A_AS;
 	XDEST_A_AD = sext(XDEST_A_AD[0,20]);
 	# Result Flags...
-	$(SIGN) = (XDEST_A_AD s< 0x0);			# S Flag
+	$(SIGN) = XDEST_A_AD[19, 1] == 1;
 	$(ZERO) = (XDEST_A_AD == 0x0);			# Z Flag
 	$(CARRY) = (XDEST_A_AD != 0x0);			# C Flag
 	build postIncrementStore;
@@ -3254,7 +3258,7 @@ define pcodeop bcd_add;
 :RRAX.A XRREG_A_AS_DEST 		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x1 & bow=0x1 & postRegIncrement & XRREG_A_AS_DEST {
 	<top>
 	$(CARRY) = XRREG_A_AS_DEST[0,1];
-	XRREG_A_AS_DEST = (XRREG_A_AS_DEST s>> 1);
+	XRREG_A_AS_DEST = (XRREG_A_AS_DEST << 12 s>> 13) & 0xfffff;
 	$(OVERFLOW) = 0;
 	$(SIGN) = (XRREG_A_AS_DEST[19,1] != 0);
 	$(ZERO) = (XRREG_A_AS_DEST == 0);
@@ -3345,7 +3349,7 @@ define pcodeop bcd_add;
 	XRREG_A_AS_DEST = ((zext(tmp) << 0x13) | ((XRREG_A_AS_DEST >> 0x1) & 0xEFFFF));
 	XRREG_A_AS_DEST = sext(XRREG_A_AS_DEST[0,20]);
 	# Result Flags...
-	$(SIGN) = (XRREG_A_AS_DEST s< 0x0);			# S Flag
+	$(SIGN) = XRREG_A_AS_DEST[19, 1] == 1;
 	$(ZERO) = (XRREG_A_AS_DEST == 0x0);			# Z Flag
 	build postRegIncrement;
 	if (CNT == 0) goto inst_next;
@@ -3418,7 +3422,7 @@ define pcodeop bcd_add;
 	# Operation...	
 	XRREG_A_AS_DEST2 = sext(XRREG_A_AS_DEST2:1);
 	# Result Flags...
-	$(SIGN) = (XRREG_A_AS_DEST2 s< 0x0);			# S Flag
+	$(SIGN) = XRREG_A_AS_DEST2[19, 1] == 1;
 	$(ZERO) = (XRREG_A_AS_DEST2 == 0x0);			# Z Flag
 	$(CARRY) = (XRREG_A_AS_DEST2 != 0x0);			# C Flag
 	build postRegIncrement;
@@ -3475,7 +3479,7 @@ define pcodeop bcd_add;
 
 :RRAX.A XREG_A_AS_DEST 	is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x0 & bow=0x1 & postRegIncrement) ... & XREG_A_AS_DEST {
 	$(CARRY) = XREG_A_AS_DEST[0,1];
-	XREG_A_AS_DEST = (XREG_A_AS_DEST s>> 1);
+	XREG_A_AS_DEST = (XREG_A_AS_DEST << 12 s>> 13) & 0xfffff;
 	$(OVERFLOW) = 0;
 	$(SIGN) = (XREG_A_AS_DEST[19,1] != 0);
 	$(ZERO) = (XREG_A_AS_DEST == 0);
@@ -3517,7 +3521,7 @@ define pcodeop bcd_add;
 	XREG_A_AS_DEST = ((zext(tmp) << 0x13) | ((XREG_A_AS_DEST >> 0x1) & 0xEFFFF));
 	XREG_A_AS_DEST = sext(XREG_A_AS_DEST[0,20]);
 	# Result Flags...
-	$(SIGN) = (XREG_A_AS_DEST s< 0x0);			# S Flag
+	$(SIGN) = XREG_A_AS_DEST[19, 1] == 1;
 	$(ZERO) = (XREG_A_AS_DEST == 0x0);			# Z Flag
 	build postRegIncrement;
 }
@@ -3559,7 +3563,7 @@ define pcodeop bcd_add;
 	# Operation...	
 	XREG_A_AS_DEST2 = sext(XREG_A_AS_DEST2:1);
 	# Result Flags...
-	$(SIGN) = (XREG_A_AS_DEST2 s< 0x0);			# S Flag
+	$(SIGN) = XREG_A_AS_DEST2[19, 1] == 1;
 	$(ZERO) = (XREG_A_AS_DEST2 == 0x0);			# Z Flag
 	$(CARRY) = (XREG_A_AS_DEST2 != 0x0);			# C Flag
 	build postRegIncrement;

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -3363,8 +3363,7 @@ define pcodeop bcd_add;
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = XRREG_A_AS_DEST[0,1];
-	XRREG_A_AS_DEST = ((zext(tmp) << 0x13) | ((XRREG_A_AS_DEST >> 0x1) & 0xEFFFF));
-	XRREG_A_AS_DEST = sext(XRREG_A_AS_DEST[0,20]);
+	XRREG_A_AS_DEST = ((zext(tmp) << 0x13) | ((XRREG_A_AS_DEST >> 0x1) & 0x7FFFF));
 	# Result Flags...
 	$(SIGN) = XRREG_A_AS_DEST[19, 1] == 1;
 	$(ZERO) = (XRREG_A_AS_DEST == 0x0);			# Z Flag
@@ -3538,8 +3537,7 @@ define pcodeop bcd_add;
 	# Operation...
 	tmp:1 = $(CARRY);
 	$(CARRY) = XREG_A_AS_DEST[0,1];
-	XREG_A_AS_DEST = ((zext(tmp) << 0x13) | ((XREG_A_AS_DEST >> 0x1) & 0xEFFFF));
-	XREG_A_AS_DEST = sext(XREG_A_AS_DEST[0,20]);
+	XREG_A_AS_DEST = ((zext(tmp) << 0x13) | ((XREG_A_AS_DEST >> 0x1) & 0x7FFFF));
 	# Result Flags...
 	$(SIGN) = XREG_A_AS_DEST[19, 1] == 1;
 	$(ZERO) = (XREG_A_AS_DEST == 0x0);			# Z Flag

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -2993,24 +2993,30 @@ define pcodeop bcd_add;
 	build postStorePC;
 }
 
-:POPX.B	XDEST_B_AD						is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & tbl_bzero) ... & XDEST_B_AD ...  {
-	XDEST_B_AD = *:1 SP;
+:POPX.B	XDEST_B_AD						is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & tbl_bzero & postStorePC) ... & XDEST_B_AD ...  {
+	local tmp:1 = *:1 SP;
+	SP = SP + 0x2;
+	XDEST_B_AD = tmp;
 	build tbl_bzero;
-	SP = SP + 0x2;
 	#Status bits are not affected
+	build postStorePC;
 }
 
-:POPX.W	XDEST_W_AD						is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=0 & tbl_wzero) ... & XDEST_W_AD ... {
-	XDEST_W_AD = *:2 SP;
+:POPX.W	XDEST_W_AD						is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=0 & tbl_wzero & postStorePC) ... & XDEST_W_AD ... {
+	local tmp:2 = *:2 SP;
+	SP = SP + 0x2;
+	XDEST_W_AD = tmp;
 	build tbl_wzero;
-	SP = SP + 0x2;
 	#Status bits are not affected
+	build postStorePC;
 }
 
-:POPX.A	XDEST_A_AD						is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1) ... & XDEST_A_AD ... {
-	XDEST_A_AD = *:4 SP;
+:POPX.A	XDEST_A_AD						is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & postStorePC) ... & XDEST_A_AD ... {
+	local tmp:4 = *:4 SP;
 	SP = SP + 0x4;
-	XDEST_A_AD = sext(XDEST_A_AD[0,20]);
+	tmp = zext(tmp[0,20]);
+	XDEST_A_AD = tmp;
+	build postStorePC;
 }
 
 :SBCX.B XDEST_B_AD						is ctx_haveext=7 & ctx_al=1 & (op16_12_4=0x7 & bow=1 & src16_8_4=0x3 & as=0x0 & tbl_bzero & postIncrementStore) ... & XDEST_B_AD ...  {

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -948,7 +948,7 @@ macro adda(dst, src) {
 }
 
 :MOVA "#"^Abs20s, DST20_0_4				is ctx_haveext=0 & op16_12_4=0 & insid=0x8 & imm_8_4 & DST20_0_4 ; Abs20s [ctx_ctregdest=imm_8_4;] {
-	DST20_0_4 = sext(Abs20s);
+	DST20_0_4 = sext(Abs20s) & 0xfffff;
 }
 
 :MOVA SRC20_8_4, DST20_0_4					is ctx_haveext=0 & op16_12_4=0 & insid=0xC & SRC20_8_4 & DST20_0_4 {
@@ -2057,7 +2057,7 @@ define pcodeop bcd_add;
 
 :MOVX.A	XRSRC_A_AS, DST20_0_4				is ctx_haveext=4 & op16_12_4=0x4 & bow=1 & ctx_al=0 & postIncrementStore & XRSRC_A_AS & DST20_0_4 {
 	<top>
-	DST20_0_4 = XRSRC_A_AS;
+	DST20_0_4 = XRSRC_A_AS & 0xfffff;
 	build postIncrementStore;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
@@ -2981,7 +2981,7 @@ define pcodeop bcd_add;
 }
 
 :MOVX.A	XSRC_A_AS, XDEST_A_AD			is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x4 & bow=1 & postIncrementStore) ... & XSRC_A_AS ... & XDEST_A_AD ... {
-	XDEST_A_AD = XSRC_A_AS;
+	XDEST_A_AD = XSRC_A_AS & 0xfffff;
 	build postIncrementStore;
 }
 
@@ -3215,7 +3215,7 @@ define pcodeop bcd_add;
 :PUSHX.A XRREG_A_AS 		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x2 & bow=0x1 & postRegIncrement & XRREG_A_AS {
 	<top>
 	SP = SP - 0x4;
-	*:$(REG_SIZE) SP = XRREG_A_AS;
+	*:$(REG_SIZE) SP = XRREG_A_AS & 0xfffff;
 	#Status bits are not affected
 	build postRegIncrement;
 	if (CNT == 0) goto inst_next;
@@ -3420,7 +3420,7 @@ define pcodeop bcd_add;
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;						# V Flag
 	# Operation...	
-	XRREG_A_AS_DEST2 = sext(XRREG_A_AS_DEST2:1);
+	XRREG_A_AS_DEST2 = sext(XRREG_A_AS_DEST2:1) & 0xfffff;
 	# Result Flags...
 	$(SIGN) = XRREG_A_AS_DEST2[19, 1] == 1;
 	$(ZERO) = (XRREG_A_AS_DEST2 == 0x0);			# Z Flag
@@ -3449,7 +3449,7 @@ define pcodeop bcd_add;
 
 :PUSHX.A XREG_A_AS 		is ctx_haveext=7 & ctx_al=0 & (op16_12_4=0x1 & op16_8_4=0x2 & op16_7_1=0x0 & bow=0x1 & postRegIncrement) ... & XREG_A_AS {
 	SP = SP - 0x4;
-	*:$(REG_SIZE) SP = XREG_A_AS;
+	*:$(REG_SIZE) SP = XREG_A_AS & 0xfffff;
 	build postRegIncrement;
 }	
 
@@ -3561,7 +3561,7 @@ define pcodeop bcd_add;
 	# Operation Flags...
 	$(OVERFLOW) = 0x0;						# V Flag
 	# Operation...	
-	XREG_A_AS_DEST2 = sext(XREG_A_AS_DEST2:1);
+	XREG_A_AS_DEST2 = sext(XREG_A_AS_DEST2:1) & 0xfffff;
 	# Result Flags...
 	$(SIGN) = XREG_A_AS_DEST2[19, 1] == 1;
 	$(ZERO) = (XREG_A_AS_DEST2 == 0x0);			# Z Flag

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -39,16 +39,25 @@ Abs20: val						is ctx_ctregdest & imm_0_16 [ val=(ctx_ctregdest << 16) | imm_0_
 Abs20s: val						is ctx_ctregdests & imm_0_16 [ val=(ctx_ctregdests << 16) | imm_0_16;] {export *[const]:3 val;}
 Abs20add: val					is ctx_ctregdest & imm_0_16 [ val=(ctx_ctregdest << 16) | imm_0_16;] {export *:4 val;}
 
+Imm20Dst: val		is ctx_ctregdest & imm_0_16 [ val=(ctx_ctregdest << 16) | imm_0_16;] {export *[const]:4 val;}
+ImmS20Dst: val		is ctx_ctregdests & imm_0_16 [ val=(ctx_ctregdests << 16) | imm_0_16;] {export *[const]:4 val;}
+Imm20Src: val		is ctx_regsrc & imm_0_16 [ val=(ctx_regsrc << 16) | imm_0_16;] {export *[const]:4 val;}
+ImmS20Src: val		is ctx_regsrcs & imm_0_16 [ val=(ctx_regsrcs << 16) | imm_0_16;] {export *[const]:4 val;}
+
+Label20Src: labelCalc		is ctx_regsrcs & imm_0_16 [ labelCalc = inst_start + 4 + ((ctx_regsrcs << 16) | imm_0_16);] {export *[const]:4 labelCalc;}
+Label20Dst: labelCalc		is ctx_ctregdests & imm_0_16 [ labelCalc = inst_start + 4 + ((ctx_ctregdests << 16) | imm_0_16);] {export *[const]:4 labelCalc;}
+Label20DstExt: labelCalc	is ctx_ctregdests & imm_0_16 [ labelCalc = inst_start + 6 + ((ctx_ctregdests << 16) | imm_0_16);] {export *[const]:4 labelCalc;}
+
 IMM4: val					is imm_4_4 [val = imm_4_4+1;] {export *[const]:1 val;}
 NUM2: val					is rrn [ val = rrn+1;] {export *[const]:1 val;}
 
 XREG_B_AS: DST8_0_4 			 		 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
-XREG_B_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + indexExtWord16_0_16s; export *:1 tmp;}
+XREG_B_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src; export *:1 tmp;}
 XREG_B_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XREG_B_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_B_AS: labelCalc 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ] {export *:1 labelCalc; } # Symbolic
-XREG_B_AS: "#"^indexExtWord16_0_16 		 is reg16_0_4=0x0 & as=0x3 & bow=0x1 ; indexExtWord16_0_16 {export *[const]:1 indexExtWord16_0_16; } # Immediate
-XREG_B_AS: "&"^indexExtWord16_0_16 		 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
+XREG_B_AS: Label20Src 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Src {export *:1 Label20Src; } # Symbolic
+XREG_B_AS: "#"^ImmS20Dst 		 is reg16_0_4=0x0 & as=0x3 & bow=0x1 ; ImmS20Dst {export *[const]:1 ImmS20Dst; } # Immediate
+XREG_B_AS: "&"^Imm20Dst 		 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:1 Imm20Dst; } # Absolute
 XREG_B_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:1;}		# Constant
 XREG_B_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x1  { export 8:1;}		# Constant
 XREG_B_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:1;}		# Constant
@@ -67,12 +76,12 @@ XRREG_B_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:1;}		# C
 XRREG_B_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1;} 	# Constant	
 
 XREG_W_AS: DST16_0_4 			 		 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
-XREG_W_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + indexExtWord16_0_16s; export *:2 tmp;}
+XREG_W_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src; export *:2 tmp;}
 XREG_W_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XREG_W_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_W_AS: labelCalc 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ] {export *:2 labelCalc; } # Symbolic
-XREG_W_AS: "#"^indexExtWord16_0_16 		 is reg16_0_4=0x0 & as=0x3 & bow=0x0 ; indexExtWord16_0_16 {export *[const]:2 indexExtWord16_0_16; } # Immediate
-XREG_W_AS: "&"^indexExtWord16_0_16 		 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; indexExtWord16_0_16 {export *:2 indexExtWord16_0_16; } # Absolute
+XREG_W_AS: Label20Src 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Src {export *:2 Label20Src; } # Symbolic
+XREG_W_AS: "#"^ImmS20Dst 		 is reg16_0_4=0x0 & as=0x3 & bow=0x0 ; ImmS20Dst {export *[const]:2 ImmS20Dst; } # Immediate
+XREG_W_AS: "&"^Imm20Dst 		 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {export *:2 Imm20Dst; } # Absolute
 XREG_W_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x0  { export 4:2;}		# Constant
 XREG_W_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x0  { export 8:2;}		# Constant
 XREG_W_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x0  { export 0:2;}		# Constant
@@ -91,12 +100,12 @@ XRREG_W_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x0  { export 2:2;}		# C
 XRREG_W_AS: "#-1" 					 	 is	reg16_0_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2;} 	    # Constant
 
 XREG_A_AS: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
-XREG_A_AS: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + indexExtWord16_0_16s; export *:$(REG_SIZE) tmp;}
+XREG_A_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src; export *:$(REG_SIZE) tmp;}
 XREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_A_AS: labelCalc 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 [labelCalc = inst_start + 4 + ((ctx_ctregdests << 16) | indexExtWord16_0_16); ] {export *:$(REG_SIZE) labelCalc; } # Symbolic
-XREG_A_AS: "#"^val 						 is reg16_0_4=0x0 & as=0x3 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_ctregdests << 16) | indexExtWord16_0_16; ] {export *[const]:$(REG_SIZE) val; } # Immediate
-XREG_A_AS: "&"^val 						 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_ctregdest << 16) | indexExtWord16_0_16; ] {export *:$(REG_SIZE) val; } # Absolute
+XREG_A_AS: Label20Src 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Src  {export *:$(REG_SIZE) Label20Src; } # Symbolic
+XREG_A_AS: "#"^ImmS20Dst 						 is reg16_0_4=0x0 & as=0x3 & bow=0x1 ; ImmS20Dst {export *[const]:$(REG_SIZE) ImmS20Dst; } # Immediate
+XREG_A_AS: "&"^Imm20Dst 						 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
 XREG_A_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE);}		# Constant
 XREG_A_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE);}		# Constant
 XREG_A_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE);}		# Constant
@@ -115,53 +124,53 @@ XRREG_A_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SI
 XRREG_A_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE);} 	# Constant	
 
 XREG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
-XREG_B_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + indexExtWord16_0_16s; export *:1 tmp;}
+XREG_B_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst; export *:1 tmp;}
 XREG_B_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_B_AS_DEST: labelCalc 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ] {export *:1 labelCalc; } # Symbolic
-XREG_B_AS_DEST: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
+XREG_B_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Dst {export *:1 Label20Dst; } # Symbolic
+XREG_B_AS_DEST: "&"^Imm20Dst 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:1 Imm20Dst; } # Absolute
 
 XRREG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x1  { ztmp:1 = DST8_0_4; reg_Direct16_0_4=0; DST8_0_4 = ztmp; export DST8_0_4;} # Word/Register Direct (Rn):
 XRREG_B_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XRREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
 
-XREG_W_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + indexExtWord16_0_16s; export *:2 tmp;}
+XREG_W_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
 XREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_W_AS_DEST: labelCalc 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ] {export *:2 labelCalc; } # Symbolic
-XREG_W_AS_DEST: "&"^indexExtWord16_0_16 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; indexExtWord16_0_16 {export *:2 indexExtWord16_0_16; } # Absolute
+XREG_W_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {export *:2 Label20Dst; } # Symbolic
+XREG_W_AS_DEST: "&"^Imm20Dst 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {export *:2 Imm20Dst; } # Absolute
 
 XRREG_W_AS_DEST: DST16_0_4 			 is DST16_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x0  {ztmp:2 = DST16_0_4; reg_Direct16_0_4=0; DST16_0_4 = ztmp;export DST16_0_4;} # Word/Register Direct (Rn):
 XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:2 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
 
-XREG_A_AS_DEST: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + indexExtWord16_0_16s; export *:$(REG_SIZE) tmp;}
+XREG_A_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
 XREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_A_AS_DEST: labelCalc 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 [labelCalc = inst_start + 4 + ((ctx_ctregdests << 16) | indexExtWord16_0_16); ] {export *:$(REG_SIZE) labelCalc; } # Symbolic
-XREG_A_AS_DEST: "&"^val 					 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_ctregdest << 16) | indexExtWord16_0_16; ] {export *:$(REG_SIZE) val; } # Absolute
+XREG_A_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
+XREG_A_AS_DEST: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
 
 XRREG_A_AS_DEST: dest_0_4						 is dest_0_4 & as=0 & bow=0x1 {export dest_0_4;}
 XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
 
-XREG_A_AS_DEST2: indexExtWord16_0_16s^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + indexExtWord16_0_16s; export *:$(REG_SIZE) tmp;}
+XREG_A_AS_DEST2: Imm20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; Imm20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + Imm20Dst; export *:$(REG_SIZE) tmp;}
 XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XREG_A_AS_DEST2: labelCalc 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; indexExtWord16_0_16 [labelCalc = inst_start + 4 + ((ctx_ctregdests << 16) | indexExtWord16_0_16);  ] {export *:$(REG_SIZE) labelCalc; } # Symbolic
-XREG_A_AS_DEST2: "&"^val 					 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; indexExtWord16_0_16 [val=(ctx_ctregdest << 16) | indexExtWord16_0_16; ] {export *:$(REG_SIZE) val; } # Absolute
+XREG_A_AS_DEST2: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
+XREG_A_AS_DEST2: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
 
 XRREG_A_AS_DEST2: dest_0_4						 is dest_0_4 & as=0 & bow=0x0 {export dest_0_4;}
 XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
 XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {export *:$(REG_SIZE) reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):	
 
 XSRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & as=0x0 & bow=0x1 { export SRC8_8_4;} # Word/Register Direct (Rn):
-XSRC_B_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = src_Indexed16_8_4 + indexExtWord16_0_16s; export *:1 tmp;}
+XSRC_B_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:1 tmp;}
 XSRC_B_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
 XSRC_B_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XSRC_B_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ] {export *:1 labelCalc; } # Symbolic
-XSRC_B_AS: "#"^indexExtWord16_0_16 	 is src16_8_4=0x0 & as=0x3 & bow=0x1 ; indexExtWord16_0_16 {export *[const]:1 indexExtWord16_0_16;} # Immediate
-XSRC_B_AS: "&"^indexExtWord16_0_16 	 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 {export *:1 indexExtWord16_0_16; } # Absolute
+XSRC_B_AS: Label20Src 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 ; Label20Src {export *:1 Label20Src; } # Symbolic
+XSRC_B_AS: "#"^ImmS20Src 	 is src16_8_4=0x0 & as=0x3 & bow=0x1 ; ImmS20Src {export *[const]:1 ImmS20Src;} # Immediate
+XSRC_B_AS: "&"^Imm20Src 	 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; Imm20Src {export *:1 Imm20Src; } # Absolute
 XSRC_B_AS: "#4" 						 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:1; }		# Constant
 XSRC_B_AS: "#8" 						 is src16_8_4=0x2 & as=0x3 & bow=0x1  { export 8:1; }		# Constant
 XSRC_B_AS: "#0" 						 is src16_8_4=0x3 & as=0x0 & bow=0x1  { export 0:1; }		# Constant
@@ -181,12 +190,12 @@ XRSRC_B_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1; } 
 
 
 XSRC_W_AS: SRC16_8_4 			 	 is SRC16_8_4 & as=0x0 & bow=0x0 {export SRC16_8_4;} # Word/Register Direct (Rn):
-XSRC_W_AS: indexExtWord16_0_16s^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x0 ; indexExtWord16_0_16s {tmp:$(REG_SIZE) = src_Indexed16_8_4 + indexExtWord16_0_16s; export *:2 tmp;}
+XSRC_W_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x0 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:2 tmp;}
 XSRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0  {export *:2 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
 XSRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0  {export *:2 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XSRC_W_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ] {export *:2 labelCalc; } # Symbolic
-XSRC_W_AS: "#"^indexExtWord16_0_16 	 is src16_8_4=0x0 & as=0x3 & bow=0x0 ; indexExtWord16_0_16 {export *[const]:2 indexExtWord16_0_16; } # Immediate
-XSRC_W_AS: "&"^indexExtWord16_0_16 	 is src16_8_4=0x2 & as=0x1 & bow=0x0 ; indexExtWord16_0_16 {export *:2 indexExtWord16_0_16; } # Absolute
+XSRC_W_AS: Label20Src 				 is src16_8_4=0x0 & as=0x1 & bow=0x0 ; Label20Src {export *:2 Label20Src; } # Symbolic
+XSRC_W_AS: "#"^ImmS20Src 	 is src16_8_4=0x0 & as=0x3 & bow=0x0 ; ImmS20Src {export *[const]:2 ImmS20Src; } # Immediate
+XSRC_W_AS: "&"^Imm20Src 	 is src16_8_4=0x2 & as=0x1 & bow=0x0 ; Imm20Src {export *:2 Imm20Src; } # Absolute
 XSRC_W_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x0  { export 4:2; }		# Constant
 XSRC_W_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x0  { export 8:2; }		# Constant
 XSRC_W_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x0  { export 0:2; }		# Constant
@@ -205,12 +214,12 @@ XRSRC_W_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x0  { export 2:2; }		# C
 XRSRC_W_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2; } 	# Constant	
 
 XSRC_A_AS: src_8_4 			 		 is src_8_4 & as=0x0 & bow=0x1 { export src_8_4;} # Word/Register Direct (Rn):
-XSRC_A_AS: val^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_regsrcs << 16) | indexExtWord16_0_16; ] {tmp:$(REG_SIZE) = src_Indexed16_8_4 + val; export *:$(REG_SIZE) tmp;}
+XSRC_A_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:$(REG_SIZE) tmp;}
 XSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:$(REG_SIZE) src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
 XSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:$(REG_SIZE) src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):	
-XSRC_A_AS: labelCalc 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 [labelCalc = inst_start + 4 + ((ctx_regsrcs << 16) | indexExtWord16_0_16); ] {export *:$(REG_SIZE) labelCalc; } # Symbolic
-XSRC_A_AS: "#"^val 	 				 is src16_8_4=0x0 & as=0x3 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_regsrcs << 16) | indexExtWord16_0_16; ] {export *[const]:$(REG_SIZE) val; } # Immediate
-XSRC_A_AS: "&"^val 	 				 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_regsrc << 16) | indexExtWord16_0_16; ] {export *:$(REG_SIZE) val; } # Absolute
+XSRC_A_AS: Label20Src 				 is src16_8_4=0x0 & as=0x1 & bow=0x1 ; Label20Src {export *:$(REG_SIZE) Label20Src; } # Symbolic
+XSRC_A_AS: "#"^ImmS20Src 	 				 is src16_8_4=0x0 & as=0x3 & bow=0x1 ; ImmS20Src {export *[const]:$(REG_SIZE) ImmS20Src; } # Immediate
+XSRC_A_AS: "&"^Imm20Src 	 				 is src16_8_4=0x2 & as=0x1 & bow=0x1 ; Imm20Src {export *:$(REG_SIZE) Imm20Src; } # Absolute
 XSRC_A_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE); }		# Constant
 XSRC_A_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE); }		# Constant
 XSRC_A_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE); }		# Constant
@@ -230,67 +239,67 @@ XRSRC_A_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff
 
 XDEST_B_AD: DST8_0_4 		  		 is DST8_0_4 & ad=0x0 & bow=0x1
      { export DST8_0_4; }        # Word/Register Direct (Rn):
-XDEST_B_AD: indexExtWord16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 ; indexExtWord16_0_16s
-     { tmp:$(REG_SIZE) = dest_Indexed16_0_4 + indexExtWord16_0_16s; export *:1 tmp;}
-XDEST_B_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     { tmp:$(REG_SIZE) = dest_Indexed16_0_4 + indexExt2Word16_0_16s; export *:1 tmp;}
-XDEST_B_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     { tmp:$(REG_SIZE) = dest_Indexed16_0_4 + indexExt2Word16_0_16s; export *:1 tmp;}
-XDEST_B_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ]
-     { export *:1 labelCalc; } # Symbolic
-XDEST_B_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 6 + indexExt2Word16_0_16s; ]
-     {export *:1 labelCalc; } # Symbolic
-XDEST_B_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 6 + indexExt2Word16_0_16s; ]
-     {export *:1 labelCalc; } # Symbolic
-XDEST_B_AD: "&"^indexExtWord16_0_16 	  is dest=0x2 & ad=0x1 & bow=0x1 ; indexExtWord16_0_16
-     {export *:1 indexExtWord16_0_16; } # Absolute
-XDEST_B_AD: "&"^indexExt2Word16_0_16   is dest=0x2 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16
-     {export *:1 indexExt2Word16_0_16; } # Absolute
-XDEST_B_AD: "&"^indexExt2Word16_0_16   is dest=0x2 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16
-     {export *:1 indexExt2Word16_0_16; } # Absolute
+XDEST_B_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 ; ImmS20Dst
+     { tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:1 tmp;}
+XDEST_B_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; ImmS20Dst
+     { tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:1 tmp;}
+XDEST_B_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; ImmS20Dst
+     { tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:1 tmp;}
+XDEST_B_AD: Label20Dst 				  is dest=0x0 & ad=0x1 & bow=0x1 ; Label20Dst
+     { export *:1 Label20Dst; } # Symbolic
+XDEST_B_AD: Label20DstExt 				  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Label20DstExt
+     {export *:1 Label20DstExt; } # Symbolic
+XDEST_B_AD: Label20DstExt 				  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Label20DstExt
+     {export *:1 Label20DstExt; } # Symbolic
+XDEST_B_AD: "&"^Imm20Dst 	  is dest=0x2 & ad=0x1 & bow=0x1 ; Imm20Dst
+     {export *:1 Imm20Dst; } # Absolute
+XDEST_B_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Imm20Dst
+     {export *:1 Imm20Dst; } # Absolute
+XDEST_B_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Imm20Dst
+     {export *:1 Imm20Dst; } # Absolute
 
 
 XDEST_W_AD: DST16_0_4 		  		 is DST16_0_4 & ad=0x0 & bow=0x0
      {export DST16_0_4;} # Word/Register Direct (Rn):
-XDEST_W_AD: indexExtWord16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 ; indexExtWord16_0_16s
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + indexExtWord16_0_16s; export *:2 tmp;}
-XDEST_W_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + indexExt2Word16_0_16s; export *:2 tmp;}
-XDEST_W_AD: indexExt2Word16_0_16s^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + indexExt2Word16_0_16s; export *:2 tmp;}
-XDEST_W_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x0 ; indexExtWord16_0_16s [labelCalc = inst_start + 4 + indexExtWord16_0_16s; ]
-     {export *:2 labelCalc; } # Symbolic
-XDEST_W_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 6 + indexExt2Word16_0_16s; ]
-     {export *:2 labelCalc; } # Symbolic
-XDEST_W_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16s [labelCalc = inst_start + 6 + indexExt2Word16_0_16s; ]
-     {export *:2 labelCalc; } # Symbolic
-XDEST_W_AD: "&"^indexExtWord16_0_16 	  is dest=0x2 & ad=0x1 & bow=0x0 ; indexExtWord16_0_16
-     {export *:2 indexExtWord16_0_16; } # Absolute
-XDEST_W_AD: "&"^indexExt2Word16_0_16   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16
-     {export *:2 indexExt2Word16_0_16; } # Absolute
-XDEST_W_AD: "&"^indexExt2Word16_0_16   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16
-     {export *:2 indexExt2Word16_0_16; } # Absolute
+XDEST_W_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 ; ImmS20Dst
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
+XDEST_W_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; ImmS20Dst
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
+XDEST_W_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; ImmS20Dst
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:2 tmp;}
+XDEST_W_AD: Label20Dst 				  is dest=0x0 & ad=0x1 & bow=0x0 ; Label20Dst
+     {export *:2 Label20Dst; } # Symbolic
+XDEST_W_AD: Label20DstExt 				  is dest=0x0 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Label20DstExt
+     {export *:2 Label20DstExt; } # Symbolic
+XDEST_W_AD: Label20DstExt 				  is dest=0x0 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Label20DstExt
+     {export *:2 Label20DstExt; } # Symbolic
+XDEST_W_AD: "&"^Imm20Dst 	  is dest=0x2 & ad=0x1 & bow=0x0 ; Imm20Dst
+     {export *:2 Imm20Dst; } # Absolute
+XDEST_W_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Imm20Dst
+     {export *:2 Imm20Dst; } # Absolute
+XDEST_W_AD: "&"^Imm20Dst   is dest=0x2 & ad=0x1 & bow=0x0 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Imm20Dst
+     {export *:2 Imm20Dst; } # Absolute
 
 XDEST_A_AD: dest_0_4 		  		 is dest_0_4 & ad=0x0 & bow=0x1
      { export dest_0_4; }        # Word/Register Direct (Rn):
-XDEST_A_AD: val^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_ctregdests << 16) | indexExtWord16_0_16; ]
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + val; export *:$(REG_SIZE) tmp;}
-XDEST_A_AD: val^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16 [val=(ctx_ctregdests << 16) | indexExt2Word16_0_16; ]
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + val; export *:$(REG_SIZE) tmp;}
-XDEST_A_AD: val^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16 [val=(ctx_ctregdests << 16) | indexExt2Word16_0_16; ]
-     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + val; export *:$(REG_SIZE) tmp;}
-XDEST_A_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 ; indexExtWord16_0_16 [labelCalc = inst_start + 4 + ((ctx_ctregdests << 16) | indexExtWord16_0_16);  ]
-     {export *:$(REG_SIZE) labelCalc; } # Symbolic
-XDEST_A_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16 [labelCalc = inst_start + 4 + ((ctx_ctregdests << 16) | indexExt2Word16_0_16);  ]
-     {export *:$(REG_SIZE) labelCalc; } # Symbolic
-XDEST_A_AD: labelCalc 				  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16 [labelCalc = inst_start + 4 + ((ctx_ctregdests << 16) | indexExt2Word16_0_16);  ]
-     {export *:$(REG_SIZE) labelCalc; } # Symbolic
-XDEST_A_AD: "&"^val 	  			  is dest=0x2 & ad=0x1 & bow=0x1 ; indexExtWord16_0_16 [val=(ctx_ctregdest << 16) | indexExtWord16_0_16; ]
-     {export *:$(REG_SIZE) val; } # Absolute
-XDEST_A_AD: "&"^val   				  is dest=0x2 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; indexExt2Word16_0_16 [val=(ctx_ctregdest << 16) | indexExt2Word16_0_16; ]
-     {export *:$(REG_SIZE) val; } # Absolute
-XDEST_A_AD: "&"^val   				  is dest=0x2 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; indexExt2Word16_0_16 [val=(ctx_ctregdest << 16) | indexExt2Word16_0_16; ]
-     {export *:$(REG_SIZE) val; } # Absolute
+XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 ; ImmS20Dst
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
+XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; ImmS20Dst
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
+XDEST_A_AD: ImmS20Dst^"("^dest_Indexed16_0_4^")" is dest_Indexed16_0_4 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; ImmS20Dst
+     {tmp:$(REG_SIZE) = dest_Indexed16_0_4 + ImmS20Dst; export *:$(REG_SIZE) tmp;}
+XDEST_A_AD: Label20Dst 				  is dest=0x0 & ad=0x1 & bow=0x1 ; Label20Dst
+     {export *:$(REG_SIZE) Label20Dst; } # Symbolic
+XDEST_A_AD: Label20DstExt			  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ;Label20DstExt
+     {export *:$(REG_SIZE) Label20DstExt; } # Symbolic
+XDEST_A_AD: Label20DstExt			  is dest=0x0 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Label20DstExt
+     {export *:$(REG_SIZE) Label20DstExt; } # Symbolic
+XDEST_A_AD: "&"^Imm20Dst 			  is dest=0x2 & ad=0x1 & bow=0x1 ; Imm20Dst
+     {export *:$(REG_SIZE) Imm20Dst; } # Absolute
+XDEST_A_AD: "&"^Imm20Dst			  is dest=0x2 & ad=0x1 & bow=0x1 & as=0x1 & ((src16_8_4>=0x0 & src16_8_4<=0x2) | (src16_8_4>=0x4 & src16_8_4<=0xF)) ; indexExtWord16_0_16 ; Imm20Dst
+     {export *:$(REG_SIZE) Imm20Dst; } # Absolute
+XDEST_A_AD: "&"^Imm20Dst			  is dest=0x2 & ad=0x1 & bow=0x1 & as=0x3 & src16_8_4=0x0 ; indexExtWord16_0_16 ; Imm20Dst
+     {export *:$(REG_SIZE) Imm20Dst; } # Absolute
 
 #Use repeat_carry with a build directive at the beginning of a RPT loop
 

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI430X.sinc
@@ -19,9 +19,6 @@
 
 :^instruction							is ctx_haveext=1 & instruction & op16_7_9=0x23 & as=0 [ctx_haveext=3;] {build instruction;}
 :^instruction							is ctx_haveext=1 & instruction & op16_7_9=0x21 & as=0 [ctx_haveext=3;] {build instruction;}
-:^instruction							is ctx_haveext=1 & instruction & op16_12_4=0x1 & as=1 & reg16_0_4=3 [ctx_haveext=3;] {build instruction;}
-:^instruction							is ctx_haveext=1 & instruction & op16_12_4=0x1 & as=1 [ctx_haveext=7;] {build instruction;}
-:^instruction							is ctx_haveext=1 & instruction & op16_12_4=0x1 & as=3 & reg16_0_4=0 [ctx_haveext=7;] {build instruction;}
 
 # removed haveext=2
 #:^instruction							is ctx_haveext=2 & instruction & as=0 & ad=0 [ctx_haveext=3;] {build instruction;}
@@ -64,15 +61,8 @@ XREG_B_AS: "#1" 						 is reg16_0_4=0x3 & as=0x1 & bow=0x1  { export 1:1;}		# Co
 XREG_B_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:1;}		# Constant
 XREG_B_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1;} 	# Constant	
 
-XRREG_B_AS: DST8_0_4 			 		 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
-XRREG_B_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_B_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
-XRREG_B_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:1;}		# Constant
-XRREG_B_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x1  { export 8:1;}		# Constant
-XRREG_B_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:1;}		# Constant
-XRREG_B_AS: "#1" 						 is reg16_0_4=0x3 & as=0x1 & bow=0x1  { export 1:1;}		# Constant
-XRREG_B_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:1;}		# Constant
-XRREG_B_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1;} 	# Constant	
+XRREG_B_AS: DST8_0_4						 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
+XRREG_B_AS: "#0"						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:1;}		# Constant
 
 XREG_W_AS: DST16_0_4 			 		 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
 XREG_W_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src & ~1; export *:2 tmp;}
@@ -88,15 +78,8 @@ XREG_W_AS: "#1" 						 is reg16_0_4=0x3 & as=0x1 & bow=0x0  { export 1:2;}		# Co
 XREG_W_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x0  { export 2:2;}		# Constant
 XREG_W_AS: "#-1" 					 	 is	reg16_0_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2;} 	    # Constant
 
-XRREG_W_AS: DST16_0_4 			 		 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
-XRREG_W_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
-XRREG_W_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-XRREG_W_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x0  { export 4:2;}		# Constant
-XRREG_W_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x0  { export 8:2;}		# Constant
-XRREG_W_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x0  { export 0:2;}		# Constant
-XRREG_W_AS: "#1" 						 is reg16_0_4=0x3 & as=0x1 & bow=0x0  { export 1:2;}		# Constant
-XRREG_W_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x0  { export 2:2;}		# Constant
-XRREG_W_AS: "#-1" 					 	 is	reg16_0_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2;} 	    # Constant
+XRREG_W_AS: DST16_0_4						 is DST16_0_4 & as=0x0 & bow=0x0  {export DST16_0_4;} # Word/Register Direct (Rn):
+XRREG_W_AS: "#0"						 is reg16_0_4=0x3 & as=0x0 & bow=0x0  { export 0:2;}		# Constant
 
 XREG_A_AS: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x1 {export DST20_0_4;}
 XREG_A_AS: ImmS20Src^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Src & ~1; export *:$(REG_SIZE) tmp;}
@@ -113,14 +96,7 @@ XREG_A_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZ
 XREG_A_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE);} 	# Constant	
 
 XRREG_A_AS: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x1 {export DST20_0_4;}
-XRREG_A_AS: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
-XRREG_A_AS: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-XRREG_A_AS: "#4" 						 is reg16_0_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE);}		# Constant
-XRREG_A_AS: "#8" 						 is reg16_0_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE);}		# Constant
 XRREG_A_AS: "#0" 						 is reg16_0_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE);}		# Constant
-XRREG_A_AS: "#1" 						 is reg16_0_4=0x3 & as=0x1 & bow=0x1  { export 1:$(REG_SIZE);}		# Constant
-XRREG_A_AS: "#2" 						 is reg16_0_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZE);}		# Constant
-XRREG_A_AS: "#-1" 						 is	reg16_0_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE);} 	# Constant	
 
 XREG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & as=0x0 & bow=0x1  { export DST8_0_4;} # Word/Register Direct (Rn):
 XREG_B_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst; export *:1 tmp;}
@@ -129,9 +105,7 @@ XREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow
 XREG_B_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Dst {export *:1 Label20Dst; } # Symbolic
 XREG_B_AS_DEST: "&"^Imm20Dst 	 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:1 Imm20Dst; } # Absolute
 
-XRREG_B_AS_DEST: DST8_0_4 			 	 is DST8_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x1  { ztmp:1 = DST8_0_4; reg_Direct16_0_4=0; DST8_0_4 = ztmp; export DST8_0_4;} # Word/Register Direct (Rn):
-XRREG_B_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect (@Rn):
-XRREG_B_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {export *:1 reg_InDirect16_0_4;} # Word/Register Indirect Autoincrement (@Rn+):
+XRREG_B_AS_DEST: DST8_0_4					 is DST8_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x1  { ztmp:1 = DST8_0_4; reg_Direct16_0_4=0; DST8_0_4 = ztmp; export DST8_0_4;} # Word/Register Direct (Rn):
 
 XREG_W_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 & AMASK ; ImmS20Dst {tmp:$(REG_SIZE) = (reg_Indexed16_0_4 + ImmS20Dst) & AMASK; export *:2 tmp;}
 XREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
@@ -139,9 +113,7 @@ XREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow
 XREG_W_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {local tmp:$(REG_SIZE) = Label20Dst & ~1; export *:2 tmp; } # Symbolic
 XREG_W_AS_DEST: "&"^Imm20Dst 	 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:2 tmp; } # Absolute
 
-XRREG_W_AS_DEST: DST16_0_4 			 is DST16_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x0  {ztmp:2 = DST16_0_4; reg_Direct16_0_4=0; DST16_0_4 = ztmp;export DST16_0_4;} # Word/Register Direct (Rn):
-XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
-XRREG_W_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
+XRREG_W_AS_DEST: DST16_0_4					 is DST16_0_4 & as=0x0 & reg_Direct16_0_4 & bow=0x0  {ztmp:2 = DST16_0_4; reg_Direct16_0_4=0; DST16_0_4 = ztmp;export DST16_0_4;} # Word/Register Direct (Rn):
 
 XREG_A_AS_DEST: ImmS20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x1 ; ImmS20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + ImmS20Dst & ~1; export *:$(REG_SIZE) tmp;}
 XREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
@@ -149,9 +121,7 @@ XREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow
 XREG_A_AS_DEST: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x1 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
 XREG_A_AS_DEST: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x1 ; Imm20Dst {export *:$(REG_SIZE) Imm20Dst; } # Absolute
 
-XRREG_A_AS_DEST: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x1 {export DST20_0_4;}
-XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
-XRREG_A_AS_DEST: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
+XRREG_A_AS_DEST: DST20_0_4					 is DST20_0_4 & as=0 & bow=0x1 {export DST20_0_4;}
 
 XREG_A_AS_DEST2: Imm20Dst^"("^reg_Indexed16_0_4^")" is reg_Indexed16_0_4 & as=0x1 & bow=0x0 ; Imm20Dst {tmp:$(REG_SIZE) = reg_Indexed16_0_4 + Imm20Dst & ~1; export *:$(REG_SIZE) tmp;}
 XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
@@ -159,9 +129,7 @@ XREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bo
 XREG_A_AS_DEST2: Label20Dst 					 is reg16_0_4=0x0 & as=0x1 & bow=0x0 ; Label20Dst {export *:$(REG_SIZE) Label20Dst; } # Symbolic
 XREG_A_AS_DEST2: "&"^Imm20Dst 					 is reg16_0_4=0x2 & as=0x1 & bow=0x0 ; Imm20Dst {local tmp:$(REG_SIZE) = Imm20Dst & ~1; export *:$(REG_SIZE) tmp; } # Absolute
 
-XRREG_A_AS_DEST2: DST20_0_4						 is DST20_0_4 & as=0 & bow=0x0 {export DST20_0_4;}
-XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4 		 is reg_InDirect16_0_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
-XRREG_A_AS_DEST2: "@"^reg_InDirect16_0_4^"+"	 is reg_InDirect16_0_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = reg_InDirect16_0_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
+XRREG_A_AS_DEST2: DST20_0_4					 is DST20_0_4 & as=0 & bow=0x0 {export DST20_0_4;}
 
 XSRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & as=0x0 & bow=0x1 { export SRC8_8_4;} # Word/Register Direct (Rn):
 XSRC_B_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:1 tmp;}
@@ -177,16 +145,8 @@ XSRC_B_AS: "#1" 						 is src16_8_4=0x3 & as=0x1 & bow=0x1  { export 1:1; }		# C
 XSRC_B_AS: "#2" 						 is src16_8_4=0x3 & as=0x2 & bow=0x1  { export 2:1; }		# Constant
 XSRC_B_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1; } 	# Constant
 
-XRSRC_B_AS: SRC8_8_4 			 		 is SRC8_8_4 & as=0x0 & bow=0x1 { export SRC8_8_4;} # Word/Register Direct (Rn):
-XRSRC_B_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect (@Rn):
-XRSRC_B_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {export *:1 src_InDirect16_8_4;} # Word/Register Indirect Autoincrement (@Rn+):
-XRSRC_B_AS: "#4" 						 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:1; }		# Constant
-XRSRC_B_AS: "#8" 						 is src16_8_4=0x2 & as=0x3 & bow=0x1  { export 8:1; }		# Constant
+XRSRC_B_AS: SRC8_8_4						 is SRC8_8_4 & as=0x0 & bow=0x1 { export SRC8_8_4;} # Word/Register Direct (Rn):
 XRSRC_B_AS: "#0" 						 is src16_8_4=0x3 & as=0x0 & bow=0x1  { export 0:1; }		# Constant
-XRSRC_B_AS: "#1" 						 is src16_8_4=0x3 & as=0x1 & bow=0x1  { export 1:1; }		# Constant
-XRSRC_B_AS: "#2" 						 is src16_8_4=0x3 & as=0x2 & bow=0x1  { export 2:1; }		# Constant
-XRSRC_B_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xff:1; } 	# Constant
-
 
 XSRC_W_AS: SRC16_8_4 			 	 is SRC16_8_4 & as=0x0 & bow=0x0 {export SRC16_8_4;} # Word/Register Direct (Rn):
 XSRC_W_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x0 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src; export *:2 tmp;}
@@ -202,15 +162,8 @@ XSRC_W_AS: "#1" 					 is src16_8_4=0x3 & as=0x1 & bow=0x0  { export 1:2; }		# Co
 XSRC_W_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x0  { export 2:2; }		# Constant
 XSRC_W_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2; } 	# Constant	
 
-XRSRC_W_AS: SRC16_8_4 			 	 is SRC16_8_4 & as=0x0 & bow=0x0 {export SRC16_8_4;} # Word/Register Direct (Rn):
-XRSRC_W_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x0  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:2 tmp;} # Word/Register Indirect (@Rn):
-XRSRC_W_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x0  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:2 tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-XRSRC_W_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x0  { export 4:2; }		# Constant
-XRSRC_W_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x0  { export 8:2; }		# Constant
+XRSRC_W_AS: SRC16_8_4					 is SRC16_8_4 & as=0x0 & bow=0x0 {export SRC16_8_4;} # Word/Register Direct (Rn):
 XRSRC_W_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x0  { export 0:2; }		# Constant
-XRSRC_W_AS: "#1" 					 is src16_8_4=0x3 & as=0x1 & bow=0x0  { export 1:2; }		# Constant
-XRSRC_W_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x0  { export 2:2; }		# Constant
-XRSRC_W_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x0  { export 0xffff:2; } 	# Constant	
 
 XSRC_A_AS: SRC20_8_4 			 		 is SRC20_8_4 & as=0x0 & bow=0x1 { export SRC20_8_4;} # Word/Register Direct (Rn):
 XSRC_A_AS: ImmS20Src^"("^src_Indexed16_8_4^")" is src_Indexed16_8_4 & as=0x1 & bow=0x1 ; ImmS20Src {tmp:$(REG_SIZE) = src_Indexed16_8_4 + ImmS20Src & ~1; export *:$(REG_SIZE) tmp;}
@@ -227,14 +180,7 @@ XSRC_A_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZE
 XSRC_A_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE); } 	# Constant	
 
 XRSRC_A_AS: SRC20_8_4 			 		 is SRC20_8_4 & as=0x0 & bow=0x1 { export SRC20_8_4;} # Word/Register Direct (Rn):
-XRSRC_A_AS: "@"^src_InDirect16_8_4 	 is src_InDirect16_8_4 & as=0x2 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect (@Rn):
-XRSRC_A_AS: "@"^src_InDirect16_8_4^"+" is src_InDirect16_8_4 & as=0x3 & bow=0x1  {local tmp:$(REG_SIZE) = src_InDirect16_8_4 & ~1; export *:$(REG_SIZE) tmp;} # Word/Register Indirect Autoincrement (@Rn+):
-XRSRC_A_AS: "#4" 					 is src16_8_4=0x2 & as=0x2 & bow=0x1  { export 4:$(REG_SIZE); }		# Constant
-XRSRC_A_AS: "#8" 					 is src16_8_4=0x2 & as=0x3 & bow=0x1  { export 8:$(REG_SIZE); }		# Constant
 XRSRC_A_AS: "#0" 					 is src16_8_4=0x3 & as=0x0 & bow=0x1  { export 0:$(REG_SIZE); }		# Constant
-XRSRC_A_AS: "#1" 					 is src16_8_4=0x3 & as=0x1 & bow=0x1  { export 1:$(REG_SIZE); }		# Constant
-XRSRC_A_AS: "#2" 					 is src16_8_4=0x3 & as=0x2 & bow=0x1  { export 2:$(REG_SIZE); }		# Constant
-XRSRC_A_AS: "#-1" 					 is	src16_8_4=0x3 & as=0x3 & bow=0x1  { export 0xffffffff:$(REG_SIZE); } 	# Constant	
 
 XDEST_B_AD: DST8_0_4 		  		 is DST8_0_4 & ad=0x0 & bow=0x1
      { export DST8_0_4; }        # Word/Register Direct (Rn):
@@ -2087,7 +2033,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:POPX.B	DST8_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & ctx_al=1 & XRSRC_B_AS & DST8_0_4 & reg_Direct16_0_4 {
+:POPX.B	DST8_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & ctx_al=1 & DST8_0_4 & reg_Direct16_0_4 {
 	<top>
 	DST8_0_4 = *:1 SP;
 	bzero(reg_Direct16_0_4,DST8_0_4);
@@ -2098,7 +2044,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:POPX.W	DST16_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=0 & ctx_al=1 & XRSRC_W_AS & DST16_0_4 & reg_Direct16_0_4 {
+:POPX.W	DST16_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=0 & ctx_al=1 & DST16_0_4 & reg_Direct16_0_4 {
 	<top>
 	DST16_0_4 = *:2 SP;
 	wzero(reg_Direct16_0_4,DST16_0_4);
@@ -2109,7 +2055,7 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:POPX.A	DST20_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & ctx_al=0 & XRSRC_A_AS & DST20_0_4 {
+:POPX.A	DST20_0_4							is ctx_haveext=4 & op16_12_4=0x4 & src16_8_4=0x1 & as=0x3 & bow=1 & ctx_al=0 & DST20_0_4 {
 	<top>
 	DST20_0_4 = *:4 SP;
 	SP = SP + 0x4;
@@ -3439,32 +3385,32 @@ define pcodeop bcd_add;
 	goto <top>;
 }
 
-:SXTX.W XRREG_W_AS_DEST 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x1 & as=0x0 & bow=0x0 & postRegIncrement & XRREG_W_AS_DEST {
+:SXTX.W DST20_0_4 		is ctx_haveext=4 & ctx_al=1 & op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x1 & as=0x0 & bow=0x0 & postRegIncrement & DST20_0_4 {
 	<top>
 	# Operation Flags...
-	$(OVERFLOW) = 0x0;						# V Flag
+	$(OVERFLOW) = 0x0;					# V Flag
 	# Operation...	
-	XRREG_W_AS_DEST = sext(XRREG_W_AS_DEST:1);
+	DST20_0_4 = sext(DST20_0_4:1) & 0xfffff;
 	# Result Flags...
-	$(SIGN) = (XRREG_W_AS_DEST s< 0x0);			# S Flag
-	$(ZERO) = (XRREG_W_AS_DEST == 0x0);			# Z Flag
-	$(CARRY) = (XRREG_W_AS_DEST != 0x0);			# C Flag
+	$(SIGN) = (DST20_0_4[19,1] == 1);			# S Flag
+	$(ZERO) = (DST20_0_4 == 0x0);				# Z Flag
+	$(CARRY) = (DST20_0_4 != 0x0);				# C Flag
 	build postRegIncrement;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;
 	goto <top>;
 }
 
-:SXTX.A XRREG_A_AS_DEST2		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x1 & as=0x0 & bow=0x0 & postRegIncrement & XRREG_A_AS_DEST2 {
+:SXTX.A DST20_0_4		is ctx_haveext=4 & ctx_al=0 & op16_12_4=0x1 & op16_8_4=0x1 & op16_7_1=0x1 & as=0x0 & bow=0x0 & postRegIncrement & DST20_0_4 {
 	<top>
 	# Operation Flags...
-	$(OVERFLOW) = 0x0;						# V Flag
-	# Operation...	
-	XRREG_A_AS_DEST2 = sext(XRREG_A_AS_DEST2:1) & 0xfffff;
+	$(OVERFLOW) = 0x0;					# V Flag
+	# Operation...
+	DST20_0_4 = sext(DST20_0_4:1) & 0xfffff;
 	# Result Flags...
-	$(SIGN) = XRREG_A_AS_DEST2[19, 1] == 1;
-	$(ZERO) = (XRREG_A_AS_DEST2 == 0x0);			# Z Flag
-	$(CARRY) = (XRREG_A_AS_DEST2 != 0x0);			# C Flag
+	$(SIGN) = DST20_0_4[19, 1] == 1;
+	$(ZERO) = (DST20_0_4 == 0x0);				# Z Flag
+	$(CARRY) = (DST20_0_4 != 0x0);				# C Flag
 	build postRegIncrement;
 	if (CNT == 0) goto inst_next;
 	CNT = CNT - 1;

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI_MSP430.pspec
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI_MSP430.pspec
@@ -8,9 +8,6 @@
   <programcounter register="PC"/>
 
   <context_data>
-    <context_set space="RAM" first="0x0000" last="0xFFFF">
-      <set name="ctx_isHi" val="1" description="1 instruction starts > 64K"/>
-    </context_set>
   </context_data>
   <volatile outputop="ioWrite" inputop="ioRead">
     <range space="RAM" first="0x18" last="0x3F"/>         <!-- Digital I/O -->

--- a/Ghidra/Processors/TI_MSP430/data/languages/TI_MSP430.pspec
+++ b/Ghidra/Processors/TI_MSP430/data/languages/TI_MSP430.pspec
@@ -8,6 +8,9 @@
   <programcounter register="PC"/>
 
   <context_data>
+    <context_set space="RAM" first="0x0000" last="0xFFFF">
+      <set name="ctx_al" val="1" description="A/L feild of the instruction"/>
+    </context_set>
   </context_data>
   <volatile outputop="ioWrite" inputop="ioRead">
     <range space="RAM" first="0x18" last="0x3F"/>         <!-- Digital I/O -->


### PR DESCRIPTION
As part of a research project testing the accuracy of the SLEIGH specifications compared to real hardware, we observed unexpected behavior in a number of MSP430 and MSP430X instructions. As the fixes for these instructions where difficult to fully separate from each other this has been submitted as one pull request with each commit fixing a single issue. Where not mentioned the commit does not affect de-compilation to the best of our knowledge. The hardware compared to was an MSP430FR5969 and the documentation used was [slau367p](https://www.ti.com/lit/ug/slau367p/slau367p.pdf). TI's Code Composer Studios (CCS) was also used as a source of truth. To assist in checking these each heading links to the relevant commit.

## [Fix ADDA/SUBA/CMPA with CG registers](https://github.com/Sleigh-InSPECtor/ghidra/commit/55c36263575c849a1aafc62676e82fc4964b1f50)
This commit adds support to the address instructions for using immediate from the constant generator and status register. The normal use of this is described in section [4.3.4](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=119). We have found that TI has added custom behavior to the normal addressing modes for the SR and CG to use these immediates. The behavior of these has been verified with hardware and the decompiler window of CCS.

## [Fix carry flag for SUBA](https://github.com/Sleigh-InSPECtor/ghidra/commit/e1fbbdf3f735f199d0e1ec2246d1398a3b802897)
The carry flag for subtraction in msp430 should be set if there is a not borrow. This is opposite to what the documentation says for the `SUBA` instructions [4.6.4.10](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=268), but was found to be what the hardware does. It is also the same as the current behavior in sleigh for the `SUB` instruction. Currently the `SUBA` instruction does the opposite of this.

## [Fix issue with index address when base register is in low memory](https://github.com/Sleigh-InSPECtor/ghidra/commit/5e8cf8cfc208b3578bc60c98284867c59c5e6da1)
When MSP430 instructions use the indexed addressing mode they should behave differently depending on if the base register is located in the upper or lower 64KB of memory. This is described in section [4.4.2](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=124). Currently when MSP430 instructions use the indexing mode with the base register in the lower 64KB of memory they do not mask the final address to the lower 64KB of memory. 

It looks like `ctx_isHi` was meant to handle this, but as the value in the base register isn't known during disassembly and varies during execution, this cant be used.

This does show up in de-compilation.
```C
// Before
*(undefined2 *)((ulong)(puVar1 + 9) & 0xffff) = uVar2;
// After
*(undefined2 *)((ulong)(puVar1 + 9) & ((ulong)(((ulong)(puVar1 + 2) & 0xf0000) != 0) * 0xf0000 | 0xffff)) = uVar2;
```

## [Fix upper register zeroing for single operand instructions](https://github.com/Sleigh-InSPECtor/ghidra/commit/3ffa96e2fe5f6119c0ffe23809c5e07b3c9b835b)
Single operand MSP430 word instructions should clear the upper 16-19 bits for MSP430X, this is described in [4.3.5](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=120). Double operand word instructions as well as single and double operand byte instructions current clear the upper bits, but single operand word instructions has been missed.

## [Use correct size for jump offset for CPUX mode](https://github.com/Sleigh-InSPECtor/ghidra/commit/b253af6d70c75d6dd456a0fb94260b7c5c5665f0)
For MSP430X, the MSP430 `JMP` instruction should have the immediate sign extended to 20 bits and then added to the 20 bit PC as described in [4.5.1.3](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=143). Currently it is fixed to the MSP430 width of 16 bits.

## [Fix handling of addressing modes that involve 20-bit immediates for 'X' suffix instructions](https://github.com/Sleigh-InSPECtor/ghidra/commit/af057e7d7e58ca5d853aa4e1571c113d57df0226)
MSP430X instructions which use the extended instruction word encode the upper 4 bits of the immediate in the source field of the non-register mode extension word. This is described in section [4.5.2.2](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=146). Currently these bits are ignored for the immediate, label, and indexed address modes for these instructions.

## [Add handling for the RRUX instruction](https://github.com/Sleigh-InSPECtor/ghidra/commit/b2a0990ed9366378abd5a8d735d1d90f2a187696)
The current note about the `RRUX` instruction is partially correct. CCS does replace `RRUX.W` and `RRUX.A` with `RRUM.W #1, ..` and `RRUM.A #1, ..` as it is a 1 byte instead of a 2 byte instruction. But it is incorrect for `RRUX.B` which it inserts a `RRUX.B` instructions for. `RRUX.W` and `RRUX.A` are also valid instructions as when you put them into the assembly as the following, CCS correctly dissembles is as `RRUX.W R15`
```asm
.short 0x1940
.short 0x100F
```

## [Reset overflow bit in RRCX](https://github.com/Sleigh-InSPECtor/ghidra/commit/311d268d0a8f6c295c97e544b38e5244604664a3)
The `RRCX` instruction should reset the overflow bit ([4.6.3.28](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=243)), currently it does not.

## [Even align SP and PC](https://github.com/Sleigh-InSPECtor/ghidra/commit/d873a35486d69ba232aab3fe4af0f8030cd27376)
The stack pointer and program counter should always have the least significant bit set to 0 ([4.3.1 - 4.3.2](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=116)). Currently there are some instructions which can write odd values to these registers. This fix could affect de-compilation of some of the MSP430X instructions which did not have masks already, as existing masks already show in de-compilation.

The `postIncrementStore` constructor is currently very repetitive and can be simplified. It also includes a redundant zero extend (`zeroExtend`) only for byte instructions.

## [Use signed immediate in symbolic mode](https://github.com/Sleigh-InSPECtor/ghidra/commit/a9f3dc3998289f94f86ecce67fa22f23cabfb6f8)
The symbolic addressing mode should add the signed immediate to the program counter ([4.4.3](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=130)). Currently it adds the unsigned immediate.

## [Word align word and address memory accesses](https://github.com/Sleigh-InSPECtor/ghidra/commit/355fedfce053d59075a13b5422f2193041db718e)
We have found that the hardware ignores the lower bit of word and address memory accesses to forcefully align them to 16 bits. While this is not mentioned in the documentation it has been mentioned as the correct behavior on TI's support forum [Accessing unaligned memory](https://e2e.ti.com/support/microcontrollers/msp-low-power-microcontrollers-group/msp430/f/msp-low-power-microcontroller-forum/237580/accessing-unaligned-memory).

## [Stop POPM from writing to SP and CG](https://github.com/Sleigh-InSPECtor/ghidra/commit/e19a66e7d1c8d35079f1502bab871964e9b4f479)
POPM currently writes values to the stack pointer and constant generator when restoring registers from the stack. From testing with hardware we have found that the value in memory which is meant to be restored to the stack pointer is ignored. This value is meant to be the current SP value which is likely why this is the case. It is also incorrect to write any value to the constant generator register as it does not exist as a register. 

## [ctx_al should default to 1](https://github.com/Sleigh-InSPECtor/ghidra/commit/989a7dec24feed4a75d0373edffe516a537fcde8)
The `ctx_al` context field represents the A/L bit of the extension word. This bit is set to 1 for byte and word instructions and 0 for address instructions. To allow `postRegIncrement` and other constructors shared between the MSP430 and MSP430X instructions to work this field should default to 1.

## [Replaced dest_0_4 with new DST20_0_4](https://github.com/Sleigh-InSPECtor/ghidra/commit/33c5a3a7b23308a3083253c43eaffddcdfcc3908)
This commit replaces most occurrences of the `dest_0_4` reg in the MSP430X.sinc file with a new constructor `DEST20_0_4`. This constructor sets the value of the PC to the start of the next instruction before exporting it. Currently the PC holds the address of the start of the current instruction which causes register accesses to read the wrong value.

## [Signed 20 bit values are not properly handled](https://github.com/Sleigh-InSPECtor/ghidra/commit/dc1288940dd69aab0a522c530f220b9043be9af3)
As sleigh only supports byte sized registers, 20 bit values are stored in a larger register, minimum 3 bytes. Due to this signed operations like `s<`, `s>>`, and `sext()` do not work as the 20th bit is never the sign bit.

## [Mask address register accesses to 20 bits](https://github.com/Sleigh-InSPECtor/ghidra/commit/c27a6b6327f1f8a985013172e0dba5898e369cc2)
MSP430X registers should hold at most 20 bits as that is the register width. Some instructions which read a value from memory or sign extend a smaller value to the full width allow writing larger values. These mask appear in de-compilation.

## [Added temporary for src in adda and suba macro](https://github.com/Sleigh-InSPECtor/ghidra/commit/ce9c7669667ed1a32d1d6774ce8d18fb4b34ea83)
When the source and destination registers are the same the source get overwritten when writing the destination. This then produces wrong values for the flags.

## [POP.W POP.B need to delay building the destination reg](https://github.com/Sleigh-InSPECtor/ghidra/commit/96f2254657c538d7b494e802c128cd1852724d2f)
We have found that the `POP` instruction first reads the value from the stack, increments the stack pointer, and then moves the value found to the current destination. This is different to the current behavior of the `POP` instruction which first builds the destination. This fixes cases such as `POP 0x0(SP)` as they now write to memory at the address of the SP after incrementing.

## [MOV, MOVX, MOVA, and BRA @rn+ do not correctly order opperations](https://github.com/Sleigh-InSPECtor/ghidra/commit/fa4d202a2449bf018baefbfe580b1a7d6b6f3930)
This is similar to the above fix as `POP` is an emulated instruction, therefore `POP 0x0(SP)` is actually `MOV @SP+,0x0(SP)`. `BRA` is also an emulated instruction making `BRA @rn+` really `MOVA @rn+, PC`. We have found that in general `MOV` instructions fetch the source, auto-increment, fetch the destination, and move what the source value was to the destination.

## [Fixed ordering of SP decrementing for CALLA](https://github.com/Sleigh-InSPECtor/ghidra/commit/2c8b50a8ecb0b0e05edbb210ed061d800309e159)
We have found that for `CALLA SP` instructions the initial value of the stack pointer is used as the jump destination. The current behavior of this instructions is to jump to the value of the stack pointer minus 4.

## [POPX fixes](https://github.com/Sleigh-InSPECtor/ghidra/commit/da450e86678d5d15626710b912a22671a6cf4246)
The `POPX` instructions currently does not jump when the PC is used as the destination register. `POPX` also had the same ordering issues fixed previously with the `POP` instructions.

## [Check correct sign bit for RRAM.W and RLAM.W](https://github.com/Sleigh-InSPECtor/ghidra/commit/6c01e6d459cc8cd99563f6a13314f1d1d2fe868a)
Currently the `RRAM.W` and `RLAM.W` instructions check the 20th bit for the sign value. This is incorrect as they are word instructions and clear the upper bits.

## [SXT sign extend through 20 bits](https://github.com/Sleigh-InSPECtor/ghidra/commit/260bf26657dc562f8be01a395befb8b90f4e92fb)
For MSP430X, the MSP430 `SXT` instruction should sign extend through the full register ([4.3.5](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=120)). Currently it only sign extends up to a word.

## [Add address support to postRegIncrement](https://github.com/Sleigh-InSPECtor/ghidra/commit/d65aaa448fc2e9ffe6fa1998a7d38364f88433d1)
Currently the `postRegIncrement` table doesn't handle 20 bit sizes, but is used in single operand address sized instructions. This causes instructions which access address sized memory with the indirect auto-increment addressing mode ([4.4](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=122)) to increment by 1 instead of 4. It also causes jumps from using the PC as the destination register to be masked to a byte.

## [Fix ordering for PUSHX instructions](https://github.com/Sleigh-InSPECtor/ghidra/commit/3aa6032e5a96c44f57287d8a80f66f25730d6092)
The correct ordering for a push instruction is to fetch the source value, decrement the SP, and write the value to the memory at that location. [Figure 4-8](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=117) shows he result after a `PUSH SP` instruction. Currently the `PUSHX` instruction does not do this and instead writes the value of the new SP to the memory the SP addresses.

## [RRCX.A uses wrong value for address mask](https://github.com/Sleigh-InSPECtor/ghidra/commit/03dc61bdb8e47a02f5ae165ec253c39de76cb81f)
In the `RRCX.A` instruction the register is shifted to the right one, and then the upper 19 bits should be masked for the main result. Currently the value `0x0xEFFFF` is used as the mask instead of `0x7FFFF`.

## [SXTX, RRAX, and RRCX overlaps for rpt](https://github.com/Sleigh-InSPECtor/ghidra/commit/15d33acc09eced6f67937c90651e8717dec65e7d)
Currently the `SXTX`, `RRAX`, and `RRCX` instructions overlap as the 7th bit is not checked in the disassembly. The `RRAX` and `RRCX` instructions use the extended single-operand format shown in [figure 4-31](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=150).

## [Address instructions use wrong value for pc with indexed mode](https://github.com/Sleigh-InSPECtor/ghidra/commit/5c711b46aa6aec4827cee4cedc671b553510f473)
We found that when using the program counter as the base register for the indexed accessing mode for address instructions, the address of the start of the immediate field should be used. As the address instructions take up 2 bytes this is the instruction start + 2.

## [Add postStorePC to rpt RLAX instructions](https://github.com/Sleigh-InSPECtor/ghidra/commit/35097176b1589941e1b25a017e49851d4994fa66)
The non-register repeat variant of the `RLAX` instructions should jump when changing the program counter, currently they do not.

## [rpt must use register addressing mode](https://github.com/Sleigh-InSPECtor/ghidra/commit/f27aded1ac61c078ceb4e3530f4fb2ceb65466d2)
The repeat instructions are only valid when using the register addressing mode. This is shown in [4.5.2](https://www.ti.com/lit/ug/slau367p/slau367p.pdf#page=146). Currently other addressing modes are allow and where possible Ghidra will prefer the repeat format over the regular instruction.

## [PUSHM SP and PC fixes](https://github.com/Sleigh-InSPECtor/ghidra/commit/deeb01b2ec35ce2c0f106dc2c865918ae2f360e0)
We found that the `PUSHM` instructions push the address of the next instruction when pushing the program counter, currently it is pushing the start address of the current instructions. The `PUSHM` instructions where also found to push the value of the stack pointer before decrementing instead of the value after as is currently done.

## [Use postStorePC for address instructions instead of duplicating](https://github.com/Sleigh-InSPECtor/ghidra/commit/130950186c1506551470b5da35e061084fc044aa)
By using the `postStorePC` constructor, special cases of the address instructions with the PC as the destination can be removed. This commit does not fix any behavioural issues.