### PR TITLE
Fix potential IndexOutOfBoundsException in PDB parsing

### DIFF
--- a/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/SymbolRecords.java
+++ b/Ghidra/Features/PDB/src/main/java/ghidra/app/util/bin/format/pdb2/pdbreader/SymbolRecords.java
@@ -135,6 +135,9 @@ public class SymbolRecords {
 		if (debugInfo == null) {
 			return;
 		}
+		if (debugInfo.getModuleInformationList().size() == 0) {
+			return;
+		}
 		// We are assuming that first in the list is the one to look at for cases 1 and 2.
 		//  If something else like lowest stream number, then need to change the logic.
 		ModuleInformation moduleInfo = debugInfo.getModuleInformationList().get(0);


### PR DESCRIPTION
Loading a PDB from IDA

```
java.lang.reflect.InvocationTargetException
	at ghidra.app.plugin.core.analysis.AutoAnalysisManager$AnalysisWorkerCommand.applyTo(AutoAnalysisManager.java:1705)
	at ghidra.app.plugin.core.analysis.AutoAnalysisManager$AnalysisWorkerCommand.applyTo(AutoAnalysisManager.java:1586)
	at ghidra.app.plugin.core.analysis.AutoAnalysisManager$AnalysisTaskWrapper.run(AutoAnalysisManager.java:660)
	at ghidra.app.plugin.core.analysis.AutoAnalysisManager.startAnalysis(AutoAnalysisManager.java:760)
	at ghidra.app.plugin.core.analysis.AutoAnalysisManager.startAnalysis(AutoAnalysisManager.java:639)
	at ghidra.app.plugin.core.analysis.AutoAnalysisManager.startAnalysis(AutoAnalysisManager.java:604)
	at ghidra.app.plugin.core.analysis.AnalysisBackgroundCommand.applyTo(AnalysisBackgroundCommand.java:55)
	at ghidra.app.plugin.core.analysis.AnalysisBackgroundCommand.applyTo(AnalysisBackgroundCommand.java:33)
	at ghidra.framework.plugintool.mgr.BackgroundCommandTask.run(BackgroundCommandTask.java:103)
	at ghidra.framework.plugintool.mgr.ToolTaskManager.run(ToolTaskManager.java:351)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at ghidra.app.util.bin.format.pdb2.pdbreader.SymbolRecords.determineCvSigValues(SymbolRecords.java:140)
	at ghidra.app.util.bin.format.pdb2.pdbreader.SymbolRecords.initialize(SymbolRecords.java:119)
	at ghidra.app.util.bin.format.pdb2.pdbreader.PdbNewDebugInfo.initializeAdditionalComponentsForSubstreams(PdbNewDebugInfo.java:153)
	at ghidra.app.util.bin.format.pdb2.pdbreader.PdbDebugInfo.initialize(PdbDebugInfo.java:126)
	at ghidra.app.util.bin.format.pdb2.pdbreader.AbstractPdb.deserializeSubstreams(AbstractPdb.java:551)
	at ghidra.app.util.bin.format.pdb2.pdbreader.AbstractPdb.deserialize(AbstractPdb.java:186)
	at ghidra.app.plugin.core.analysis.PdbUniversalAnalyzer.doAnalysis(PdbUniversalAnalyzer.java:206)
	at pdb.LoadPdbTask.parseWithNewParser(LoadPdbTask.java:145)
	at pdb.LoadPdbTask$2.analysisWorkerCallback(LoadPdbTask.java:85)
	at ghidra.app.plugin.core.analysis.AutoAnalysisManager$AnalysisWorkerCommand.applyTo(AutoAnalysisManager.java:1699)
	... 10 more
```

This may be an issue with https://github.com/Mixaill/FakePDB not conforming to spec. Maybe we want to throw w/ a human readable message here instead of letting the generic "Index 0 out of bounds for length 0" message reach the user?