### PR TITLE
feat: cache vfunctions list

### DIFF
--- a/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RecoveredClassHelper.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/classrecovery/RecoveredClassHelper.java
@@ -137,6 +137,7 @@ public class RecoveredClassHelper {
 	protected final boolean createBookmarks;
 	protected final boolean useShortTemplates;
 	protected final boolean nameVfunctions;
+	public HashMap<Address, Set<Function>> allVfunctions = new HashMap<>();
 
 	public RecoveredClassHelper(Program program, ServiceProvider serviceProvider,
 			FlatProgramAPI api, boolean createBookmarks, boolean useShortTemplates,
@@ -478,20 +479,25 @@ public class RecoveredClassHelper {
 		return functionToLoadPcodeOps.get(function);
 	}
 
-	public Set<Function> getAllVfunctions(List<Address> vftableAddresses)
-			throws CancelledException {
-
-		Set<Function> allVfunctionsSet = new HashSet<Function>();
-
+	public Set<Function> getAllVfunctions(List<Address> vftableAddresses) throws CancelledException {
 		if (vftableAddresses.isEmpty()) {
-			return allVfunctionsSet;
+			return Collections.emptySet();
 		}
+
+		Set<Function> vfunctionSet = new HashSet<>();
 		for (Address vftableAddress : vftableAddresses) {
 			monitor.checkCancelled();
-			allVfunctionsSet.addAll(getVfunctions(vftableAddress));
+			if (!allVfunctions.containsKey(vftableAddress)) {
+				List<Function> funcList = getVfunctions(vftableAddress);
+				if (funcList == null) {
+					funcList = new ArrayList<>();
+				}
+				allVfunctions.put(vftableAddress, new HashSet<>(funcList));
+			}
+			vfunctionSet.addAll(allVfunctions.get(vftableAddress));
 		}
 
-		return allVfunctionsSet;
+		return vfunctionSet;
 	}
 
 	public Set<Function> getAllClassFunctionsWithVtableRef(List<Address> vftables)


### PR DESCRIPTION
The vfunctions are collected and compared in two loops against all the recoveredClasses, this takes time if the binary have many classes. This commit makes the vfunctions list and the vftable addresses to be stored in a map, making the vfunctions collection and createFunction happen only once.

From what I've understood from the RTTI scripts, all the vftables are collected at the start (createRecoveredClasses, before processConstructorAndDestructors). When the method getAllVfunctions is called the vftables were already all in the vftableToClassMap, and none is added anymore. Also, the getReferencedFunction will be called only once now, but from what I've seen from that function this would not be a problem, since the function creation needs to happen only once.

I hope I'm not missing something. This change reduces the analysis time from 11h10m to 0h55m.