### PR TITLE
Corrected use after free vulnerability in Sleigh decompiler backend

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.cc
@@ -181,8 +181,9 @@ Translate *SleighArchitecture::buildTranslator(DocumentStorage &store)
     iter->second.reset(loader, context);
     return &iter->second;
   }
-  translators[languageindex] = Sleigh(loader,context);
-  return &translators[languageindex];
+  pair<map<int4,Sleigh>::iterator,bool> res;
+  res = translators.emplace(piecewise_construct,forward_as_tuple(languageindex),forward_as_tuple(loader,context));
+  return &(*res.first).second;
 }
 
 PcodeInjectLibrary *SleighArchitecture::buildPcodeInjectLibrary(void)

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.cc
@@ -33,7 +33,7 @@ ElementId ELEM_DESCRIPTION = ElementId("description",233);
 ElementId ELEM_LANGUAGE = ElementId("language",234);
 ElementId ELEM_LANGUAGE_DEFINITIONS = ElementId("language_definitions",235);
 
-map<int4,Sleigh *> SleighArchitecture::translators;
+map<int4,Sleigh> SleighArchitecture::translators;
 vector<LanguageDescription> SleighArchitecture::description;
 
 FileManage SleighArchitecture::specpaths; // Global specfile manager
@@ -174,17 +174,15 @@ bool SleighArchitecture::isTranslateReused(void)
 Translate *SleighArchitecture::buildTranslator(DocumentStorage &store)
 
 {				// Build a sleigh translator
-  map<int4,Sleigh *>::const_iterator iter;
-  Sleigh *sleigh;
+  map<int4,Sleigh>::iterator iter;
+
   iter = translators.find(languageindex);
   if (iter != translators.end()) {
-    sleigh = (*iter).second;
-    sleigh->reset(loader,context);
-    return sleigh;
+    iter->second.reset(loader, context);
+    return &iter->second;
   }
-  sleigh = new Sleigh(loader,context);
-  translators[languageindex] = sleigh;
-  return sleigh;
+  translators[languageindex] = Sleigh(loader,context);
+  return &translators[languageindex];
 }
 
 PcodeInjectLibrary *SleighArchitecture::buildPcodeInjectLibrary(void)
@@ -627,10 +625,6 @@ const vector<LanguageDescription> &SleighArchitecture::getDescriptions(void)
 void SleighArchitecture::shutdown(void)
 
 {
-  if (translators.empty()) return;	// Already cleared
-  for(map<int4,Sleigh *>::const_iterator iter=translators.begin();iter!=translators.end();++iter)
-    delete (*iter).second;
-  translators.clear();
   // description.clear();  // static vector is destroyed by the normal exit handler
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh_arch.hh
@@ -106,7 +106,7 @@ public:
 /// Generally a \e language \e id (i.e. x86:LE:64:default) is provided, then this
 /// object is able to automatically load in configuration and construct the Translate object.
 class SleighArchitecture : public Architecture {
-  static map<int4,Sleigh *> translators;		///< Map from language index to instantiated translators
+  static map<int4,Sleigh> translators;		///< Map from language index to instantiated translators
   static vector<LanguageDescription> description;	///< List of languages we know about
   int4 languageindex;					///< Index (within LanguageDescription array) of the active language
   string filename;					///< Name of active load-image file


### PR DESCRIPTION
This resolves a use-after-free vulnerability in the Sleigh decompiler backend, associated with this report: https://github.com/NationalSecurityAgency/ghidra/security/advisories/GHSA-4g43-2f29-xvp4.

It's not necessarily the best style, but per the contribution guidelines it is the most conservative change I can think of to mitigate the issue.  With this change, the only destruction of the contents of `SleighArchitecture::translators` will be the automatic one.