### PR TITLE
Add missing switch case in `PcodeOp.getMnemonic` for `SEGMENTOP`

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeOp.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/PcodeOp.java
@@ -689,6 +689,8 @@ public class PcodeOp {
 				return "PTRADD";
 			case PTRSUB:
 				return "PTRSUB";
+			case SEGMENTOP:
+				return "SEGMENTOP";
 			case CPOOLREF:
 				return "CPOOLREF";
 			case NEW:


### PR DESCRIPTION
`PcodeOp.getMnemonic` had switch cases for all op codes except `SEGMENTOP`.