### PR TITLE
Correct bounds checking in ArraySequence::formByteArray

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.cc
@@ -112,7 +112,7 @@ int4 ArraySequence::formByteArray(int4 sz,int4 slot,uint8 rootOff,bool bigEndian
   int4 elSize = charType->getSize();
   for(int4 i=0;i<moveOps.size();++i) {
     int4 bytePos = moveOps[i].offset - rootOff;
-    if (bytePos + elSize > sz) continue;
+    if (bytePos < 0 || bytePos + elSize > sz) continue;
     uint8 val = moveOps[i].op->getIn(slot)->getOffset();
     used[bytePos] = (val == 0) ? 2 : 1;		// Mark byte as used, a 2 indicates a null terminator
     if (bigEndian) {


### PR DESCRIPTION
This fixes an out-of-bounds write that could happen if an `ArraySequence` is detected that has negative offsets, such as in this example:
```c
char *demo() {
    char str[80];
    char *strPtr = &str[79];

    for (int i = 0; i < 80; i++) {
        strPtr[0] = '\0';
        strPtr[-1] = '\0';
        strPtr[-2] = '\0';
        strPtr[-3] = '\0';
        strPtr[-4] = '\0';
        strPtr[-5] = '\0';
        strPtr[-6] = '\0';
        strPtr[-7] = '\0';
        strPtr -= 8;
    }

    return strPtr;
}
```
[heap_strings_bounds.zip](https://github.com/user-attachments/files/17231367/heap_strings_bounds.zip)


This fix at least keeps the decompiler from crashing - I'm not sure if there needs to be more logic to e.g. prevent negative offsets from being in `moveOps` in the first place, but even with some experimenting nothing broke after I applied this fix.