### PR TITLE
Detect more rust binaries

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/rust/RustConstants.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/rust/RustConstants.java
@@ -21,6 +21,7 @@ public class RustConstants {
 	public static final CategoryPath RUST_CATEGORYPATH = new CategoryPath("/rust");
 	public static final byte[] RUST_SIGNATURE_1 = "RUST_BACKTRACE".getBytes();
 	public static final byte[] RUST_SIGNATURE_2 = "/rustc/".getBytes();
+	public static final byte[] RUST_SIGNATURE_3 = "RUST_MIN_STACK".getBytes();
 	public static final String RUST_EXTENSIONS_PATH = "extensions/rust/";
 	public static final String RUST_EXTENSIONS_UNIX = "unix";
 	public static final String RUST_EXTENSIONS_WINDOWS = "windows";

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/rust/RustUtilities.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/rust/RustUtilities.java
@@ -38,7 +38,11 @@ import ghidra.xml.XmlParseException;
 public class RustUtilities {
 	/**
 	 * Checks if a given {@link MemoryBlock} contains a Rust signature
-	 * 
+	 *
+	 * This is used in the loader to determine if a program was compiled with rust.
+	 * If the program is determined to be rust, then the compiler property is set to
+	 * {@Link RustConstants.RUST_COMPILER}.
+	 *
 	 * @param block The {@link MemoryBlock} to scan for Rust signatures
 	 * @return True if the given {@link MemoryBlock} is not null and contains a Rust signature; 
 	 *   otherwise, false
@@ -53,6 +57,9 @@ public class RustUtilities {
 			return true;
 		}
 		if (containsBytes(bytes, RustConstants.RUST_SIGNATURE_2)) {
+			return true;
+		}
+		if (containsBytes(bytes, RustConstants.RUST_SIGNATURE_3)) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Some rust binaries do not contain the `rustc` or `RUST_BACKTRACE` strings. Also detect `RUST_MIN_STACK` which is in these binaries.

For example: [baa676b671e771bf04b245e648f49516b338e1f49cbd9b4d237cc36d57ab858d](https://bazaar.abuse.ch/sample/baa676b671e771bf04b245e648f49516b338e1f49cbd9b4d237cc36d57ab858d/)

With this change, the rust analyzers are correctly enabled and strings are correctly unpacked.