### PR TITLE
OMF-51 Loader Fixups & Public/External Refs implementation

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51ExternalDef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51ExternalDef.java
@@ -1,0 +1,106 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.omf.omf51;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.format.omf.OmfString;
+import ghidra.app.util.bin.format.omf.OmfUtils;
+
+public class Omf51ExternalDef {
+
+	// ID Block Types
+	public static final int ID_BLOCK_SEGMENT = 0;
+	public static final int ID_BLOCK_RELOCATABLE = 1;
+	public static final int ID_BLOCK_EXTERNAL = 2;
+
+	private byte blockType;
+	private int extId;
+	private byte info;
+	private OmfString name;
+
+	/**
+	 * Creates a new {@link Omf51ExternalDef}
+	 * 
+	 * @param reader A {@link BinaryReader} positioned at the start of the segment definition
+	 * @param largeSegmentId True if the segment ID is 2 bytes; false if 1 byte
+	 * @throws IOException if an IO-related error occurred
+	 */
+	public Omf51ExternalDef(BinaryReader reader, boolean largeSegmentId) throws IOException {
+		blockType = reader.readNextByte();
+		extId = largeSegmentId ? reader.readNextUnsignedShort() : reader.readNextUnsignedByte();
+		info = reader.readNextByte();
+		reader.readNextByte(); // unused
+		name = OmfUtils.readString(reader);
+	}
+
+	/**
+	 * {@return the block type (should always be 2 - ID_BLOCK_EXTERNAL}
+	 */
+	public byte getBlockType() {
+		return blockType;
+	}
+	
+	/**
+	 * {@return the external reference id}
+	 */
+	public int getExtId() {
+		return extId;
+	}
+
+	/**
+	 * {@return the symbol info}
+	 */
+	public byte getInfo() {
+		return info;
+	}
+
+	/**
+	 * {@return the symbol name}
+	 */
+	public OmfString getName() {
+		return name;
+	}
+
+	/**
+	 * {@return the usage type (CODE, XDATA, etc)}
+	 */
+	public int getUsageType() {
+		return info & 0x07;
+	}
+
+	/**
+	 * {@return whether or not this symbol is a variable or not}
+	 */
+	public boolean isVariable() {
+		return (info & 0x40) != 0;
+	}
+	
+	/**
+	 * {@return whether or not this procedure is fixed to a register bank}
+	 */
+	public boolean isFixedReg() {
+		return (info & 0x20) != 0;
+	}
+	
+	/**
+	 * {@return the register bank this procedure is fixed to}
+	 */
+	public int getRegBank() {
+		return (info & 0x18) >> 7;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51Fixup.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51Fixup.java
@@ -1,0 +1,94 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.omf.omf51;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+
+public class Omf51Fixup {
+
+	// Reference Types
+	public static final int REF_TYPE_LOW = 0;
+	public static final int REF_TYPE_BYTE = 1;
+	public static final int REF_TYPE_RELATIVE = 2;
+	public static final int REF_TYPE_HIGH = 3;
+	public static final int REF_TYPE_WORD = 4;
+	public static final int REF_TYPE_INBLOCK = 5;
+	public static final int REF_TYPE_BIT = 6;
+	public static final int REF_TYPE_CONV = 7;
+
+	// ID Block Types
+	public static final int ID_BLOCK_SEGMENT = 0;
+	public static final int ID_BLOCK_RELOCATABLE = 1;
+	public static final int ID_BLOCK_EXTERNAL = 2;
+
+	private int refLoc;
+	private byte refType;
+	private byte blockType;
+	private int blockId;
+	private int offset;
+
+	/**
+	 * Creates a new {@link Omf51PublicDef}
+	 * 
+	 * @param reader A {@link BinaryReader} positioned at the start of the segment definition
+	 * @param largeSegmentId True if the segment ID is 2 bytes; false if 1 byte
+	 * @throws IOException if an IO-related error occurred
+	 */
+	public Omf51Fixup(BinaryReader reader, boolean largeSegmentId) throws IOException {
+		refLoc = reader.readNextUnsignedShort();
+		refType = reader.readNextByte();
+		blockType = reader.readNextByte();
+		blockId = largeSegmentId ? reader.readNextUnsignedShort() : reader.readNextUnsignedByte();
+		offset = reader.readNextUnsignedShort();
+	}
+
+	/**
+	 * {@return the reference location (REFLOC)}
+	 */
+	public int getRefLoc() {
+		return refLoc;
+	}
+	
+	/**
+	 * {@return the reference type (REF TYP)}
+	 */
+	public int getRefType() {
+		return refType;
+	}
+	
+	/**
+	 * {@return the operand block type (ID BLK)}
+	 */
+	public int getBlockType() {
+		return blockType;
+	}
+	
+	/**
+	 * {@return the operand id (segment ID or EXT ID)}
+	 */
+	public int getBlockId() {
+		return blockId;
+	}
+
+	/**
+	 * {@return the operand offset}
+	 */
+	public int getOffset() {
+		return offset;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51PublicDef.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51PublicDef.java
@@ -1,0 +1,122 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.omf.omf51;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.format.omf.OmfString;
+import ghidra.app.util.bin.format.omf.OmfUtils;
+
+public class Omf51PublicDef {
+
+	// Usage Types
+	public static final int CODE = 0;
+	public static final int XDATA = 1;
+	public static final int DATA = 2;
+	public static final int IDATA = 3;
+	public static final int BIT = 4;
+	public static final int NUMBER = 5;
+
+	// Register Banks
+	public static final int REG_BANK_0 = 0;
+	public static final int REG_BANK_1 = 1;
+	public static final int REG_BANK_2 = 2;
+	public static final int REG_BANK_3 = 3;
+
+	private int segId;
+	private byte info;
+	private int offset;
+	private OmfString name;
+
+	/**
+	 * Creates a new {@link Omf51PublicDef}
+	 * 
+	 * @param reader A {@link BinaryReader} positioned at the start of the segment definition
+	 * @param largeSegmentId True if the segment ID is 2 bytes; false if 1 byte
+	 * @throws IOException if an IO-related error occurred
+	 */
+	public Omf51PublicDef(BinaryReader reader, boolean largeSegmentId) throws IOException {
+		segId = largeSegmentId ? reader.readNextUnsignedShort() : reader.readNextUnsignedByte();
+		info = reader.readNextByte();
+		offset = reader.readNextUnsignedShort();
+		reader.readNextByte(); // unused
+		name = OmfUtils.readString(reader);
+	}
+
+	/**
+	 * {@return the segment id}
+	 */
+	public int getSegId() {
+		return segId;
+	}
+
+	/**
+	 * {@return the segment info}
+	 */
+	public byte getInfo() {
+		return info;
+	}
+
+	/**
+	 * {@return the offset into the segment}
+	 */
+	public int getOffset() {
+		return offset;
+	}
+
+	/**
+	 * {@return the symbol name}
+	 */
+	public OmfString getName() {
+		return name;
+	}
+
+	/**
+	 * {@return the usage type (CODE, XDATA, etc)}
+	 */
+	public int getUsageType() {
+		return info & 0x07;
+	}
+
+	/**
+	 * {@return whether or not this symbol is a variable or not}
+	 */
+	public boolean isVariable() {
+		return (info & 0x40) != 0;
+	}
+	
+	/**
+	 * {@return whether or not this procedure is indirectly callable}
+	 */
+	public boolean isIndirectlyCallable() {
+		return (info & 0x80) != 0;
+	}
+	
+	/**
+	 * {@return whether or not this procedure is fixed to a register bank}
+	 */
+	public boolean isFixedReg() {
+		return (info & 0x20) != 0;
+	}
+	
+	/**
+	 * {@return the register bank this procedure is fixed to}
+	 */
+	public int getRegBank() {
+		return (info & 0x18) >> 7;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51PublicDefsRecord.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51PublicDefsRecord.java
@@ -24,17 +24,19 @@ import ghidra.app.util.bin.format.omf.*;
 import ghidra.program.model.data.*;
 import ghidra.util.exception.DuplicateNameException;
 
-public class Omf51FixupRecord extends OmfRecord {
-	private boolean largeSegmentId;
-	private List<Omf51Fixup> fixups = new ArrayList<>();
+public class Omf51PublicDefsRecord extends OmfRecord {
 
+	private boolean largeSegmentId;
+	private List<Omf51PublicDef> defs = new ArrayList<>();
+	
 	/**
-	 * Creates a new {@link Omf51FixupRecord} record
+	 * Creates a new {@link Omf51PublicDefsRecord} record
 	 * 
 	 * @param reader A {@link BinaryReader} positioned at the start of the record
+	 * @param largeSegmentId True if the segment ID is 2 bytes; false if 1 byte
 	 * @throws IOException if an IO-related error occurred
 	 */
-	public Omf51FixupRecord(BinaryReader reader, boolean largeSegmentId) throws IOException {
+	public Omf51PublicDefsRecord(BinaryReader reader, boolean largeSegmentId) throws IOException {
 		super(reader);
 		this.largeSegmentId = largeSegmentId;
 	}
@@ -42,7 +44,7 @@ public class Omf51FixupRecord extends OmfRecord {
 	@Override
 	public void parseData() throws IOException, OmfException {
 		while (dataReader.getPointerIndex() < dataEnd) {
-			fixups.add(new Omf51Fixup(dataReader, largeSegmentId));
+			defs.add(new Omf51PublicDef(dataReader, largeSegmentId));
 		}
 	}
 
@@ -51,16 +53,13 @@ public class Omf51FixupRecord extends OmfRecord {
 		StructureDataType struct = new StructureDataType(Omf51RecordTypes.getName(recordType), 0);
 		struct.add(BYTE, "type", null);
 		struct.add(WORD, "length", null);
-		
-		StructureDataType fixupStruct = new StructureDataType("Omf51Fixup", 0);
-		fixupStruct.setCategoryPath(new CategoryPath(OmfUtils.CATEGORY_PATH));
-		fixupStruct.add(WORD, "refLoc", null);
-		fixupStruct.add(BYTE, "refType", null);
-		fixupStruct.add(BYTE, "blockType", null);
-		fixupStruct.add(largeSegmentId ? WORD : BYTE, "blockId", null);
-		fixupStruct.add(WORD, "offset", null);
-		
-		struct.add(new ArrayDataType(fixupStruct, fixups.size()), "fixups", null);
+		for (Omf51PublicDef def : defs) {
+			struct.add(largeSegmentId ? WORD : BYTE, "seg id", null);
+			struct.add(BYTE, "info", null);
+			struct.add(WORD, "offset", null);
+			struct.add(BYTE, "unused", null);
+			struct.add(def.getName().toDataType(), def.getName().getDataTypeSize(), "name", null);
+		}
 		struct.add(BYTE, "checksum", null);
 
 		struct.setCategoryPath(new CategoryPath(OmfUtils.CATEGORY_PATH));
@@ -68,11 +67,9 @@ public class Omf51FixupRecord extends OmfRecord {
 	}
 
 	/**
-	 * Gets a {@link List} of fixups
-	 * 
-	 * @return A {@link List} of fixups
+	 * {@return the list of segments}
 	 */
-	public List<Omf51Fixup> getFixups() {
-		return fixups;
+	public List<Omf51PublicDef> getDefs() {
+		return defs;
 	}
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordFactory.java
@@ -51,19 +51,27 @@ public class Omf51RecordFactory extends AbstractOmfRecordFactory {
 			case Omf166RecordTypes.DEPLST:
 				yield new Omf166DepList(reader);
 			case Content:
+				yield new Omf51Content(reader, false);
 			case KeilContent:
 				yield new Omf51Content(reader, true);
 			case SegmentDEF:
 				yield new Omf51SegmentDefs(reader, false);
 			case KeilSegmentDEF:
 				yield new Omf51SegmentDefs(reader, true);
-			case KeilFixup:
-				yield new Omf51FixupRecord(reader);
 			case Fixup:
+				yield new Omf51FixupRecord(reader, false);
+			case KeilFixup:
+				yield new Omf51FixupRecord(reader, true);
+			case PublicDEF:
+				yield new Omf51PublicDefsRecord(reader, false);
+			case KeilPublicDEF:
+				yield new Omf51PublicDefsRecord(reader, true);
+			case ExternalDEF:
+				yield new Omf51ExternalDefsRecord(reader, false);
+			case KeilExternalDEF:
+				yield new Omf51ExternalDefsRecord(reader, true);
 			case ScopeDEF:
 			case DebugItem:
-			case PublicDEF:
-			case ExternalDEF:
 			case LibModLocs:
 			case LibModNames:
 			case LibDictionary:

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/omf/omf51/Omf51RecordTypes.java
@@ -44,10 +44,11 @@ public class Omf51RecordTypes {
 	public final static int KeilFixup = Fixup + 1;
 	public final static int KeilSegmentDEF = SegmentDEF + 1;
 	public final static int KeilScopeDEF = ScopeDEF + 1;
+	public final static int KeilPublicDEF = PublicDEF + 1;
+	public final static int KeilExternalDEF = ExternalDEF + 1;
 	public final static int KeilDebugItemOBJ = 0x22;         // Keil debug items, in linker output format
 	public final static int KeilDebugItemSRC = 0x23;         // Keil debug item, in compiler output format
 	public final static int KeilModuleSourceName = 0x24;     // Name of the current module's source file
-	public final static int KeilPublicDEF = PublicDEF + 1;
 	public final static int KeilSourceBrowserFiles = 0x61;   // Sequence of source filenames, for Keil debugger's source browser
 
 	// The three type values 0x62, 0x63, and 0x64, which are produced by ARM Keil's 8051 toolchain,

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Omf51Loader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Omf51Loader.java
@@ -25,15 +25,20 @@ import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.bin.StructConverter;
 import ghidra.app.util.bin.format.omf.*;
 import ghidra.app.util.bin.format.omf.omf51.*;
-import ghidra.app.util.bin.format.omf.omf51.Omf51FixupRecord.Omf51Fixup;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.program.database.mem.FileBytes;
 import ghidra.program.model.address.*;
 import ghidra.program.model.data.DataUtilities;
 import ghidra.program.model.listing.Data;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.listing.Library;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.reloc.Relocation.Status;
+import ghidra.program.model.symbol.ExternalLocation;
+import ghidra.program.model.symbol.SourceType;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
 
@@ -83,7 +88,10 @@ public class Omf51Loader extends AbstractProgramWrapperLoader {
 			List<OmfRecord> records = OmfUtils.readRecords(factory);
 			Map<Integer, Address> segmentToAddr =
 				processMemoryBlocks(program, fileBytes, records, log, monitor);
-			performFixups(program, fileBytes, records, segmentToAddr, log, monitor);
+			Map<Integer, Address> extIdToAddr =
+				processExternalDefs(program, records, log, monitor);
+			performFixups(program, fileBytes, records, segmentToAddr, extIdToAddr, log, monitor);
+			markupPublicDefs(program, records, segmentToAddr, log, monitor);
 			markupRecords(program, fileBytes, records, log, monitor);
 		}
 		catch (Exception e) {
@@ -163,9 +171,62 @@ public class Omf51Loader extends AbstractProgramWrapperLoader {
 		}
 		return segmentToAddr;
 	}
+	
+	private Map<Integer, Address> processExternalDefs(Program program, List<OmfRecord> records,
+			MessageLog log, TaskMonitor monitor)
+			throws Exception {
+		
+		Map<Integer, Address> map = new HashMap<>();
+		List<Omf51ExternalDef> defs = OmfUtils.filterRecords(records, Omf51ExternalDefsRecord.class)
+				.map(Omf51ExternalDefsRecord::getDefs)
+				.flatMap(List::stream)
+				.filter(def -> !def.isVariable())
+				.sorted((a, b) -> Integer.compare(a.getExtId(), b.getExtId()))
+				.toList();
+		
+		int externalSize = defs.size();
+		
+		Address codeEndAddr = Arrays.stream(program.getMemory().getBlocks())
+			.filter(block -> block.getSourceName().equals("CODE"))
+			.map(block -> block.getEnd())
+			.sorted((a, b) -> a.compareTo(b))
+			.reduce((a, b) -> b)
+			.get();
+		
+		int availableSize = (int)(program.getAddressFactory()
+				.getAddressSpace("CODE").getMaxAddress().getOffset() - codeEndAddr.getOffset());
+		
+		if (availableSize < externalSize) {
+			throw new Exception("Not enough CODE space for externals");
+		}
+		
+		// Create an artificial 'EXTERNAL' block in CODE space.
+		MemoryBlock block = MemoryBlockUtils.createUninitializedBlock(program, false, "EXTERNAL",
+				codeEndAddr.add(1), externalSize, "", "CODE", false, false, true, log);
+		
+		block.setArtificial(true);
+		block.setComment("NOTE: This block is artificial and allows external fixups to work correctly");
+		
+		// Create thunks for each external procedure def.
+		Address addr = codeEndAddr;
+		for (Omf51ExternalDef def : defs) {
+			addr = addr.add(1);
+			
+			Function f = program.getFunctionManager().createFunction(def.getName().str(), addr,
+					new AddressSet(addr), SourceType.IMPORTED);
+			ExternalLocation extLoc = program.getExternalManager()
+					.addExtFunction(Library.UNKNOWN, def.getName().str(), null, SourceType.IMPORTED);
+			f.setThunkedFunction(extLoc.getFunction());
+			
+			map.put(def.getExtId(), addr);
+		}
+		
+		return map;
+	}
 
 	private void performFixups(Program program, FileBytes fileBytes, List<OmfRecord> records,
-			Map<Integer, Address> segmentToAddr, MessageLog log, TaskMonitor monitor)
+			Map<Integer, Address> segmentToAddr, Map<Integer, Address> extIdToAddr,
+			MessageLog log, TaskMonitor monitor)
 			throws Exception {
 		OmfRecord previous = null;
 		for (OmfRecord record : records) {
@@ -174,18 +235,128 @@ public class Omf51Loader extends AbstractProgramWrapperLoader {
 					throw new Exception("Record prior to fixup is not content!");
 				}
 				Address segmentAddr = segmentToAddr.get(content.getSegId());
+				
 				if (segmentAddr == null) {
-					throw new Exception("Failed to get lookup segment ID 0x%x for content fixup!"
+					throw new Exception("Failed to lookup segment ID 0x%x for content fixup!"
 							.formatted(content.getSegId()));
 				}
+				
+				Address contentAddr = segmentAddr.add(content.getOffset());
+				
 				for (Omf51Fixup fixup : fixupRec.getFixups()) {
-					Address fixupAddr = segmentAddr.add(fixup.refLoc());
+					Address refLocAddr = contentAddr.add(fixup.getRefLoc());
+					Address baseAddr = null;
+					Address addr = null;
+					Status status = Status.UNSUPPORTED;
+					
+					switch (fixup.getBlockType()) {
+						case Omf51Fixup.ID_BLOCK_SEGMENT:
+						case Omf51Fixup.ID_BLOCK_RELOCATABLE:
+							baseAddr = segmentToAddr.get(fixup.getBlockId());
+							addr = fixup.getRefType() == Omf51Fixup.REF_TYPE_CONV
+									? baseAddr.getNewAddress(((baseAddr.getOffset() - 0x20) * 8) + fixup.getOffset())
+									: baseAddr.add(fixup.getOffset());
+							break;
+						case Omf51Fixup.ID_BLOCK_EXTERNAL:
+							addr = extIdToAddr.get(fixup.getBlockId());
+							break;
+					}
+					
+					if (addr != null) {
+						applyFixup(program, refLocAddr, addr, fixup.getRefType());
+						status = Status.APPLIED;
+					}
+					
 					program.getRelocationTable()
-							.add(fixupAddr, Status.UNSUPPORTED, fixup.refType(),
-								new long[] { fixup.operand() }, 0, null);
+							.add(refLocAddr, status, fixup.getRefType(),
+								new long[] {
+									fixup.getRefLoc(), fixup.getRefType(), fixup.getBlockType(),
+									fixup.getBlockId(), fixup.getOffset()
+								}, 0, null);
 				}
 			}
 			previous = record;
+		}
+	}
+	
+	private void applyFixup(Program program, Address refLocAddr, Address addr, int refType)
+			throws MemoryAccessException, Exception {
+		int normAddr = (int)addr.getOffset() & 0xFFFF;
+		
+		// Validation
+		switch (refType) {
+			case Omf51Fixup.REF_TYPE_BIT:
+			case Omf51Fixup.REF_TYPE_CONV:
+				if (normAddr > 127) {
+					throw new Exception("Bad address 0x%04x for BIT fixup!"
+							.formatted(normAddr));
+				}
+				break;
+			case Omf51Fixup.REF_TYPE_BYTE:
+				if (normAddr > 255) {
+					throw new Exception("Bad address 0x%04x for BYTE fixup!"
+							.formatted(normAddr));
+				}
+				break;
+		}
+		
+		// Patching
+		switch (refType) {
+			case Omf51Fixup.REF_TYPE_LOW:
+			case Omf51Fixup.REF_TYPE_BYTE:
+			case Omf51Fixup.REF_TYPE_BIT:
+			case Omf51Fixup.REF_TYPE_CONV:
+				program.getMemory()
+					.setByte(refLocAddr, (byte)(normAddr & 0xFF));
+				break;
+			case Omf51Fixup.REF_TYPE_HIGH:
+				program.getMemory()
+					.setByte(refLocAddr, (byte)((normAddr >> 7) & 0xFF));
+				break;
+			case Omf51Fixup.REF_TYPE_WORD:
+				program.getMemory()
+					.setShort(refLocAddr, (short)(normAddr & 0xFFFF));
+				break;
+			default:
+				throw new Exception("Unhandled ref type");
+		}
+	}
+	
+	private void markupPublicDefs(Program program, List<OmfRecord> records,
+			Map<Integer, Address> segmentToAddr, MessageLog log, TaskMonitor monitor)
+			throws Exception {
+		monitor.setMessage("Marking up public defs...");
+		for (OmfRecord record : records) {
+			if (record instanceof Omf51PublicDefsRecord publicDefRec) {
+				for (Omf51PublicDef def : publicDefRec.getDefs()) {
+					if (def.getUsageType() == Omf51PublicDef.NUMBER) {
+						log.appendMsg("Skipping NUMBER public def");
+						continue;
+					}
+					Address segmentAddr = segmentToAddr.get(def.getSegId());
+					if (segmentAddr == null) {
+						throw new Exception("Failed to get lookup segment ID 0x%x for public def!"
+								.formatted(def.getSegId()));
+					}
+					
+					Address defAddress = segmentAddr.add(def.getOffset());
+					
+					if (!def.isVariable()) {
+						FunctionManager functionMgr = program.getFunctionManager();
+						Function function = functionMgr.getFunctionAt(defAddress);
+						if (function == null) {
+							function = functionMgr.createFunction(def.getName().str(), defAddress, new AddressSet(defAddress),
+								SourceType.IMPORTED);
+						}
+					}
+					
+					program.getSymbolTable()
+							.createLabel(defAddress, def.getName().str(), null, SourceType.IMPORTED);
+					
+					program.getSymbolTable()
+							.addExternalEntryPoint(defAddress);
+				}
+			}
 		}
 	}
 
@@ -233,7 +404,11 @@ public class Omf51Loader extends AbstractProgramWrapperLoader {
 				usedAddresses.add(start, end);
 				yield start;
 			}
-			case Omf51Segment.UNIT: {
+			case Omf51Segment.UNIT:
+			case Omf51Segment.BITADDRESSABLE:
+			case Omf51Segment.INPAGE:
+			case Omf51Segment.INBLOCK:
+			case Omf51Segment.PAGE: {
 				Address lastEnd = segmentEnds.get(key(segment));
 				if (lastEnd != null) {
 					Address start = lastEnd.add(1);
@@ -255,10 +430,7 @@ public class Omf51Loader extends AbstractProgramWrapperLoader {
 				segmentEnds.put(key(segment), end);
 				yield start;
 			}
-			case Omf51Segment.BITADDRESSABLE:
-			case Omf51Segment.INPAGE:
-			case Omf51Segment.INBLOCK:
-			case Omf51Segment.PAGE:
+			
 			default:
 				throw new Exception(
 					"Skipping segment '%s'. Relocation type 0x%x is not yet supported"

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Omf51Loader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Omf51Loader.java
@@ -186,11 +186,13 @@ public class Omf51Loader extends AbstractProgramWrapperLoader {
 		
 		int externalSize = defs.size();
 		
+		if (externalSize == 0) return map;
+		
 		Address codeEndAddr = Arrays.stream(program.getMemory().getBlocks())
 			.filter(block -> block.getSourceName().equals("CODE"))
 			.map(block -> block.getEnd())
-			.sorted((a, b) -> a.compareTo(b))
-			.reduce((a, b) -> b)
+			.sorted((a, b) -> b.compareTo(a))
+			.findFirst()
 			.get();
 		
 		int availableSize = (int)(program.getAddressFactory()
@@ -203,6 +205,10 @@ public class Omf51Loader extends AbstractProgramWrapperLoader {
 		// Create an artificial 'EXTERNAL' block in CODE space.
 		MemoryBlock block = MemoryBlockUtils.createUninitializedBlock(program, false, "EXTERNAL",
 				codeEndAddr.add(1), externalSize, "", "CODE", false, false, true, log);
+		
+		if (block == null) {
+			throw new Exception("Couldn't create EXTERNAL block");
+		}
 		
 		block.setArtificial(true);
 		block.setComment("NOTE: This block is artificial and allows external fixups to work correctly");


### PR DESCRIPTION
**Public References**
- Parse the public reference record structure
- Mark references as Exports

**External References**
- Parse the external reference record structure
- Create external functions
- Create 'EXTERNAL' CODE memory region with thunks to external functions

 **Fixup**
- Fully parse the fixup record structure
- Apply fixup byte modifications
- Apply 'EXTERNAL' address for external reference fixups