### PR TITLE
Fix wrong namespaces when using XML imports

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/SymbolTableXmlMgr.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/xml/SymbolTableXmlMgr.java
@@ -197,7 +197,7 @@ class SymbolTableXmlMgr {
 			String addrStr = element.getAttribute("ADDRESS");
 			String namespace = element.getAttribute("NAMESPACE");
 			if (namespace != null && namespace.endsWith("::")) {
-				namespace = namespace.substring(namespace.length() - 2);
+				namespace = namespace.substring(0, namespace.length() - 2);
 			}
 			String primary = element.getAttribute("PRIMARY");
 			String sourceTypeString = element.getAttribute("SOURCE_TYPE");
@@ -233,13 +233,8 @@ class SymbolTableXmlMgr {
 				scope = localNamespace;
 			}
 			else if (namespace != null && namespace.length() != 0) {
-				if (program.getGlobalNamespace().equals(localNamespace)) {
-					scope = NamespaceUtils.createNamespaceHierarchy(namespace,
-						program.getGlobalNamespace(), program, sourceType);
-				}
-				else {
-					name = namespace + name;
-				}
+				scope = NamespaceUtils.createNamespaceHierarchy(namespace,
+					program.getGlobalNamespace(), program, sourceType);
 			}
 
 			Symbol s = symbolTable.getPrimarySymbol(addr);


### PR DESCRIPTION
When importing a Ghidra XML, the namespaces weren't getting applied properly due to a bug in the code that strips the final `::`, resulting in all the functions being put in the global namespace instead of their respective namespaces.