### PR TITLE
Gui: Rework listing highlighter colors (dark theme)

### DIFF
--- a/Ghidra/Features/Base/data/base.listing.theme.properties
+++ b/Ghidra/Features/Base/data/base.listing.theme.properties
@@ -115,9 +115,8 @@ font.listing.header = SansSerif-PLAIN-11
 color.bg.highlight.listing.diff = #4D4D2A
 
 
-// non-palette colors; these are currently ugly, but bright enough for easy scanning
-color.bg.listing.highlighter.default = yellow
-color.bg.listing.highlighter.scoped.read = darkorange 
-color.bg.listing.highlighter.scoped.write = lime 
+color.bg.listing.highlighter.default = #666600
+color.bg.listing.highlighter.scoped.read = #996600
+color.bg.listing.highlighter.scoped.write = #009900
 
 


### PR DESCRIPTION
I use Ghidra in dark mode and often rely on the cursor text highlighting in the listing view. Currently the highlight colors are way too bright making the text hard to read. I turned down the brightness in my local settings but like a comment in the .properties file suggests others might also find these colors annoying and difficult to work with.

No highlight:

![image](https://github.com/user-attachments/assets/db677063-167a-46ee-a7f6-abace70ad761)

Highlight (before):

![image](https://github.com/user-attachments/assets/8209f914-dc2b-419c-9c52-6a7c744ecb15)

Highlight (after):

![image](https://github.com/user-attachments/assets/6c4b1cb7-1125-4386-999c-545f4042ba4b)
