### PR TITLE
Fixes #6662: Add qemu-gdb option to get all section mappings for target.

### DIFF
--- a/Ghidra/Debug/Debugger-agent-gdb/data/debugger-launchers/qemu-gdb.sh
+++ b/Ghidra/Debug/Debugger-agent-gdb/data/debugger-launchers/qemu-gdb.sh
@@ -33,6 +33,7 @@
 #@env OPT_EXTRA_QEMU_ARGS:str="" "Extra qemu arguments" "Extra arguments to pass to qemu. Use with care."
 #@env OPT_GDB_PATH:file="gdb-multiarch" "gdb command" "The path to gdb. Omit the full path to resolve using the system PATH."
 #@env OPT_EXTRA_TTY:bool=false "QEMU TTY" "Provide a separate terminal emulator for the target."
+#@env OPT_PULL_ALL_SECTIONS:bool=false "Pull all section mappings" "Force gdb to send all mappings to Ghidra. This can be costly (see help)."
 #@tty TTY_TARGET if env:OPT_EXTRA_TTY
 
 if [ -d ${GHIDRA_HOME}/ghidra/.git ]
@@ -60,17 +61,31 @@ fi
 # Give QEMU a moment to open the socket
 sleep 0.1
 
-"$OPT_GDB_PATH" \
-  -q \
-  -ex "set pagination off" \
-  -ex "set confirm off" \
-  -ex "show version" \
-  -ex "python import ghidragdb" \
-  -ex "file \"$target_image\"" \
-  -ex "set args $target_args" \
-  -ex "ghidra trace connect \"$GHIDRA_TRACE_RMI_ADDR\"" \
-  -ex "ghidra trace start" \
-  -ex "ghidra trace sync-enable" \
-  -ex "target remote localhost:$QEMU_GDB" \
-  -ex "set confirm on" \
-  -ex "set pagination on"
+gdb_args=(
+    -q
+    -ex "set pagination off"
+    -ex "set confirm off"
+    -ex "show version"
+    -ex "python import ghidragdb"
+    -ex "file \"$target_image\""
+    -ex "set args $target_args"
+    -ex "ghidra trace connect \"$GHIDRA_TRACE_RMI_ADDR\""
+    -ex "ghidra trace start"
+    -ex "ghidra trace sync-enable"
+    -ex "target remote localhost:$QEMU_GDB"
+    -ex "set confirm on"
+    -ex "set pagination on"
+)
+
+# If using OPT_PULL_ALL_SECTIONS, append instructions to push all sections from qemu
+if [ "$OPT_PULL_ALL_SECTIONS" = "true" ]
+then
+  gdb_args+=(
+    -ex "ghidra trace tx-start put-all-sections"
+    -ex "ghidra trace put-sections -all-objects"
+    -ex "ghidra trace tx-commit"
+  )
+fi
+
+IFS=""
+"$OPT_GDB_PATH" ${gdb_args[*]}

--- a/Ghidra/Debug/Debugger-rmi-trace/src/main/help/help/topics/TraceRmiLauncherServicePlugin/TraceRmiLauncherServicePlugin.html
+++ b/Ghidra/Debug/Debugger-rmi-trace/src/main/help/help/topics/TraceRmiLauncherServicePlugin/TraceRmiLauncherServicePlugin.html
@@ -373,6 +373,13 @@ target remote | ssh user@host gdbserver - /path/to/image
 
       <LI><B>QEMU TTY</B>: This works similarly as in GDB, but just runs QEMU in the second
       Terminal window.</LI>
+
+      <LI><B>Pull all section mappings</B>: For some targets the memory mappings for the target
+      are not correctly relayed to Ghidra. This setting forces gdb to send the mappings to Ghidra.
+      This option is disabled by default because for large targets the action could be expensive,
+      so it should only be enabled if required (e.g. unable to correctly place breakpoints).
+      <I>Auto-Map by Section</I> must be enabled in the Modules debugger window for this to work.
+      </LI>
     </UL>
 
     <H3><A name="gdb_wine"></A>Wine + GDB</H3>


### PR DESCRIPTION
This new optional setting for qemu-gdb debugger forces all section mappings to be pushed to Ghidra. This solves issues observed with some targets where breakpoints cannot be placed correctly without a repetitive workaround for each test iteration.