### PR TITLE
(Mach-O) Start using `long` for symbol table offsets instead of `int`.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DynamicSymbolTableCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/DynamicSymbolTableCommand.java
@@ -304,7 +304,7 @@ public class DynamicSymbolTableCommand extends LoadCommand {
 	}
 
 	@Override
-	public int getLinkerDataOffset() {
+	public long getLinkerDataOffset() {
 		return indirectsymoff;
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/LinkEditDataCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/LinkEditDataCommand.java
@@ -58,7 +58,7 @@ public class LinkEditDataCommand extends LoadCommand {
 	}
 
 	@Override
-	public int getLinkerDataOffset() {
+	public long getLinkerDataOffset() {
 		return dataoff;
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/LoadCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/LoadCommand.java
@@ -91,7 +91,7 @@ public abstract class LoadCommand implements StructConverter {
 	 * 
 	 * @return The file offset of this load command's "linker data", or 0 if it has no linker data
 	 */
-	public int getLinkerDataOffset() {
+	public long getLinkerDataOffset() {
 		return 0;
 	}
 
@@ -170,7 +170,7 @@ public abstract class LoadCommand implements StructConverter {
 	 * @param size The size (actual size not important, but 0 will cause null to be returned)
 	 * @return The converted {@link Address}, or null if there is no corresponding {@link Address}
 	 */
-	protected Address fileOffsetToAddress(Program program, MachHeader header, int fileOffset,
+	protected Address fileOffsetToAddress(Program program, MachHeader header, long fileOffset,
 			int size) {
 		if (fileOffset != 0 && size != 0) {
 			AddressSpace space = program.getAddressFactory().getDefaultAddressSpace();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/SymbolTableCommand.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/SymbolTableCommand.java
@@ -37,9 +37,9 @@ import ghidra.util.task.TaskMonitor;
  * Represents a symtab_command structure
  */
 public class SymbolTableCommand extends LoadCommand {
-	private int symoff;
+	private long symoff;
 	private int nsyms;
-	private int stroff;
+	private long stroff;
 	private int strsize;
 
 	private List<NList> symbols = new ArrayList<NList>();
@@ -58,9 +58,9 @@ public class SymbolTableCommand extends LoadCommand {
 			MachHeader header) throws IOException {
 		super(loadCommandReader);
 
-		symoff = loadCommandReader.readNextInt();
+		symoff = loadCommandReader.readNextUnsignedInt();
 		nsyms = loadCommandReader.readNextInt();
-		stroff = loadCommandReader.readNextInt();
+		stroff = loadCommandReader.readNextUnsignedInt();
 		strsize = loadCommandReader.readNextInt();
 
 		List<NList> nlistList = new ArrayList<>(nsyms);
@@ -90,7 +90,7 @@ public class SymbolTableCommand extends LoadCommand {
 	 * The symbol table is an array of nlist data structures.
 	 * @return symbol table offset
 	 */
-	public int getSymbolOffset() {
+	public long getSymbolOffset() {
 		return symoff;
 	}
 
@@ -107,7 +107,7 @@ public class SymbolTableCommand extends LoadCommand {
 	 * location of the string table.
 	 * @return string table offset
 	 */
-	public int getStringTableOffset() {
+	public long getStringTableOffset() {
 		return stroff;
 	}
 
@@ -169,7 +169,7 @@ public class SymbolTableCommand extends LoadCommand {
 	}
 
 	@Override
-	public int getLinkerDataOffset() {
+	public long getLinkerDataOffset() {
 		return symoff;
 	}
 

--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/ExtractedMacho.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/ExtractedMacho.java
@@ -98,7 +98,7 @@ public class ExtractedMacho {
 					if (cmd instanceof SymbolTableCommand symbolTable) {
 						symbolTable.addSymbols(getExtraSymbols());
 					}
-					int offset = cmd.getLinkerDataOffset();
+					long offset = cmd.getLinkerDataOffset();
 					int size = cmd.getLinkerDataSize();
 					if (offset == 0 || size == 0) {
 						continue;


### PR DESCRIPTION
This addresses #7289, or at least tries to.

In short: file offsets are being parsed as signed integers when they should be parsed as unsigned integers. Java doesn't have a native concept of unsigned integers, so this required converting some `int`-typed values to be `long`-typed.

Please note that I have not tested this thoroughly, but it does compile. The extent of my testing has been to build the latest `master` branch with and without my changes and compare importing a single dylib from a dyld shared cache.

Interestingly, the latest `master` seems to correctly resolve the function names for some exports when the current release (11.2.1) struggles to do so. However, without my changes, many other functions failed to have their names properly resolved, so I do believe this is helping to some degree.

TL;DR:

1. This uses the more appropriate "unsigned int" (`long` because "unsigned int" isn't Java-native) type to store file offsets for Mach-O symbol tables, because file offsets should never be negative.
2. I changed the `SymbolTableCommand` file and then only made minimal other changes so that it would build. More changes might be needed to make this patch nicer and more complete.
3. Symbol name resolution seems to have improved slightly between the current release (11.2.1) and the current `master`, but it is still lacking in ways this attempts to fix.

As a final note, my development environment is currently not geared towards any form of rapid development and/or testing, so I would appreciate help and guidance in how to get this to a better state so it can be merged.

Thank you! 