### PR TITLE
BSim: Fix paths in DatabaseConfiguration.html

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
@@ -170,13 +170,13 @@
             <DIV class="informalexample">
               <TABLE border="0" summary="Simple list" class="simplelist">
 		<TR>
-                  <TD><CODE class="computeroutput">$(ROOT)/Ghidra/Features/BSim/build/os/linux64/postgresql
+                  <TD><CODE class="computeroutput">$(ROOT)/Ghidra/Features/BSim/build/os/linux_x86_64/postgresql
                       OR</CODE></TD>
 		</TR>
 		
 		<TR>
                   <TD><CODE class=
-			    "computeroutput">$(ROOT)/Ghidra/Features/BSim/build/os/osx64/postgresql</CODE></TD>
+			    "computeroutput">$(ROOT)/Ghidra/Features/BSim/build/os/mac_x86_64/postgresql</CODE></TD>
 		</TR>
               </TABLE>
             </DIV>


### PR DESCRIPTION
The documentation is not aligned with the [implementation](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/BSim/make-postgres.sh#L84) so I fixed it.