### PR TITLE
BSim: Rework feature visualizer colors (dark theme)

### DIFF
--- a/Ghidra/Features/BSimFeatureVisualizer/data/bsim.theme.properties
+++ b/Ghidra/Features/BSimFeatureVisualizer/data/bsim.theme.properties
@@ -27,3 +27,7 @@ color.bsim.graph.edge.controlflow.true = color.palette.green
 color.bsim.graph.edge.controlflow.false = color.palette.red
 
 [Dark Defaults]
+
+color.bsim.graph.dataflow.vertex.base = color.palette.darkgray
+color.bsim.graph.dataflow.vertex.base.2 = color.palette.gray
+color.bsim.graph.dataflow.vertex.pcode.op = #996600


### PR DESCRIPTION
Fixes #7309 

Seems like the BSim feature visualizer is not optimized for the dark theme at the moment. This PR improves it.

Before (1):

![image](https://github.com/user-attachments/assets/68980e73-155f-4943-bfd8-97341a42755f)

![image](https://github.com/user-attachments/assets/b72d5eec-fb03-4326-af9b-48b61074995a)

After (1):

![image](https://github.com/user-attachments/assets/5045ed8f-6f89-4817-869e-7b68c1109b13)

Before (2):

![image](https://github.com/user-attachments/assets/55ddc3c2-8296-477d-89b3-08fbed0b6f41)

![image](https://github.com/user-attachments/assets/d110c16b-66ba-4283-a0a1-9ec073dce097)

After (2):

![image](https://github.com/user-attachments/assets/e980136d-2c0f-4e29-aa53-24b23e8fa635)

Before (3):

![image](https://github.com/user-attachments/assets/3d86b5ea-dc4b-4189-a7e8-df014187c93d)

![image](https://github.com/user-attachments/assets/ad4ecdee-e48a-4362-9b91-8abfd1a64859)

After (3):

![image](https://github.com/user-attachments/assets/891d36e5-c78d-47ec-b37b-773a3c922f91)
