### PR TITLE
make error messages match logic

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/BinaryLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/BinaryLoader.java
@@ -135,7 +135,7 @@ public class BinaryLoader extends AbstractProgramLoader {
 						fileOffset = -1;
 					}
 					if (fileOffset < 0 || fileOffset >= origFileLength) {
-						return "File Offset must be greater than 0 and less than file length " +
+						return "File Offset must be greater than or equal to 0 and less than file length " +
 							origFileLength + " (0x" + Long.toHexString(origFileLength) + ")";
 					}
 				}
@@ -147,7 +147,7 @@ public class BinaryLoader extends AbstractProgramLoader {
 						length = -1;
 					}
 					if (length < 0 || length > origFileLength) {
-						return "Length must be greater than 0 and less than or equal to file length " +
+						return "Length must be greater than or equal to 0 and less than or equal to file length " +
 							origFileLength + " (0x" + Long.toHexString(origFileLength) + ")";
 					}
 


### PR DESCRIPTION
The logic in two places checks against `< 0` whose opposite is `>= 0` but the error text said "... must be greater than 0"

I changed it to "greater than or equal to 0" to match the style of the second error but personally I prefer the more succinct "... must be at least"