### PR TITLE
Adds address space id to BSim  #6896

### DIFF
--- a/Ghidra/Features/BSim/ghidra_scripts/QueryWithFiltersScript.java
+++ b/Ghidra/Features/BSim/ghidra_scripts/QueryWithFiltersScript.java
@@ -30,6 +30,7 @@ import ghidra.features.bsim.query.protocol.BSimFilter;
 import ghidra.features.bsim.query.protocol.PreFilter;
 import ghidra.program.database.symbol.FunctionSymbol;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.symbol.SourceType;
 import ghidra.util.exception.CancelledException;
@@ -272,9 +273,11 @@ public class QueryWithFiltersScript extends GhidraScript {
 	 * @return true if the symbol is NOT an analysis source type
 	 */
 	public static boolean isNotAnalysisSourceType(Program program, FunctionDescription funcDesc) {
-		Address address =
-			program.getAddressFactory().getDefaultAddressSpace().getAddress(funcDesc.getAddress());
-
+		AddressSpace space = program.getAddressFactory().getAddressSpace(funcDesc.getSpaceID());
+		if (space == null) {
+			space = program.getAddressFactory().getDefaultAddressSpace();
+		}
+		Address address = space.getAddress(funcDesc.getAddress());
 		Function function = program.getFunctionManager().getFunctionAt(address);
 		if (function == null || !function.getName().equals(funcDesc.getFunctionName())) {
 			return false;

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/gui/search/results/BSimMatchResultsModel.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/gui/search/results/BSimMatchResultsModel.java
@@ -34,6 +34,7 @@ import ghidra.features.bsim.query.description.FunctionDescription;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.framework.plugintool.ServiceProvider;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.symbol.Namespace;
@@ -195,8 +196,11 @@ public class BSimMatchResultsModel extends AddressBasedTableModel<BSimMatchResul
 	 * @return the entry point address of the function (if it exists), or just the address within the default space
 	 */
 	public static Address recoverAddress(FunctionDescription desc, Program prog) {
-		Address address =
-			prog.getAddressFactory().getDefaultAddressSpace().getAddress(desc.getAddress());
+		AddressSpace space = prog.getAddressFactory().getAddressSpace(desc.getSpaceID());
+		if (space == null) {
+			space = prog.getAddressFactory().getDefaultAddressSpace();
+		}
+		Address address = space.getAddress(desc.getAddress());
 		// Verify that we got the right function
 		Function func = prog.getFunctionManager().getFunctionAt(address);
 		if (func != null) {

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/gui/search/results/BSimSearchResultsProvider.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/gui/search/results/BSimSearchResultsProvider.java
@@ -53,6 +53,7 @@ import ghidra.framework.plugintool.ComponentProviderAdapter;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.database.symbol.FunctionSymbol;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.listing.*;
 import ghidra.util.HelpLocation;
 import ghidra.util.Msg;
@@ -526,9 +527,12 @@ public class BSimSearchResultsProvider extends ComponentProviderAdapter {
 					resultRow.getSimilarFunctionName() + ".");
 		}
 		FunctionDescription matchFunctionDescription = resultRow.getMatchFunctionDescription();
-		long matchOffset = matchFunctionDescription.getAddress();
-		Address matchEntryPoint =
-			matchProgram.getAddressFactory().getDefaultAddressSpace().getAddress(matchOffset);
+
+		AddressSpace space = program.getAddressFactory().getAddressSpace(matchFunctionDescription.getSpaceID());
+		if (space == null) {
+			space = program.getAddressFactory().getDefaultAddressSpace();
+		}
+		Address matchEntryPoint = space.getAddress(matchFunctionDescription.getAddress());
 		FunctionManager matchFunctionManager = matchProgram.getFunctionManager();
 		Function matchFunction = matchFunctionManager.getFunctionAt(matchEntryPoint);
 		if (matchFunction == null) {

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/gui/search/results/apply/AbstractBSimApplyTask.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/gui/search/results/apply/AbstractBSimApplyTask.java
@@ -158,7 +158,11 @@ public abstract class AbstractBSimApplyTask extends ProgramTask {
 
 		FunctionDescription matchDescription = result.getMatchFunctionDescription();
 		long addressOffset = matchDescription.getAddress();
-		AddressSpace space = remoteProgram.getAddressFactory().getDefaultAddressSpace();
+		int spaceid = matchDescription.getSpaceID();
+		AddressSpace space = remoteProgram.getAddressFactory().getAddressSpace(spaceid);
+		if (space == null) {
+			space = remoteProgram.getAddressFactory().getDefaultAddressSpace();
+		}
 		Address address = space.getAddress(addressOffset);
 		FunctionManager remoteFunctionManager = remoteProgram.getFunctionManager();
 		Function matchFunction = remoteFunctionManager.getFunctionAt(address);

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/client/ExecutableComparison.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/client/ExecutableComparison.java
@@ -247,7 +247,7 @@ public class ExecutableComparison {
 		ExecutableRecord exeRecord = query.manage.newExecutableRecord(
 			"bbbbaaaabbbbaaaabbbbaaaabbbbaaaa", null, null, null, null, null, null, null);
 		FunctionDescription function =
-			query.manage.newFunctionDescription("tmp", 0x1000L, exeRecord);
+			query.manage.newFunctionDescription("tmp", 344, 0x1000L, exeRecord);
 		SignatureRecord signature = query.manage.newSignature(vector, 1);
 		query.manage.attachSignature(function, signature);
 

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/description/CallgraphEntry.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/description/CallgraphEntry.java
@@ -40,6 +40,7 @@ public class CallgraphEntry implements Comparable<CallgraphEntry> {
 		StringBuilder buf = new StringBuilder();
 		buf.append("<call");
 		SpecXmlUtils.xmlEscapeAttribute(buf, "dest", dest.getFunctionName());
+		SpecXmlUtils.encodeSignedIntegerAttribute(buf, "spaceid", dest.getSpaceID());
 		if (dest.getAddress() != -1) {
 			SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "addr", dest.getAddress());
 		}
@@ -78,6 +79,7 @@ public class CallgraphEntry implements Comparable<CallgraphEntry> {
 		XmlElement el = parser.start("call");
 		String destnm = el.getAttribute("dest");
 		long address = -1;			// Default if no "addr" attribute present
+		int spaceid = SpecXmlUtils.decodeInt(el.getAttribute("addr"));
 		String addrString = el.getAttribute("addr");
 		if (addrString != null) {
 			address = SpecXmlUtils.decodeLong(addrString);
@@ -107,18 +109,18 @@ public class CallgraphEntry implements Comparable<CallgraphEntry> {
 			} while(parser.peek().isStart());
 			if (md5 == null) {
 				ExecutableRecord destexe = man.newExecutableLibrary(dest_enm,dest_arch,null);
-				FunctionDescription destfunc = man.newFunctionDescription(destnm, address, destexe);
+				FunctionDescription destfunc = man.newFunctionDescription(destnm, spaceid, address, destexe);
 				man.makeCallgraphLink(src, destfunc, val);
 			}
 			else {
 				ExecutableRecord destexe = man.newExecutableRecord(md5, dest_enm, dest_cnm, dest_arch, null, srcexe.getRepository(), srcexe.getPath(), null);
-				FunctionDescription destfunc = man.newFunctionDescription(destnm, address, destexe);
+				FunctionDescription destfunc = man.newFunctionDescription(destnm, spaceid, address, destexe);
 				man.makeCallgraphLink(src, destfunc, val);
 			}
 		}
 		else {	// Assume dest is in same executable as src
 			FunctionDescription destfunc =
-				man.newFunctionDescription(destnm, address, src.getExecutableRecord());
+				man.newFunctionDescription(destnm, spaceid, address, src.getExecutableRecord());
 			man.makeCallgraphLink(src, destfunc, val);
 		}
 		parser.end();

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/description/DescriptionManager.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/description/DescriptionManager.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import generic.lsh.vector.LSHVector;
 import generic.lsh.vector.LSHVectorFactory;
 import ghidra.features.bsim.query.LSHException;
+import ghidra.program.model.address.Address;
 import ghidra.util.xml.SpecXmlUtils;
 import ghidra.xml.XmlElement;
 import ghidra.xml.XmlPullParser;
@@ -196,11 +197,12 @@ public class DescriptionManager {
 	 * @param fnm is the name of the new function
 	 * @param address is the address (offset) of the function
 	 * @param erec is the executable containing the function
+	 * @param spaceid the id of the address space containing the function
 	 * @return the new FunctionDescription
 	 */
-	public FunctionDescription newFunctionDescription(String fnm, long address,
+	public FunctionDescription newFunctionDescription(String fnm, int spaceid, long address,
 			ExecutableRecord erec) {
-		FunctionDescription newfunc = new FunctionDescription(erec, fnm, address);
+		FunctionDescription newfunc = new FunctionDescription(erec, fnm, spaceid, address);
 		if (!funcrec.add(newfunc)) {
 			newfunc = funcrec.floor(newfunc);
 		}
@@ -311,7 +313,7 @@ public class DescriptionManager {
 			throws LSHException {
 		ExecutableRecord erec = transferExecutable(fdesc.getExecutableRecord());
 		FunctionDescription res =
-			newFunctionDescription(fdesc.getFunctionName(), fdesc.getAddress(), erec);
+			newFunctionDescription(fdesc.getFunctionName(),fdesc.getSpaceID(), fdesc.getAddress(), erec);
 		res.setVectorId(fdesc.getVectorId());
 		res.setFlags(fdesc.getFlags());
 		SignatureRecord srec = fdesc.getSignatureRecord();
@@ -436,9 +438,9 @@ public class DescriptionManager {
 	 * @return the FunctionDescription
 	 * @throws LSHException if a matching function does not exist
 	 */
-	public FunctionDescription findFunction(String fname, long address, ExecutableRecord exe)
+	public FunctionDescription findFunction(String fname, int spaceid, long address, ExecutableRecord exe)
 			throws LSHException {
-		FunctionDescription fdesc = new FunctionDescription(exe, fname, address);
+		FunctionDescription fdesc = new FunctionDescription(exe, fname, spaceid, address);
 
 		FunctionDescription res = funcrec.floor(fdesc);
 		if (res == null || (!res.equals(fdesc))) {
@@ -455,7 +457,7 @@ public class DescriptionManager {
 	 * @return a FunctionDescription or null 
 	 */
 	public FunctionDescription findFunctionByName(String fname, ExecutableRecord exe) {
-		FunctionDescription fdesc = new FunctionDescription(exe, fname, 0);
+		FunctionDescription fdesc = new FunctionDescription(exe, fname, 0, 0);
 		FunctionDescription res = funcrec.ceiling(fdesc);
 		if (res == null || !fname.equals(res.getFunctionName()) ||
 			!res.getExecutableRecord().equals(exe)) {
@@ -472,9 +474,9 @@ public class DescriptionManager {
 	 * @param exe - the executable (possibly) containing the function
 	 * @return a FunctionDescription or null
 	 */
-	public FunctionDescription containsDescription(String fname, long address,
+	public FunctionDescription containsDescription(String fname, Address address,
 			ExecutableRecord exe) {
-		FunctionDescription fdesc = new FunctionDescription(exe, fname, address);
+		FunctionDescription fdesc = new FunctionDescription(exe, fname, address.getAddressSpace().getSpaceID(), address.getOffset());
 		FunctionDescription res = funcrec.floor(fdesc);
 		if (res == null || (!res.equals(fdesc))) {
 			return null;
@@ -493,7 +495,7 @@ public class DescriptionManager {
 		if (startexe == null) {
 			return null;
 		}
-		FunctionDescription startfunc = new FunctionDescription(startexe, "", 0);
+		FunctionDescription startfunc = new FunctionDescription(startexe, "", 0, 0);
 		startfunc = funcrec.ceiling(startfunc);
 		if (startfunc == null) { // No functions in exe or after
 			startfunc = funcrec.last();
@@ -501,7 +503,7 @@ public class DescriptionManager {
 		}
 		FunctionDescription endfunc = null;
 		if (endexe != null) {
-			endfunc = new FunctionDescription(endexe, "", 0);
+			endfunc = new FunctionDescription(endexe, "", 0, 0);
 			endfunc = funcrec.ceiling(endfunc);
 		}
 		if (endfunc == null) {

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/ClusterNote.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/ClusterNote.java
@@ -50,6 +50,7 @@ public class ClusterNote {
 		buf.append("<note");
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "id", func.getExecutableRecord().getXrefIndex());
 		SpecXmlUtils.xmlEscapeAttribute(buf, "name", func.getFunctionName());
+		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "spaceid", func.getSpaceID());
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "addr", func.getAddress());
 		buf.append(">\n");
 		buf.append(" <setsize>").append(SpecXmlUtils.encodeSignedInteger(setsize)).append("</setsize>\n");
@@ -63,8 +64,9 @@ public class ClusterNote {
 		XmlElement el = parser.start("note");
 		int id = SpecXmlUtils.decodeInt(el.getAttribute("id"));
 		ExecutableRecord exe = xrefMap.get(id);
+		int spaceid = SpecXmlUtils.decodeInt(el.getAttribute("spaceid"));
 		long address = SpecXmlUtils.decodeLong(el.getAttribute("addr"));
-		func = manage.findFunction(el.getAttribute("name"), address, exe);
+		func = manage.findFunction(el.getAttribute("name"), spaceid, address, exe);
 		parser.start("setsize");
 		setsize = SpecXmlUtils.decodeInt(parser.end().getText());
 		parser.start("sim");

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/FunctionEntry.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/FunctionEntry.java
@@ -29,6 +29,7 @@ import ghidra.xml.XmlPullParser;
  */
 public class FunctionEntry {
 	public String funcName;			// Name of the function within the executable
+	public int spaceid;			// id of the Address Space of the function
 	public long address;			// Address of the function
 
 	private FunctionEntry() {
@@ -37,12 +38,15 @@ public class FunctionEntry {
 	
 	public FunctionEntry(FunctionDescription desc) {
 		funcName = desc.getFunctionName();
+		spaceid = desc.getSpaceID();
 		address = desc.getAddress();
 	}
 
 	public void saveXml(Writer writer) throws IOException {
 		writer.append("<fentry name=\"");
 		SpecXmlUtils.xmlEscapeWriter(writer, funcName);
+		writer.append("\" spaceid=\"");
+		writer.append(Long.toString(spaceid));
 		writer.append("\" addr=\"0x");
 		writer.append(Long.toHexString(address));
 		writer.append("\"/>\n");
@@ -52,6 +56,7 @@ public class FunctionEntry {
 		FunctionEntry functionEntry = new FunctionEntry();
 		XmlElement startEl = parser.start("fentry");
 		functionEntry.funcName = startEl.getAttribute("name");
+		functionEntry.spaceid = SpecXmlUtils.decodeInt(startEl.getAttribute("spaceid"));
 		functionEntry.address = SpecXmlUtils.decodeLong(startEl.getAttribute("addr"));
 		parser.end(startEl);
 		return functionEntry;

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/ResponseChildren.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/ResponseChildren.java
@@ -69,7 +69,7 @@ public class ResponseChildren extends QueryResponseRecord {
 
 		ExecutableRecord exe = manage.findExecutable(md5string);
 		for (FunctionEntry entry : qchild.functionKeys) {
-			correspond.add(manage.findFunction(entry.funcName, entry.address, exe));
+			correspond.add(manage.findFunction(entry.funcName, entry.spaceid, entry.address, exe));
 		}
 		parser.end();
 	}

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/ResponseUpdate.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/ResponseUpdate.java
@@ -68,6 +68,8 @@ public class ResponseUpdate extends QueryResponseRecord {
 				SpecXmlUtils.encodeUnsignedInteger(func.getExecutableRecord().getXrefIndex()));
 			fwrite.append("\" name=\"");
 			SpecXmlUtils.xmlEscapeWriter(fwrite, func.getFunctionName());
+			fwrite.append("\" spaceid=\"");
+			fwrite.append(SpecXmlUtils.encodeSignedInteger(func.getSpaceID()));
 			fwrite.append("\" addr=\"");
 			fwrite.append(SpecXmlUtils.encodeUnsignedInteger(func.getAddress()));
 			fwrite.append("\">\n");
@@ -91,10 +93,11 @@ public class ResponseUpdate extends QueryResponseRecord {
 			}
 			else if (el.getName().equals("badfunc")) {
 				int id = SpecXmlUtils.decodeInt(el.getAttribute("id"));
+				int spaceid = SpecXmlUtils.decodeInt(el.getAttribute("spaceid"));
 				long address = SpecXmlUtils.decodeLong(el.getAttribute("addr"));
 				ExecutableRecord exe = exeMap.get(id);
 				FunctionDescription func =
-					manage.findFunction(el.getAttribute("name"), address, exe);
+					manage.findFunction(el.getAttribute("name"), spaceid, address, exe);
 				badfunc.add(func);
 			}
 			parser.end();

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/SimilarityNote.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/SimilarityNote.java
@@ -63,6 +63,7 @@ public class SimilarityNote implements Comparable<SimilarityNote> {
 		buf.append("<note");
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "id", func.getExecutableRecord().getXrefIndex());
 		SpecXmlUtils.xmlEscapeAttribute(buf, "name", func.getFunctionName());
+		SpecXmlUtils.encodeSignedIntegerAttribute(buf, "spaceid", func.getSpaceID());
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "addr", func.getAddress());
 		buf.append(">\n");
 		buf.append(" <sim>").append(Double.toString(sim)).append("</sim>\n");
@@ -75,8 +76,9 @@ public class SimilarityNote implements Comparable<SimilarityNote> {
 		XmlElement el = parser.start("note");
 		int id = SpecXmlUtils.decodeInt(el.getAttribute("id"));
 		ExecutableRecord exe = exeMap.get(id);
+		int spaceid = SpecXmlUtils.decodeInt(el.getAttribute("spaceid"));
 		long address = SpecXmlUtils.decodeLong(el.getAttribute("addr"));
-		func = manage.findFunction(el.getAttribute("name"), address, exe);
+		func = manage.findFunction(el.getAttribute("name"), spaceid, address, exe);
 		parser.start("sim");
 		sim = Double.parseDouble(parser.end().getText());
 		parser.start("sig");

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/SimilarityResult.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/SimilarityResult.java
@@ -78,7 +78,7 @@ public class SimilarityResult implements Iterable<SimilarityNote> {
 		DescriptionManager rmanage, boolean transsig) throws LSHException {
 		ExecutableRecord erec = qmanage.findExecutable(op2.basefunc.getExecutableRecord().getMd5());
 		basefunc =
-			qmanage.findFunction(op2.basefunc.getFunctionName(), op2.basefunc.getAddress(), erec);
+			qmanage.findFunction(op2.basefunc.getFunctionName(), op2.basefunc.getSpaceID(), op2.basefunc.getAddress(), erec);
 		totalcount = op2.totalcount;
 		notes = new ArrayList<SimilarityNote>();
 		for (SimilarityNote item : op2.notes) {
@@ -94,6 +94,7 @@ public class SimilarityResult implements Iterable<SimilarityNote> {
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "id",
 			basefunc.getExecutableRecord().getXrefIndex());
 		SpecXmlUtils.xmlEscapeAttribute(buf, "name", basefunc.getFunctionName());
+		SpecXmlUtils.encodeSignedIntegerAttribute(buf, "spaceid", basefunc.getSpaceID());
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "addr", basefunc.getAddress());
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "total", totalcount);
 		buf.append(">\n");
@@ -113,8 +114,9 @@ public class SimilarityResult implements Iterable<SimilarityNote> {
 		XmlElement el = parser.start("simres");
 		int id = SpecXmlUtils.decodeInt(el.getAttribute("id"));
 		ExecutableRecord exe = qMap.get(id);
+		int spaceid = SpecXmlUtils.decodeInt(el.getAttribute("spaceid"));
 		long address = SpecXmlUtils.decodeLong(el.getAttribute("addr"));
-		basefunc = qmanage.findFunction(el.getAttribute("name"), address, exe);
+		basefunc = qmanage.findFunction(el.getAttribute("name"), spaceid, address, exe);
 		totalcount = SpecXmlUtils.decodeInt(el.getAttribute("total"));
 		while (parser.peek().isStart()) {
 			SimilarityNote newnote = new SimilarityNote();

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/SimilarityVectorResult.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/protocol/SimilarityVectorResult.java
@@ -81,6 +81,7 @@ public class SimilarityVectorResult {
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "id",
 			basefunc.getExecutableRecord().getXrefIndex());
 		SpecXmlUtils.xmlEscapeAttribute(buf, "name", basefunc.getFunctionName());
+		SpecXmlUtils.encodeSignedIntegerAttribute(buf, "spaceid", basefunc.getSpaceID());
 		SpecXmlUtils.encodeUnsignedIntegerAttribute(buf, "addr", basefunc.getAddress());
 		buf.append(">\n");
 		write.append(buf.toString());
@@ -97,8 +98,9 @@ public class SimilarityVectorResult {
 		XmlElement el = parser.start("simvecres");
 		int id = SpecXmlUtils.decodeInt(el.getAttribute("id"));
 		ExecutableRecord exe = exeMap.get(id);
+		int spaceid = SpecXmlUtils.decodeInt(el.getAttribute("spaceid"));
 		long address = SpecXmlUtils.decodeLong(el.getAttribute("addr"));
-		basefunc = qmanage.findFunction(el.getAttribute("name"), address, exe);
+		basefunc = qmanage.findFunction(el.getAttribute("name"), spaceid, address, exe);
 		totalcount = 0;
 		while (parser.peek().isStart()) {
 			VectorResult newnote = new VectorResult();

--- a/Ghidra/Features/BSim/src/screen/java/help/screenshot/BSimSearchPluginScreenShots.java
+++ b/Ghidra/Features/BSim/src/screen/java/help/screenshot/BSimSearchPluginScreenShots.java
@@ -263,13 +263,13 @@ public class BSimSearchPluginScreenShots extends GhidraScreenShotGenerator {
 		// create some canned data
 		ResponseNearest response = new ResponseNearest(null);
 		response.result.add(new TestSimilarityResult("queryFunction", "exec1", "matchFunction1",
-			0x01001100, 0.9d, 15.0d));
+			0, 0x01001100, 0.9d, 15.0d));
 		response.result.add(new TestSimilarityResult("queryFunction", "exec2", "matchFunction2",
-			0x01001100, 0.9d, 15.0d));
+			0, 0x01001100, 0.9d, 15.0d));
 		response.result.add(new TestSimilarityResult("queryFunction", "exec1", "matchFunction3",
-			0x01001100, 0.9d, 15.0d));
+			0, 0x01001100, 0.9d, 15.0d));
 		response.result.add(new TestSimilarityResult("queryFunction", "exec1", "matchFunction4",
-			0x01001100, 0.9d, 15.0d));
+			0, 0x01001100, 0.9d, 15.0d));
 
 		database.setQueryResponse(response); // set a valid response to be returned on query
 		database.setCanInitialize(true); // initialize may be called--this is OK

--- a/Ghidra/Features/BSim/src/test.slow/java/ghidra/features/bsim/gui/BSimSearchPluginTest.java
+++ b/Ghidra/Features/BSim/src/test.slow/java/ghidra/features/bsim/gui/BSimSearchPluginTest.java
@@ -132,13 +132,13 @@ public class BSimSearchPluginTest extends AbstractBSimPluginTest {
 		// create some canned data
 		ResponseNearest response = new ResponseNearest(null);
 		response.result.add(new TestSimilarityResult("queryFunction", "exec1", "matchFunction1",
-			01001100, 0.9d, 15.0d));
+			0, 01001100, 0.9d, 15.0d));
 		response.result.add(new TestSimilarityResult("queryFunction", "exec2", "matchFunction2",
-			01001100, 0.9d, 15.0d));
+			0, 01001100, 0.9d, 15.0d));
 		response.result.add(new TestSimilarityResult("queryFunction", "exec1", "matchFunction3",
-			01001100, 0.9d, 15.0d));
+			0, 01001100, 0.9d, 15.0d));
 		response.result.add(new TestSimilarityResult("queryFunction", "exec1", "matchFunction4",
-			01001100, 0.9d, 15.0d));
+			0, 01001100, 0.9d, 15.0d));
 
 		database.setQueryResponse(response); // set a valid response to be returned on query
 		database.setCanInitialize(true); // initialize may be called--this is OK

--- a/Ghidra/Features/BSim/src/test.slow/java/ghidra/query/test/BSimServerTest.java
+++ b/Ghidra/Features/BSim/src/test.slow/java/ghidra/query/test/BSimServerTest.java
@@ -75,6 +75,7 @@ public class BSimServerTest {
 		return parser;
 	}
 
+
 	@BeforeClass
 	public static void setUp() throws Exception {
 		util = new BSimServerTestUtil();
@@ -196,8 +197,8 @@ public class BSimServerTest {
 			assertTrue(readRec.hasCategory("Test Category", "shared"));
 			// Comparing function "history_filename"
 			FunctionDescription bashFunc =
-				originalBash.findFunction("FUN_001cc840", 0x1cc840, bashRec);
-			FunctionDescription readFunc = manager.findFunction("FUN_00134a70", 0x134a70, readRec);
+				originalBash.findFunction("FUN_001cc840", 433, 0x1cc840, bashRec);
+			FunctionDescription readFunc = manager.findFunction("FUN_00134a70", 433, 0x134a70, readRec);
 			VectorCompare compareData = new VectorCompare();
 			double sig = bashFunc.getSignatureRecord()
 					.getLSHVector()
@@ -217,7 +218,7 @@ public class BSimServerTest {
 		while (iter.hasNext()) {
 			FunctionDescription func1 = iter.next();
 			FunctionDescription func2 =
-				manager2.findFunction(func1.getFunctionName(), func1.getAddress(), eRec2);
+				manager2.findFunction(func1.getFunctionName(), func1.getSpaceID(), func1.getAddress(), eRec2);
 			assertEquals(func1.getFlags(), func2.getFlags());
 			if (func1.getSignatureRecord() == null) {
 				assertTrue(func2.getSignatureRecord() == null);
@@ -553,7 +554,7 @@ public class BSimServerTest {
 		List<CategoryRecord> catrec = new ArrayList<>();
 		catrec.add(new CategoryRecord("Test Category", "SHARED!"));
 		update.manage.setExeCategories(exerec, catrec);
-		update.manage.newFunctionDescription("my_remove_history", 0x131c00, exerec);
+		update.manage.newFunctionDescription("my_remove_history", 433, 0x131c00, exerec);
 		ResponseUpdate respUpdate = update.execute(client);
 		testForError(respUpdate);
 		assertEquals(respUpdate.exeupdate, 1);
@@ -595,7 +596,7 @@ public class BSimServerTest {
 		catrec = new ArrayList<>();
 		catrec.add(new CategoryRecord("Test Category", "shared"));
 		update.manage.setExeCategories(exerec, catrec);
-		update.manage.newFunctionDescription("remove_history", 0x131c00, exerec);
+		update.manage.newFunctionDescription("remove_history", 433, 0x131c00, exerec);
 		testForError(update.execute(client));
 		if (util.isElasticSearch) {
 			Thread.sleep(2000);		// Give chance for refresh timer to expire

--- a/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/client/BSimFunctionDatabaseTest.java
+++ b/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/client/BSimFunctionDatabaseTest.java
@@ -73,11 +73,11 @@ public class BSimFunctionDatabaseTest extends AbstractGhidraHeadlessIntegrationT
 			// Create a list of function descriptions; we'll loop over all of these, 
 			// trying to query each one in turn.
 			List<FunctionDescription> descs = new ArrayList<>();
-			FunctionDescription desc1 = new FunctionDescription(erec, "d1", 0x10100);
-			FunctionDescription desc2 = new FunctionDescription(erec, "d2", 0x10200);
-			FunctionDescription desc3 = new FunctionDescription(erec, "d3", 0x10300);
-			FunctionDescription desc4 = new FunctionDescription(erec, "d4", 0x10400);
-			FunctionDescription desc5 = new FunctionDescription(erec, "d5", 0x10500);
+			FunctionDescription desc1 = new FunctionDescription(erec, "d1", 0, 0x10100);
+			FunctionDescription desc2 = new FunctionDescription(erec, "d2", 0, 0x10200);
+			FunctionDescription desc3 = new FunctionDescription(erec, "d3", 0, 0x10300);
+			FunctionDescription desc4 = new FunctionDescription(erec, "d4", 0, 0x10400);
+			FunctionDescription desc5 = new FunctionDescription(erec, "d5", 0, 0x10500);
 
 			// Now create 2 different LSH vectors. Make them slightly different so 
 			// we should treat them as distinct vectors. (Note that we already have tests

--- a/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/facade/TestNearestVectorResult.java
+++ b/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/facade/TestNearestVectorResult.java
@@ -41,7 +41,7 @@ public class TestNearestVectorResult extends SimilarityVectorResult {
 			new ExecutableRecord(hash, executableName, "gcc", "x86", new Date(), null, null, null);
 
 		FunctionDescription description =
-			new FunctionDescription(executableRecord, queryFunctionName, 0x10000);
+			new FunctionDescription(executableRecord, queryFunctionName, 0, 0x10000);
 		description.setSignatureRecord(new SignatureRecord(new TestLSHVector()));
 		return description;
 	}

--- a/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/facade/TestSimilarityResult.java
+++ b/Ghidra/Features/BSim/src/test/java/ghidra/features/bsim/query/facade/TestSimilarityResult.java
@@ -28,20 +28,20 @@ public class TestSimilarityResult extends SimilarityResult {
 //	protected static Random random = new Random();
 
 	public TestSimilarityResult(String queryFunctionName, String executableName,
-			String matchFunction, long address, double significance, double confidence) {
-		super(createFunctionDescription(queryFunctionName, executableName, address));
-		addNote(createFunctionDescription(matchFunction, executableName, address), significance,
+			String matchFunction, int spaceid, long address, double significance, double confidence) {
+		super(createFunctionDescription(queryFunctionName, executableName, spaceid, address));
+		addNote(createFunctionDescription(matchFunction, executableName, spaceid, address), significance,
 			confidence);
 	}
 
 	protected static FunctionDescription createFunctionDescription(String queryFunctionName,
-			String executableName, long address) {
+			String executableName, int spaceid, long address) {
 		String hash = getMd5(executableName);
 		ExecutableRecord executableRecord =
 			new ExecutableRecord(hash, executableName, "gcc", "x86", new Date(), null, null, null);
 
 		FunctionDescription description =
-			new FunctionDescription(executableRecord, queryFunctionName, address);
+			new FunctionDescription(executableRecord, queryFunctionName, spaceid, address);
 		return description;
 	}
 


### PR DESCRIPTION
See #6896 for explanation.

### Backwards Compatibility
I want to note that this solution creates an issue of backwards compatibility with existing BSim servers. This is because I added a new column to the `desctable` to store the address space id with the functions offset. Querying a database that has not been created by the updated version of the client would cause errors as that column would be missing. I'm unsure of the best step forward to resolve this concern, but I would be interested in speaking about potential options like using the `DatabaseInformation` object to check for compatibility.