### PR TITLE
Let FileSystem extensions set filetype icons in filesystem browser

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/fileinfo/FileAttributeType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/fileinfo/FileAttributeType.java
@@ -56,6 +56,7 @@ public enum FileAttributeType {
 
 	SYMLINK_DEST_ATTR("Symbolic link destination", MISC_INFO, String.class),
 	COMMENT_ATTR("Comment", MISC_INFO, String.class),
+	FILENAME_EXT_OVERRIDE("Extension override", MISC_INFO, String.class),
 
 	UNKNOWN_ATTRIBUTE("Other attribute", ADDITIONAL_INFO, Object.class);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBComponentProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBComponentProvider.java
@@ -192,9 +192,17 @@ public class FSBComponentProvider extends ComponentProviderAdapter
 					overlays.add(FSBIcons.MISSING_PASSWORD_OVERLAY_ICON);
 				}
 
+				String ext = node.getFilenameExtOverride();
+				if (ext != null && !ext.isEmpty()) {
+					if (!ext.startsWith(".")) {
+						Msg.error(this, "Extension override '" + ext + "' does not begin with a dot");
+					} else {
+						filename += ext;
+					}
+				}
+
 				Icon icon = fsbIcons.getIcon(filename, overlays);
 				setIcon(icon);
-
 			}
 		});
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBFileNode.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBFileNode.java
@@ -38,6 +38,7 @@ public class FSBFileNode extends FSBNode {
 	protected boolean hasPassword;
 	protected String symlinkDest;
 	protected long lastModified;
+	protected String filenameExtOverride;
 
 	FSBFileNode(GFile file) {
 		this.file = file;
@@ -83,6 +84,10 @@ public class FSBFileNode extends FSBNode {
 		return symlinkDest != null;
 	}
 
+	public String getFilenameExtOverride() {
+		return filenameExtOverride;
+	}
+
 	@Override
 	public int hashCode() {
 		return file.hashCode();
@@ -95,6 +100,7 @@ public class FSBFileNode extends FSBNode {
 		symlinkDest = fattrs.get(SYMLINK_DEST_ATTR, String.class, null);
 		Date lastModDate = fattrs.get(MODIFIED_DATE_ATTR, Date.class, null);
 		lastModified = lastModDate != null ? lastModDate.getTime() : 0;
+		filenameExtOverride = fattrs.get(FILENAME_EXT_OVERRIDE, String.class, null);
 	}
 
 	@Override


### PR DESCRIPTION
Provides the feature I asked about in "Can a FileSystem extension set icons for files in the FileSystem viewer/browser?" https://github.com/NationalSecurityAgency/ghidra/discussions/6953

This solution involves the fewest modifications to the existing code.

In a `FileSystem`'s `getFileAttributes()` method you just add a `typeExt` attribute which is just a file extension including the dot, as in `.txt` and in this way leverages the existing system which uses the file's extension to decide which icon to use. `FileSystem`s which know the types of their files and which do not use the file extension convention can thus set the types of files:

```java
@Override
public FileAttributes getFileAttributes(GFile file, TaskMonitor monitor) {
        Metadata metadata = fsIndex.getMetadata(file);
        FileAttributes result = new FileAttributes();
        if (metadata != null) {
                result.add(FileAttributeType.NAME_ATTR, metadata.name);
                result.add(FileAttributeType.SIZE_ATTR, metadata.size);
                if (metadata.filetypeCode == 4) {
                        result.add("typeExt", ".txt");
                }
        }
        return result;
}
```

The mapping of file extensions to icons is at `Ghidra/Features/Base/data/base.file.extensions.icons.theme.properties` and the icons themselves are in `Ghidra/Features/Base/bin/main/images`

(I would actually say a bunch of useful ones are still missing, such as `.exe`, `.dll`, `.o`, etc.)