### PR TITLE
remove redundant duplicated line of code

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/options/editor/FontPropertyEditor.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/options/editor/FontPropertyEditor.java
@@ -158,7 +158,6 @@ public class FontPropertyEditor extends PropertyEditorSupport {
 			sizeCombo =
 				new GComboBox<>(IntStream.rangeClosed(1, 72).boxed().toArray(Integer[]::new));
 			sizeCombo.setMaximumRowCount(9);
-			sizeCombo.setMaximumRowCount(9);
 			sizeCombo.addActionListener(actionListener);
 			panel.add(sizeCombo);
 


### PR DESCRIPTION
this line was there twice. 2nd will have no effect. probably cut and paste error?
```
    sizeCombo.setMaximumRowCount(9);
```