### PR TITLE
BSim: Enable stderr display on console in runCommand()

### DIFF
--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/BSimControlLaunchable.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/BSimControlLaunchable.java
@@ -691,8 +691,9 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 		Process process = processBuilder.start();
 
 		new IOThread(process.getInputStream(), true).start();
-		IOThread errThread = new IOThread(process.getErrorStream(), true);
+		IOThread errThread = new IOThread(process.getErrorStream(), false);
 		errThread.start();
+		errThread.join(); // Ensure all stderr output is processed to avoid mixed-up console output
 
 		int retval = process.waitFor();
 		return retval;


### PR DESCRIPTION
Edit: fixes #6932 

`bsim_ctl` uses `runCommand()` to execute commands like `pg_ctl init`, `pg_ctl start` etc. Currently both `stdout` and `stderr` outputs are suppressed. IMO suppressing `stdout` makes sense. But suppressing `stderr` is different as there are cases where `bsim_ctl` fails leaving the user unaware of the cause.

Running databases in Docker is fairly common and I wanted to set up a BSim DB in Docker as well. But when running `bsim_ctl` in a dockerized environment (where root is the default user) it fails without clear feedback:

```
$ sudo docker run --rm -v /home/gemesa/git-repos/bsim-docker-db:/mnt/pg -p 5432:5432 ubuntu-ghidra-java21-tem
openjdk version "21.0.4" 2024-07-16
OpenJDK Runtime Environment (build 21.0.4+7-Ubuntu-1ubuntu224.04)
OpenJDK 64-Bit Server VM (build 21.0.4+7-Ubuntu-1ubuntu224.04, mixed mode)
No client authentication
Initializing data directory
Unexpected error
java.io.IOException: Error initializing postgres database
	at ghidra.features.bsim.query.BSimControlLaunchable.initializeDataDirectory(BSimControlLaunchable.java:901)
	at ghidra.features.bsim.query.BSimControlLaunchable.startCommand(BSimControlLaunchable.java:1000)
	at ghidra.features.bsim.query.BSimControlLaunchable.run(BSimControlLaunchable.java:1395)
	at ghidra.features.bsim.query.BSimControlLaunchable.launch(BSimControlLaunchable.java:1459)
	at ghidra.GhidraLauncher.launch(GhidraLauncher.java:81)
	at ghidra.Ghidra.main(Ghidra.java:54)
```

No log file is generated either:

```
$ cat /home/gemesa/git-repos/bsim-docker-db/logfile
cat: /home/gemesa/git-repos/bsim-docker-db/logfile: No such file or directory
```

The issue becomes obvious if `stderr` is shown:

```
$ sudo ./support/bsim_ctl start ~/git-repos/bsim-db
openjdk version "21.0.5" 2024-10-15
OpenJDK Runtime Environment (Red_Hat-21.0.5.0.11-1) (build 21.0.5+11)
OpenJDK 64-Bit Server VM (Red_Hat-21.0.5.0.11-1) (build 21.0.5+11, mixed mode)
No client authentication
Initializing data directory
Unexpected error
pg_ctl: cannot be run as root
Please log in (using, e.g., "su") as the (unprivileged) user that will
java.io.IOException: Error initializing postgres database
own the server process.
	at ghidra.features.bsim.query.BSimControlLaunchable.initializeDataDirectory(BSimControlLaunchable.java:901)
	at ghidra.features.bsim.query.BSimControlLaunchable.startCommand(BSimControlLaunchable.java:1000)
	at ghidra.features.bsim.query.BSimControlLaunchable.run(BSimControlLaunchable.java:1395)
	at ghidra.features.bsim.query.BSimControlLaunchable.launch(BSimControlLaunchable.java:1459)
	at ghidra.GhidraLauncher.launch(GhidraLauncher.java:81)
	at ghidra.Ghidra.main(Ghidra.java:54)
```

Another case occurs when stopping a server that isnt running resulting in `java.io.IOException: Error shutting down postgres server process` without any logfile entries.

Displaying `stderr` on the console resolves these issues. However since the subcommands (like `pg_ctl`) run on separate threads their outputs might get mixed:

```
$ ./support/bsim_ctl stop ~/git-repos/bsim-db
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Unexpected error
java.io.IOException: Error shutting down postgres server process
	at ghidra.features.bsim.query.BSimControlLaunchable.stopCommand(BSimControlLaunchable.java:1057)
pg_ctl: PID file "/home/gemesa/git-repos/bsim-db/postmaster.pid" does not exist
	at ghidra.features.bsim.query.BSimControlLaunchable.run(BSimControlLaunchable.java:1398)
	at ghidra.features.bsim.query.BSimControlLaunchable.launch(BSimControlLaunchable.java:1459)
Is server running?
	at ghidra.GhidraLauncher.launch(GhidraLauncher.java:81)
	at ghidra.Ghidra.main(Ghidra.java:54)
```

This is fixed by adding `errThread.join()` ensuring all `stderr` output is processed before continuing.