### PR TITLE
BSim: Add DN_OPTION to fix bsim_ctl changeauth for PKI authentication

### DIFF
--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/BSimControlLaunchable.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/BSimControlLaunchable.java
@@ -97,7 +97,7 @@ public class BSimControlLaunchable implements GhidraLaunchable {
 			Set.of(DN_OPTION);
 	private static final Set<String> DROPUSER_OPTIONS = Set.of();
 	private static final Set<String> CHANGEAUTH_OPTIONS = Set.of(
-		AUTH_OPTION, NO_LOCAL_AUTH_OPTION, CAFILE_OPTION);
+		AUTH_OPTION, DN_OPTION, NO_LOCAL_AUTH_OPTION, CAFILE_OPTION);
 	
 	//@formatter:on
 	private static final Map<String, Set<String>> ALLOWED_OPTION_MAP = new HashMap<>();


### PR DESCRIPTION
Fixes #7105

The linked issue can be fixed by simply adding `DN_OPTION` to the allowed options.

Before:

```
$ ./support/bsim_ctl changeauth ~/git-repos/bsim-db --auth pki
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
New local authentication: pki
Error establishing server certificate
Distinguished name required (dn="..")

$ ./support/bsim_ctl changeauth ~/git-repos/bsim-db --auth pki --dn CN=gemesa
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Error in command line arguments
Unsupported option use: --dn
```

After:

```
$ ./support/bsim_ctl changeauth ~/git-repos/bsim-db --auth pki --dn=CN=gemesa --cafile=/home/gemesa/git-repos/bsim-pki/ca.crt
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
New local authentication: pki
New host authentication: pki
```