### PR TITLE
Fix segfault after Sleigh::reset

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
@@ -547,7 +547,19 @@ void Sleigh::reset(LoadImage *ld,ContextDatabase *c_db)
   loader = ld;
   context_db = c_db;
   cache = new ContextCache(c_db);
-  discache = (DisassemblyCache *)0;
+  initializeDisassemblyCache();
+}
+
+/// Initializes the disassembly cache when sleigh is initialized
+/// or when it is reset for a new image.
+void Sleigh::initializeDisassemblyCache(){
+    uint4 parser_cachesize = 2;
+    uint4 parser_windowsize = 32;
+    if ((maxdelayslotbytes > 1)||(unique_allocatemask != 0)) {
+        parser_cachesize = 8;
+        parser_windowsize = 256;
+    }
+    discache = new DisassemblyCache(this,cache,getConstantSpace(),parser_cachesize,parser_windowsize);
 }
 
 /// The .sla file from the document store is loaded and cache objects are prepared
@@ -569,13 +581,7 @@ void Sleigh::initialize(DocumentStorage &store)
   }
   else
     reregisterContext();
-  uint4 parser_cachesize = 2;
-  uint4 parser_windowsize = 32;
-  if ((maxdelayslotbytes > 1)||(unique_allocatemask != 0)) {
-    parser_cachesize = 8;
-    parser_windowsize = 256;
-  }
-  discache = new DisassemblyCache(this,cache,getConstantSpace(),parser_cachesize,parser_windowsize);
+  initializeDisassemblyCache();
 }
 
 /// \brief Obtain a parse tree for the instruction at the given address

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.hh
@@ -166,6 +166,7 @@ class Sleigh : public SleighBase {
   mutable DisassemblyCache *discache;	///< Cache of recently parsed instructions
   mutable PcodeCacher pcode_cache;	///< Cache of p-code data just prior to emitting
   void clearForDelete(void);		///< Delete the context and disassembly caches
+  void initializeDisassemblyCache();    ///< Initializes the disassembly cache for a new program
 protected:
   ParserContext *obtainContext(const Address &addr,int4 state) const;
   void resolve(ParserContext &pos) const;	///< Generate a parse tree suitable for disassembly


### PR DESCRIPTION
Hello!

I'm writing software using sleigh as a library dependency and ran into a bug in sleigh.

When using `Sleigh::reset` to load a new image, `discache` is set to `0`, but never re-initialized, so any subsequent disassembly/pcode lifting immediately segfaults.

I've factored the initialization of the disassembly cache out of `Sleigh::initialize` into its own private function and reused it in `Sleigh::reset`.

This change eliminates the segfaults I was getting from my library.