### PR TITLE
Fix eBPF CALL operand decoding

### DIFF
--- a/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
@@ -350,7 +350,7 @@ SysCall:  imm is imm { export *[syscall]:1 imm; }
     call SysCall;
 }
 
-disp32: reloc is imm [ reloc = inst_next + imm; ] { export *:4 reloc; }
+disp32: reloc is imm [ reloc = inst_next + imm * 8; ] { export *:4 reloc; }
 
 :CALL disp32 is imm & src=1 & op_alu_jmp_opcode=0x8 & op_alu_jmp_source=0 & op_insn_class=0x5 & disp32 {
     call disp32;

--- a/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationHandler.java
+++ b/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationHandler.java
@@ -79,7 +79,7 @@ public class eBPF_ElfRelocationHandler
 				long instr_next = relocationAddress.add(0x8).getAddressableWordOffset();
 				if (symbol.isFunction()) {
 					new_value = symbolAddr.getAddressableWordOffset();
-					int offset = (int) (new_value - instr_next);
+					int offset = (int) ((new_value - instr_next) / 8);
 					memory.setInt(relocationAddress.add(0x4), offset);
 				}
 				else if (symbol.isSection()) {
@@ -96,7 +96,7 @@ public class eBPF_ElfRelocationHandler
 						// according to formula in "kernel.org" docs: https://www.kernel.org/doc/html/latest/bpf/llvm_reloc.html
 						int func_sec_offset = (current_imm + 1) * 8;
 						long func_addr = section_start + func_sec_offset;
-						int offset = (int) (func_addr - instr_next);
+						int offset = (int) ((func_addr - instr_next) / 8);
 						memory.setInt(relocationAddress.add(0x4), offset);
 					}
 //					else {


### PR DESCRIPTION
The operand of the CALL instruction missed multiplying the immediate value by 8. Without this, calls are not decoded correctly.

Such a CALL instruction can be emitted when compiling this simple `single_call.c` program:

```c
static int one(void) {
    return 1;
}

int call_one(void) {
    return one();
}
```

with:

    clang -O0 -target bpf -c single_call.c -o single_call.ebpf

Disassembling with LLVM shows:

    $ llvm-objdump -d single_call.ebpf
    single_call.ebpf:	file format elf64-bpf

    Disassembly of section .text:

    0000000000000000 <call_one>:
           0:	85 10 00 00 01 00 00 00	call 1
           1:	95 00 00 00 00 00 00 00	exit

    0000000000000010 <one>:
           2:	b7 00 00 00 01 00 00 00	r0 = 1
           3:	95 00 00 00 00 00 00 00	exit

The first instruction ("call 1") calls the function located at 0x10 (at index `2:` in the listing). Ghidra considered the call to target address 9 instead (as `inst_next = 8` and `imm = 1`). Fix this by multiplying `imm` by 8 when encountering a `disp32` operand (which is only used by instruction `CALL`).