### PR TITLE
Fix null exception in PropagateExternalParametersScript.java

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/PropagateExternalParametersScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/PropagateExternalParametersScript.java
@@ -134,8 +134,8 @@ public class PropagateExternalParametersScript extends GhidraScript {
 		for (Reference extRef : extRefs) {
 
 			Address refAddr = extRef.getFromAddress();
-
 			String refMnemonic = listing.getCodeUnitAt(refAddr).getMnemonicString();
+
 			Function calledFromFunc = listing.getFunctionContaining(refAddr);
 			if (calledFromFunc == null) {
 				continue;
@@ -147,8 +147,14 @@ public class PropagateExternalParametersScript extends GhidraScript {
 				while (tempIter.hasNext()) {
 					Reference thunkRef = tempIter.next();
 					Address thunkRefAddr = thunkRef.getFromAddress();
-					String thunkRefMnemonic =
-						listing.getCodeUnitAt(thunkRefAddr).getMnemonicString();
+                                        
+					CodeUnit cu = listing.getCodeUnitAt(thunkRefAddr);
+					if(cu == null) {
+						// println("Referenced CodeUnit is null: " + thunkRefAddr);
+						continue;
+					}
+					String thunkRefMnemonic = cu.getMnemonicString();
+
 					Function thunkRefFunc = listing.getFunctionContaining(thunkRefAddr);
 					if ((thunkRefMnemonic.equals(new String("CALL")) && (thunkRefFunc != null))) {
 						CodeUnitIterator cuIt =
@@ -297,7 +303,7 @@ public class PropagateExternalParametersScript extends GhidraScript {
 					setEOLComment(cu.getMinAddress(), params[index].getDataType().getDisplayName() +
 						" " + params[index].getName() + " for " + extFuncName);
 					// add the following to the EOL comment to see the value of the optype
-					//	+" " + toHexString(currentProgram.getListing().getInstructionAt(cu.getMinAddress()).getOperandType(0), false, true)
+					//	+ " | " + ghidra.program.model.lang.OperandType.toString(currentProgram.getListing().getInstructionAt(cu.getMinAddress()).getOperandType(0))
 					addResult(params[index].getName(), params[index].getDataType(),
 						cu.getMinAddress(), extFuncName);
 					index++;


### PR DESCRIPTION
Added a null check to account for when an address refers to a to a pointer.  The screenshots highlight two cases where this occurs in [msinfo32.exe](https://msdl.microsoft.com/download/symbols/msinfo32.exe/EA82EE4860000/msinfo32.exe) on Windows due to MFC/CFG addresses.

![image](https://github.com/user-attachments/assets/eddd3c1b-d6fa-472a-90bc-ea4a3be6ab38)

![image](https://github.com/user-attachments/assets/bf9e647a-d364-417b-9c22-f4a851f4d8a2)
