### PR TITLE
FunctionID: Add AddSingleFunction.java Ghidra script

### DIFF
--- a/Ghidra/Features/FunctionID/ghidra_scripts/AddSingleFunction.java
+++ b/Ghidra/Features/FunctionID/ghidra_scripts/AddSingleFunction.java
@@ -1,0 +1,115 @@
+
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//Adds the function at the current address to the chosen FID library.
+//@category FunctionID
+
+import java.util.List;
+
+import ghidra.app.script.GhidraScript;
+import ghidra.feature.fid.db.*;
+import ghidra.feature.fid.hash.FidHashQuad;
+import ghidra.feature.fid.service.FidService;
+import ghidra.feature.fid.service.FidServiceLibraryIngest;
+import ghidra.framework.model.DomainFile;
+import ghidra.program.model.lang.CompilerSpec;
+import ghidra.program.model.lang.Language;
+import ghidra.program.model.lang.LanguageID;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionManager;
+
+public class AddSingleFunction extends GhidraScript {
+
+	private FidDB fidDb = null;
+
+	@Override
+	protected void run() throws Exception {
+
+		if (currentProgram == null) {
+			printerr("No current program");
+			return;
+		}
+		if (currentAddress == null) {
+			printerr("No current address (?)");
+			return;
+		}
+		FunctionManager functionManager = currentProgram.getFunctionManager();
+		Function function = functionManager.getFunctionContaining(currentAddress);
+		if (function == null) {
+			printerr("No current function");
+			return;
+		}
+
+		FidService service = new FidService();
+		FidHashQuad hashFunction = service.hashFunction(function);
+		if (hashFunction == null) {
+			printerr("Function too small");
+			return;
+		}
+
+		FidFileManager fidFileManager = FidFileManager.getInstance();
+		List<FidFile> userFid = fidFileManager.getUserAddedFiles();
+		if (userFid.isEmpty()) {
+			printerr("No available FID DB");
+			return;
+		}
+		FidFile fidFile =
+			askChoice("FID database", "Choose FID database", userFid, userFid.get(0));
+		try {
+			fidDb = fidFile.getFidDB(true);
+
+			List<LibraryRecord> libraries = fidDb.getAllLibraries();
+			LibraryRecord library;
+			if (libraries == null || libraries.isEmpty()) {
+				println("No libraries found. Creating one...");
+
+				String libraryFamilyName =
+					askString("Library Family Name", "Choose Library Family Name");
+				String libraryVersion = askString("Library Version", "Choose Library Version");
+				String libraryVariant = askString("Library Variant", "Choose Library Variant");
+				LanguageID languageId = currentProgram.getLanguageID();
+				Language language = currentProgram.getLanguage();
+				CompilerSpec compilerSpec = currentProgram.getCompilerSpec();
+				library = fidDb.createNewLibrary(libraryFamilyName, libraryVersion, libraryVariant,
+					getGhidraVersion(), languageId, language.getVersion(),
+					language.getMinorVersion(), compilerSpec.getCompilerSpecID());
+			}
+			else {
+				library =
+					askChoice("FID libraries", "Choose FID library", libraries, libraries.get(0));
+			}
+
+			boolean disableNamespaceStripping =
+				askYesNo("Namespace stripping",
+					"Do you want to disable namespace stripping?");
+
+			long offset = function.getEntryPoint().getOffset();
+
+			boolean hasTerminator = FidServiceLibraryIngest.findTerminator(function, monitor);
+
+			DomainFile domainFile = getCurrentProgram().getDomainFile();
+
+			fidDb.createNewFunction(library, hashFunction,
+				function.getName(disableNamespaceStripping), offset, domainFile.getName(),
+				hasTerminator);
+
+			fidDb.saveDatabase("Saving", monitor);
+		}
+		finally {
+			fidDb.close();
+		}
+	}
+}

--- a/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidServiceLibraryIngest.java
+++ b/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidServiceLibraryIngest.java
@@ -37,7 +37,7 @@ import ghidra.util.exception.CancelledException;
 import ghidra.util.exception.VersionException;
 import ghidra.util.task.TaskMonitor;
 
-class FidServiceLibraryIngest {
+public class FidServiceLibraryIngest {
 	private static final int MAXIMUM_NUMBER_OF_NAME_RESOLUTION_RELATIONS = 12;
 
 	private FidDB fidDb; // The database being populated
@@ -523,7 +523,7 @@ class FidServiceLibraryIngest {
 	 * @return if a terminating flow was found in the function body
 	 * @throws CancelledException if the user cancels
 	 */
-	private static boolean findTerminator(Function function, TaskMonitor monitor)
+	public static boolean findTerminator(Function function, TaskMonitor monitor)
 			throws CancelledException {
 		boolean retFound = false;
 		AddressSetView body = function.getBody();


### PR DESCRIPTION
Fixes #5212

### Introduction

As described in the linked issue there is currently no way to add a single function to a FID DB which is something I have wanted for a long time as well. The Ghidra script `AddSingleFunction.java` now implements this functionality.

### Overview of the script

Prerequisites:
- A FID DB must be created and attached.
- An address must be selected in the listing view.

The script checks if there is any available library in the FID DB. If a library exists the user can select it. If not the user will be prompted to create one. The user can then decide whether to preserve the namespaces of the selected function or save only the basename. Finally the function entry is saved.

### Testing

#### Empty FID DB (create new library)

Select a function (`rayon::main`):

![image](https://github.com/user-attachments/assets/84a18963-2035-4365-860c-2d473523b585)

Run `AddSingleFunction.java`:

![image](https://github.com/user-attachments/assets/9dd25456-0f30-401d-81c0-eb0e3d69afed)

![image](https://github.com/user-attachments/assets/d97f57fb-c945-4233-9aad-2247a24dd71a)

![image](https://github.com/user-attachments/assets/13b2998a-92ed-4e21-80fd-391ce8319f2e)

![image](https://github.com/user-attachments/assets/ce3219de-0b14-4aec-bcdf-97881ad6d07d)

![image](https://github.com/user-attachments/assets/dc214bc7-b3fe-48b1-95e8-218e89f9c02a)

List the FID DB content with `ListFunctions.java`:

```
$ cat fid-list.txt
rust-rayon rust_rayon::main
```

#### Non-empty FID DB (already contains at least one library)

Select a function (`crossbeam_deque::deque::Stealer<T>::steal`):

![image](https://github.com/user-attachments/assets/6cb288ed-5418-4c92-be4b-771a4f23bf26)

Run `AddSingleFunction.java`:

![image](https://github.com/user-attachments/assets/5a5dcd64-e1a9-4591-97be-9797c4369283)

![image](https://github.com/user-attachments/assets/d0cb7624-78b2-4b9b-90c7-e1b54db87234)

![image](https://github.com/user-attachments/assets/be47a13f-3934-4dc1-a1a1-5eb90dec8467)

List the FID DB content with `ListFunctions.java`:

```
$ cat fid-list.txt
rust-rayon crossbeam_deque::deque::Stealer<T>::steal
rust-rayon rust_rayon::main
```

### Additional notes

I needed to make `FidServiceLibraryIngest` and `findTerminator()` public because they are required to calculate `hasTerminator` which is passed to `createNewFunction()`. If this is not allowed let me know and I will duplicate `findTerminator()` instead.