### PR TITLE
Base: Allow non-existent file/dir in parse methods in headless mode

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/script/GhidraScript.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/script/GhidraScript.java
@@ -1871,11 +1871,12 @@ public abstract class GhidraScript extends FlatProgramAPI {
 	 *
 	 * @param s The string to parse.
 	 * @return The file that was parsed from the string.
-	 * @throws IllegalArgumentException if the parsed value is not a valid file.
+	 * @throws IllegalArgumentException if running in GUI mode and the parsed value is not a valid file.
 	 */
 	public File parseFile(String s) {
+		boolean isHeadless = isRunningHeadless();
 		File f = new File(s);
-		if (!f.isFile()) {
+		if (!f.isFile() && !isHeadless) {
 			throw new IllegalArgumentException("Invalid file: " + f);
 		}
 		return f;
@@ -2038,7 +2039,7 @@ public abstract class GhidraScript extends FlatProgramAPI {
 	 * 			or when using .properties file)
 	 * @return the selected file or null if no tool was available
 	 * @throws CancelledException if the user hit the 'cancel' button in GUI mode
-	 * @throws IllegalArgumentException if in headless mode, there was a missing or invalid file
+	 * @throws IllegalArgumentException if in headless mode, there was a missing file
 	 * 			name specified in the .properties file
 	 */
 	public File askFile(final String title, final String approveButtonText)
@@ -2074,11 +2075,12 @@ public abstract class GhidraScript extends FlatProgramAPI {
 	 *
 	 * @param val The string to parse.
 	 * @return The directory that was parsed from the string.
-	 * @throws IllegalArgumentException if the parsed value is not a valid directory.
+	 * @throws IllegalArgumentException if running in GUI mode and the parsed value is not a valid directory.
 	 */
 	public File parseDirectory(String val) {
+		boolean isHeadless = isRunningHeadless();
 		File dir = new File(val);
-		if (!dir.isDirectory()) {
+		if (!dir.isDirectory() && !isHeadless) {
 			throw new IllegalArgumentException("Invalid directory: " + dir);
 		}
 		return dir;
@@ -2115,7 +2117,7 @@ public abstract class GhidraScript extends FlatProgramAPI {
 	 * 			when using .properties file)
 	 * @return the selected directory or null if no tool was available
 	 * @throws CancelledException if the user hit the 'cancel' button in GUI mode
-	 * @throws IllegalArgumentException if in headless mode, there was a missing or invalid
+	 * @throws IllegalArgumentException if in headless mode, there was a missing
 	 * 				directory name specified in the .properties file
 	 */
 	public File askDirectory(final String title, final String approveButtonText)


### PR DESCRIPTION
Fixes #7025 without changing GUI behavior.

## Testing the modifications

Run `RepackFid.java` in headless mode with cmd line args (works as expected):

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-project -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript RepackFid.java ~/in.fidb out.fidb -noanalysis
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
INFO  Using log config file: jar:file:/home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Framework/Generic/lib/Generic.jar!/generic.log4j.xml (LoggingInitialization)  
INFO  Using log file: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/application.log (LoggingInitialization)  
INFO  Loading user preferences: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/preferences (Preferences)  
INFO  Searching for classes... (ClassSearcher)  
INFO  Class search complete (968 ms) (ClassSearcher)  
INFO  Initializing SSL Context (SSLContextInitializer)  
INFO  Initializing Random Number Generator... (SecureRandomFactory)  
INFO  Random Number Generator initialization complete: NativePRNGNonBlocking (SecureRandomFactory)  
INFO  Trust manager disabled, cacerts have not been set (ApplicationTrustManagerFactory)  
WARN  Neither the -import parameter nor the -process parameter was specified; therefore, the specified prescripts and/or postscripts will be executed without any type of program context. (HeadlessAnalyzer)  
INFO  Headless startup complete (1976 ms) (AnalyzeHeadless)  
INFO  Class searcher loaded 57 extension points (18 false positives) (ClassSearcher)  
INFO  HEADLESS Script Paths:
    /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts
...
    /home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Features/WildcardAssembler/ghidra_scripts (HeadlessAnalyzer)  
INFO  HEADLESS: execution starts (HeadlessAnalyzer)  
INFO  Opening existing project: /home/gemesa/git-repos/my-projects/fidb-project (HeadlessAnalyzer)  
INFO  Opening project: /home/gemesa/git-repos/my-projects/fidb-project (HeadlessProject)  
INFO  SCRIPT: /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts/RepackFid.java (HeadlessAnalyzer)  
INFO  Packed database cache: /var/tmp/gemesa-ghidra/packed-db-cache (PackedDatabaseCache)  
$ file ~/in.fidb out.fidb 
/home/gemesa/in.fidb: Java serialization data, version 5
out.fidb:             Java serialization data, version 5
```

Run `RepackFid.java` in headless mode with a property file (works as expected):

```
$ cat RepackFid.properties 
Select FID database file to repack OK = /home/gemesa/in.fidb
Select name for copy OK = out.fidb
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-project -propertiesPath /home/gemesa/git-repos/my-projects -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript RepackFid.java -noanalysis
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
INFO  Using log config file: jar:file:/home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Framework/Generic/lib/Generic.jar!/generic.log4j.xml (LoggingInitialization)  
INFO  Using log file: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/application.log (LoggingInitialization)  
INFO  Loading user preferences: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/preferences (Preferences)  
INFO  Searching for classes... (ClassSearcher)  
INFO  Class search complete (1007 ms) (ClassSearcher)  
INFO  Initializing SSL Context (SSLContextInitializer)  
INFO  Initializing Random Number Generator... (SecureRandomFactory)  
INFO  Random Number Generator initialization complete: NativePRNGNonBlocking (SecureRandomFactory)  
INFO  Trust manager disabled, cacerts have not been set (ApplicationTrustManagerFactory)  
WARN  Neither the -import parameter nor the -process parameter was specified; therefore, the specified prescripts and/or postscripts will be executed without any type of program context. (HeadlessAnalyzer)  
INFO  Headless startup complete (1912 ms) (AnalyzeHeadless)  
INFO  Class searcher loaded 57 extension points (18 false positives) (ClassSearcher)  
INFO  HEADLESS Script Paths:
    /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts
...
    /home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Features/WildcardAssembler/ghidra_scripts (HeadlessAnalyzer)  
INFO  HEADLESS: execution starts (HeadlessAnalyzer)  
INFO  Opening existing project: /home/gemesa/git-repos/my-projects/fidb-project (HeadlessAnalyzer)  
INFO  Opening project: /home/gemesa/git-repos/my-projects/fidb-project (HeadlessProject)  
INFO  SCRIPT: /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts/RepackFid.java (HeadlessAnalyzer)  
INFO  Reading script properties file: /home/gemesa/git-repos/my-projects/RepackFid.properties (GhidraScriptProperties)  
INFO  Packed database cache: /var/tmp/gemesa-ghidra/packed-db-cache (PackedDatabaseCache)  
$ file ~/in.fidb out.fidb
/home/gemesa/in.fidb: Java serialization data, version 5
out.fidb:             Java serialization data, version 5
```

Run `RepackFid.java` in headless mode with a broken property file (`IllegalArgumentException` is raised as expected):

```
$ cat RepackFid.properties                            
Select FID database file to repack OK = /home/gemesa/in.fidb
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-project -propertiesPath /home/gemesa/git-repos/my-projects -scriptPath /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts -preScript RepackFid.java -noanalysis
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
INFO  Using log config file: jar:file:/home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Framework/Generic/lib/Generic.jar!/generic.log4j.xml (LoggingInitialization)  
INFO  Using log file: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/application.log (LoggingInitialization)  
INFO  Loading user preferences: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/preferences (Preferences)  
INFO  Searching for classes... (ClassSearcher)  
INFO  Class search complete (1012 ms) (ClassSearcher)  
INFO  Initializing SSL Context (SSLContextInitializer)  
INFO  Initializing Random Number Generator... (SecureRandomFactory)  
INFO  Random Number Generator initialization complete: NativePRNGNonBlocking (SecureRandomFactory)  
INFO  Trust manager disabled, cacerts have not been set (ApplicationTrustManagerFactory)  
WARN  Neither the -import parameter nor the -process parameter was specified; therefore, the specified prescripts and/or postscripts will be executed without any type of program context. (HeadlessAnalyzer)  
INFO  Headless startup complete (1924 ms) (AnalyzeHeadless)  
INFO  Class searcher loaded 57 extension points (18 false positives) (ClassSearcher)  
INFO  HEADLESS Script Paths:
    /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts
...
    /home/gemesa/git-repos/ghidra/build/dist/ghidra_11.3_DEV/Ghidra/Features/WildcardAssembler/ghidra_scripts (HeadlessAnalyzer)  
INFO  HEADLESS: execution starts (HeadlessAnalyzer)  
INFO  Opening existing project: /home/gemesa/git-repos/my-projects/fidb-project (HeadlessAnalyzer)  
INFO  Opening project: /home/gemesa/git-repos/my-projects/fidb-project (HeadlessProject)  
INFO  SCRIPT: /home/gemesa/git-repos/ghidra/Ghidra/Features/FunctionID/ghidra_scripts/RepackFid.java (HeadlessAnalyzer)  
INFO  Reading script properties file: /home/gemesa/git-repos/my-projects/RepackFid.properties (GhidraScriptProperties)  
INFO  Packed database cache: /var/tmp/gemesa-ghidra/packed-db-cache (PackedDatabaseCache)  
ERROR REPORT SCRIPT ERROR:  (HeadlessAnalyzer) java.lang.IllegalArgumentException: Error processing variable 'Select name for copy OK' in headless mode -- it was not found in a .properties file.
	at ghidra.app.script.GhidraScript.loadAskValue(GhidraScript.java:1942)
	at ghidra.app.script.GhidraScript.loadAskValue(GhidraScript.java:1899)
	at ghidra.app.script.GhidraScript.askFile(GhidraScript.java:2049)
	at RepackFid.run(RepackFid.java:62)
	at ghidra.app.script.GhidraScript.executeNormal(GhidraScript.java:405)
	at ghidra.app.script.GhidraScript.doExecute(GhidraScript.java:260)
	at ghidra.app.script.GhidraScript.execute(GhidraScript.java:238)
	at ghidra.app.util.headless.HeadlessAnalyzer.runScript(HeadlessAnalyzer.java:588)
	at ghidra.app.util.headless.HeadlessAnalyzer.runScriptsList(HeadlessAnalyzer.java:926)
	at ghidra.app.util.headless.HeadlessAnalyzer.processWithImport(HeadlessAnalyzer.java:1781)
	at ghidra.app.util.headless.HeadlessAnalyzer.processLocal(HeadlessAnalyzer.java:457)
	at ghidra.app.util.headless.AnalyzeHeadless.launch(AnalyzeHeadless.java:198)
	at ghidra.GhidraLauncher.launch(GhidraLauncher.java:81)
	at ghidra.Ghidra.main(Ghidra.java:54)
```

Run `RepackFid.java` in the GUI (works as expected):

![image](https://github.com/user-attachments/assets/86fe65ab-872c-4c92-8f2b-40a0d407ff4e)

![image](https://github.com/user-attachments/assets/1253a40c-9a86-4d02-85bb-af851d881d11)

![image](https://github.com/user-attachments/assets/1e0a06f9-ced0-47d2-adc8-e82e563f9eeb)

```
$ file in.fidb out.fidb 
in.fidb:  Java serialization data, version 5
out.fidb: Java serialization data, version 5
```