### PR TITLE
Memory Map: ensure columns exist on initialization

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapProvider.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/memory/MemoryMapProvider.java
@@ -473,41 +473,55 @@ class MemoryMapProvider extends ComponentProviderAdapter {
 		TableColumn column = table.getColumn(MemoryMapModel.READ_COL);
 		int width = 25;
 		int maxWidth = resizable ? Integer.MAX_VALUE : width;
-		column.setMaxWidth(maxWidth);
-		column.setMinWidth(width);
-		column.setResizable(resizable);
+		if (column != null) {
+			column.setMaxWidth(maxWidth);
+			column.setMinWidth(width);
+			column.setResizable(resizable);
+		}
 
 		column = table.getColumn(MemoryMapModel.WRITE_COL);
-		column.setMaxWidth(maxWidth);
-		column.setMinWidth(width);
-		column.setResizable(resizable);
+		if (column != null) {
+			column.setMaxWidth(maxWidth);
+			column.setMinWidth(width);
+			column.setResizable(resizable);
+		}
 
 		column = table.getColumn(MemoryMapModel.EXECUTE_COL);
-		column.setMaxWidth(maxWidth);
-		column.setMinWidth(width);
-		column.setResizable(resizable);
+		if (column != null) {
+			column.setMaxWidth(maxWidth);
+			column.setMinWidth(width);
+			column.setResizable(resizable);
+		}
 
 		column = table.getColumn(MemoryMapModel.VOLATILE_COL);
 		width = 65;
 		maxWidth = resizable ? Integer.MAX_VALUE : width;
-		column.setMaxWidth(maxWidth);
-		column.setMinWidth(width);
-		column.setResizable(resizable);
+		if (column != null) {
+			column.setMaxWidth(maxWidth);
+			column.setMinWidth(width);
+			column.setResizable(resizable);
+		}
 
 		column = table.getColumn(MemoryMapModel.ARTIFICIAL_COL);
-		column.setMaxWidth(maxWidth);
-		column.setMinWidth(width);
-		column.setResizable(resizable);
+		if (column != null) {
+			column.setMaxWidth(maxWidth);
+			column.setMinWidth(width);
+			column.setResizable(resizable);
+		}
 
 		column = table.getColumn(MemoryMapModel.BLOCK_TYPE_COL);
 		width = 25;
 		maxWidth = resizable ? Integer.MAX_VALUE : width;
-		column.setMinWidth(width);
+		if (column != null) {
+			column.setMinWidth(width);
+		}
 
 		column = table.getColumn(MemoryMapModel.INIT_COL);
-		column.setMaxWidth(maxWidth);
-		column.setMinWidth(width);
-		column.setResizable(resizable);
+		if (column != null) {
+			column.setMaxWidth(maxWidth);
+			column.setMinWidth(width);
+			column.setResizable(resizable);
+		}
 
 	}
 


### PR DESCRIPTION
The Memory Map plugin configures the maximum and minimum size of some of the columns.

This initialization does not take into account that a user is able to hide columns, which results in a null pointer exception.

This commit checks that these objects are not null before configuring them.

Fixes: f4b89fd26cd8 ("GP-4984 - Fixed row selection while using the filter; updated columns to be resizable")

Related to #1744 