### PR TITLE
FunctionID: Add scripts for creating and attaching FID databases 

### DIFF
--- a/Ghidra/Features/FunctionID/ghidra_scripts/AttachFidDatabase.java
+++ b/Ghidra/Features/FunctionID/ghidra_scripts/AttachFidDatabase.java
@@ -1,0 +1,35 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Attach an existing FID database.
+// The functionality is similar to "Tools -> Function ID -> Attach existing FidDb..."
+// but this script can be executed in both GUI and headless modes.
+// The attached database can later be populated,
+// for example by `CreateMultipleLibraries.java` when running in headless mode or
+// by "Tools -> Function ID -> Populate FidDb from programs..." when running in GUI mode.
+//@category FunctionID
+import ghidra.app.script.GhidraScript;
+import ghidra.feature.fid.db.FidFileManager;
+import java.io.File;
+
+public class AttachFidDatabase extends GhidraScript {
+
+	@Override
+	protected void run() throws Exception {
+		File dbFile = askFile("Attach existing FidDb", "Attach");
+
+		FidFileManager.getInstance().addUserFidFile(dbFile);
+	}
+}

--- a/Ghidra/Features/FunctionID/ghidra_scripts/CreateEmptyFidDatabase.java
+++ b/Ghidra/Features/FunctionID/ghidra_scripts/CreateEmptyFidDatabase.java
@@ -1,0 +1,36 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Create and add (attach) an empty FID database.
+// The functionality is similar to "Tools -> Function ID -> Create new empty FidDb..."
+// but this script can be executed in both GUI and headless modes.
+// The created database can later be populated,
+// for example by `CreateMultipleLibraries.java` when running in headless mode or
+// by "Tools -> Function ID -> Populate FidDb from programs..." when running in GUI mode.
+//@category FunctionID
+import ghidra.app.script.GhidraScript;
+import ghidra.feature.fid.db.FidFileManager;
+import java.io.File;
+
+public class CreateEmptyFidDatabase extends GhidraScript {
+
+	@Override
+	protected void run() throws Exception {
+		File dbFile = askFile("Create new FidDb file", "Create");
+
+		FidFileManager.getInstance().createNewFidDatabase(dbFile);
+		FidFileManager.getInstance().addUserFidFile(dbFile);
+	}
+}


### PR DESCRIPTION
## Overview

I have been working a lot lately with FID databases through the GUI as not all FID scripts work in headless mode. Currently there is no way to create and/or attach a `.fidb` file in headless mode which can then be populated by other scripts like `CreateMultipleLibraries.java` (or `Tools -> Function ID -> Populate FidDb from programs...` in the GUI). A new `.fidb` can only be created by navigating to `Tools -> Function ID -> Create new empty FidDb...` or attached by `Tools -> Function ID -> Attach existing FidDb...` but `CreateEmptyFidDatabase.java` and `AttachFidDatabase.java` resolve these issues. The code has been inspired by [`createFidDb()`](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/plugin/FidPlugin.java#L201) and [`attachFidDb()`](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/plugin/FidPlugin.java#L228). With these new scripts, `.fidb` files can be created, populated, repacked and later reattached if necessary, entirely in headless mode.

Note: if you approve this PR, I will update the [DevGuide](https://github.com/NationalSecurityAgency/ghidra/blob/master/DevGuide.md#building-fid-databases) (in a separate PR) to include instructions for headless mode  as well.

## Simple headless mode workflow

Create some test binaries:

```
$ ls -R rustlib-small 
rustlib-small:
rustc-1-81.0

rustlib-small/rustc-1-81.0:
testlib

rustlib-small/rustc-1-81.0/testlib:
1.0.0

rustlib-small/rustc-1-81.0/testlib/1.0.0:
x64-debug-build

rustlib-small/rustc-1-81.0/testlib/1.0.0/x64-debug-build:
45c91108d938afe8-absvdi2.o  45c91108d938afe8-absvsi2.o  45c91108d938afe8-absvti2.o
```

Create a project, import the binaries and analyze them using the proper FID scripts (`FunctionIDHeadlessPrescript.java` and `FunctionIDHeadlessPostscript.java`):

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-rust -import /home/gemesa/git-repos/tmp/rust-lib/rustlib-small/rustc-1-81.0 -recursive -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript FunctionIDHeadlessPrescript.java -postScript FunctionIDHeadlessPostscript.java -overwrite
```

Create and add an empty FID database (`CreateEmptyFidDatabase.java`), populate it (`CreateMultipleLibraries.java`) then list its content (`ListFunctions.java`):

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-rust -propertiesPath /home/gemesa/git-repos/my-projects -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript CreateEmptyFidDatabase.java rust.fidb -postScript CreateMultipleLibraries.java -postScript ListFunctions.java
$ cat rust.txt
/rustc-1-81.0/testlib/1.0.0/x64-debug-build/45c91108d938afe8-absvsi2.o __absvsi2
/rustc-1-81.0/testlib/1.0.0/x64-debug-build/45c91108d938afe8-absvdi2.o __absvdi2
/rustc-1-81.0/testlib/1.0.0/x64-debug-build/45c91108d938afe8-absvti2.o __absvti2
```

Note: I use the following property files:

```
$ cat /home/gemesa/git-repos/my-projects/CreateMultipleLibraries.properties 
Duplicate Results File OK = /home/gemesa/git-repos/my-projects/duplicates.txt
Do Duplication Detection Do you want to detect duplicates = true
Choose destination FidDB Please choose the destination FidDB for population = test-script.fidb
Select root folder containing all libraries (at a depth of 3): = /rustc-1-81.0
Common symbols file (optional): OK = /home/gemesa/git-repos/my-projects/common_symbols.txt
Enter LanguageID To Process Language ID: = x86:LE:64:default
$ cat /home/gemesa/git-repos/my-projects/ListFunctions.properties 
List Functions Choose FID database = rust.fidb
Output file Choose output file: = rust.txt
```

Repack the final FID database using `RepackFid.java`:

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-rust -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript RepackFid.java rust.fidb rust-repacked.fidb -noanalysis
$ file rust.fidb rust-repacked.fidb 
rust.fidb:          Java serialization data, version 5
rust-repacked.fidb: Java serialization data, version 5
```

The FID database can later be reattached by `AttachFidDatabase.java` (to dump and examine its content for example) if necessary:

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-rust -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript AttachFidDatabase.java rust.fidb -preScript ListDomainFiles.java rust.fidb rust-domain.txt
...
INFO  SCRIPT: /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts/ListDomainFiles.java (HeadlessAnalyzer)  
INFO  ListDomainFiles.java> /rustc-1-81.0/testlib/1.0.0/x64-debug-build/45c91108d938afe8-absvdi2.o (GhidraScript)  
INFO  ListDomainFiles.java> /rustc-1-81.0/testlib/1.0.0/x64-debug-build/45c91108d938afe8-absvsi2.o (GhidraScript)  
INFO  ListDomainFiles.java> /rustc-1-81.0/testlib/1.0.0/x64-debug-build/45c91108d938afe8-absvti2.o (GhidraScript) 
```

## Testing the scripts in the GUI

The scripts can also be run in the GUI though it is not their primary purpose.

### Create and attach the empty FID database:

![image](https://github.com/user-attachments/assets/dc92cd41-319c-45e5-b8f6-1881ebbd2074)

Select and populate it:

![image](https://github.com/user-attachments/assets/886cb94d-9ccf-4314-972f-5d83cbe485e5)

### Attach a FID database:

![image](https://github.com/user-attachments/assets/a73f2ee2-7a5a-4135-9daf-0e1703bd62ea)

Select and populate it:

![image](https://github.com/user-attachments/assets/69a50701-5514-4cd3-83d4-c180a488edae)

