### PR TITLE
Use python venv for package building

### DIFF
--- a/gradle/hasPythonPackage.gradle
+++ b/gradle/hasPythonPackage.gradle
@@ -55,7 +55,7 @@ task buildPyPackage {
 		File setuptools = project(":Debugger-rmi-trace").findPyDep(".")
 		exec {
 			workingDir { "build/pypkg" }
-			commandLine rootProject.PYTHON3
+			commandLine rootProject.PYTHON3_VENV
 			args "-m", "pip", "wheel", "-w", "dist/", "--no-index", "--no-deps", "-f", setuptools, "."
 		}
 	}

--- a/gradle/root/distribution.gradle
+++ b/gradle/root/distribution.gradle
@@ -276,7 +276,7 @@ task createGhidraStubsWheel {
 		
 		exec {
 			workingDir { typestubsDir }
-			commandLine PYTHON3
+			commandLine PYTHON3_VENV
 			args "-m", "pip", "wheel", "-w", distDir, "--no-index", "-f", setuptools, "."
 		}
 	}


### PR DESCRIPTION
Why:

When building ghidra from the build instructions I got the error
```
/nix/store/zv1kaq7f1q20x62kbjv6pfjygw5jmwl6-python3-3.12.7/bin/python3: No module named pip
```

Setting the caveats of my OS aside, the problem is that Ghidra (only when building wheels) tries to use a system python3, instead of the one provided by venv. This is a problem for me, since python distributed by my OS has no module named "pip". As far as I know there may be other situations where OS-level python has no `pip` support. Meanwhile, python3 installed in venv is guaranteed to have a working `pip`.

This PR suggests to build wheels using python3 from venv. The benefit is that the build will become more robust. I confirmed that this fixes the problem for me, and I assume other people may be affected too. I personally don't see any downsides - it neither complicates the code, nor breaks the build for anyone else.

PS. PyGhidra is great, I can't wait for official release