### PR TITLE
Processors: Rename TriCore Siemens to Infineon

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfConstants.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfConstants.java
@@ -213,7 +213,7 @@ public interface ElfConstants {
 	public static final short EM_SH = 42;
 	/** SPARC v9 64-bit */
 	public static final short EM_SPARCV9 = 43;
-	/**Siemens Tricore */
+	/**Infineon Tricore */
 	public static final short EM_TRICORE = 44;
 	/**Argonaut RISC Core */
 	public static final short EM_ARC = 45;

--- a/Ghidra/Processors/tricore/data/languages/tricore.ldefs
+++ b/Ghidra/Processors/tricore/data/languages/tricore.ldefs
@@ -11,7 +11,7 @@
             processorspec="tricore.pspec"
 	    manualindexfile="../manuals/tricore2.idx"
             id="tricore:LE:32:default">
-    <description>Siemens Tricore Embedded Processor</description>
+    <description>Infineon Tricore Embedded Processor</description>
     <compiler name="default" spec="tricore.cspec" id="default"/>
     <external_name tool="DWARF.register.mapping.file" name="tricore.dwarf"/>
   </language>
@@ -24,7 +24,7 @@
             processorspec="tc29x.pspec"
 	    manualindexfile="../manuals/tricore2.idx"
             id="tricore:LE:32:tc29x">
-    <description>Siemens Tricore Embedded Processor TC29x</description>
+    <description>Infineon Tricore Embedded Processor TC29x</description>
     <compiler name="default" spec="tricore.cspec" id="default"/>
     <external_name tool="DWARF.register.mapping.file" name="tricore.dwarf"/>
   </language>
@@ -37,7 +37,7 @@
             processorspec="tc172x.pspec"
 	    manualindexfile="../manuals/tricore.idx"
             id="tricore:LE:32:tc172x">
-    <description>Siemens Tricore Embedded Processor TC1724/TC1728</description>
+    <description>Infineon Tricore Embedded Processor TC1724/TC1728</description>
     <compiler name="default" spec="tricore.cspec" id="default"/>
     <external_name tool="DWARF.register.mapping.file" name="tricore.dwarf"/>
   </language>
@@ -50,7 +50,7 @@
             processorspec="tc176x.pspec"
 	    manualindexfile="../manuals/tricore.idx"
             id="tricore:LE:32:tc176x">
-    <description>Siemens Tricore Embedded Processor TC1762/TC1766</description>
+    <description>Infineon Tricore Embedded Processor TC1762/TC1766</description>
     <compiler name="default" spec="tricore.cspec" id="default"/>
     <external_name tool="DWARF.register.mapping.file" name="tricore.dwarf"/>
   </language>


### PR DESCRIPTION
Infineon [split off from Siemens](https://en.wikipedia.org/wiki/Infineon_Technologies) a long time ago and it now [owns and develops TriCore](https://www.infineon.com/cms/en/product/microcontroller/32-bit-tricore-microcontroller/).