### PR TITLE
Omf51 objectmarkup change record type symbolic name "LibModName" to "LibModNames"

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordFactory.java
@@ -58,7 +58,7 @@ public class Omf51RecordFactory extends AbstractOmfRecordFactory {
 			case PublicDEF:
 			case ExternalDEF:
 			case LibModLocs:
-			case LibModName:
+			case LibModNames:
 			case LibDictionary:
 			case LibHeader:
 				yield new OmfUnsupportedRecord(reader, Omf51RecordTypes.class);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
@@ -38,21 +38,25 @@ public class Omf51RecordTypes {
 	public final static int LibDictionary = 0x2a;
 	public final static int LibHeader = 0x2c;
 
-	// The five following record types with names ending in "Keil", which are produced by ARM Keil's
+	// Record types with names ending in "Keil", which are produced by ARM Keil's
 	// 8051 tooling, are only slight variants of the similarly-named record types in the Intel spec.
 	public final static int SegmentDEFKeil = SegmentDEF + 1;
 	public final static int ScopeDEFKeil = ScopeDEF + 1;
-	public final static int DebugItemKeil = DebugItem + 1;
+	public final static int KeilDebugItemOBJ = 0x22;		// Keil debug items, in linker output format
+	public final static int KeilDebugItemSRC = 0x23;		// Keil debug item, in compiler output format
 	public final static int PublicDEFKeil = PublicDEF + 1;
 
 	// The three type values 0x62, 0x63, and 0x64, which are produced by ARM Keil's 8051 toolchain,
 	// contain data that is used for source-level debugging in the company's uVision IDE--such 
 	// information as function prototypes, struct definitions, function variable names and types,
 	// etc. As more is learned about their content, more descriptive names could be considered.
-	public final static int DebugData62Keil = 0x62;
-	public final static int DebugData63Keil = 0x63;
-	public final static int DebugData64Keil = 0x64;
+	public final static int KeilDebugData62 = 0x62;
+	public final static int KeilDebugData63 = 0x63;
+	public final static int KeilDebugData64 = 0x64;
 
+	public final static int KeilModuleSourceName = 0x24;	// Name of the current module's source file
+
+	public final static int KeilSourceBrowserFiles = 0x61;	// Sequence of source filenames, for Keil debugger's source browser
 	/**
 	 * Gets the name of the given record type
 	 * 
@@ -60,6 +64,6 @@ public class Omf51RecordTypes {
 	 * @return The name of the given record type
 	 */
 	public final static String getName(int type) {
-		return OmfUtils.getRecordName(type, Omf51RecordTypes.class);
+		return OmfUtils./(type, Omf51RecordTypes.class);
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
@@ -34,7 +34,7 @@ public class Omf51RecordTypes {
 	public final static int PublicDEF = 0x16;
 	public final static int ExternalDEF = 0x18;
 	public final static int LibModLocs = 0x26;
-	public final static int LibModName = 0x28;
+	public final static int LibModNames = 0x28;
 	public final static int LibDictionary = 0x2a;
 	public final static int LibHeader = 0x2c;
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
@@ -61,6 +61,6 @@ public class Omf51RecordTypes {
 	 * @return The name of the given record type
 	 */
 	public final static String getName(int type) {
-		return OmfUtils.GetRecordName(type, Omf51RecordTypes.class);
+		return OmfUtils.getRecordName(type, Omf51RecordTypes.class);
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
@@ -44,8 +44,9 @@ public class Omf51RecordTypes {
 	public final static int ScopeDEFKeil = ScopeDEF + 1;
 	public final static int KeilDebugItemOBJ = 0x22;		// Keil debug items, in linker output format
 	public final static int KeilDebugItemSRC = 0x23;		// Keil debug item, in compiler output format
+	public final static int KeilModuleSourceName = 0x24;		// Name of the current module's source file
 	public final static int PublicDEFKeil = PublicDEF + 1;
-
+	public final static int KeilSourceBrowserFiles = 0x61;		// Sequence of source filenames, for Keil debugger's source browser
 	// The three type values 0x62, 0x63, and 0x64, which are produced by ARM Keil's 8051 toolchain,
 	// contain data that is used for source-level debugging in the company's uVision IDE--such 
 	// information as function prototypes, struct definitions, function variable names and types,
@@ -53,10 +54,6 @@ public class Omf51RecordTypes {
 	public final static int KeilDebugData62 = 0x62;
 	public final static int KeilDebugData63 = 0x63;
 	public final static int KeilDebugData64 = 0x64;
-
-	public final static int KeilModuleSourceName = 0x24;	// Name of the current module's source file
-
-	public final static int KeilSourceBrowserFiles = 0x61;	// Sequence of source filenames, for Keil debugger's source browser
 	/**
 	 * Gets the name of the given record type
 	 * 
@@ -64,6 +61,6 @@ public class Omf51RecordTypes {
 	 * @return The name of the given record type
 	 */
 	public final static String getName(int type) {
-		return OmfUtils./(type, Omf51RecordTypes.class);
+		return OmfUtils.GetRecordName(type, Omf51RecordTypes.class);
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
@@ -40,12 +40,12 @@ public class Omf51RecordTypes {
 
 	// Record types with names ending in "Keil", which are produced by ARM Keil's
 	// 8051 tooling, are only slight variants of the similarly-named record types in the Intel spec.
-	public final static int SegmentDEFKeil = SegmentDEF + 1;
-	public final static int ScopeDEFKeil = ScopeDEF + 1;
+	public final static int KeilSegmentDEF = SegmentDEF + 1;
+	public final static int KeilScopeDEF = ScopeDEF + 1;
 	public final static int KeilDebugItemOBJ = 0x22;		// Keil debug items, in linker output format
 	public final static int KeilDebugItemSRC = 0x23;		// Keil debug item, in compiler output format
 	public final static int KeilModuleSourceName = 0x24;		// Name of the current module's source file
-	public final static int PublicDEFKeil = PublicDEF + 1;
+	public final static int KeilPublicDEF = PublicDEF + 1;
 	public final static int KeilSourceBrowserFiles = 0x61;		// Sequence of source filenames, for Keil debugger's source browser
 	// The three type values 0x62, 0x63, and 0x64, which are produced by ARM Keil's 8051 toolchain,
 	// contain data that is used for source-level debugging in the company's uVision IDE--such 


### PR DESCRIPTION
Rename LibModName to LibModNames because this record type consists of a series of module names, rather than a single module name