### PR TITLE
Let FileSystem extensions set filetype icons in filesystem browser

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/fileinfo/FileAttributeType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/fileinfo/FileAttributeType.java
@@ -56,6 +56,7 @@ public enum FileAttributeType {
 
 	SYMLINK_DEST_ATTR("Symbolic link destination", MISC_INFO, String.class),
 	COMMENT_ATTR("Comment", MISC_INFO, String.class),
+	FILENAME_EXT_OVERRIDE("Extension override", MISC_INFO, String.class),
 
 	UNKNOWN_ATTRIBUTE("Other attribute", ADDITIONAL_INFO, Object.class);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBComponentProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBComponentProvider.java
@@ -192,6 +192,15 @@ public class FSBComponentProvider extends ComponentProviderAdapter
 					overlays.add(FSBIcons.MISSING_PASSWORD_OVERLAY_ICON);
 				}
 
+				String ext = node.getFilenameExtOverride();
+				if (ext != null && !ext.isEmpty()) {
+					if (!ext.startsWith(".")) {
+						Msg.error(this, "Extension override '" + ext + "' does not begin with a dot");
+					} else {
+						filename += ext;
+					}
+				}
+
 				Icon icon = fsbIcons.getIcon(filename, overlays);
 				setIcon(icon);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBFileNode.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugins/fsbrowser/FSBFileNode.java
@@ -38,6 +38,7 @@ public class FSBFileNode extends FSBNode {
 	protected boolean hasPassword;
 	protected String symlinkDest;
 	protected long lastModified;
+	protected String filenameExtOverride;
 
 	FSBFileNode(GFile file) {
 		this.file = file;
@@ -83,6 +84,10 @@ public class FSBFileNode extends FSBNode {
 		return symlinkDest != null;
 	}
 
+	public String getFilenameExtOverride() {
+		return filenameExtOverride;
+	}
+
 	@Override
 	public int hashCode() {
 		return file.hashCode();
@@ -95,6 +100,7 @@ public class FSBFileNode extends FSBNode {
 		symlinkDest = fattrs.get(SYMLINK_DEST_ATTR, String.class, null);
 		Date lastModDate = fattrs.get(MODIFIED_DATE_ATTR, Date.class, null);
 		lastModified = lastModDate != null ? lastModDate.getTime() : 0;
+		filenameExtOverride = fattrs.get(FILENAME_EXT_OVERRIDE, String.class, null);
 	}
 
 	@Override


### PR DESCRIPTION
2nd try. Originally https://github.com/NationalSecurityAgency/ghidra/pull/7062/files