### PR TITLE
FunctionID: Add description and category tag to ListDomainFiles.java

### DIFF
--- a/Ghidra/Features/FunctionID/ghidra_scripts/ListDomainFiles.java
+++ b/Ghidra/Features/FunctionID/ghidra_scripts/ListDomainFiles.java
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Lets user choose a specific FID database and output file, then dumps all domain paths.
+//@category FunctionID
 import java.io.File;
 import java.io.FileWriter;
 import java.util.*;


### PR DESCRIPTION
## Overview

There is a script called `ListDomainFiles.java` in the FunctionID script folder but it lacks a category tag and description. This means it is not registered and available in the script manager. I use it fairly often and I think others might find it useful as well so I added the missing description and category.

## Testing it in the GUI

![image](https://github.com/user-attachments/assets/21e64b96-bb98-4a88-ab65-603fd317dba4)

![image](https://github.com/user-attachments/assets/02c88c5d-fc7d-4efe-a73c-edc13bddf196)

![image](https://github.com/user-attachments/assets/1b755bf5-8ded-482c-84a6-6ae87ddc3565)

```
$ cat test3-domains.txt 
/rust
```