### PR TITLE
Fix PTRSUB matching logic to no longer cause an infinite loop

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
@@ -1112,13 +1112,13 @@ bool TypePointer::isPtrsubMatching(int8 off,int8 extra,int8 multiplier) const
     if (off != 0)
       return false;
     multiplier = AddrSpace::addressToByteInt(multiplier,wordsize);
-    if (multiplier >= ptrto->getAlignSize())
+    if (multiplier > ptrto->getAlignSize())
       return false;
   }
   else if (meta == TYPE_STRUCT) {
     int4 typesize = ptrto->getSize();
     multiplier = AddrSpace::addressToByteInt(multiplier,wordsize);
-    if (multiplier >= ptrto->getAlignSize())
+    if (multiplier > ptrto->getAlignSize())
       return false;
     int8 newoff = AddrSpace::addressToByteInt(off,wordsize);
     extra = AddrSpace::addressToByteInt(extra, wordsize);


### PR DESCRIPTION
Resolves a regression caused by 34adcff8308d2fce92424dcf817e5e3152dbce8c.

The decompiler would get stuck forever while trying to decompile the following program:
(Debug XML also attached inside)
[test_propbool.zip](https://github.com/user-attachments/files/17174799/test_propbool.zip)

It would keep doing `RuleStructOffset0`, then undo that change with `RulePtrsubUndo`, then `RuleStructOffset0` again etc.
With this fix, this no longer happens.
I'm not entirely sure what the idea of the line `if (multiplier >= ptrto->getAlignSize())` is, but in any case, changing `>=` to `>` fixes the issue.
