### PR TITLE
Fix tricore relocation 24REL handling

### DIFF
--- a/Ghidra/Processors/tricore/src/main/java/ghidra/app/util/bin/format/elf/relocation/Tricore_ElfRelocationHandler.java
+++ b/Ghidra/Processors/tricore/src/main/java/ghidra/app/util/bin/format/elf/relocation/Tricore_ElfRelocationHandler.java
@@ -355,8 +355,7 @@ public class Tricore_ElfRelocationHandler
 	 */
 	private int relocate_relB(Memory memory, Address relocationAddress, long rv)
 			throws MemoryAccessException {
-		// TODO ff000000..00fffffe?
-		long mask = 0xfffffffeL;
+		long mask = 0x00000001L;
 		long val = ~mask & rv;
 		int iw = memory.getInt(relocationAddress) & 0xff;
 		iw |= ((val & 0x1fffe) << 15);


### PR DESCRIPTION
The mask was accidentally inverted, and currently (i.e. without this PR) all relocations of this type result in `[OP 00 00 00]` bytes rather than actually applying the relocation. With this change, the semantics of the relocation handler now fit the comment/description. Confirmed with some partially-linked tricore .o files.

Given that this is embedded these relocations rarely come up, which is most likely how it was missed :)

Edit: I should add that I looked at the other relocation handlers in this file and the masks used seem to be correct, or at least in sync with the comment describing the relocation semantics.