### PR TITLE
+ macOS macho-o dynamic lib file extension .dylib to file dialog filter

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/plugin/importer/ImporterUtilities.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugin/importer/ImporterUtilities.java
@@ -63,7 +63,7 @@ public class ImporterUtilities {
 	 * TODO: will be refactored to use file_extension_icon.xml file info.
 	 */
 	public static final GhidraFileFilter LOADABLE_FILES_FILTER = ExtensionFileFilter.forExtensions(
-		"Loadable files", "exe", "dll", "obj", "drv", "bin", "hex", "o", "a", "so", "class", "lib");
+		"Loadable files", "exe", "dll", "obj", "drv", "bin", "hex", "o", "a", "so", "class", "lib", "dylib");
 
 	/**
 	 * File extension filter for well known 'container' files for GhidraFileChoosers.


### PR DESCRIPTION
The `LOADABLE_FILES_FILTER` `ExtensionFileFilter` contains well-known file extensions of loadable code files such as `.exe`, `.dll`, `.o`, etc but was missing `.dylib` used for dynamic libraries in Mach-O format on macOS