### PR TITLE
Add Xilinx PicoBlaze KCPSM3 and KCPSM6 processors

### DIFF
--- a/Ghidra/Processors/PicoBlaze/README.md
+++ b/Ghidra/Processors/PicoBlaze/README.md
@@ -1,0 +1,1 @@
+# PicoBlaze

--- a/Ghidra/Processors/PicoBlaze/build.gradle
+++ b/Ghidra/Processors/PicoBlaze/build.gradle
@@ -1,0 +1,20 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+apply from: "$rootProject.projectDir/gradle/distributableGhidraModule.gradle"
+apply from: "$rootProject.projectDir/gradle/processorProject.gradle"
+apply plugin: 'eclipse'
+
+eclipse.project.name = 'Processors PicoBlaze'

--- a/Ghidra/Processors/PicoBlaze/data/buildLanguage.xml
+++ b/Ghidra/Processors/PicoBlaze/data/buildLanguage.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  + Compile sleigh languages within this module.
+  + Sleigh compiler options are read from the sleighArgs.txt file.
+  + Eclipse: right-click on this file and choose menu item "Run As->Ant Build"
+  -->
+                                     
+<project name="privateBuildDeveloper" default="sleighCompile">
+	
+	<property name="sleigh.compile.class" value="ghidra.pcodeCPort.slgh_compile.SleighCompile"/>
+
+	<!--Import optional ant properties.  GhidraDev Eclipse plugin produces this so this file can find the Ghidra installation-->
+	<import file="../.antProperties.xml" optional="false" />
+	
+	<target name="sleighCompile">
+	    
+		<!-- If language module is detached from installation, get Ghidra installation directory path from imported properties -->
+		<property name="framework.path" value="${ghidra.install.dir}/Ghidra/Framework"/>
+		
+		<path id="sleigh.class.path">
+			<fileset dir="${framework.path}/SoftwareModeling/lib">
+				<include name="*.jar"/>
+			</fileset>
+			<fileset dir="${framework.path}/Generic/lib">
+				<include name="*.jar"/>
+			</fileset>
+			<fileset dir="${framework.path}/Utility/lib">
+				<include name="*.jar"/>
+			</fileset>
+		</path>
+		
+		<available classname="${sleigh.compile.class}" classpathref="sleigh.class.path" property="sleigh.compile.exists"/>
+			
+		<fail unless="sleigh.compile.exists" />
+		
+		<java classname="${sleigh.compile.class}"
+			classpathref="sleigh.class.path"
+			fork="true"
+			failonerror="true">
+			<jvmarg value="-Xmx2048M"/>
+			<arg value="-i"/>
+			<arg value="sleighArgs.txt"/>
+			<arg value="-a"/>
+			<arg value="./languages"/>
+		</java>
+		
+ 	</target>
+
+</project>

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.cspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.cspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<compiler_spec>
+  <global>
+    <range space="rom"/>
+  </global>
+  <stackpointer register="SP" space="stack_buffer"/>
+  
+  <default_proto>
+    <prototype name="__stdcall" extrapop="0" stackshift="0" strategy="register">
+      <input>
+      </input>
+      <output>
+      </output>
+    </prototype>
+  </default_proto>
+</compiler_spec>

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.pspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.pspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<processor_spec>
+  <default_symbols>
+    <symbol name="entry" address="rom:0000" entry="true"/>
+    <!-- 0x3FF * 3 -->
+    <symbol name="ISR" address="rom:0xBDF"/>
+  </default_symbols>
+</processor_spec>

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
@@ -3,14 +3,7 @@
 # Known differences from actual KCPSM3:
 # - PC should be a 10-bit value with wraparound, Ghidra cannot handle non byte-aligned space sizes
 
-define endian=big;
-define alignment=3;
-
-# This should be rom_space but thats not actually supported in the sleigh compiler
-define space rom            type=ram_space      size=3   wordsize=1 default;
-define space scratchpad     type=ram_space      size=1   wordsize=1;
-define space stack_buffer   type=ram_space      size=1   wordsize=1;
-define space register       type=register_space size=1;
+@include "picoblaze_common.sinc"
 
 
 define token opcode(24)
@@ -32,27 +25,16 @@ define token opcode(24)
 	reg4_7 = (4, 7)
 ;
 
-define register offset=0x00 size=1 [
-	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF 
-    SP
-    flags
-];
-
-define bitrange Z=flags[0,1]
-                C=flags[1,1]
-;
-
 attach variables [ reg8_11 reg4_7 ] [
 	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF
 ];
 
-define pcodeop enable_interrupt;
-define pcodeop disable_interrupt;
 
 macro push(v) {
     *[stack_buffer]:2 SP = v;
     SP = (SP + 1) % 32;
 }
+
 
 # JUMP
 
@@ -64,19 +46,19 @@ jtgt: tgt is op0_9 [ tgt = op0_9 * 3; ] {
 # Conditional
 with jcond: op12=1 {
     :"Z"  is op10_11=0b00 {
-        local v:1 = Z == 0;
-        export v;
-    }
-    :"NZ"  is op10_11=0b01 {
         local v:1 = Z != 0;
         export v;
     }
+    :"NZ"  is op10_11=0b01 {
+        local v:1 = Z == 0;
+        export v;
+    }
     :"C"  is op10_11=0b10 {
-        local v:1 = C == 0;
+        local v:1 = C != 0;
         export v;
     }
     :"NC" is op10_11=0b11 {
-        local v:1 = C != 0;
+        local v:1 = C == 0;
         export v;
     }
 }

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
@@ -1,0 +1,392 @@
+# Specification for the PicoBlaze KCPSM3 processor
+
+# Known differences from actual KCPSM3:
+# - PC should be a 10-bit value with wraparound, Ghidra cannot handle non byte-aligned space sizes
+
+define endian=big;
+define alignment=3;
+
+# This should be rom_space but thats not actually supported in the sleigh compiler
+define space rom            type=ram_space      size=3   wordsize=1 default;
+define space scratchpad     type=ram_space      size=1   wordsize=1;
+define space stack_buffer   type=ram_space      size=1   wordsize=1;
+define space register       type=register_space size=1;
+
+
+define token opcode(24)
+	op0_17 = (0, 17)
+
+	op6_7 = (6,7)
+	op3_7 = (3,7)
+	op0_9 = (0,9)
+	op0_7 = (0,7)
+	op0_5 = (0,5)
+	op0_3 = (0,3)
+	op0_2 = (0,2)
+	op12_17 = (12, 17)
+	op10_11 = (10, 11)
+	op12 = (12, 12)
+	op13_17 = (13, 17)
+	
+	reg8_11 = (8, 11)
+	reg4_7 = (4, 7)
+;
+
+define register offset=0x00 size=1 [
+	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF 
+    SP
+    flags
+];
+
+define bitrange Z=flags[0,1]
+                C=flags[1,1]
+;
+
+attach variables [ reg8_11 reg4_7 ] [
+	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF
+];
+
+define pcodeop enable_interrupt;
+define pcodeop disable_interrupt;
+
+macro push(v) {
+    *[stack_buffer]:2 SP = v;
+    SP = (SP + 1) % 32;
+}
+
+# JUMP
+
+jtgt: tgt is op0_9 [ tgt = op0_9 * 3; ] {
+    local addr:3 = tgt;
+    export addr;
+}
+
+# Conditional
+with jcond: op12=1 {
+    :"Z"  is op10_11=0b00 {
+        local v:1 = Z == 0;
+        export v;
+    }
+    :"NZ"  is op10_11=0b01 {
+        local v:1 = Z != 0;
+        export v;
+    }
+    :"C"  is op10_11=0b10 {
+        local v:1 = C == 0;
+        export v;
+    }
+    :"NC" is op10_11=0b11 {
+        local v:1 = C != 0;
+        export v;
+    }
+}
+
+:"JUMP " jcond, jtgt is op13_17=0b11010 & jcond & jtgt {
+    if(jcond == 0) goto <end>;
+    goto [jtgt];
+    <end>
+}
+# Unconditional
+:"JUMP " jtgt is op13_17=0b11010 & op12=0 & jtgt {
+    goto [jtgt];
+}
+
+# CALL
+
+:"CALL " jcond, jtgt is op13_17=0b11000 & jcond & jtgt {
+    if(jcond == 0) goto <end>;
+    local tmp:2 = inst_start;
+    push(tmp);
+    call [jtgt];
+    <end>
+}
+# Unconditional
+:"CALL " jtgt is op13_17=0b11000 & op12=0 & jtgt {
+    local tmp:2 = inst_start;
+    push(tmp);
+    call [jtgt];
+}
+
+# RETURN
+
+:"RETURN " jcond  is op13_17=0b10101 & jcond & op0_9=0 {
+    if(jcond == 0) goto <end>;
+        SP = (SP - 1) % 32;
+        local tmp:2 = *[stack_buffer]:2 SP;
+        tmp = tmp + 3;
+        return [tmp];
+    <end>
+}
+# Unconditional
+:"RETURN" is op13_17=0b10101 & op12=0 & op0_9=0 {
+    SP = (SP - 1) % 32;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    return [tmp];
+}
+
+# RETURNI
+
+:"RETURNI_ENABLE "  is op0_17=0b111000000000000001 {
+    SP = (SP - 1) % 32;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    enable_interrupt();
+    return [tmp];
+}
+
+:"RETURNI_DISABLE "  is op0_17=0b111000000000000000 {
+    SP = (SP - 1) % 32;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    disable_interrupt();
+    return [tmp];
+}
+
+# ENABLE/DISABLE INTERRUPT
+
+
+:ENABLE_INTERRUPT is op0_17=0b111100000000000001 {
+    enable_interrupt();
+}
+
+:DISABLE_INTERRUPT is op0_17=0b111100000000000000 {
+    disable_interrupt();
+}
+
+macro update_flags(v) {
+    C = 0;
+    Z = (v == 0);
+}
+
+# LOAD
+
+:LOAD reg8_11,op0_7 is op12_17=0b000000 & reg8_11 & op0_7 {
+	reg8_11 = op0_7;
+}
+
+:LOAD reg8_11,reg4_7 is op12_17=0b000001 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg4_7;
+}
+
+# AND
+
+:AND reg8_11,op0_7 is op12_17=0b001010 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 & op0_7;
+    update_flags(reg8_11);
+}
+
+:AND reg8_11,reg4_7 is op12_17=0b001011 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 & reg4_7;
+    update_flags(reg8_11);
+}
+
+# OR
+
+:OR reg8_11,op0_7 is op12_17=0b001100 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 | op0_7;
+    update_flags(reg8_11);
+}
+
+:OR reg8_11,reg4_7 is op12_17=0b001101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 | reg4_7;
+    update_flags(reg8_11);
+}
+
+# XOR
+
+:XOR reg8_11,op0_7 is op12_17=0b001110 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 ^ op0_7;
+    update_flags(reg8_11);
+}
+
+:XOR reg8_11,reg4_7 is op12_17=0b001111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 ^ reg4_7;
+    update_flags(reg8_11);
+}
+
+# TEST
+define pcodeop odd_parity;
+
+:TEST reg8_11,op0_7 is op12_17=0b010010 & reg8_11 & op0_7 {
+	local tmp:1 = reg8_11 & op0_7;
+    Z = tmp == 0;
+    C = odd_parity(tmp);
+}
+
+:TEST reg8_11,reg4_7 is op12_17=0b010010 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	local tmp:1 = reg8_11 & reg4_7;
+    Z = tmp == 0;
+    C = odd_parity(tmp);
+}
+
+# ADD
+
+:ADD reg8_11,op0_7 is op12_17=0b011000 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 + op0_7;
+    C = carry(reg8_11, op0_7);
+    Z = (reg8_11 == 0);
+}
+
+:ADD reg8_11,reg4_7 is op12_17=0b011001 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 + reg4_7;
+    C = carry(reg8_11, reg4_7);
+    Z = (reg8_11 == 0);
+}
+
+# ADDCY
+
+:ADDCY reg8_11,op0_7 is op12_17=0b011010 & reg8_11 & op0_7 {
+    local tmp:1 = reg8_11 + op0_7;
+	reg8_11 = reg8_11 + op0_7 + C;
+    C = carry(reg8_11, op0_7) || carry(tmp, C);
+    Z = (reg8_11 == 0);
+}
+
+:ADDCY reg8_11,reg4_7 is op12_17=0b011010 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    local tmp:1 = reg8_11 + reg4_7;
+	reg8_11 = reg8_11 + reg4_7 + C;
+    C = carry(reg8_11, reg4_7) || carry(tmp, C);
+    Z = (reg8_11 == 0);
+}
+
+# SUB
+
+:SUB reg8_11,op0_7 is op12_17=0b011100 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 - op0_7;
+    C = reg8_11 < op0_7;
+    Z = reg8_11 == 0;
+}
+
+:SUB reg8_11,reg4_7 is op12_17=0b011100 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 - reg4_7;
+    C = reg8_11 < reg4_7;
+    Z = reg8_11 == 0;
+}
+
+# SUBCY
+
+:SUBCY reg8_11,op0_7 is op12_17=0b011110 & reg8_11 & op0_7 {
+    local tmp:1 = reg8_11 - op0_7;
+	reg8_11 = reg8_11 - op0_7 - C;
+    C = reg8_11 < op0_7 || tmp < C;
+    Z = (reg8_11 == 0);
+}
+
+:SUBCY reg8_11,reg4_7 is op12_17=0b011111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    local tmp:1 = reg8_11 - reg4_7;
+	reg8_11 = reg8_11 - reg4_7 - C;
+    C = reg8_11 < reg4_7 || tmp < C;
+    Z = (reg8_11 == 0);
+}
+
+# COMPARE
+
+:COMPARE reg8_11,op0_7 is op12_17=0b010100 & reg8_11 & op0_7 {
+    Z = (reg8_11 == op0_7);
+    C = (reg8_11 < op0_7);
+}
+
+:COMPARE reg8_11,reg4_7 is op12_17=0b010101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    Z = (reg8_11 == reg4_7);
+    C = (reg8_11 < reg4_7);
+}
+
+# SR0 / SR1 / SRX / SRA / RR
+
+:SR0 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b110 {
+    C = reg8_11 & 1;
+    reg8_11 = reg8_11 >> 1;
+    Z = reg8_11 == 0;
+}
+:SR1 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b111 {
+    Z = 0;
+    C = reg8_11 & 1;
+    reg8_11 = (0b10000000 | ( reg8_11 >> 1));
+}
+:SRX reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b010 {
+    C = reg8_11 & 1;
+    reg8_11 = (( reg8_11 & 0b10000000) | ( reg8_11 >> 1));
+    Z = reg8_11 == 0;
+}
+:SRA reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b000 {
+    local tmp:1 = reg8_11 & 1;
+    reg8_11 = (( C << 7) | ( reg8_11 >> 1));
+    C = tmp;
+    Z = reg8_11 == 0;
+}
+:RR reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b100 {
+    C = reg8_11 & 1;
+    reg8_11 = (( C << 7) | ( reg8_11 >> 1));
+    Z = reg8_11 == 0;
+}
+
+# SL0 / SL1 / SLX / SLA / RL
+:SL0 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b110 {
+    C = reg8_11 >> 7;
+    reg8_11 = reg8_11 << 1;
+    Z = reg8_11 == 0;
+}
+:SL1 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b111 {
+    Z = 0;
+    C = reg8_11 >> 7;
+    reg8_11 = (1 | ( reg8_11 << 1));
+}
+:SLX reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b010 {
+    C = reg8_11 >> 7;
+    reg8_11 = (( reg8_11 & 1) | ( reg8_11 << 1));
+    Z = reg8_11 == 0;
+}
+:SLA reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b000 {
+    local tmp:1 = reg8_11 >> 7;
+    reg8_11 = ( C | ( reg8_11 << 1));
+    C = tmp;
+    Z = reg8_11 == 0;
+}
+:RL reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b100 {
+    C = reg8_11 >> 7;
+    reg8_11 = (( C ) | ( reg8_11 << 1));
+    Z = reg8_11 == 0;
+}
+
+# OUTPUT
+
+define pcodeop output;
+
+:OUTPUT reg8_11,op0_7 is op12_17=0b101100 & reg8_11 & op0_7 {
+    output(reg8_11, op0_7:1);
+}
+
+:OUTPUT reg8_11,reg4_7 is op12_17=0b101101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    output(reg8_11, reg4_7);
+}
+
+# INPUT
+
+define pcodeop input;
+
+:INPUT reg8_11,op0_7 is op12_17=0b000100 & reg8_11 & op0_7 {
+    reg8_11 = input(op0_7:1);
+}
+
+:INPUT reg8_11,reg4_7 is op12_17=0b000101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    reg8_11 = input(reg4_7);	
+}
+
+# STORE
+
+:STORE reg8_11,op0_5 is op12_17=0b101110 & reg8_11 & op6_7=0 & op0_5 {
+    *[scratchpad]:1 op0_5:1 = reg8_11;
+}
+
+:STORE reg8_11,reg4_7 is op12_17=0b101111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    *[scratchpad]:1 reg4_7 = reg8_11;
+}
+
+# FETCH
+
+:FETCH reg8_11,op0_5 is op12_17=0b000110 & reg8_11 & op6_7=0 & op0_5 {
+    reg8_11 = *[scratchpad]:1 op0_5:1;
+}
+
+:FETCH reg8_11,reg4_7 is op12_17=0b000111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    reg8_11 = *[scratchpad]:1 reg4_7;
+}

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
@@ -1,0 +1,377 @@
+# Specification for the PicoBlaze KCPSM3 processor
+
+# Known differences from actual KCPSM3:
+# - PC should be a 10-bit value with wraparound, Ghidra cannot handle non byte-aligned space sizes
+
+@include "picoblaze_common.sinc"
+
+
+define token opcode(24)
+	op0_17 = (0, 17)
+
+	op6_7 = (6,7)
+	op3_7 = (3,7)
+	op0_9 = (0,9)
+	op0_7 = (0,7)
+	op0_5 = (0,5)
+	op0_3 = (0,3)
+	op0_2 = (0,2)
+	op12_17 = (12, 17)
+	op10_11 = (10, 11)
+	op12 = (12, 12)
+	op13_17 = (13, 17)
+	
+	reg8_11 = (8, 11)
+	reg4_7 = (4, 7)
+;
+
+attach variables [ reg8_11 reg4_7 ] [
+	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF
+];
+
+
+macro push(v) {
+    *[stack_buffer]:2 SP = v;
+    SP = (SP + 1) % 32;
+}
+
+
+# JUMP
+
+jtgt: tgt is op0_9 [ tgt = op0_9 * 3; ] {
+    local addr:3 = tgt;
+    export addr;
+}
+
+# Conditional
+with jcond: op12=1 {
+    :"Z"  is op10_11=0b00 {
+        local v:1 = Z != 0;
+        export v;
+    }
+    :"NZ"  is op10_11=0b01 {
+        local v:1 = Z == 0;
+        export v;
+    }
+    :"C"  is op10_11=0b10 {
+        local v:1 = C != 0;
+        export v;
+    }
+    :"NC" is op10_11=0b11 {
+        local v:1 = C == 0;
+        export v;
+    }
+}
+
+:JUMP jcond, jtgt is op13_17=0b11010 & jcond & jtgt {
+    if(jcond == 0) goto <end>;
+    goto [jtgt];
+    <end>
+}
+# Unconditional
+:JUMP jtgt is op13_17=0b11010 & op12=0 & jtgt {
+    goto [jtgt];
+}
+
+# CALL
+
+:CALL jcond, jtgt is op13_17=0b11000 & jcond & jtgt {
+    if(jcond == 0) goto <end>;
+    local tmp:2 = inst_start;
+    push(tmp);
+    call [jtgt];
+    <end>
+}
+# Unconditional
+:CALL jtgt is op13_17=0b11000 & op12=0 & jtgt {
+    local tmp:2 = inst_start;
+    push(tmp);
+    call [jtgt];
+}
+
+# RETURN
+
+:RETURN jcond  is op13_17=0b10101 & jcond & op0_9=0 {
+    if(jcond == 0) goto <end>;
+        SP = (SP - 1) % 32;
+        local tmp:2 = *[stack_buffer]:2 SP;
+        tmp = tmp + 3;
+        return [tmp];
+    <end>
+}
+# Unconditional
+:RETURN is op13_17=0b10101 & op12=0 & op0_9=0 {
+    SP = (SP - 1) % 32;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    return [tmp];
+}
+
+# RETURNI
+
+:RETURNI_ENABLE  is op0_17=0b111000000000000001 {
+    SP = (SP - 1) % 32;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    enable_interrupt();
+    return [tmp];
+}
+
+:RETURNI_DISABLE  is op0_17=0b111000000000000000 {
+    SP = (SP - 1) % 32;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    disable_interrupt();
+    return [tmp];
+}
+
+# ENABLE/DISABLE INTERRUPT
+
+
+:ENABLE_INTERRUPT is op0_17=0b111100000000000001 {
+    enable_interrupt();
+}
+
+:DISABLE_INTERRUPT is op0_17=0b111100000000000000 {
+    disable_interrupt();
+}
+
+macro update_flags(v) {
+    C = 0;
+    Z = (v == 0);
+}
+
+# LOAD
+
+:LOAD reg8_11,op0_7 is op12_17=0b000000 & reg8_11 & op0_7 {
+	reg8_11 = op0_7;
+}
+
+:LOAD reg8_11,reg4_7 is op12_17=0b000001 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg4_7;
+}
+
+# AND
+
+:AND reg8_11,op0_7 is op12_17=0b001010 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 & op0_7;
+    update_flags(reg8_11);
+}
+
+:AND reg8_11,reg4_7 is op12_17=0b001011 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 & reg4_7;
+    update_flags(reg8_11);
+}
+
+# OR
+
+:OR reg8_11,op0_7 is op12_17=0b001100 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 | op0_7;
+    update_flags(reg8_11);
+}
+
+:OR reg8_11,reg4_7 is op12_17=0b001101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 | reg4_7;
+    update_flags(reg8_11);
+}
+
+# XOR
+
+:XOR reg8_11,op0_7 is op12_17=0b001110 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 ^ op0_7;
+    update_flags(reg8_11);
+}
+
+:XOR reg8_11,reg4_7 is op12_17=0b001111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 ^ reg4_7;
+    update_flags(reg8_11);
+}
+
+# TEST
+:TEST reg8_11,op0_7 is op12_17=0b010010 & reg8_11 & op0_7 {
+	local tmp:1 = reg8_11 & op0_7;
+    Z = tmp == 0;
+    C = popcount(tmp) & 1;
+}
+
+:TEST reg8_11,reg4_7 is op12_17=0b010011 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	local tmp:1 = reg8_11 & reg4_7;
+    Z = tmp == 0;
+    C = popcount(tmp) & 1;
+}
+
+# ADD
+
+:ADD reg8_11,op0_7 is op12_17=0b011000 & reg8_11 & op0_7 {
+	reg8_11 = reg8_11 + op0_7;
+    C = carry(reg8_11, op0_7);
+    Z = (reg8_11 == 0);
+}
+
+:ADD reg8_11,reg4_7 is op12_17=0b011001 & reg8_11 & reg4_7 & op0_3=0b0000 {
+	reg8_11 = reg8_11 + reg4_7;
+    C = carry(reg8_11, reg4_7);
+    Z = (reg8_11 == 0);
+}
+
+# ADDCY
+
+:ADDCY reg8_11,op0_7 is op12_17=0b011010 & reg8_11 & op0_7 {
+    local tmp:1 = reg8_11 + op0_7;
+	reg8_11 = reg8_11 + op0_7 + C;
+    C = carry(reg8_11, op0_7) || carry(tmp, C);
+    Z = (reg8_11 == 0);
+}
+
+:ADDCY reg8_11,reg4_7 is op12_17=0b011010 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    local tmp:1 = reg8_11 + reg4_7;
+	reg8_11 = reg8_11 + reg4_7 + C;
+    C = carry(reg8_11, reg4_7) || carry(tmp, C);
+    Z = (reg8_11 == 0);
+}
+
+# SUB
+
+:SUB reg8_11,op0_7 is op12_17=0b011100 & reg8_11 & op0_7 {
+    C = reg8_11 < op0_7;
+	reg8_11 = reg8_11 - op0_7;
+    Z = reg8_11 == 0;
+}
+
+:SUB reg8_11,reg4_7 is op12_17=0b011100 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    C = reg8_11 < reg4_7;
+	reg8_11 = reg8_11 - reg4_7;
+    Z = reg8_11 == 0;
+}
+
+# SUBCY
+
+:SUBCY reg8_11,op0_7 is op12_17=0b011110 & reg8_11 & op0_7 {
+    local tmp:1 = reg8_11 - op0_7;
+	reg8_11 = reg8_11 - op0_7 - C;
+    C = reg8_11 < op0_7 || tmp < C;
+    Z = (reg8_11 == 0);
+}
+
+:SUBCY reg8_11,reg4_7 is op12_17=0b011111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    local tmp:1 = reg8_11 - reg4_7;
+	reg8_11 = reg8_11 - reg4_7 - C;
+    C = reg8_11 < reg4_7 || tmp < C;
+    Z = (reg8_11 == 0);
+}
+
+# COMPARE
+
+:COMPARE reg8_11,op0_7 is op12_17=0b010100 & reg8_11 & op0_7 {
+    Z = (reg8_11 == op0_7);
+    C = (reg8_11 < op0_7);
+}
+
+:COMPARE reg8_11,reg4_7 is op12_17=0b010101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    Z = (reg8_11 == reg4_7);
+    C = (reg8_11 < reg4_7);
+}
+
+# SR0 / SR1 / SRX / SRA / RR
+
+:SR0 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b110 {
+    C = reg8_11 & 1;
+    reg8_11 = reg8_11 >> 1;
+    Z = reg8_11 == 0;
+}
+:SR1 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b111 {
+    Z = 0;
+    C = reg8_11 & 1;
+    reg8_11 = (0b10000000 | ( reg8_11 >> 1));
+}
+:SRX reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b010 {
+    C = reg8_11 & 1;
+    reg8_11 = (( reg8_11 & 0b10000000) | ( reg8_11 >> 1));
+    Z = reg8_11 == 0;
+}
+:SRA reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b000 {
+    local tmp:1 = reg8_11 & 1;
+    reg8_11 = (( C << 7) | ( reg8_11 >> 1));
+    C = tmp;
+    Z = reg8_11 == 0;
+}
+:RR reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b100 {
+    local new_c:1 = reg8_11 & 1;
+    reg8_11 = (( C << 7) | ( reg8_11 >> 1));
+
+    C = new_c;
+    Z = reg8_11 == 0;
+}
+
+# SL0 / SL1 / SLX / SLA / RL
+:SL0 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b110 {
+    C = reg8_11 >> 7;
+    reg8_11 = reg8_11 << 1;
+    Z = reg8_11 == 0;
+}
+:SL1 reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b111 {
+    Z = 0;
+    C = reg8_11 >> 7;
+    reg8_11 = (1 | ( reg8_11 << 1));
+}
+:SLX reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b010 {
+    C = reg8_11 >> 7;
+    reg8_11 = (( reg8_11 & 1) | ( reg8_11 << 1));
+    Z = reg8_11 == 0;
+}
+:SLA reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b000 {
+    local tmp:1 = reg8_11 >> 7;
+    reg8_11 = ( C | ( reg8_11 << 1));
+    C = tmp;
+    Z = reg8_11 == 0;
+}
+:RL reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b100 {
+    local new_c:1 = reg8_11 >> 7;
+    reg8_11 = (( C ) | ( reg8_11 << 1));
+    C = new_c;
+    Z = reg8_11 == 0;
+}
+
+# OUTPUT
+
+define pcodeop output;
+
+:OUTPUT reg8_11,op0_7 is op12_17=0b101100 & reg8_11 & op0_7 {
+    output(reg8_11, op0_7:1);
+}
+
+:OUTPUT reg8_11,reg4_7 is op12_17=0b101101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    output(reg8_11, reg4_7);
+}
+
+# INPUT
+
+define pcodeop input;
+
+:INPUT reg8_11,op0_7 is op12_17=0b000100 & reg8_11 & op0_7 {
+    reg8_11 = input(op0_7:1);
+}
+
+:INPUT reg8_11,reg4_7 is op12_17=0b000101 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    reg8_11 = input(reg4_7);	
+}
+
+# STORE
+
+:STORE reg8_11,op0_5 is op12_17=0b101110 & reg8_11 & op6_7=0 & op0_5 {
+    *[scratchpad]:1 op0_5:1 = reg8_11;
+}
+
+:STORE reg8_11,reg4_7 is op12_17=0b101111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    *[scratchpad]:1 reg4_7 = reg8_11;
+}
+
+# FETCH
+
+:FETCH reg8_11,op0_5 is op12_17=0b000110 & reg8_11 & op6_7=0 & op0_5 {
+    reg8_11 = *[scratchpad]:1 op0_5:1;
+}
+
+:FETCH reg8_11,reg4_7 is op12_17=0b000111 & reg8_11 & reg4_7 & op0_3=0b0000 {
+    reg8_11 = *[scratchpad]:1 reg4_7;
+}

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
@@ -188,18 +188,16 @@ macro update_flags(v) {
 }
 
 # TEST
-define pcodeop odd_parity;
-
 :TEST reg8_11,op0_7 is op12_17=0b010010 & reg8_11 & op0_7 {
 	local tmp:1 = reg8_11 & op0_7;
     Z = tmp == 0;
-    C = odd_parity(tmp);
+    C = popcount(tmp) & 1;
 }
 
 :TEST reg8_11,reg4_7 is op12_17=0b010011 & reg8_11 & reg4_7 & op0_3=0b0000 {
 	local tmp:1 = reg8_11 & reg4_7;
     Z = tmp == 0;
-    C = odd_parity(tmp);
+    C = popcount(tmp) & 1;
 }
 
 # ADD

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM3.slaspec
@@ -63,19 +63,19 @@ with jcond: op12=1 {
     }
 }
 
-:"JUMP " jcond, jtgt is op13_17=0b11010 & jcond & jtgt {
+:JUMP jcond, jtgt is op13_17=0b11010 & jcond & jtgt {
     if(jcond == 0) goto <end>;
     goto [jtgt];
     <end>
 }
 # Unconditional
-:"JUMP " jtgt is op13_17=0b11010 & op12=0 & jtgt {
+:JUMP jtgt is op13_17=0b11010 & op12=0 & jtgt {
     goto [jtgt];
 }
 
 # CALL
 
-:"CALL " jcond, jtgt is op13_17=0b11000 & jcond & jtgt {
+:CALL jcond, jtgt is op13_17=0b11000 & jcond & jtgt {
     if(jcond == 0) goto <end>;
     local tmp:2 = inst_start;
     push(tmp);
@@ -83,7 +83,7 @@ with jcond: op12=1 {
     <end>
 }
 # Unconditional
-:"CALL " jtgt is op13_17=0b11000 & op12=0 & jtgt {
+:CALL jtgt is op13_17=0b11000 & op12=0 & jtgt {
     local tmp:2 = inst_start;
     push(tmp);
     call [jtgt];
@@ -91,7 +91,7 @@ with jcond: op12=1 {
 
 # RETURN
 
-:"RETURN " jcond  is op13_17=0b10101 & jcond & op0_9=0 {
+:RETURN jcond  is op13_17=0b10101 & jcond & op0_9=0 {
     if(jcond == 0) goto <end>;
         SP = (SP - 1) % 32;
         local tmp:2 = *[stack_buffer]:2 SP;
@@ -100,7 +100,7 @@ with jcond: op12=1 {
     <end>
 }
 # Unconditional
-:"RETURN" is op13_17=0b10101 & op12=0 & op0_9=0 {
+:RETURN is op13_17=0b10101 & op12=0 & op0_9=0 {
     SP = (SP - 1) % 32;
     local tmp:2 = *[stack_buffer]:2 SP;
     tmp = tmp + 3;
@@ -109,16 +109,18 @@ with jcond: op12=1 {
 
 # RETURNI
 
-:"RETURNI_ENABLE "  is op0_17=0b111000000000000001 {
+:RETURNI_ENABLE  is op0_17=0b111000000000000001 {
     SP = (SP - 1) % 32;
     local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
     enable_interrupt();
     return [tmp];
 }
 
-:"RETURNI_DISABLE "  is op0_17=0b111000000000000000 {
+:RETURNI_DISABLE  is op0_17=0b111000000000000000 {
     SP = (SP - 1) % 32;
     local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
     disable_interrupt();
     return [tmp];
 }
@@ -194,7 +196,7 @@ define pcodeop odd_parity;
     C = odd_parity(tmp);
 }
 
-:TEST reg8_11,reg4_7 is op12_17=0b010010 & reg8_11 & reg4_7 & op0_3=0b0000 {
+:TEST reg8_11,reg4_7 is op12_17=0b010011 & reg8_11 & reg4_7 & op0_3=0b0000 {
 	local tmp:1 = reg8_11 & reg4_7;
     Z = tmp == 0;
     C = odd_parity(tmp);
@@ -233,14 +235,14 @@ define pcodeop odd_parity;
 # SUB
 
 :SUB reg8_11,op0_7 is op12_17=0b011100 & reg8_11 & op0_7 {
-	reg8_11 = reg8_11 - op0_7;
     C = reg8_11 < op0_7;
+	reg8_11 = reg8_11 - op0_7;
     Z = reg8_11 == 0;
 }
 
 :SUB reg8_11,reg4_7 is op12_17=0b011100 & reg8_11 & reg4_7 & op0_3=0b0000 {
-	reg8_11 = reg8_11 - reg4_7;
     C = reg8_11 < reg4_7;
+	reg8_11 = reg8_11 - reg4_7;
     Z = reg8_11 == 0;
 }
 
@@ -296,8 +298,10 @@ define pcodeop odd_parity;
     Z = reg8_11 == 0;
 }
 :RR reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00001 & op0_2=0b100 {
-    C = reg8_11 & 1;
+    local new_c:1 = reg8_11 & 1;
     reg8_11 = (( C << 7) | ( reg8_11 >> 1));
+
+    C = new_c;
     Z = reg8_11 == 0;
 }
 
@@ -324,8 +328,9 @@ define pcodeop odd_parity;
     Z = reg8_11 == 0;
 }
 :RL reg8_11 is op12_17=0b100000 & reg8_11 & op3_7=0b00000 & op0_2=0b100 {
-    C = reg8_11 >> 7;
+    local new_c:1 = reg8_11 >> 7;
     reg8_11 = (( C ) | ( reg8_11 << 1));
+    C = new_c;
     Z = reg8_11 == 0;
 }
 

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.pspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.pspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<processor_spec>
+  <default_symbols>
+    <symbol name="entry" address="rom:0000" entry="true"/>
+    <!-- 0x3FF * 3 -->
+    <symbol name="ISR" address="rom:0xBDF"/>
+  </default_symbols>
+</processor_spec>

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
@@ -1,0 +1,400 @@
+# Specification for the PicoBlaze KCPSM6 processor
+# Implementation based on this spec: https://web.archive.org/web/20240817205135/https://www.eng.auburn.edu/~nelsovp/courses/elec4200/PicoBlaze/kcpsm6.pdf
+
+# Known differences from actual KCPSM6:
+# - Stack overflows are not checked, on real implementations they cause a reset
+# - As in KCPSM3, PC wraparound is not supported
+
+@include "picoblaze_common.sinc"
+
+
+define token opcode(24)
+	opc=(12,17)
+	sX=(8,11)
+	sY=(4,7)
+	op0_3=(0,3)
+	kk=(0,7) 
+	kk2=(4,11)
+	p=(0,3)
+	ins=(0,17)
+	aaa=(0,11)
+	
+	op12_13=(12,13)
+	op14_16=(14,16)
+	op17=(17,17)
+;
+
+
+attach variables [ sX sY  ] [
+	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF
+];
+
+define bitrange regBank=flags[2,1];
+
+macro push(v) {
+	# In KCPSM6 stack overflow is a reset rather than a wraparound
+    *[stack_buffer]:2 SP = v;
+}
+
+# Loading
+
+:LOAD sX, sY is opc=0x00 & sX & sY & op0_3=0 {
+	sX = sY;
+}
+
+:LOAD sX, kk is opc=0x01 & sX & kk {
+	sX = kk;
+}
+
+define pcodeop move_banks;
+
+:STAR sX, sY is opc=0x16 & sX & sY & op0_3=0 {
+	move_banks(sX, sY);
+}
+
+# Logical
+
+:AND sX, sY is opc=0x02 & sX & sY & op0_3=0 {
+	sX = sX & sY;
+	C = 0;
+	Z = sX == 0;
+}
+:AND sX, kk is opc=0x03 & sX & kk {
+	sX = sX & kk;
+	C = 0;
+	Z = sX == 0;
+}
+
+:OR sX, sY is opc=0x04 & sX & sY & op0_3=0 {
+	sX = sX | sY;
+	C = 0;
+	Z = sX == 0;
+}
+:OR sX, kk is opc=0x05 & sX & kk {
+	sX = sX | kk;
+	C = 0;
+	Z = sX == 0;
+}
+
+:XOR sX, sY is opc=0x06 & sX & sY & op0_3=0 {
+	sX = sX ^ sY;
+	C = 0;
+	Z = sX == 0;
+}
+:XOR sX, kk is opc=0x07 & sX & kk {
+	sX = sX ^ kk;
+	C = 0;
+	Z = sX == 0;
+}
+
+# Arithmetic
+
+:ADD sX, sY is opc=0x10 & sX & sY & op0_3=0 {
+	C = carry(sX, sY);
+	sX = sX + sY;
+	Z = sX == 0;
+}
+:ADD sX, kk is opc=0x11 & sX & kk {
+	C = carry(sX, kk);
+	sX = sX + kk;
+	Z = sX == 0;
+}
+
+:ADDCY sX, sY is opc=0x12 & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sX) + zext(sY) + zext(C);
+	C = tmp > 0xFF;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+:ADDCY sX, kk is opc=0x13 & sX & kk {
+	local tmp:2 = zext(sX) + zext(kk:1) + zext(C);
+	C = tmp > 0xFF;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+
+:SUB sX, sY is opc=0x18 & sX & sY & op0_3=0 {
+	C = scarry(sX, sY);
+	sX = sX - sY;
+	Z = sX == 0;
+}
+:SUB sX, kk is opc=0x19 & sX & kk {
+	C = scarry(sX, kk);
+	sX = sX - kk;
+	Z = sX == 0;
+}
+
+:SUBCY sX, sY is opc=0x1A & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sX) - zext(sY) - zext(C);
+	C = tmp s< 0;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+:SUBCY sX, kk is opc=0x1B & sX & kk {
+	local tmp:2 = zext(sX) - zext(kk:1) - zext(C);
+	C = tmp s< 0;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+
+# Test and compare
+
+define pcodeop odd_parity;
+
+:TEST sX, sY is opc=0x0C & sX & sY & op0_3=0 {
+	local tmp:1 = sX & sY;
+    Z = tmp == 0;
+    C = odd_parity(tmp);
+}
+:TEST sX, kk is opc=0x0D & sX & kk {
+	local tmp:1 = sX & kk;
+    Z = tmp == 0;
+    C = odd_parity(tmp);
+}
+
+:TESTCY sX, sY is opc=0x0E & sX & sY & op0_3=0 {
+	local tmp:1 = sX & sY;
+    Z = (tmp == 0) & Z;
+    C = odd_parity(tmp, C);
+}
+:TESTCY sX, kk is opc=0x0F & sX & kk {
+	local tmp:1 = sX & kk;
+    Z = (tmp == 0) & Z;
+    C = odd_parity(tmp, C);
+}
+
+:COMPARE sX, sY is opc=0x1C & sX & sY & op0_3=0 {
+	local tmp:1 = sX - sY;
+    Z = (tmp == 0);
+    C = scarry(sX, sY);
+}
+:COMPARE sX, kk is opc=0x1D & sX & kk {
+	local tmp:1 = sX - kk;
+    Z = (tmp == 0);
+    C = scarry(sX, kk);
+}
+
+:COMPARECY sX, sY is opc=0x1E & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sX) - zext(sY) - zext(C);
+    Z = (tmp:1 == 0) & Z;
+    C = tmp s< 0;
+}
+:COMPARECY sX, kk is opc=0x1F & sX & kk {
+	local tmp:2 = zext(sX) - zext(kk:1) - zext(C);
+    Z = (tmp:1 == 0) & Z;
+    C = tmp s< 0;
+}
+
+# Shift and Rotate
+
+:SL0 sX is opc=0x14 & sX & kk=0x06 {
+	C = sX >> 7;
+    sX = sX << 1;
+    Z = sX == 0;
+}
+:SL1 sX is opc=0x14 & sX & kk=0x07 {
+	Z = 0;
+    C = sX >> 7;
+    sX = (1 | ( sX << 1));
+}
+:SLX sX is opc=0x14 & sX & kk=0x04 {
+	C = sX >> 7;
+    sX = (( sX & 1) | ( sX << 1));
+    Z = sX == 0;
+}
+:SLA sX is opc=0x14 & sX & kk=0x00 {
+	local tmp:1 = sX >> 7;
+    sX = ( C | ( sX << 1));
+    C = tmp;
+    Z = sX == 0;
+}
+:RL sX is opc=0x14 & sX & kk=0x02 {
+	C = sX >> 7;
+    sX = (( C ) | ( sX << 1));
+    Z = sX == 0;
+}
+
+:SR0 sX is opc=0x14 & sX & kk=0x0E {
+	C = sX & 1;
+    sX = sX >> 1;
+    Z = sX == 0;
+}
+:SR1 sX is opc=0x14 & sX & kk=0x0F {
+	Z = 0;
+    C = sX & 1;
+    sX = (0b10000000 | ( sX >> 1));
+}
+:SRX sX is opc=0x14 & sX & kk=0x0A {
+	C = sX & 1;
+    sX = (( sX & 0b10000000) | ( sX >> 1));
+    Z = sX == 0;
+}
+:SRA sX is opc=0x14 & sX & kk=0x08 {
+	local tmp:1 = sX & 1;
+    sX = (( C << 7) | ( sX >> 1));
+    C = tmp;
+    Z = sX == 0;
+}
+:RR sX is opc=0x14 & sX & kk=0x0C {
+	C = sX & 1;
+    sX = (( C << 7) | ( sX >> 1));
+    Z = sX == 0;
+}
+
+# Register Bank
+
+define pcodeop regbank_a;
+define pcodeop regbank_b;
+
+:"REGBANK A" is ins=0x37000 {
+    regbank_a();
+}
+
+:"REGBANK B" is ins=0x37001 {
+    regbank_b();
+}
+
+# Input and Output
+
+define pcodeop input;
+define pcodeop output;
+
+:INPUT sX, sY is opc=0x08 & sX & sY & op0_3=0 {
+	sX = input(sY);
+}
+:INPUT sX, kk is opc=0x09 & sX & kk {
+	sX = input(kk:1);
+}
+
+:OUTPUT sX, sY is opc=0x2C & sX & sY & op0_3=0 {
+	output(sX, sY);
+}
+:OUTPUT sX, kk is opc=0x2D & sX & kk {
+	output(sX, kk:1);
+}
+
+:OUTPUTK kk2, p is opc=0x2B & kk2 & p {
+	output(kk2:1, p:1);
+}
+
+# Scratch pad memory
+
+:STORE sX, sY is opc=0x2E & sX & sY & op0_3=0 {
+	*[scratchpad]:1 sX = sY;
+}
+
+:STORE sX, kk is opc=0x2F & sX & kk {
+	*[scratchpad]:1 kk:1 = sX;
+}
+
+:FETCH sX, sY is opc=0x0A & sX & sY & op0_3=0 {
+	sX = *[scratchpad]:1 sY;
+}
+
+:FETCH sX, kk is opc=0x0B & sX & kk {
+	sX = *[scratchpad]:1 kk:1;
+}
+
+# Interrupt handling
+
+:DISABLE_INTERRUPT is ins=0x28000 {
+    disable_interrupt();
+}
+:ENABLE_INTERRUPT is ins=0x28001 {
+    enable_interrupt();
+}
+
+# On interrupt Z, C and REGBANK are pushed with PC, on RETURNI they are restored
+# This simulates that, as we don't model the interrupt "push" side of this  
+define pcodeop restore_interrupt_flags;
+:RETURNI_DISABLE is ins=0x29000 {
+    SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    disable_interrupt();
+    flags = restore_interrupt_flags();
+    return [tmp];
+}
+:RETURNI_ENABLE is ins=0x29001 {
+    SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    enable_interrupt();
+    flags = restore_interrupt_flags();
+    return [tmp];
+}
+
+# Jump
+
+jcond:"Z" is op14_16=0b100 { local a:1 = Z != 0; export a; }
+jcond:"NZ" is op14_16=0b101 { local a:1 = Z == 0; export a; }
+jcond:"C" is op14_16=0b110 { local a:1 = C != 0; export a; }
+jcond:"NC" is op14_16=0b111 { local a:1 = C == 0; export a; }  
+
+:JUMP tgt is op12_13=0b10 & op14_16=0b000 & op17=1 & aaa [tgt = aaa * 3;] {
+	local a:2 = tgt;
+	goto [a];
+}
+:JUMP jcond, tgt is op12_13=0b10 & jcond & op17=1 & aaa [tgt = aaa * 3;]  {
+	if(jcond == 0) goto <end>;
+		local a:2 = tgt;
+		goto [a];
+	<end>
+}
+:JUMP@ (sX, sY) is opc=0x26 & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sY) | ((zext(sX) & 0xF) << 8);
+	tmp = tmp * 3;
+	goto [tmp];
+}
+
+:CALL tgt is op12_13=0b00 & op14_16=0b000 & op17=1 & aaa [tgt = aaa * 3;] {
+	local tmp:2 = inst_start;
+    push(tmp);
+    local a:2 = tgt;
+    call [a];
+}
+:CALL jcond, tgt is op12_13=0b00 & jcond & op17=1 & aaa [tgt = aaa * 3;] {
+	if(jcond == 0) goto <end>;
+	    local tmp:2 = inst_start;
+	    push(tmp);
+	    local a:2 = tgt;
+	    call [a];
+    <end>
+}
+:CALL@ (sX, sY) is opc=0x24 & sX & sY & op0_3=1 {
+	local tmp:2 = inst_start;
+    push(tmp);
+	local tmp2:2 = zext(sY) | ((zext(sX) & 0xF) << 8);
+	call [tmp2];
+}
+
+:RETURN is ins=0x25000 {
+    SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    return [tmp];
+}
+:RETURN jcond is op12_13=0b01 & jcond & op17=1 & aaa=0 {
+	if(jcond == 0) goto <end>;
+        SP = SP - 1;
+        local tmp:2 = *[stack_buffer]:2 SP;
+        tmp = tmp + 3;
+        return [tmp];
+    <end>
+}
+:LOAD_RETURN sX, kk is opc=0x21 & sX & kk {
+	sX = kk;
+	
+	SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    return [tmp];
+}
+
+# Version control
+
+define pcodeop hwbuild;
+
+:HWBUILD sX is opc=0x14 & sX & kk=0x80 {
+	C = 1;
+	sX = hwbuild();
+	Z = sX == 0;
+}

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
@@ -139,28 +139,28 @@ define pcodeop move_banks;
 
 # Test and compare
 
-define pcodeop odd_parity;
-
 :TEST sX, sY is opc=0x0C & sX & sY & op0_3=0 {
 	local tmp:1 = sX & sY;
     Z = tmp == 0;
-    C = odd_parity(tmp);
+    C = popcount(tmp) & 1;
 }
 :TEST sX, kk is opc=0x0D & sX & kk {
 	local tmp:1 = sX & kk;
     Z = tmp == 0;
-    C = odd_parity(tmp);
+    C = popcount(tmp) & 1;
 }
 
 :TESTCY sX, sY is opc=0x0E & sX & sY & op0_3=0 {
 	local tmp:1 = sX & sY;
     Z = (tmp == 0) & Z;
-    C = odd_parity(tmp, C);
+    local tmp2:2 = (zext(tmp)<<1) | zext(C);
+    C = popcount(tmp2) & 1;
 }
 :TESTCY sX, kk is opc=0x0F & sX & kk {
 	local tmp:1 = sX & kk;
     Z = (tmp == 0) & Z;
-    C = odd_parity(tmp, C);
+    local tmp2:2 = (zext(tmp)<<1) | zext(C);
+    C = popcount(tmp2) & 1;
 }
 
 :COMPARE sX, sY is opc=0x1C & sX & sY & op0_3=0 {

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
@@ -1,0 +1,402 @@
+# Specification for the PicoBlaze KCPSM6 processor
+# Implementation based on this spec: https://web.archive.org/web/20240817205135/https://www.eng.auburn.edu/~nelsovp/courses/elec4200/PicoBlaze/kcpsm6.pdf
+
+# Known differences from actual KCPSM6:
+# - Stack overflows are not checked, on real implementations they cause a reset
+# - As in KCPSM3, PC wraparound is not supported
+
+@include "picoblaze_common.sinc"
+
+
+define token opcode(24)
+	opc=(12,17)
+	sX=(8,11)
+	sY=(4,7)
+	op0_3=(0,3)
+	kk=(0,7) 
+	kk2=(4,11)
+	p=(0,3)
+	ins=(0,17)
+	aaa=(0,11)
+	
+	op12_13=(12,13)
+	op14_16=(14,16)
+	op17=(17,17)
+;
+
+
+attach variables [ sX sY  ] [
+	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF
+];
+
+define bitrange regBank=flags[2,1];
+
+macro push(v) {
+	# In KCPSM6 stack overflow is a reset rather than a wraparound
+    *[stack_buffer]:2 SP = v;
+}
+
+# Loading
+
+:LOAD sX, sY is opc=0x00 & sX & sY & op0_3=0 {
+	sX = sY;
+}
+
+:LOAD sX, kk is opc=0x01 & sX & kk {
+	sX = kk;
+}
+
+define pcodeop move_banks;
+
+:STAR sX, sY is opc=0x16 & sX & sY & op0_3=0 {
+	move_banks(sX, sY);
+}
+
+# Logical
+
+:AND sX, sY is opc=0x02 & sX & sY & op0_3=0 {
+	sX = sX & sY;
+	C = 0;
+	Z = sX == 0;
+}
+:AND sX, kk is opc=0x03 & sX & kk {
+	sX = sX & kk;
+	C = 0;
+	Z = sX == 0;
+}
+
+:OR sX, sY is opc=0x04 & sX & sY & op0_3=0 {
+	sX = sX | sY;
+	C = 0;
+	Z = sX == 0;
+}
+:OR sX, kk is opc=0x05 & sX & kk {
+	sX = sX | kk;
+	C = 0;
+	Z = sX == 0;
+}
+
+:XOR sX, sY is opc=0x06 & sX & sY & op0_3=0 {
+	sX = sX ^ sY;
+	C = 0;
+	Z = sX == 0;
+}
+:XOR sX, kk is opc=0x07 & sX & kk {
+	sX = sX ^ kk;
+	C = 0;
+	Z = sX == 0;
+}
+
+# Arithmetic
+
+:ADD sX, sY is opc=0x10 & sX & sY & op0_3=0 {
+	C = carry(sX, sY);
+	sX = sX + sY;
+	Z = sX == 0;
+}
+:ADD sX, kk is opc=0x11 & sX & kk {
+	C = carry(sX, kk);
+	sX = sX + kk;
+	Z = sX == 0;
+}
+
+:ADDCY sX, sY is opc=0x12 & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sX) + zext(sY) + zext(C);
+	C = tmp > 0xFF;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+:ADDCY sX, kk is opc=0x13 & sX & kk {
+	local tmp:2 = zext(sX) + zext(kk:1) + zext(C);
+	C = tmp > 0xFF;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+
+:SUB sX, sY is opc=0x18 & sX & sY & op0_3=0 {
+	C = sborrow(sX, sY);
+	sX = sX - sY;
+	Z = sX == 0;
+}
+:SUB sX, kk is opc=0x19 & sX & kk {
+	C = sborrow(sX, kk);
+	sX = sX - kk;
+	Z = sX == 0;
+}
+
+:SUBCY sX, sY is opc=0x1A & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sX) - zext(sY) - zext(C);
+	C = tmp s< 0;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+:SUBCY sX, kk is opc=0x1B & sX & kk {
+	local tmp:2 = zext(sX) - zext(kk:1) - zext(C);
+	C = tmp s< 0;
+	sX = tmp:1;
+	Z = (sX == 0) & Z;
+}
+
+# Test and compare
+
+:TEST sX, sY is opc=0x0C & sX & sY & op0_3=0 {
+	local tmp:1 = sX & sY;
+    Z = tmp == 0;
+    C = popcount(tmp) & 1;
+}
+:TEST sX, kk is opc=0x0D & sX & kk {
+	local tmp:1 = sX & kk;
+    Z = tmp == 0;
+    C = popcount(tmp) & 1;
+}
+
+:TESTCY sX, sY is opc=0x0E & sX & sY & op0_3=0 {
+	local tmp:1 = sX & sY;
+    Z = (tmp == 0) & Z;
+    local tmp2:2 = (zext(tmp)<<1) | zext(C);
+    C = popcount(tmp2) & 1;
+}
+:TESTCY sX, kk is opc=0x0F & sX & kk {
+	local tmp:1 = sX & kk;
+    Z = (tmp == 0) & Z;
+    local tmp2:2 = (zext(tmp)<<1) | zext(C);
+    C = popcount(tmp2) & 1;
+}
+
+:COMPARE sX, sY is opc=0x1C & sX & sY & op0_3=0 {
+	local tmp:1 = sX - sY;
+    Z = (tmp == 0);
+    C = sborrow(sX, sY);
+}
+:COMPARE sX, kk is opc=0x1D & sX & kk {
+	local tmp:1 = sX - kk;
+    Z = (tmp == 0);
+    C = sborrow(sX, kk);
+}
+
+:COMPARECY sX, sY is opc=0x1E & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sX) - zext(sY) - zext(C);
+    Z = (tmp:1 == 0) & Z;
+    C = tmp s< 0;
+}
+:COMPARECY sX, kk is opc=0x1F & sX & kk {
+	local tmp:2 = zext(sX) - zext(kk:1) - zext(C);
+    Z = (tmp:1 == 0) & Z;
+    C = tmp s< 0;
+}
+
+# Shift and Rotate
+
+:SL0 sX is opc=0x14 & sX & kk=0x06 {
+	C = sX >> 7;
+    sX = sX << 1;
+    Z = sX == 0;
+}
+:SL1 sX is opc=0x14 & sX & kk=0x07 {
+	Z = 0;
+    C = sX >> 7;
+    sX = (1 | ( sX << 1));
+}
+:SLX sX is opc=0x14 & sX & kk=0x04 {
+	C = sX >> 7;
+    sX = (( sX & 1) | ( sX << 1));
+    Z = sX == 0;
+}
+:SLA sX is opc=0x14 & sX & kk=0x00 {
+	local tmp:1 = sX >> 7;
+    sX = ( C | ( sX << 1));
+    C = tmp;
+    Z = sX == 0;
+}
+:RL sX is opc=0x14 & sX & kk=0x02 {
+	local new_c:1 = sX >> 7;
+    sX = (( C ) | ( sX << 1));
+    C = new_c;
+    Z = sX == 0;
+}
+
+:SR0 sX is opc=0x14 & sX & kk=0x0E {
+	C = sX & 1;
+    sX = sX >> 1;
+    Z = sX == 0;
+}
+:SR1 sX is opc=0x14 & sX & kk=0x0F {
+	Z = 0;
+    C = sX & 1;
+    sX = (0b10000000 | ( sX >> 1));
+}
+:SRX sX is opc=0x14 & sX & kk=0x0A {
+	C = sX & 1;
+    sX = (( sX & 0b10000000) | ( sX >> 1));
+    Z = sX == 0;
+}
+:SRA sX is opc=0x14 & sX & kk=0x08 {
+	local tmp:1 = sX & 1;
+    sX = (( C << 7) | ( sX >> 1));
+    C = tmp;
+    Z = sX == 0;
+}
+:RR sX is opc=0x14 & sX & kk=0x0C {
+	local new_c:1 = sX & 1;
+    sX = (( C << 7) | ( sX >> 1));
+    C = new_c;
+    Z = sX == 0;
+}
+
+# Register Bank
+
+define pcodeop regbank_a;
+define pcodeop regbank_b;
+
+:"REGBANK A" is ins=0x37000 {
+    regbank_a();
+}
+
+:"REGBANK B" is ins=0x37001 {
+    regbank_b();
+}
+
+# Input and Output
+
+define pcodeop input;
+define pcodeop output;
+
+:INPUT sX, sY is opc=0x08 & sX & sY & op0_3=0 {
+	sX = input(sY);
+}
+:INPUT sX, kk is opc=0x09 & sX & kk {
+	sX = input(kk:1);
+}
+
+:OUTPUT sX, sY is opc=0x2C & sX & sY & op0_3=0 {
+	output(sX, sY);
+}
+:OUTPUT sX, kk is opc=0x2D & sX & kk {
+	output(sX, kk:1);
+}
+
+:OUTPUTK kk2, p is opc=0x2B & kk2 & p {
+	output(kk2:1, p:1);
+}
+
+# Scratch pad memory
+
+:STORE sX, sY is opc=0x2E & sX & sY & op0_3=0 {
+	*[scratchpad]:1 sY = sX;
+}
+
+:STORE sX, kk is opc=0x2F & sX & kk {
+	*[scratchpad]:1 kk:1 = sX;
+}
+
+:FETCH sX, sY is opc=0x0A & sX & sY & op0_3=0 {
+	sX = *[scratchpad]:1 sY;
+}
+
+:FETCH sX, kk is opc=0x0B & sX & kk {
+	sX = *[scratchpad]:1 kk:1;
+}
+
+# Interrupt handling
+
+:DISABLE_INTERRUPT is ins=0x28000 {
+    disable_interrupt();
+}
+:ENABLE_INTERRUPT is ins=0x28001 {
+    enable_interrupt();
+}
+
+# On interrupt Z, C and REGBANK are pushed with PC, on RETURNI they are restored
+# This simulates that, as we don't model the interrupt "push" side of this  
+define pcodeop restore_interrupt_flags;
+:RETURNI_DISABLE is ins=0x29000 {
+    SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    disable_interrupt();
+    flags = restore_interrupt_flags();
+    return [tmp];
+}
+:RETURNI_ENABLE is ins=0x29001 {
+    SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    enable_interrupt();
+    flags = restore_interrupt_flags();
+    return [tmp];
+}
+
+# Jump
+
+jcond:"Z" is op14_16=0b100 { local a:1 = Z != 0; export a; }
+jcond:"NZ" is op14_16=0b101 { local a:1 = Z == 0; export a; }
+jcond:"C" is op14_16=0b110 { local a:1 = C != 0; export a; }
+jcond:"NC" is op14_16=0b111 { local a:1 = C == 0; export a; }  
+
+:JUMP tgt is op12_13=0b10 & op14_16=0b000 & op17=1 & aaa [tgt = aaa * 3;] {
+	local a:2 = tgt;
+	goto [a];
+}
+:JUMP jcond, tgt is op12_13=0b10 & jcond & op17=1 & aaa [tgt = aaa * 3;]  {
+	if(jcond == 0) goto <end>;
+		local a:2 = tgt;
+		goto [a];
+	<end>
+}
+:JUMP@ (sX, sY) is opc=0x26 & sX & sY & op0_3=0 {
+	local tmp:2 = zext(sY) | ((zext(sX) & 0xF) << 8);
+	tmp = tmp * 3;
+	goto [tmp];
+}
+
+:CALL tgt is op12_13=0b00 & op14_16=0b000 & op17=1 & aaa [tgt = aaa * 3;] {
+	local tmp:2 = inst_start;
+    push(tmp);
+    local a:2 = tgt;
+    call [a];
+}
+:CALL jcond, tgt is op12_13=0b00 & jcond & op17=1 & aaa [tgt = aaa * 3;] {
+	if(jcond == 0) goto <end>;
+	    local tmp:2 = inst_start;
+	    push(tmp);
+	    local a:2 = tgt;
+	    call [a];
+    <end>
+}
+:CALL@ (sX, sY) is opc=0x24 & sX & sY & op0_3=0 {
+	local tmp:2 = inst_start;
+    push(tmp);
+	local tmp2:2 = zext(sY) | ((zext(sX) & 0xF) << 8);
+	call [tmp2];
+}
+
+:RETURN is ins=0x25000 {
+    SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    return [tmp];
+}
+:RETURN jcond is op12_13=0b01 & jcond & op17=1 & aaa=0 {
+	if(jcond == 0) goto <end>;
+        SP = SP - 1;
+        local tmp:2 = *[stack_buffer]:2 SP;
+        tmp = tmp + 3;
+        return [tmp];
+    <end>
+}
+:LOAD_RETURN sX, kk is opc=0x21 & sX & kk {
+	sX = kk;
+	
+	SP = SP - 1;
+    local tmp:2 = *[stack_buffer]:2 SP;
+    tmp = tmp + 3;
+    return [tmp];
+}
+
+# Version control
+
+define pcodeop hwbuild;
+
+:HWBUILD sX is opc=0x14 & sX & kk=0x80 {
+	C = 1;
+	sX = hwbuild();
+	Z = sX == 0;
+}

--- a/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
+++ b/Ghidra/Processors/PicoBlaze/data/languages/KCPSM6.slaspec
@@ -114,12 +114,12 @@ define pcodeop move_banks;
 }
 
 :SUB sX, sY is opc=0x18 & sX & sY & op0_3=0 {
-	C = scarry(sX, sY);
+	C = sborrow(sX, sY);
 	sX = sX - sY;
 	Z = sX == 0;
 }
 :SUB sX, kk is opc=0x19 & sX & kk {
-	C = scarry(sX, kk);
+	C = sborrow(sX, kk);
 	sX = sX - kk;
 	Z = sX == 0;
 }
@@ -166,12 +166,12 @@ define pcodeop odd_parity;
 :COMPARE sX, sY is opc=0x1C & sX & sY & op0_3=0 {
 	local tmp:1 = sX - sY;
     Z = (tmp == 0);
-    C = scarry(sX, sY);
+    C = sborrow(sX, sY);
 }
 :COMPARE sX, kk is opc=0x1D & sX & kk {
 	local tmp:1 = sX - kk;
     Z = (tmp == 0);
-    C = scarry(sX, kk);
+    C = sborrow(sX, kk);
 }
 
 :COMPARECY sX, sY is opc=0x1E & sX & sY & op0_3=0 {
@@ -209,8 +209,9 @@ define pcodeop odd_parity;
     Z = sX == 0;
 }
 :RL sX is opc=0x14 & sX & kk=0x02 {
-	C = sX >> 7;
+	local new_c:1 = sX >> 7;
     sX = (( C ) | ( sX << 1));
+    C = new_c;
     Z = sX == 0;
 }
 
@@ -236,8 +237,9 @@ define pcodeop odd_parity;
     Z = sX == 0;
 }
 :RR sX is opc=0x14 & sX & kk=0x0C {
-	C = sX & 1;
+	local new_c:1 = sX & 1;
     sX = (( C << 7) | ( sX >> 1));
+    C = new_c;
     Z = sX == 0;
 }
 
@@ -280,7 +282,7 @@ define pcodeop output;
 # Scratch pad memory
 
 :STORE sX, sY is opc=0x2E & sX & sY & op0_3=0 {
-	*[scratchpad]:1 sX = sY;
+	*[scratchpad]:1 sY = sX;
 }
 
 :STORE sX, kk is opc=0x2F & sX & kk {
@@ -359,7 +361,7 @@ jcond:"NC" is op14_16=0b111 { local a:1 = C == 0; export a; }
 	    call [a];
     <end>
 }
-:CALL@ (sX, sY) is opc=0x24 & sX & sY & op0_3=1 {
+:CALL@ (sX, sY) is opc=0x24 & sX & sY & op0_3=0 {
 	local tmp:2 = inst_start;
     push(tmp);
 	local tmp2:2 = zext(sY) | ((zext(sX) & 0xF) << 8);

--- a/Ghidra/Processors/PicoBlaze/data/languages/picoblaze.ldefs
+++ b/Ghidra/Processors/PicoBlaze/data/languages/picoblaze.ldefs
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<language_definitions>
+
+   <language processor="PicoBlaze"
+            endian="big"
+            size="24"
+            variant="KCPSM3"
+            version="1.0"
+            slafile="KCPSM3.sla"
+            processorspec="KCPSM3.pspec"
+            id="KCPSM3:BE:24:default">            
+    <description>PicoBlaze KCPSM3</description>
+    <compiler name="default" spec="KCPSM3.cspec" id="default"/>
+  </language> 
+  
+      <language processor="PicoBlaze"
+            endian="big"
+            size="24"
+            variant="KCPSM6"
+            version="1.0"
+            slafile="KCPSM6.sla"
+            processorspec="KCPSM6.pspec"
+            id="KCPSM6:BE:24:default">
+                <description>PicoBlaze KCPSM6</description>
+    <compiler name="default" spec="KCPSM3.cspec" id="default"/>
+  </language> 
+  
+</language_definitions>

--- a/Ghidra/Processors/PicoBlaze/data/languages/picoblaze.ldefs
+++ b/Ghidra/Processors/PicoBlaze/data/languages/picoblaze.ldefs
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<language_definitions>
+
+   <language processor="Xilinx PicoBlaze"
+            endian="big"
+            size="24"
+            variant="KCPSM3"
+            version="1.0"
+            slafile="KCPSM3.sla"
+            processorspec="KCPSM3.pspec"
+            id="KCPSM3:LE:24:default">
+    <description>PicoBlaze KCPSM3</description>
+    <compiler name="default" spec="KCPSM3.cspec" id="default"/>
+  </language> 
+</language_definitions>

--- a/Ghidra/Processors/PicoBlaze/data/languages/picoblaze.ldefs
+++ b/Ghidra/Processors/PicoBlaze/data/languages/picoblaze.ldefs
@@ -3,15 +3,28 @@
 
 <language_definitions>
 
-   <language processor="Xilinx PicoBlaze"
+   <language processor="PicoBlaze"
             endian="big"
             size="24"
             variant="KCPSM3"
             version="1.0"
             slafile="KCPSM3.sla"
             processorspec="KCPSM3.pspec"
-            id="KCPSM3:LE:24:default">
+            id="KCPSM3:BE:24:default">            
     <description>PicoBlaze KCPSM3</description>
     <compiler name="default" spec="KCPSM3.cspec" id="default"/>
   </language> 
+  
+      <language processor="PicoBlaze"
+            endian="big"
+            size="24"
+            variant="KCPSM6"
+            version="1.0"
+            slafile="KCPSM6.sla"
+            processorspec="KCPSM6.pspec"
+            id="KCPSM6:BE:24:default">
+                <description>PicoBlaze KCPSM6</description>
+    <compiler name="default" spec="KCPSM3.cspec" id="default"/>
+  </language> 
+  
 </language_definitions>

--- a/Ghidra/Processors/PicoBlaze/data/languages/picoblaze_common.sinc
+++ b/Ghidra/Processors/PicoBlaze/data/languages/picoblaze_common.sinc
@@ -1,0 +1,21 @@
+define endian=big;
+define alignment=3;
+
+# This should be rom_space but thats not actually supported in the sleigh compiler
+define space rom            type=ram_space      size=3   wordsize=1 default;
+define space scratchpad     type=ram_space      size=1   wordsize=1;
+define space stack_buffer   type=ram_space      size=1   wordsize=1;
+define space register       type=register_space size=1;
+
+define register offset=0x00 size=1 [
+	s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 sA sB sC sD sE sF 
+    SP
+    flags
+];
+
+define bitrange Z=flags[0,1]
+                C=flags[1,1]
+;
+
+define pcodeop enable_interrupt;
+define pcodeop disable_interrupt;

--- a/Ghidra/Processors/PicoBlaze/data/sleighArgs.txt
+++ b/Ghidra/Processors/PicoBlaze/data/sleighArgs.txt
@@ -1,0 +1,6 @@
+# Add sleigh compiler options to this file (one per line) which will
+# be used when compiling each language within this module.
+# All options should start with a '-' character.
+#
+# IMPORTANT: The -a option should NOT be specified
+#


### PR DESCRIPTION
This adds support for the Xilinx PicoBlaze KCPSM3 and KCPSM6 processors, as specified:
For KCPSM3: [here](https://docs.amd.com/v/u/en-US/ug129) as well as [here](https://web.archive.org/web/20250215204715/https://www-users.york.ac.uk/~mjf5/bomb/Docs/KCPSM3_Manual.pdf)
For KCPSM6: [here](https://web.archive.org/web/20240817205135/https://www.eng.auburn.edu/~nelsovp/courses/elec4200/PicoBlaze/kcpsm6.pdf)

Example programs can be found [here](https://github.com/FlatAssembler/PicoBlaze_Simulator_in_JS/blob/master/sevenSegment.psm)

Tested with the `opbasm` assember, which can be found [here](https://kevinpt.github.io/opbasm/)

By default binaries consist of 18-bit instructions, this plugin assumes instructions have been padded to 24-bit due to SLEIGH token alignment requirements which can be done like so:
```shell
opbasm <file>.psm -3 -x # assemble to HEX file
sed -i -e 's/^/0/' <file>.hex # pad each line with 0
xxd -r -p <file>.hex <out>.bin # convert to bin
```

Currently, as documented in the slaspec the 10-bit PC wraparound is not implemented as Ghidra doesn't support non byte-sized spaces. In addition the reset on stack overflow logic in KCPSM6 is not modeled.

~~Additionally, the rom space is defined as type `ram_space` as while documented [here](https://github.com/NationalSecurityAgency/ghidra/blob/2eff37f655159574593b15bc19273915fc780cf2/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml#L699) the `rom_space` type is not actually supported by the lexer [here](https://github.com/NationalSecurityAgency/ghidra/blob/2eff37f655159574593b15bc19273915fc780cf2/Ghidra/Features/Decompiler/src/decompile/cpp/slghscan.l#L532)~~ (This is now fixed)

Originally this pr only added support for KCPSM3, however due to similarities between KCPSM3 and KCPSM6 I've added both and merged common elements into a `.sinc` as I think this simplifies reviewing (If not, please let me know and I can split them out)

Update:
- (09/05/2026): Fixed up some incorrect instruction definitions, rebased
- (28/05/2026): Removed `odd_parity` pcodeop, replaced with `popcount`
- (08/09/2026): Squashed as per contributing guide