### PR TITLE
DyldChainedImport: fix offset mask bug

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/chained/DyldChainedImport.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/macho/commands/chained/DyldChainedImport.java
@@ -64,7 +64,7 @@ public class DyldChainedImport implements StructConverter {
 				long ival = reader.readNextLong();
 				lib_ordinal = (int) (ival & 0xffff);
 				weak_import = ((ival >> 8) & 1) == 1;
-				name_offset = (ival >> 32 & 0xffffffff);
+				name_offset = ((ival >> 32) & 0xffffffffL);
 				addend = reader.readNextLong();
 				break;
 			}


### PR DESCRIPTION
fix name_offset extraction to support values stored in the high 32 bits that are larger than 2G (highest bit set)

this bug may not occur in practice, but is easy to prevent by using a long literal for the masking, rather than integer


Discussion:

Values in the high bits < 2G are unaffected:
(0x12341234ffffffffL >> 32) & 0xffffffff == 0x12341234

Values in the high bits >2G don't come out right using the integer mask:
(0xe2341234ffffffffL >> 32) & 0xffffffff == 0xFFFFFFFFE2341234
(0xe2341234ffffffffL >> 32) & 0xffffffffL == 0xE2341234

Alternative implementation using unsigned right shift exists:
0xe2341234ffffffffL >>> 32 == 0xE2341234