### PR TITLE
BSim: Add status subcommand to bsim_ctl

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
@@ -41,6 +41,7 @@
 <CODE class="computeroutput">
     bsim_ctl start           &lt;/datadir-path&gt; [--auth|-a&nbsp;pki|password|trust] [--noLocalAuth] [--cafile&nbsp;&lt;/cacert-path&gt;] [--dn&nbsp;"&lt;distinguished-name&gt;"]
     bsim_ctl stop            &lt;/datadir-path&gt; [--force]
+    bsim_ctl status          &lt;/datadir-path&gt;
     bsim_ctl adduser         &lt;/datadir-path&gt; &lt;username&gt; [--dn&nbsp;"&lt;distinguished-name&gt;"]
     bsim_ctl dropuser        &lt;/datadir-path&gt; &lt;username&gt;
     bsim_ctl resetpassword   &lt;username&gt;
@@ -134,6 +135,13 @@
                 <P><SPAN class="command"><STRONG>--force</STRONG></SPAN> - causes existing
                 connections to be forcibly closed and the PostgreSQL server to shut down
                 immediately.</P>
+              </DD>
+
+              <DT><SPAN class="term"><SPAN class="bold"><STRONG>status</STRONG></SPAN></SPAN></DT>
+
+              <DD>
+                <P>Retrieves the status of a PostgreSQL server (running/down). The path to the
+                actively used data directory must be provided.</P>
               </DD>
 
               <DT><SPAN class="term"><SPAN class="bold"><STRONG>adduser</STRONG></SPAN></SPAN></DT>

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/BSimControlLaunchable.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/BSimControlLaunchable.java
@@ -52,6 +52,7 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 	// bsim_ctl commands
 	public final static String COMMAND_START = "start";
 	public final static String COMMAND_STOP = "stop";
+	public final static String COMMAND_STATUS = "status";
 	public final static String COMMAND_RESET_PASSWORD = "resetpassword";
 	public final static String COMMAND_CHANGE_PRIVILEGE = "changeprivilege";
 	public final static String COMMAND_ADDUSER = "adduser";
@@ -91,6 +92,7 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 			Set.of(AUTH_OPTION, DN_OPTION, NO_LOCAL_AUTH_OPTION, CAFILE_OPTION);
 	private static final Set<String> STOP_OPTIONS = 
 			Set.of(FORCE_OPTION);
+	private static final Set<String> STATUS_OPTIONS = Set.of();
 	private static final Set<String> RESET_PASSWORD_OPTIONS = Set.of();
 	private static final Set<String> CHANGE_PRIVILEGE_OPTIONS = Set.of();
 	private static final Set<String> ADDUSER_OPTIONS = 
@@ -104,6 +106,7 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 	static {
 		ALLOWED_OPTION_MAP.put(COMMAND_START, START_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_STOP, STOP_OPTIONS);
+		ALLOWED_OPTION_MAP.put(COMMAND_STATUS, STATUS_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_RESET_PASSWORD, RESET_PASSWORD_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_CHANGE_PRIVILEGE, CHANGE_PRIVILEGE_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_ADDUSER, ADDUSER_OPTIONS);
@@ -198,6 +201,9 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 				scanDataDirectory(params, slot++);
 				break;
 			case COMMAND_STOP:
+				scanDataDirectory(params, slot++);
+				break;
+			case COMMAND_STATUS:
 				scanDataDirectory(params, slot++);
 				break;
 			case COMMAND_ADDUSER:
@@ -1060,6 +1066,30 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 	}
 
 	/**
+	 * Retrieve the status of a PostgreSQL server.
+	 * @throws IOException if server status can not be retrieved
+	 * @throws InterruptedException if the status command is interrupted
+	 */
+	private void statusCommand() throws IOException, InterruptedException {
+		discoverPostgresInstall();
+		List<String> command = new ArrayList<String>();
+		command.add(postgresControl.getAbsolutePath());
+		command.add("status");
+		command.add("-D");
+		command.add(dataDirectory.getAbsolutePath());
+		int res = runCommand(null, command, loadLibraryVar, loadLibraryValue);
+		if (res == 0) {
+			System.out.println("Server running");
+		}
+		else if (res == 3) {
+			System.out.println("Server down");
+		}
+		else {
+			throw new IOException("Error getting postgres server status");
+		}
+	}
+
+	/**
 	 * Trigger a server running on the local host to rescan its identity file to pickup
 	 * any changes to the user mapping
 	 * @throws IOException if creating a new user fails
@@ -1397,6 +1427,9 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 				case COMMAND_STOP:
 					stopCommand();
 					break;
+				case COMMAND_STATUS:
+					statusCommand();
+					break;
 				case COMMAND_ADDUSER:
 					addUserCommand();
 					break;
@@ -1432,6 +1465,7 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 			"USAGE: bsim_ctl [command]  required-args... [OPTIONS...}\n\n" +
 			"                start      </datadir-path> [--auth|-a pki|password|trust] [--noLocalAuth] [--cafile \"</cacert-path>\"] [--dn \"<distinguished-name>\"]\n" +
 			"                stop       </datadir-path> [--force]\n" +
+			"                status     </datadir-path>\n" +
 			"                adduser    </datadir-path> <username> [--dn \"<distinguished-name>\"]\n" +
 			"                dropuser   </datadir-path> <username>\n" +
 			"                changeauth </datadir-path> [--auth|-a pki|password|trust] [--noLocalAuth] [--cafile \"</cacert-path>\"]\n" +


### PR DESCRIPTION
I added the `status` subcommand to `bsim_ctl` because I really miss it. While one can run `pg_ctl` directly to check the status it is easier to use `bsim_ctl` instead. I think this is a commonly used feature that others might also find helpful.

PostgreSQL reference is available [here](https://www.postgresql.org/docs/15/app-pg-ctl.html).

```
$ ls ~/git-repos/bsim-db
                                                                                                                      
$ ./support/bsim_ctl status ~/git-repos/bsim-db
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Unexpected error
java.io.IOException: Error getting postgres server status
	at ghidra.features.bsim.query.BSimControlLaunchable.statusCommand(BSimControlLaunchable.java:1088)
	at ghidra.features.bsim.query.BSimControlLaunchable.run(BSimControlLaunchable.java:1431)
	at ghidra.features.bsim.query.BSimControlLaunchable.launch(BSimControlLaunchable.java:1493)
	at ghidra.GhidraLauncher.launch(GhidraLauncher.java:81)
	at ghidra.Ghidra.main(Ghidra.java:54)
                                                                                                                      
$ ./support/bsim_ctl start ~/git-repos/bsim-db
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
No client authentication
Initializing data directory
Generating servers SSL certificate
Server started
BSim extension enabled
                                                                                                                      
$ ./support/bsim_ctl status ~/git-repos/bsim-db
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Server running
                                                                                                                      
$ ./support/bsim_ctl stop ~/git-repos/bsim-db
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Server shutdown complete
                                                                                                                      
$ ./support/bsim_ctl status ~/git-repos/bsim-db
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Server down
```