### PR TITLE
Add content records (restoring files accidentally removed)

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51Content.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51Content.java
@@ -1,0 +1,75 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.omf.omf51;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.format.omf.*;
+import ghidra.program.model.data.*;
+import ghidra.util.exception.DuplicateNameException;
+
+public class Omf51Content extends OmfRecord {
+
+	private byte segId;
+	private short offset; 
+	private byte[] contentBytes;
+
+	/**
+	 * Creates a new {@link Omf51Content} record
+	 * 
+	 * @param reader A {@link BinaryReader} positioned at the start of the record
+	 * @throws IOException if an IO-related error occurred
+	 */
+	public Omf51Content(BinaryReader reader) throws IOException {
+		super(reader);
+	}
+
+	@Override
+	public void parseData() throws IOException, OmfException {
+		segId = dataReader.readNextByte();
+		offset = dataReader.readNextShort();
+	    // Record length includes type byte, length bytes, content, and checksum
+	    // We need to subtract: type(1) + length(2) + seg_id(1) + offset(2) + checksum(1)
+	    int remainingBytes = getRecordLength() - 4;
+	    if (remainingBytes > 0) {
+	        contentBytes = dataReader.readNextByteArray(remainingBytes);
+	    } else {
+	        contentBytes = new byte[0];  // Empty array if no content
+	    }
+	}
+
+	/**
+	 * {@return the segment ID}
+	 */
+	public byte getSegId() {
+		return segId;
+	}
+
+	@Override
+	public DataType toDataType() throws DuplicateNameException, IOException {
+		StructureDataType struct = new StructureDataType(Omf51RecordTypes.getName(recordType), 0);
+		struct.add(BYTE, "type", null);
+		struct.add(WORD, "length", null);
+		struct.add(BYTE, "SEG ID", null);
+		struct.add(WORD, "offset", null);
+	    struct.add(new ArrayDataType(BYTE, contentBytes.length, 1), "content", null);
+		struct.add(BYTE, "checksum", null);
+
+		struct.setCategoryPath(new CategoryPath(OmfUtils.CATEGORY_PATH));
+		return struct;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordFactory.java
@@ -51,6 +51,7 @@ public class Omf51RecordFactory extends AbstractOmfRecordFactory {
 			case Omf166RecordTypes.DEPLST:
 				yield new Omf166DepList(reader);
 			case Content:
+				yield new Omf51Content(reader);
 			case Fixup:
 			case SegmentDEF:
 			case ScopeDEF:


### PR DESCRIPTION
Added support for content records.
(Of course, to test this you'll need an OMF-51 object file which actually contains one or more such records.)

"(Restoring files accidentally removed)" because I had earlier pushed them to my fork and then somehow deleted them.