### PR TITLE
Do not default to global so easily for label namespace

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/AddEditDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/AddEditDialog.java
@@ -397,11 +397,6 @@ public class AddEditDialog extends ReusableDialogComponentProvider {
 	 * </ul>
 	 */
 	private void selectNamespace() {
-		if (symbol != null && symbol.getParentNamespace() != null) {
-			namespaceChoices.setSelectedItem(new NamespaceWrapper(symbol.getParentNamespace()));
-			return;
-		}
-
 		SymbolTable symbolTable = program.getSymbolTable();
 		Namespace localNamespace = symbolTable.getNamespace(addr);
 		FunctionSymbol functionSymbol = getFunctionSymbol(addr);


### PR DESCRIPTION
When labeling symbols the namespace gets added and selected based on logic around the symbol and parent namespace.

For CodeSymbol this results in always defaulting to the global namespace in a function as they do not have associated DB records and will default to the global namespace.  The current logic directly conflicts with the documentation of the function.

Remove the logic to quickly choose the parent namespace and allow other logic to choose the appropriate namespace.

Closes #7507 