### PR TITLE
Base: Sync headless analyzer docs

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/HeadlessAnalyzer/HeadlessAnalyzer.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/HeadlessAnalyzer/HeadlessAnalyzer.htm
@@ -61,6 +61,7 @@ The Headless Analyzer can be useful when performing repetitive tasks on a projec
 	<BR>&nbsp;&nbsp;&nbsp;&nbsp;[-connect [&lt;userID&gt;]]
 	<BR>&nbsp;&nbsp;&nbsp;&nbsp;[-p]
 	<BR>&nbsp;&nbsp;&nbsp;&nbsp;[-commit [&quot;&lt;comment&gt;&quot;]]
+	<BR>&nbsp;&nbsp;&nbsp;&nbsp;[-okToDelete]
 	<BR>&nbsp;&nbsp;&nbsp;&nbsp;[-max-cpu &lt;max cpu cores to use&gt;]
 	<BR>&nbsp;&nbsp;&nbsp;&nbsp;[-librarySearchPaths &lt;path1&gt;[;&lt;path2&gt;...]]
 	<BR>&nbsp;&nbsp;&nbsp;&nbsp;[-loader &lt;desired loader name&gt;]


### PR DESCRIPTION
[HeadlessAnalyzer.htm](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Base/src/main/help/help/topics/HeadlessAnalyzer/HeadlessAnalyzer.htm#L63) is not fully synced with [analyzeHeadlessREADME.html](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/RuntimeScripts/Common/support/analyzeHeadlessREADME.html#L131).