### PR TITLE
BSim: Clarify x86_64 support for PostgreSQL server

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/BSimOverview.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/BSimOverview.html
@@ -184,7 +184,7 @@
           <H3 class="title">Note</H3>
 
           <P>The PostgreSQL server software is currently only supported for the <SPAN class=
-          "emphasis"><EM>Linux</EM></SPAN> and <SPAN class="emphasis"><EM>macOS</EM></SPAN>
+          "emphasis"><EM>Linux</EM></SPAN> and <SPAN class="emphasis"><EM>macOS x86_64</EM></SPAN>
           architectures. Elasticsearch server software must be obtained separately. Small local
           file-based databases are supported on all platforms via an embedded H2 database
           engine.  The BSim client

--- a/GhidraDocs/GhidraClass/BSim/BSimTutorial_Ghidra_Command_Line.md
+++ b/GhidraDocs/GhidraClass/BSim/BSimTutorial_Ghidra_Command_Line.md
@@ -8,7 +8,7 @@ So we can just build PostgreSQL and harvest the object files we need.
 **Note**: For the tutorial, we continue to use the H2 BSim backend. 
 We do not run any PostgreSQL code, we simply analyze some files produced when building PostgreSQL.
 
-Note that these files must be built on a machine running Linux.
+Note that these files must be built on a machine running Linux x86_64.
 Windows users can build these files in a Linux virtual machine.
 
 To build the files, execute the following commands in a shell: [^1] 


### PR DESCRIPTION
I wanted to set up a BSim PostgreSQL server on my Raspberry Pi but I noticed that currently only `x86_64` is supported according to [make-postgres.sh](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/BSim/support/make-postgres.sh#L86). Maybe this could be clarified in the docs.