### PR TITLE
BSim: Fix incomplete commands in DatabaseConfiguration.html

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
@@ -395,12 +395,12 @@
             <DIV class="informalexample">
               <TABLE border="0" summary="Simple list" class="simplelist">
                 <TR>
-                  <TD><CODE class="computeroutput">$(ROOT)/support/bsim_ctl adduser <SPAN class=
+                  <TD><CODE class="computeroutput">$(ROOT)/support/bsim_ctl adduser /path/to/datadir <SPAN class=
                   "emphasis"><EM>username</EM></SPAN></CODE></TD>
                 </TR>
 
                 <TR>
-                  <TD><CODE class="computeroutput">$(ROOT)/support/bsim_ctl adduser <SPAN class=
+                  <TD><CODE class="computeroutput">$(ROOT)/support/bsim_ctl adduser /path/to/datadir <SPAN class=
                   "emphasis"><EM>username</EM></SPAN> --dn&nbsp;"C=US,ST=MD,CN=Firstname User"</CODE></TD>
                 </TR>
               </TABLE>


### PR DESCRIPTION
Some `bsim_ctl adduser` commands in the BSim docs are incomplete because the data directory path needs to be provided as described in the [usage info](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/BSimControlLaunchable.java#L1436), similarly to the [start command](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html#L211).