### PR TITLE
misspellings of "choosen" and "preceed"

### DIFF
--- a/GPL/DemanglerGnu/src/demangler_gnu_v2_24/c/cplus-dem.c
+++ b/GPL/DemanglerGnu/src/demangler_gnu_v2_24/c/cplus-dem.c
@@ -903,7 +903,7 @@ ada_demangle (const char *mangled, int option ATTRIBUTE_UNUSED)
     goto unknown;
 
   /* Most of the demangling will trivially remove chars.  Operator names
-     may add one char but because they are always preceeded by '__' which is
+     may add one char but because they are always preceded by '__' which is
      replaced by '.', they eventually never expand the size.
      A few special names such as '___elabs' add a few chars (at most 7), but
      they occur only once.  */

--- a/GPL/DemanglerGnu/src/demangler_gnu_v2_41/c/cplus-dem.c
+++ b/GPL/DemanglerGnu/src/demangler_gnu_v2_41/c/cplus-dem.c
@@ -219,7 +219,7 @@ ada_demangle (const char *mangled, int option ATTRIBUTE_UNUSED)
     goto unknown;
 
   /* Most of the demangling will trivially remove chars.  Operator names
-     may add one char but because they are always preceeded by '__' which is
+     may add one char but because they are always preceded by '__' which is
      replaced by '.', they eventually never expand the size.
      A few special names such as '___elabs' add a few chars (at most 7), but
      they occur only once.  */

--- a/Ghidra/Features/Base/src/main/help/help/topics/DataTypeEditors/StructureEditor.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/DataTypeEditors/StructureEditor.htm
@@ -306,7 +306,7 @@
         <LI><SPAN style="font-weight: bold;">machine</SPAN> - Sets the minimum alignment to conform 
         to the machine alignment specified by the associated data organization (i.e., compiler specification).
         This genrally corresponds to the largest alignment which is ever
-        used for any data type on the program's intended machine.  If this is choosen and
+        used for any data type on the program's intended machine.  If this is chosen and
         the resulting alignment is larger, this is likely due to a component data type
         having an alignment larger than the machine alignment.
         <BR>

--- a/Ghidra/Features/Base/src/main/help/help/topics/Navigation/Navigation.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/Navigation/Navigation.htm
@@ -494,7 +494,7 @@
       <BLOCKQUOTE>
         <P>Enter <B>file(n)</B>, where <B>n</B> is a file offset of the program's source file bytes
         (at time of import), into the text area of the dialog. The file offset entered will be
-        assumed to be in decimal unless it is preceeded by <B>0x</B>. That is, "file(0x1000)" and
+        assumed to be in decimal unless it is preceded by <B>0x</B>. That is, "file(0x1000)" and
         "file(1000)" are different values.</P>
 
         <P><I><IMG alt="" src="help/shared/note.png" border="0">Ghidra does not support storing

--- a/Ghidra/Features/Base/src/main/help/help/topics/ReferencesPlugin/References_from.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/ReferencesPlugin/References_from.htm
@@ -1037,7 +1037,7 @@ c<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
     cause the <I><B>Add Reference Dialog</B></I> to be displayed for the current <I>Source</I> code
     unit. &nbsp;Once displayed, the <I>Source</I> code unit mnemonic or operand may be selected by
     clicking on it, as well as the <I>Type of Reference</I>. &nbsp;The available choices for Type
-    of Reference may be constrained based upon the choosen operand.</P>
+    of Reference may be constrained based upon the chosen operand.</P>
 
     <P><IMG src="help/shared/note.png" alt=""> <I>In general, only flow references should be set
     on an instruction mnemonic, unless of course the instruction has no operands. &nbsp;References
@@ -1061,7 +1061,7 @@ c<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
     <P align="center"><IMG src="images/AddReferenceDialog.png" alt=""></P>
 
-    <P>Based upon the choosen <I>Type of Reference</I>, the lower portion of the dialog will
+    <P>Based upon the chosen <I>Type of Reference</I>, the lower portion of the dialog will
     change. &nbsp;The following sections discuss the input panels for each of the four possible
     choices:<BR>
     </P>
@@ -1238,7 +1238,7 @@ c<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
       <BLOCKQUOTE>
         <P>This field identifies a namespace name corresponding to the <I>External Program</I> and
-        may be typed-in or choosen from the pull-down list of those previously defined. &nbsp; This
+        may be typed-in or chosen from the pull-down list of those previously defined. &nbsp; This
         is a required input.<BR>
         </P>
       </BLOCKQUOTE>

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/CommentUtils.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/CommentUtils.java
@@ -202,8 +202,8 @@ public class CommentUtils {
 			int start = word.getStart();
 			if (offset != start) {
 				// text between annotations
-				String preceeding = text.substring(offset, start);
-				results.add(new StringCommentPart(preceeding, prototype));
+				String preceding = text.substring(offset, start);
+				results.add(new StringCommentPart(preceding, prototype));
 			}
 
 			String annotationText = word.getWord();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/PreCommentFieldFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/PreCommentFieldFactory.java
@@ -242,7 +242,7 @@ public class PreCommentFieldFactory extends FieldFactory {
 	}
 
 	/**
-	 * A composite which immediately preceeds the current address may contain trailing zero-length 
+	 * A composite which immediately precedes the current address may contain trailing zero-length 
 	 * components which implicitly refer to this address and are not rendered by the opened composite.
 	 * This comment is intended to convey the existence of such hidden components which correspond
 	 * to addr.

--- a/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemProbeConflictResolver.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/formats/gfilesystem/FileSystemProbeConflictResolver.java
@@ -31,7 +31,7 @@ public interface FileSystemProbeConflictResolver {
 	 * Picks a single {@link FileSystemInfoRec} to use when mounting a filesystem.
 	 * <p>
 	 * @param factories a {@link List} of {@link FileSystemInfoRec}s.
-	 * @return the choosen FSIR, or null
+	 * @return the chosen FSIR, or null
 	 */
 	default public FileSystemInfoRec resolveFSIR(List<FileSystemInfoRec> factories) {
 		switch (factories.size()) {
@@ -51,7 +51,7 @@ public interface FileSystemProbeConflictResolver {
 	 * This method will only be called if the list contains more than a single item.
 	 * <p>
 	 * @param factories {@link List} of {@link FileSystemInfoRec}, always more than 1 element.
-	 * @return the choosen FSIR, or null
+	 * @return the chosen FSIR, or null
 	 */
 	public FileSystemInfoRec chooseFSIR(List<FileSystemInfoRec> factories);
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/plugins/importer/tasks/ImportBatchTask.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugins/importer/tasks/ImportBatchTask.java
@@ -137,7 +137,7 @@ public class ImportBatchTask extends Task {
 			LoadSpec loadSpec = batchLoadConfig.getLoadSpec(selectedBatchGroupLoadSpec);
 			if (loadSpec == null) {
 				Msg.error(this,
-					"Failed to get load spec from application that matches choosen batch load spec " +
+					"Failed to get load spec from application that matches chosen batch load spec " +
 						selectedBatchGroupLoadSpec);
 				return;
 			}

--- a/Ghidra/Features/Base/src/main/java/ghidra/program/flatapi/FlatProgramAPI.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/program/flatapi/FlatProgramAPI.java
@@ -1331,7 +1331,7 @@ public class FlatProgramAPI {
 
 	/**
 	 * Returns the defined data after the specified data or null if no data exists.
-	 * @param data preceeding data
+	 * @param data preceding data
 	 * @return the defined data after the specified data or null if no data exists
 	 */
 	public final Data getDataAfter(Data data) {

--- a/Ghidra/Features/BytePatterns/src/main/java/ghidra/closedpatternmining/ProjectedDatabase.java
+++ b/Ghidra/Features/BytePatterns/src/main/java/ghidra/closedpatternmining/ProjectedDatabase.java
@@ -237,7 +237,7 @@ public class ProjectedDatabase {
 			dittedPosition++;//advance past fixedPosition
 		}
 
-		//if all of the preceeding positions are filled, there can't be any backward
+		//if all of the preceding positions are filled, there can't be any backward
 		//extension items
 		if (positionsToSymbols.isEmpty()) {
 			return backwardExtensionItems;

--- a/Ghidra/Features/FileFormats/src/lzfse/c/lzvn_decode_base.c
+++ b/Ghidra/Features/FileFormats/src/lzfse/c/lzvn_decode_base.c
@@ -429,7 +429,7 @@ copy_literal_and_match:
   PTR_LEN_INC(dst_ptr, dst_len, L);
   PTR_LEN_INC(src_ptr, src_len, L);
   //  Check if the match distance is valid; matches must not reference
-  //  bytes that preceed the start of the output buffer, nor can the match
+  //  bytes that precede the start of the output buffer, nor can the match
   //  distance be zero.
   if (D > dst_ptr - state->dst_begin || D == 0)
     goto invalid_match_distance;

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/dump/mdmp/MemoryRange64.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/dump/mdmp/MemoryRange64.java
@@ -32,7 +32,7 @@ public class MemoryRange64 implements StructConverter {
 	// MemoryRange64 is used for full-memory minidumps where
 	// all of the raw memory is laid out sequentially at the
 	// end of the dump.  There is no need for individual RVAs
-	// as the RVA is the base RVA plus the sum of the preceeding
+	// as the RVA is the base RVA plus the sum of the preceding
 	// data blocks.
 
 	private DumpFileReader reader;

--- a/Ghidra/Features/GnuDemangler/ghidra_scripts/VxWorksSymTab_Finder.java
+++ b/Ghidra/Features/GnuDemangler/ghidra_scripts/VxWorksSymTab_Finder.java
@@ -25,7 +25,7 @@
 // table entries are deleted.  Mangled C++ symbol names are demangled.
 //
 // The VxWorks symbol table is an array [0..n-1] of (struct SYMBOL) entries.
-// The table may be immediately followed or preceeded by an (int) vxSymTblLen
+// The table may be immediately followed or preceded by an (int) vxSymTblLen
 // value.
 //
 // Prerequisites:

--- a/Ghidra/Framework/DB/src/main/java/db/Field.java
+++ b/Ghidra/Framework/DB/src/main/java/db/Field.java
@@ -343,7 +343,7 @@ public abstract class Field implements Comparable<Field> {
 
 	/**
 	 * Write the field to buf at the specified offset.  When writing variable length 
-	 * fields, the length preceeds the actual data. 
+	 * fields, the length precedes the actual data. 
 	 * @param buf data buffer
 	 * @param offset data offset
 	 * @return next available Field offset within buffer, or -1 if end of buffer reached.
@@ -354,7 +354,7 @@ public abstract class Field implements Comparable<Field> {
 
 	/**
 	 * Read the field value from buf at the specified offset. When reading variable length 
-	 * fields, the length preceeds the actual data. 
+	 * fields, the length precedes the actual data. 
 	 * @param buf data buffer
 	 * @param offset data offset
 	 * @return next Field offset within buffer, or -1 if end of buffer reached.

--- a/Ghidra/Framework/Docking/src/main/java/docking/menu/MenuHandler.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/menu/MenuHandler.java
@@ -59,7 +59,7 @@ public abstract class MenuHandler implements MenuListener, PopupMenuListener {
 	}
 
 	/**
-	 * Invoked when a menu is no longer selected.  This is always preceeded
+	 * Invoked when a menu is no longer selected.  This is always preceded
 	 * by a menuSelected invocation.  This is invoked prior to the processMenuAction 
 	 * if an action item is selected.
 	 * @see javax.swing.event.MenuListener#menuDeselected(javax.swing.event.MenuEvent)

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/util/graph/attributes/DoubleAttribute.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/util/graph/attributes/DoubleAttribute.java
@@ -150,7 +150,7 @@ public class DoubleAttribute<T extends KeyedObject> extends Attribute<T> {
 			catch (ghidra.util.exception.NoValueException exc) {
 				try {
 					value2 = getValue(ko2);
-					return 1; //ko2 is ok so it preceeds ko1
+					return 1; //ko2 is ok so it precedes ko1
 				}
 				catch (ghidra.util.exception.NoValueException exc2) {
 					if ((ko1.key() - ko2.key()) < 0) {

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/mgr/ToolTaskManager.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/plugintool/mgr/ToolTaskManager.java
@@ -217,7 +217,7 @@ public class ToolTaskManager implements Runnable {
 		taskThread.start();
 		try {
 			// Wait for background command task to start its transaction and notify us.
-			// This is done to ensure any preceeding foreground Command transaction
+			// This is done to ensure any preceding foreground Command transaction
 			// becomes entangled with the task execution.
 			wait(1000);
 		}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/symbol/SubtableSymbol.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/processors/sleigh/symbol/SubtableSymbol.java
@@ -32,7 +32,7 @@ import ghidra.program.model.pcode.DecoderException;
 
 /**
  * A collection of Constructors or a Symbol representing
- * one out of a family of Constructors, choosen based on InstructionContext
+ * one out of a family of Constructors, chosen based on InstructionContext
  */
 public class SubtableSymbol extends TripleSymbol {
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/disassemble/Disassembler.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/disassemble/Disassembler.java
@@ -1120,7 +1120,7 @@ public class Disassembler implements DisassemblerConflictHandler {
 	/**
 	 * Perform parse of instruction bytes and context to produce an instruction prototype.
 	 * @param instrMemBuffer memory buffer
-	 * @param block fallthrough sequence of instructions preceeding current instruction
+	 * @param block fallthrough sequence of instructions preceding current instruction
 	 * required to facilitate potential crossbuilds for current instruction.
 	 * @return instruction prototype
 	 * @throws InsufficientBytesException

--- a/GhidraBuild/BuildFiles/Doclets/src/main/java/ghidra/doclets/typestubs/JavadocConverter.java
+++ b/GhidraBuild/BuildFiles/Doclets/src/main/java/ghidra/doclets/typestubs/JavadocConverter.java
@@ -308,7 +308,7 @@ public class JavadocConverter extends DocConverter {
 	 * @return the converted tag
 	 */
 	private String convertSinceTag(Element el, SinceTree since) {
-		// NOTE: there must be a preceeding new line
+		// NOTE: there must be a preceding new line
 		String msg = convertTree(el, since.getBody());
 		return "\n.. versionadded:: " + msg + '\n';
 	}


### PR DESCRIPTION
While looking at the code for error bookmarks I noticed these two words misspelled. Turns out both were somewhat common in the codebase. This should fix them all.