### PR TITLE
Fixed bug in decompiler when trying to rename a label to empty

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/nodes/SymbolNode.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/nodes/SymbolNode.java
@@ -20,6 +20,8 @@ import java.util.*;
 
 import javax.swing.Icon;
 
+import org.apache.commons.lang3.StringUtils;
+
 import docking.widgets.tree.GTreeNode;
 import ghidra.app.cmd.label.CreateNamespacesCmd;
 import ghidra.app.util.SymbolPath;
@@ -213,6 +215,11 @@ public class SymbolNode extends SymbolTreeNode {
 	public void valueChanged(Object newValue) {
 		// since we allow a symbol rename to optionally include full namespace path
 		if (symbol.getName().equals(newValue) || symbol.getName(true).equals(newValue)) {
+			return;
+		}
+		
+		// Empty names are not allowed, do not change value.
+		if (StringUtils.isBlank((String) newValue)) {
 			return;
 		}
 


### PR DESCRIPTION
Fixed an inconsistent behavior in the Symbol Tree section of the CodeBrowser.

I fixed the issue of renaming a _Label_ to empty. Instead of throwing an error, with the changes in the pull request it will return out and keep the previous name. This is the same functionality that a _Function_ rename has.

Error Log (Before Changes):
```
Symbol list must contain at least one symbol name!
java.lang.IllegalArgumentException: Symbol list must contain at least one symbol name!
	at ghidra.app.util.SymbolPathParser.parse(SymbolPathParser.java:59)
	at ghidra.app.util.SymbolPathParser.parse(SymbolPathParser.java:44)
	at ghidra.app.util.SymbolPath.<init>(SymbolPath.java:49)
	at ghidra.app.plugin.core.symboltree.nodes.SymbolNode.valueChanged(SymbolNode.java:219)
	at docking.widgets.tree.internal.GTreeModel.valueForPathChanged(GTreeModel.java:115)
	at java.desktop/javax.swing.plaf.basic.BasicTreeUI.completeEditing(BasicTreeUI.java:2433)
	at java.desktop/javax.swing.plaf.basic.BasicTreeUI$Handler.editingStopped(BasicTreeUI.java:4197)
	at java.desktop/javax.swing.AbstractCellEditor.fireEditingStopped(AbstractCellEditor.java:152)
	at java.desktop/javax.swing.DefaultCellEditor$EditorDelegate.stopCellEditing(DefaultCellEditor.java:375)
	at java.desktop/javax.swing.DefaultCellEditor.stopCellEditing(DefaultCellEditor.java:234)
	at java.desktop/javax.swing.DefaultCellEditor$EditorDelegate.actionPerformed(DefaultCellEditor.java:392)
	at java.desktop/javax.swing.JTextField.fireActionPerformed(JTextField.java:525)
	at java.desktop/javax.swing.JTextField.postActionEvent(JTextField.java:740)
	at java.desktop/javax.swing.JTextField$NotifyAction.actionPerformed(JTextField.java:856)
	at java.desktop/javax.swing.SwingUtilities.notifyAction(SwingUtilities.java:1810)
	at java.desktop/javax.swing.JComponent.processKeyBinding(JComponent.java:2956)
	at java.desktop/javax.swing.JComponent.processKeyBindings(JComponent.java:3004)
	at java.desktop/javax.swing.JComponent.processKeyEvent(JComponent.java:2918)
	at java.desktop/java.awt.Component.processEvent(Component.java:6398)
	at java.desktop/java.awt.Container.processEvent(Container.java:2266)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4996)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
	at java.desktop/java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1952)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:883)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1146)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:1020)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:848)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4877)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:775)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:747)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:744)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)

---------------------------------------------------
Build Date: 2025-Feb-15
Ghidra Version: 11.4
Java Home: C:\Program Files\Java\jdk-21
JVM Version: Oracle Corporation 21.0.1
OS: Windows 10 10.0 amd64
Workstation: DESKTOP
```