### PR TITLE
BSim: Clarify install dependencies for PostgreSQL server

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/DatabaseConfiguration.html
@@ -155,7 +155,7 @@
             <DIV class="informalexample">
               <TABLE border="0" summary="Simple list" class="simplelist">
                 <TR>
-                  <TD><CODE class="computeroutput">https://www.postgresql.org/docs/current/install-requirements.html
+                  <TD><CODE class="computeroutput">https://www.postgresql.org/docs/15/install-requirements.html
 		  </CODE></TD>
                 </TR>
               </TABLE>

--- a/Ghidra/Features/BSim/support/make-postgres.sh
+++ b/Ghidra/Features/BSim/support/make-postgres.sh
@@ -38,7 +38,7 @@
 # postgresql build.  Please refer to the following web page for 
 # software dependencies:
 #
-#   https://www.postgresql.org/docs/current/install-requirements.html
+#   https://www.postgresql.org/docs/15/install-requirements.html
 #
 # Or for Linux specific package dependencies, see:
 #


### PR DESCRIPTION
Currently the BSim PostgreSQL server dependency link points to the *current* version which is the latest (version 17). This is not a huge issue as the dependencies for version 17 also work with version 15 but users following this link will install some unnecessary packages such as `perl` and the ICU library.