### PR TITLE
PCode: Add edge label information to XML encoding and expose it in Ghidra.

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/block.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/block.cc
@@ -24,6 +24,7 @@ AttributeId ATTRIB_DEPTH = AttributeId("depth",76);
 AttributeId ATTRIB_END = AttributeId("end",77);
 AttributeId ATTRIB_OPCODE = AttributeId("opcode",78);
 AttributeId ATTRIB_REV = AttributeId("rev",79);
+AttributeId ATTRIB_EDGE_LABEL = AttributeId("edgelabel",151);
 
 ElementId ELEM_BHEAD = ElementId("bhead",102);
 ElementId ELEM_BLOCK = ElementId("block",103);
@@ -36,9 +37,9 @@ void BlockEdge::encode(Encoder &encoder) const
 
 {
   encoder.openElement(ELEM_EDGE);
-  // We are not saving label currently
   encoder.writeSignedInteger(ATTRIB_END, point->getIndex());	// Reference to other end of edge
   encoder.writeSignedInteger(ATTRIB_REV, reverse_index);	// Position within other blocks edgelist
+  encoder.writeUnsignedInteger(ATTRIB_EDGE_LABEL, label);
   encoder.closeElement(ELEM_EDGE);
 }
 
@@ -49,12 +50,12 @@ void BlockEdge::decode(Decoder &decoder,BlockMap &resolver)
 
 {
   uint4 elemId = decoder.openElement(ELEM_EDGE);
-  label = 0;		// Tag does not currently contain info about label
   int4 endIndex = decoder.readSignedInteger(ATTRIB_END);
   point = resolver.findLevelBlock(endIndex);
   if (point == (FlowBlock *)0)
     throw LowlevelError("Bad serialized edge in block graph");
   reverse_index = decoder.readSignedInteger(ATTRIB_REV);
+  label = decoder.readUnsignedInteger(ATTRIB_EDGE_LABEL);
   decoder.closeElement(elemId);
 }
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/AttributeId.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/AttributeId.java
@@ -244,5 +244,8 @@ public record AttributeId(String name, int id) {
 	public static final AttributeId ATTRIB_STORAGE = new AttributeId("storage", 149);
 	public static final AttributeId ATTRIB_STACKSPILL = new AttributeId("stackspill", 150);
 
-	public static final AttributeId ATTRIB_UNKNOWN = new AttributeId("XMLunknown", 151);
+	// edge
+	public static final AttributeId ATTRIB_EDGE_LABEL = new AttributeId("edgelabel", 151);
+
+	public static final AttributeId ATTRIB_UNKNOWN = new AttributeId("XMLunknown", 152);
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeBlock.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeBlock.java
@@ -159,6 +159,7 @@ public class PcodeBlock {
 			encoder.writeSignedInteger(ATTRIB_END, point.getIndex());
 			// Position within other blocks edgelist
 			encoder.writeSignedInteger(ATTRIB_REV, reverse_index);
+			encoder.writeUnsignedInteger(ATTRIB_EDGE_LABEL, label);
 			encoder.closeElement(ELEM_EDGE);
 		}
 
@@ -170,26 +171,26 @@ public class PcodeBlock {
 		 */
 		public void decode(Decoder decoder, BlockMap resolver) throws DecoderException {
 			int el = decoder.openElement(ELEM_EDGE);
-			label = 0;		// Tag does not currently contain info about label
 			int endIndex = (int) decoder.readSignedInteger(ATTRIB_END);
 			point = resolver.findLevelBlock(endIndex);
 			if (point == null) {
 				throw new DecoderException("Bad serialized edge in block graph");
 			}
 			reverse_index = (int) decoder.readSignedInteger(ATTRIB_REV);
+			label = (int) decoder.readUnsignedInteger(ATTRIB_EDGE_LABEL);
 			decoder.closeElement(el);
 		}
 
 		public void decode(Decoder decoder, ArrayList<? extends PcodeBlock> blockList)
 				throws DecoderException {
 			int el = decoder.openElement(ELEM_EDGE);
-			label = 0;		// Tag does not currently contain info about label
 			int endIndex = (int) decoder.readSignedInteger(ATTRIB_END);
 			point = blockList.get(endIndex);
 			if (point == null) {
 				throw new DecoderException("Bad serialized edge in block list");
 			}
 			reverse_index = (int) decoder.readSignedInteger(ATTRIB_REV);
+			label = (int) decoder.readUnsignedInteger(ATTRIB_EDGE_LABEL);
 			decoder.closeElement(el);
 		}
 
@@ -257,7 +258,7 @@ public class PcodeBlock {
 		while (inEdge.point.outofthis.size() <= inEdge.reverse_index) {
 			inEdge.point.outofthis.add(null);
 		}
-		BlockEdge outEdge = new BlockEdge(this, 0, intothis.size() - 1);
+		BlockEdge outEdge = new BlockEdge(this, inEdge.label, intothis.size() - 1);
 		inEdge.point.outofthis.set(inEdge.reverse_index, outEdge);
 	}
 
@@ -275,7 +276,7 @@ public class PcodeBlock {
 		while (inEdge.point.outofthis.size() <= inEdge.reverse_index) {
 			inEdge.point.outofthis.add(null);
 		}
-		BlockEdge outEdge = new BlockEdge(this, 0, intothis.size() - 1);
+		BlockEdge outEdge = new BlockEdge(this, inEdge.label, intothis.size() - 1);
 		inEdge.point.outofthis.set(inEdge.reverse_index, outEdge);
 	}
 
@@ -283,8 +284,16 @@ public class PcodeBlock {
 		return intothis.get(i).point;
 	}
 
+	public int getInEdgeLabel(int i) {
+		return intothis.get(i).label;
+	}
+
 	public PcodeBlock getOut(int i) {
 		return outofthis.get(i).point;
+	}
+
+	public int getOutEdgeLabel(int i) {
+		return outofthis.get(i).label;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7029 

Basically just adds the 'label' field, that just wasn't encoded/decoded until now. Helpful when trying to determine the default switch case block in PCode form.