### PR TITLE
GhidraSleighEditor docs stated wrong directory for `build_README.txt`

### DIFF
--- a/GhidraBuild/EclipsePlugins/GhidraSleighEditor/ghidra.xtext.sleigh/GhidraSleighEditor_README.html
+++ b/GhidraBuild/EclipsePlugins/GhidraSleighEditor/ghidra.xtext.sleigh/GhidraSleighEditor_README.html
@@ -83,7 +83,7 @@ plugins are installed.  From Eclipse:</p>
 <ol>
   <p>To build the Sleigh Editor, follow the instructions in ghidra/DevGuide.md to setup eclipse
   for development.  Then follow the directions in
-  <i>ghidra/GhidraBuild/EclipsePlugins/GhidraSleighEditor/ghidra.xtext.sleigh.feature/build_README.txt</i>.</p>
+  <i>ghidra/GhidraBuild/EclipsePlugins/GhidraSleighEditor/ghidra.xtext.sleigh/build_README.txt</i>.</p>
 </ol>
 
 <h2><a name="Uninstall"></a>Uninstalling</h2>

--- a/GhidraDocs/languages/html/sleigh_definitions.html
+++ b/GhidraDocs/languages/html/sleigh_definitions.html
@@ -234,7 +234,7 @@ Many processors define registers that either consist of a single bit
 or otherwise don't use an integral number of bytes. A recurring
 example in many processors is the status register which is further
 subdivided into the overflow and result flags for the arithmetic
-instructions. These flags are typically have labels like ZF for the
+instructions. These flags typically have labels like ZF for the
 zero flag or CF for the carry flag and can be considered logical
 registers contained within the status register. SLEIGH allows
 registers to be defined like this using

--- a/GhidraDocs/languages/html/sleigh_symbols.html
+++ b/GhidraDocs/languages/html/sleigh_symbols.html
@@ -194,10 +194,10 @@ We list all of the symbols that are predefined by SLEIGH.
 <p>
 The most important of these to be aware of
 are <span class="emphasis"><em>inst_start</em></span>
-and <span class="emphasis"><em>inst_next</em></span>. These are family symbols which map
-in the context of particular instruction to the integer offset of
-either the address of the instruction or the address of the next
-instruction respectively. These are used in any relative branching
+and <span class="emphasis"><em>inst_next</em></span>. These are family
+symbols that map to the integer offset of either the instruction's
+address or the next instruction's address, depending on the context
+of a particular instruction. These are used in any relative branching
 situation. The <span class="emphasis"><em>inst_next2</em></span> is intended for conditional
 skip instruction situations.  The remaining symbols are rarely
 used. The <span class="emphasis"><em>const</em></span> and <span class="emphasis"><em>unique</em></span>


### PR DESCRIPTION
As confirmed [in this discussion](https://github.com/NationalSecurityAgency/ghidra/discussions/6961#discussioncomment-10774377), the `build_README.txt` file is not located in the `ghidra.xtext.sleigh.feature` directory but in the `ghidra.xtext.sleigh` directory.

This corrects the docs to give the correct directory for the build README.