### PR TITLE
Update supported Python versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To create the latest development build for your platform from this source reposi
 ##### Install build tools:
 * [JDK 21 64-bit][jdk]
 * [Gradle 8.5+][gradle] (or provided Gradle wrapper if Internet connection is available)
-* [Python3][python3] (version 3.9 to 3.12) with bundled pip
+* [Python3][python3] (version 3.9 to 3.13) with bundled pip
 * make, gcc, and g++ (Linux/macOS-only)
 * [Microsoft Visual Studio][vs] 2017+ or [Microsoft C++ Build Tools][vcbuildtools] with the
   following components installed (Windows-only):


### PR DESCRIPTION
Support for Python 3.13 is added in 7c4d91f568b1f98149bb8cfa38f792c0daa1c1a0, but README.md was not updated.