### PR TITLE
Fix outdated JavaDoc for DecompInterface.openProgram

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompInterface.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompInterface.java
@@ -59,7 +59,7 @@ import ghidra.util.task.TaskMonitor;
  *   
  *   // Setup up the actual decompiler process for a
  *   // particular program, using all the above initialization
- *   ifc.openProgram(program,language);
+ *   ifc.openProgram(program);
  *   
  *   // Make calls to the decompiler:
  *   DecompileResults res = ifc.decompileFunction(func,0,taskmonitor);


### PR DESCRIPTION
The JavaDoc for the DecompInterface.openProgram method referenced an obsolete second argument (language). Updated the documentation to match the current method signature, which only takes a single argument (program).

cc: @sheetjsdev