### PR TITLE
RecoverClassesFromRTTIScript.java: fix misspelling of the word 'analyzer'

### DIFF
--- a/Ghidra/Features/Decompiler/ghidra_scripts/RecoverClassesFromRTTIScript.java
+++ b/Ghidra/Features/Decompiler/ghidra_scripts/RecoverClassesFromRTTIScript.java
@@ -381,7 +381,7 @@ public class RecoverClassesFromRTTIScript extends GhidraScript {
 
 		if (!GhidraProgramUtilities.isAnalyzed(currentProgram)) {
 			return ("The program has not been analyzed. Please run auto-analysis and make sure " +
-				"the RTTI analzer is one of the analyzers enabled.");
+				"the RTTI analyzer is one of the analyzers enabled.");
 		}
 
 		if (isRttiAnalyzed() && !hasRtti()) {


### PR DESCRIPTION
* Fix misspelling of the word 'analyzer' in the `RecoverClassesFromRTTIScript.java` script