### PR TITLE
FunctionID: Add headless mode support to RepackFid.java

### DIFF
--- a/Ghidra/Features/FunctionID/ghidra_scripts/RepackFid.java
+++ b/Ghidra/Features/FunctionID/ghidra_scripts/RepackFid.java
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Repack FID database file to eliminate unused blocks and possibly make indices more efficient
+// Repack FID database file to eliminate unused blocks and possibly make indices more efficient.
+// This script can be executed in both GUI and headless modes.
 //@category FunctionID
 import java.io.File;
 import java.io.IOException;
@@ -55,11 +56,22 @@ public class RepackFid extends GhidraScript {
 
 	@Override
 	protected void run() throws Exception {
-		File file = askFile("Select FID database file to repack","OK");
+		File file;
+		File saveFile;
+		// headless mode: `askFile()` cannot be used to specify the output file in headless mode
+		// because the file does not exist yet and `IllegalArgumentException` will be raised
+		if (getScriptArgs().length == 2) {
+			file = new File(getScriptArgs()[0]);
+			saveFile = new File(getScriptArgs()[1]);
+		}
+		// GUI mode
+		else {
+			file = askFile("Select FID database file to repack","OK");
+			saveFile = askFile("Select name for copy","OK");
+		}
 		PackedDatabase pdb;
 		pdb = PackedDatabase.getPackedDatabase(file, false, TaskMonitor.DUMMY);
 		DBHandle handle = pdb.open(TaskMonitor.DUMMY);
-		File saveFile = askFile("Select name for copy","OK");
 		PackedDBHandle newHandle = new PackedDBHandle(pdb.getContentType());
 
 		Table[] tables = handle.getTables();


### PR DESCRIPTION
## Overview

Previously `RepackFid.java` could only be run in the GUI as it raised the following error in headless mode:

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/ghidra/my-projects fidb-project -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript RepackFid.java in.fidb out2.fidb -noanalysis
...
INFO  HEADLESS: execution starts (HeadlessAnalyzer)  
INFO  Opening existing project: /home/gemesa/git-repos/ghidra/my-projects/fidb-project (HeadlessAnalyzer)  
INFO  Opening project: /home/gemesa/git-repos/ghidra/my-projects/fidb-project (HeadlessProject)  
INFO  SCRIPT: /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts/RepackFid.java (HeadlessAnalyzer)  
ERROR REPORT SCRIPT ERROR:  (HeadlessAnalyzer) java.lang.IllegalArgumentException: Invalid file: out2.fidb
	at ghidra.app.script.GhidraScript.parseFile(GhidraScript.java:1879)
	at ghidra.app.script.GhidraScript.loadAskValue(GhidraScript.java:1922)
	at ghidra.app.script.GhidraScript.loadAskValue(GhidraScript.java:1898)
	at ghidra.app.script.GhidraScript.askFile(GhidraScript.java:2048)
	at RepackFid.run(RepackFid.java:61)
...
```
The issue was that the second `askFile()` call asks for a file that does not yet exist (will be created by the function at the end) causing it to raise an `IllegalArgumentException` [as expected](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Base/src/main/java/ghidra/app/script/GhidraScript.java#L2041).
Now it works in both GUI and headless modes. I think this is a valuable feature because creating and repacking `.fidb` databases can now be better automated.

## Testing it in the cmd line

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/ghidra/my-projects fidb-project -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript RepackFid.java in.fidb out2.fidb -noanalysis
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
INFO  Using log config file: jar:file:/home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Framework/Generic/lib/Generic.jar!/generic.log4j.xml (LoggingInitialization)  
INFO  Using log file: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/application.log (LoggingInitialization)  
INFO  Loading user preferences: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/preferences (Preferences)  
INFO  Searching for classes... (ClassSearcher)  
INFO  Class search complete (962 ms) (ClassSearcher)  
INFO  Initializing SSL Context (SSLContextInitializer)  
INFO  Initializing Random Number Generator... (SecureRandomFactory)  
INFO  Random Number Generator initialization complete: NativePRNGNonBlocking (SecureRandomFactory)  
INFO  Trust manager disabled, cacerts have not been set (ApplicationTrustManagerFactory)  
WARN  Neither the -import parameter nor the -process parameter was specified; therefore, the specified prescripts and/or postscripts will be executed without any type of program context. (HeadlessAnalyzer)  
INFO  Headless startup complete (1848 ms) (AnalyzeHeadless)  
INFO  Class searcher loaded 57 extension points (18 false positives) (ClassSearcher)  
INFO  HEADLESS Script Paths:
    /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts
...
    /home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Features/WildcardAssembler/ghidra_scripts (HeadlessAnalyzer)  
INFO  HEADLESS: execution starts (HeadlessAnalyzer)  
INFO  Opening existing project: /home/gemesa/git-repos/ghidra/my-projects/fidb-project (HeadlessAnalyzer)  
INFO  Opening project: /home/gemesa/git-repos/ghidra/my-projects/fidb-project (HeadlessProject)  
INFO  SCRIPT: /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts/RepackFid.java (HeadlessAnalyzer)  
INFO  Packed database cache: /var/tmp/gemesa-ghidra/packed-db-cache (PackedDatabaseCache)
$ file in.fidb out2.fidb 
in.fidb:   Java serialization data, version 5
out2.fidb: Java serialization data, version 5
```

## Testing it in the GUI

![image](https://github.com/user-attachments/assets/c8cdc901-7d1c-495e-911b-3bb445239c1b)

![image](https://github.com/user-attachments/assets/34d6f4ab-229f-447f-8ade-ddeca987dad2)

![image](https://github.com/user-attachments/assets/32ddf81e-99ab-4fe9-b6fc-a7fb2eff5c38)

```
$ file in.fidb out.fidb 
in.fidb:  Java serialization data, version 5
out.fidb: Java serialization data, version 5
```