### PR TITLE
Update VSCodeProjectScript.java to pre-populate formatter settings

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/VSCodeProjectScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/VSCodeProjectScript.java
@@ -114,6 +114,8 @@ public class VSCodeProjectScript extends GhidraScript {
 		json.addProperty("java.import.gradle.enabled", false);
 		json.addProperty("java.import.gradle.wrapper.enabled", false);
 		json.addProperty("java.import.gradle.version", gradleVersion);
+		json.addProperty("java.format.settings.url",
+			new File(installDir, "support/eclipse/GhidraEclipseFormatter.xml").getAbsolutePath());
 
 		JsonArray sourcePathArray = new JsonArray();
 		json.add("java.project.sourcePaths", sourcePathArray);


### PR DESCRIPTION
Pre-populate VSCodeProject settings with Ghidra formatter preferences. Tell VSCode to use the Java formatter rules shipped with Ghidra. 

While it's not strictly necessary for every plugin developed for Ghidra to use this style guide, we might as well default to it rather than whatever VSCode defaults to.