### PR TITLE
decompiler-cpp: Verbose mode for test failures

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ifacedecomp.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ifacedecomp.cc
@@ -3372,7 +3372,7 @@ void IfcLoadTestFile::execute(istream &s)
   if (dcp->conf != (Architecture *)0)
     throw IfaceExecutionError("Load image already present");
   s >> filename;
-  dcp->testCollection = new FunctionTestCollection(status);
+  dcp->testCollection = new FunctionTestCollection(status, false);
   dcp->testCollection->loadTest(filename);
 #ifdef OPACTION_DEBUG
   dcp->conf->setDebugStream(status->fileoptr);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/test.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/test.cc
@@ -112,6 +112,7 @@ int main(int argc, char **argv) {
   set<string> dataTestNames;
   string dirname("../datatests");
   string sleighdirname("../../../../../../..");
+  bool verbose = false;
   while (argc > 0) {
     string command(argv[0]);
     if (command == "-path") {
@@ -136,6 +137,11 @@ int main(int argc, char **argv) {
       argv += 1;
       argc -= 1;
     }
+    else if (command == "-verbose") {
+      verbose = true;
+      argv += 1;
+      argc -= 1;
+    }
     else if (command == "unittests") {
       runUnitTests = true;
       runDataTests = false;	// Run only unit tests
@@ -149,7 +155,7 @@ int main(int argc, char **argv) {
       break;
     }
     else {
-      cout << "USAGE: ghidra_test [-usesleighenv] [-sleighpath <sleighdir>] [-path <datatestdir>] [[unittests|datatests] [testname1 testname2 ...]]" << endl;
+      cout << "USAGE: ghidra_test [-verbose][-usesleighenv] [-sleighpath <sleighdir>] [-path <datatestdir>] [[unittests|datatests] [testname1 testname2 ...]]" << endl;
       return -1;
     }
   }
@@ -166,7 +172,7 @@ int main(int argc, char **argv) {
     vector<string> testFiles;
     gatherDataTests(dirname,dataTestNames,testFiles);
     cout << endl << endl;
-    int errors = FunctionTestCollection::runTestFiles(testFiles,cout);
+    int errors = FunctionTestCollection::runTestFiles(testFiles,cout,verbose);
     failedTests = add_exit_code(failedTests, errors);
   }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/testfunction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/testfunction.hh
@@ -36,11 +36,16 @@ class FunctionTestProperty {
   int4 minimumMatch;		///< Minimum number of times property is expected to match
   int4 maximumMatch;		///< Maximum number of times property is expected to match
   string name;			///< Name of the test, to be printed in test summaries
+  vector<string> rawPattern;	///< Raw, human-readable regex pattern(s) from test file
   vector<std::regex> pattern;	///< Regular expression(s) to match against a line(s) of output
   mutable uint4 patnum;	///< Index of current pattern to match against
   mutable uint4 count;		///< Number of times regular expression has been seen
 public:
   string getName(void) const { return name; }	///< Get the name of the property
+  int4 getMinMatch(void) const { return minimumMatch; }	///< Get the minimum number of times the property is expected to match
+  int4 getMaxMatch(void) const { return maximumMatch; }	///< Get the maximum number of times the property is expected to match
+  uint4 getCount(void) const { return count; }	///< Get the number of times the property has matched
+  const vector<string> &getRawPattern(void) const { return rawPattern; }	///< Get the raw pattern(s)
   void startTest(void) const;		///< Reset "state", counting number of matching lines
   void processLine(const string &line) const;	///< Search thru \e line, update state if match found
   bool endTest(void) const;		///< Return results of property search
@@ -74,6 +79,7 @@ class FunctionTestCollection {
   vector<string> commands;	///< Sequence of commands for current test
   IfaceStatus *console;		///< Decompiler console for executing scripts
   bool consoleOwner;		///< Set to \b true if \b this object owns the console
+  bool verbose;		///< Set to \b true to print test failures verbosely
   mutable int4 numTestsApplied;		///< Count of tests that were executed
   mutable int4 numTestsSucceeded;	///< Count of tests that passed
   void clear(void);		///< Clear any previous architecture and function
@@ -84,8 +90,8 @@ class FunctionTestCollection {
   void passLineToTests(const string &line) const;	///< Let all tests analyze a line of the results
   void evaluateTests(list<string> &lateStream) const;
 public:
-  FunctionTestCollection(ostream &s);		///< Constructor
-  FunctionTestCollection(IfaceStatus *con);	///< Constructor with preexisting console
+  FunctionTestCollection(ostream &s, bool verbose);		///< Constructor
+  FunctionTestCollection(IfaceStatus *con, bool verbose);	///< Constructor with preexisting console
   ~FunctionTestCollection(void);		///< Destructor
   int4 getTestsApplied(void) const { return numTestsApplied; }	///< Get the number of tests executed
   int4 getTestsSucceeded(void) const { return numTestsSucceeded; }	///< Get the number of tests that passed
@@ -95,7 +101,7 @@ public:
   void restoreXml(DocumentStorage &store,const Element *el);	///< Load tests from a \<decompilertest> tag.
   void restoreXmlOldForm(DocumentStorage &store,const Element *el);	///< Load tests from \<binaryimage> tag.
   void runTests(list<string> &lateStream);	///< Run the script and perform the tests
-  static int runTestFiles(const vector<string> &testFiles,ostream &s);	///< Run tests for each listed file
+  static int runTestFiles(const vector<string> &testFiles,ostream &s,bool verbose);	///< Run tests for each listed file
 };
 
 } // End namespace ghidra


### PR DESCRIPTION
This makes it easier to view and report failing tests without using a debugger.

For instance, when running `ghidra_test_dbg` with `-verbose` (on my branch) on line 260

https://github.com/NationalSecurityAgency/ghidra/blob/22f733c19ed6934ddaefa9c06fd1a047c811de66/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile#L259-L260

I get the following output and failing tests with more details when running `make test`:

```
[...]
Success -- Piece Structure #4
Success -- Piece Structure #5
Success -- Piece Structure #6
Output for ../datatests/retstruct.xml
--------------------------------
Successfully added tmp to scope retstruct

foo * retstruct(foo *rethidden,int4 x,int4 y,int4 z)

{
  int4 tmp;

  if (y < 1) {
    tmp = (int4)rethidden * 100;
  }
  else {
    tmp = (int4)&rethidden->b + 3;
  }
  return (foo *)tmp;
}

--------------------------------
FAIL -- Return Structure #1
Found 0 matches, but expected 1 to 1 matches of pattern(s):
        'tmp = x \* 100;'
FAIL -- Return Structure #2
Found 0 matches, but expected 1 to 1 matches of pattern(s):
        'tmp = x \+ 7;'
FAIL -- Return Structure #3
Found 0 matches, but expected 1 to 1 matches of pattern(s):
        'y = 0x1e;'
FAIL -- Return Structure #4
Found 0 matches, but expected 1 to 1 matches of pattern(s):
        'fVar1\.a = tmp;'
FAIL -- Return Structure #5
Found 0 matches, but expected 1 to 1 matches of pattern(s):
        'fVar1\.b = y;'
FAIL -- Return Structure #6
Found 0 matches, but expected 1 to 1 matches of pattern(s):
        'return fVar1;'
Success -- Boolean thru Less-than #1
Success -- Boolean thru Less-than #2
Success -- Implied Fields #1
[...]
```

The change in output and test failure originated from this commit https://github.com/NationalSecurityAgency/ghidra/commit/69dd166c3ae0780c753999476f1fc7ea706ec876

This was found after trying to update our sleigh CMake repo here https://github.com/lifting-bits/sleigh/pull/320