### PR TITLE
BSim: Update PostgreSQL (15.10->17.0) and add migrate commands

### DIFF
--- a/Ghidra/Features/BSim/Module.manifest
+++ b/Ghidra/Features/BSim/Module.manifest
@@ -1,5 +1,5 @@
 ##MODULE IP: Oxygen Icons - LGPL 3.0
-MODULE FILE LICENSE: postgresql-15.10.tar.gz Postgresql License
+MODULE FILE LICENSE: postgresql-17.0.tar.gz Postgresql License
 MODULE FILE LICENSE: lib/postgresql-42.7.3.jar PostgresqlJDBC License
 MODULE FILE LICENSE: lib/commons-dbcp2-2.9.0.jar Apache License 2.0
 MODULE FILE LICENSE: lib/commons-pool2-2.11.1.jar Apache License 2.0

--- a/Ghidra/Features/BSim/build.gradle
+++ b/Ghidra/Features/BSim/build.gradle
@@ -26,7 +26,7 @@ import java.nio.file.Files
 import org.gradle.util.GUtil
 
 // NOTE: fetchDependencies.gradle must be updated if postgresql version changes
-def postgresql_distro = "postgresql-15.10.tar.gz"
+def postgresql_distro = "postgresql-17.0.tar.gz"
 
 dependencies {
 	api project(":Decompiler")

--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
@@ -47,6 +47,8 @@
     bsim_ctl resetpassword   &lt;username&gt;
     bsim_ctl changeauth      &lt;/datadir-path&gt; [--auth|-a&nbsp;pki|password|trust] [--noLocalAuth] [--cafile&nbsp;&lt;/cacert-path&gt;] [--dn&nbsp;"&lt;distinguished-name&gt;"]
     bsim_ctl changeprivilege &lt;username&gt; admin|user
+    bsim_ctl dumpall         &lt;/dumpfile-path&gt;
+    bsim_ctl restore         &lt;/dumpfile-path&gt;
     
     Global Options:
         --port|-p&nbsp;&lt;portnum&gt;
@@ -222,6 +224,22 @@
                 "command"><STRONG>user</STRONG></SPAN>, and the PostgreSQL server must be
                 running.</P>
               </DD>
+
+              <DT><SPAN class="term"><SPAN class=
+                "bold"><STRONG>dumpall</STRONG></SPAN></SPAN></DT>
+  
+                <DD>
+                  <P>Dumps all PostgreSQL databases into a specified file. A dump file must be
+                  specified, and the PostgreSQL server must be running.</P>
+                </DD>
+
+              <DT><SPAN class="term"><SPAN class=
+                "bold"><STRONG>restore</STRONG></SPAN></SPAN></DT>
+  
+                <DD>
+                  <P>Restores all PostgreSQL databases from a specified file. A dump file must be
+                  specified, and the PostgreSQL server must be running.</P>
+                </DD>
 
               <DT><SPAN class="term"><SPAN class="bold"><STRONG>--Global
               Options--</STRONG></SPAN></SPAN></DT>

--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
@@ -107,13 +107,13 @@
               in the module directory <CODE>Ghidra/Features/BSim/support</CODE> that builds both the PostgreSQL
               server and the BSim extension from source and prepares the installation for use with
               Ghidra.  If not already included in the Ghidra installation, the source distribution
-              file, currently <CODE>postgresql-15.10.tar.gz</CODE>, can be obtained from the PostgreSQL
+              file, currently <CODE>postgresql-17.0.tar.gz</CODE>, can be obtained from the PostgreSQL
               website at </P>
 	    
             <DIV class="informalexample">
               <TABLE border="0" summary="Simple list" class="simplelist">
                 <TR>
-                  <TD><CODE class="computeroutput">https://www.postgresql.org/ftp/source/v15.10
+                  <TD><CODE class="computeroutput">https://www.postgresql.org/ftp/source/v17.0
 		  </CODE></TD>
                 </TR>
               </TABLE>
@@ -122,12 +122,12 @@
 	    <P>The steps to build the PostgreSQL server with the BSim extension then are:</P>
 
 	    <P>1) If not already present, place the PostgreSQL source distribution file
-	      <CODE>postgresql-15.10.tar.gz</CODE> in the Ghidra installation at</P>
+	      <CODE>postgresql-17.0.tar.gz</CODE> in the Ghidra installation at</P>
 
             <DIV class="informalexample">
               <TABLE border="0" summary="Simple list" class="simplelist">
                 <TR>
-                  <TD><CODE class="computeroutput">$(ROOT)/Ghidra/Features/BSim/support/postgresql-15.10.tar.gz
+                  <TD><CODE class="computeroutput">$(ROOT)/Ghidra/Features/BSim/support/postgresql-17.0.tar.gz
 		  </CODE></TD>
                 </TR>
               </TABLE>

--- a/Ghidra/Features/BSim/support/make-postgres.sh
+++ b/Ghidra/Features/BSim/support/make-postgres.sh
@@ -18,11 +18,11 @@
 # This script builds the postgresql server and BSim extension within a
 # GHIDRA installation.
 #
-# The PostgreSQL source distribution file postgresql-15.10.tar.gz must
+# The PostgreSQL source distribution file postgresql-17.0.tar.gz must
 # be placed in the BSim module directory prior to running this script.
 # This file can be downloaded directly from the PostgreSQL website at:
 #
-#   https://www.postgresql.org/ftp/source/v15.10
+#   https://www.postgresql.org/ftp/source/v17.0
 #
 # Within development environments, this script will first check the
 # ghidra.bin repo for this source file.
@@ -31,14 +31,14 @@
 # (POSTGRES_CONFIG_OPTIONS) may be adjusted if required (e.g., build
 # without openssl use, etc.). 
 #
-# See https://www.postgresql.org/docs/15/install-procedure.html
+# See https://www.postgresql.org/docs/17/install-procedure.html
 # for supported postgresql config options.
 #
 # Additional software may need to be installed in order to perform the 
 # postgresql build.  Please refer to the following web page for 
 # software dependencies:
 #
-#   https://www.postgresql.org/docs/15/install-requirements.html
+#   https://www.postgresql.org/docs/17/install-requirements.html
 #
 # Or for Linux specific package dependencies, see:
 #
@@ -46,7 +46,7 @@
 #
 #
 
-POSTGRES=postgresql-15.10
+POSTGRES=postgresql-17.0
 POSTGRES_GZ=${POSTGRES}.tar.gz
 POSTGRES_CONFIG_OPTIONS="--disable-rpath --with-openssl"
 

--- a/gradle/support/fetchDependencies.gradle
+++ b/gradle/support/fetchDependencies.gradle
@@ -89,9 +89,9 @@ ext.deps = [
 		destination: file("${DEPS_DIR}/GhidraServer")
 	],
 	[
-		name: "postgresql-15.10.tar.gz",
-		url: "https://ftp.postgresql.org/pub/source/v15.10/postgresql-15.10.tar.gz",
-		sha256: "173366605259a83dc189c4327ff4c37254afed65b4f866cbd8a5ef2ea449e8f3",
+		name: "postgresql-17.0.tar.gz",
+		url: "https://ftp.postgresql.org/pub/source/v17.0/postgresql-17.0.tar.gz",
+		sha256: "bf81c0c5161e456a886ede5f1f4133f43af000637e377156a02e7e83569081ad",
 		destination: file("${DEPS_DIR}/BSim")
 	],
 	[


### PR DESCRIPTION
Fixes #6115
Fixes #7084

As mentioned in the linked issues, on distros (Fedora, Arch etc.) with newer packages (especially OpenSSL), the currently used PostgreSQL (15.3) is not working properly resulting in SSL error(s) (detailed in the issues). In #7084 I fixed the SSL error by downgrading OpenSSL but this was a painful solution. In this PR I have upgraded the PostgreSQL version from 15.3 to 17.0 and now `bsim_ctl start` works on Fedora 40 with OpenSSL 3.2.2 and also on Ubuntu 22.04 with OpenSSL 3.0.2. Edit: I also added the `dumpall` and `restore` commands to `bsim_ctl` which can be used to migrate DBs from 15.3 to 17.0 (see https://github.com/NationalSecurityAgency/ghidra/pull/7085#issuecomment-2440141397).

```
$ uname -a
Linux fedora 6.10.12-200.fc40.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Sep 30 21:38:25 UTC 2024 x86_64 GNU/Linux
$ openssl version
OpenSSL 3.2.2 4 Jun 2024 (Library: OpenSSL 3.2.2 4 Jun 2024)
$ ./support/bsim_ctl start ~/git-repos/bsim-db       
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
No client authentication
Initializing data directory
Generating servers SSL certificate
Server started
BSim extension enabled
```

```
$ uname -a
Linux ubuntu-22 6.8.0-47-generic #47~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Oct  2 16:16:55 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
$ openssl version
OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022)
$ ./support/bsim_ctl start ~/git-repos/bsim-db/
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
No client authentication
Initializing data directory
Generating servers SSL certificate
Server started
BSim extension enabled
```