### PR TITLE
Fix M16C SFR memory size, add missing register. 

### DIFF
--- a/Ghidra/Processors/M16C/data/languages/M16C_60.pspec
+++ b/Ghidra/Processors/M16C/data/languages/M16C_60.pspec
@@ -153,6 +153,7 @@
     <symbol name="PUR0" address="RAM:03FC"/>
     <symbol name="PUR1" address="RAM:03FD"/>
     <symbol name="PUR2" address="RAM:03FE"/>
+    <symbol name="PCR" address="RAM:03FF"/>
     <symbol name="UNDEFINED_INSTRUCTION_INT_VECTOR" address="RAM:FFFDC" entry="true" type="code_ptr"/>
     <symbol name="OVERFLOW_INT_VECTOR" address="RAM:FFFE0" entry="true" type="code_ptr"/>
     <symbol name="BRK_INSTRUCTION_INT_VECTOR" address="RAM:FFFE4" entry="true" type="code_ptr"/>
@@ -164,6 +165,6 @@
     <symbol name="RESET_INT_VECTOR" address="RAM:FFFFC" entry="true" type="code_ptr"/>
   </default_symbols>
   <default_memory_blocks>
-    <memory_block name="SFR" start_address="RAM:0000" mode="rw" length="0x03FF" initialized="false"/>
+    <memory_block name="SFR" start_address="RAM:0000" mode="rw" length="0x0400" initialized="false"/>
   </default_memory_blocks>
 </processor_spec>

--- a/Ghidra/Processors/M16C/data/languages/M16C_80.pspec
+++ b/Ghidra/Processors/M16C/data/languages/M16C_80.pspec
@@ -291,6 +291,6 @@
     <symbol name="RESET_INT_VECTOR" address="RAM:FFFFFC" entry="true" type="code_ptr"/>
   </default_symbols>
   <default_memory_blocks>
-    <memory_block name="SFR" start_address="RAM:0000" mode="rw" length="0x03FF" initialized="false"/>
+    <memory_block name="SFR" start_address="RAM:0000" mode="rw" length="0x0400" initialized="false"/>
   </default_memory_blocks>
 </processor_spec>


### PR DESCRIPTION
All M16C/62 M16C/65 M16C/80 datasheets I checked show the SFR space going from 0x000 - 0x3FF (0x400 length)

![Screenshot 2024-12-19 at 3 36 18 PM](https://github.com/user-attachments/assets/e11ef2ae-1dd1-4b5a-80a8-661e58209579)

Also missing was the 0x3FF SFR I added in for the M16C_60.

Datasheet links below for verification.

M16C/62 ( PDF pages 35 (SFR memory size) and 41 (PCR SFR) ) 
https://www.renesas.com/en/document/dst/m16c62p-group-m16c62p-m16c62pt-datasheet

M16C/80 ( PDF page 23 (SFR memory size) )
https://datasheet.octopart.com/M30800FCFP%23U3-Renesas-datasheet-18279.pdf
