### PR TITLE
Remove an unconstrained context variable in mips16.sinc

### DIFF
--- a/Ghidra/Processors/MIPS/data/languages/mips16.sinc
+++ b/Ghidra/Processors/MIPS/data/languages/mips16.sinc
@@ -169,7 +169,6 @@ OFF_M16SP: val(sp) 					is ext_is_ext=0 & m16_iu8_imm & sp [ val = m16_iu8_imm <
 EXT_FRAME: val						is ext_value_frame=0 & m16_svrs_frame=0 [val = 128; ] {export *[const]:2 val;}
 EXT_FRAME: val						is ext_value_frame & m16_svrs_frame [val = ((ext_value_frame << 4) | m16_svrs_frame) << 3;] {export *[const]:2 val;}
 
-REGRS_STAT:							is ext_value_areg {}
 REGRS_STAT:	",a3"					is (ext_value_areg=1 | ext_value_areg=5 | ext_value_areg=9 |ext_value_areg=0xd) {
  	tsp = tsp-4;
 	MemSrcCast(a3,tsp);


### PR DESCRIPTION
Removing a line which seems to allow the aregs field to be set to any value for encodings of the "restore" instruction, some of which are invalid/resThe MIPS sleigh specification contains a constructor for the "restore" instruction which produces a result that differs from the MIPS instruction manual. More specifically, the aregs field is encoded incorrectly in the sleigh specification, as the current encoding includes a mask for the aregs field that is too general.

Take for example the instruction `restore 0x1b8,ra,s0-s1`, which contains no aregs arguments. According to page 120 of MIPS32® Architecture for Programmers Volume IV-a: The MIPS16e™ Application Specific Extension to the MIPS32® Architecture[1], valid encodings of this scenario for the aregs field include `0000`, `0100`, `1000`, `1100`, and `1110`.

[1] https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MD00076-2B-MIPS1632-AFP-02.63.pdf

However, when assembling this instruction in Ghidra, one AssemblyResolution that is returned contains an AssemblyPatternBlock where the mask for the aregs field is `0000`. This means that any encoding for the aregs field is valid for `restore 0x1b8,ra,s0-s1`, but that is incorrect. Only the five encodings listed in the paragraph above are valid for that specific instruction. We have found that removing line 172 from mips16.sinc removes the AssemblyResolution with a `0000` mask.

It's unclear to us what the purpose of this line we have removed is, however this change removes a "reserved" encoding from showing up in the "right-click" > "patch instruction" -> "autocomplete" output and fixes an incorrectly broad mask from being returned to pickled canary when assembling the example instruction above.

It also seems like this problem also exists for at least some other instructions as well with their own unconstrained context variables (e.g. the `save` instruction, specifically line 208 of this file). 
