### PR TITLE
Enable TRACE logging level for ghidra.util.classfinder, ghidra.util.extensions and the console target

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/debug/DomainFolderChangesDisplayPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/debug/DomainFolderChangesDisplayPlugin.java
@@ -60,7 +60,11 @@ public class DomainFolderChangesDisplayPlugin extends Plugin
 	@Override
 	protected void dispose() {
 		FrontEndService frontEnd = tool.getService(FrontEndService.class);
-		frontEnd.addProjectListener(this);
+
+		// FrontEndService might have been disposed already during teardown (FrontEndPlugin)
+		if (frontEnd != null) {
+			frontEnd.removeProjectListener(this);
+		}
 
 		Project activeProject = tool.getProjectManager().getActiveProject();
 		if (activeProject != null) {

--- a/Ghidra/Framework/Generic/src/main/resources/generic.log4jdev.xml
+++ b/Ghidra/Framework/Generic/src/main/resources/generic.log4jdev.xml
@@ -69,11 +69,11 @@
 		<logger name="ghidra.app.plugin.core.analysis" level="DEBUG" />
 		<logger name="ghidra.app.plugin.prototype" level="INFO" />	
 		<logger name="ghidra.app.script" level="INFO" />
-		<logger name="ghidra.app.util.importer" level="DEBUG" /> <!-- AutoImporter shows excessive path info -->
+		<logger name="ghidra.app.util.importer" level="TRACE" /> <!-- AutoImporter shows excessive path info -->
 		<logger name="ghidra.app.util.opinion" level="DEBUG" />
 		<logger name="ghidra.trace" level="DEBUG" />
-		<logger name="ghidra.util.classfinder" level="DEBUG" />		
-		<logger name="ghidra.util.extensions" level="DEBUG" />
+		<logger name="ghidra.util.classfinder" level="TRACE" />
+		<logger name="ghidra.util.extensions" level="TRACE" />
 		<logger name="ghidra.util.task" level="DEBUG" />	
 		<logger name="ghidra.sleigh.grammar" level="DEBUG" />		
 		<logger name="functioncalls" level="DEBUG" />
@@ -81,7 +81,7 @@
 		<logger name="org.jungrapht.visualization.DefaultVisualizationServer" level="DEBUG" /> 
 
 		<Root level="ALL">
-			<AppenderRef ref="console" level="DEBUG"/> 
+			<AppenderRef ref="console" level="TRACE"/>
 			<AppenderRef ref="detail" level="DEBUG"/> 
 			<AppenderRef ref="script" level="DEBUG"/> 
 			<AppenderRef ref="logPanel" level="INFO"/> 


### PR DESCRIPTION
This might alleviate situations like those described in #6937 . It does not provide a significant amount of noise to the console output, as the TRACE level is limited to the classfinder, extensions and importer classes.