### PR TITLE
Decompiler: Enable optimization for C++ source files

### DIFF
--- a/Ghidra/Features/Decompiler/buildNatives.gradle
+++ b/Ghidra/Features/Decompiler/buildNatives.gradle
@@ -230,9 +230,14 @@ model {
 				b.cppCompiler.args "/EHsc"
 				b.cppCompiler.define "_SECURE_SCL=0"
 				b.cppCompiler.define "_HAS_ITERATOR_DEBUGGING=0"
+				b.cppCompiler.args "/W3"
+				b.cppCompiler.args "/O2"
+				b.cppCompiler.args "/Oy"			// Omit frame pointer
+				b.cppCompiler.args "/GL"
 				// b.cppCompiler.args "/Zi"		// for DEBUG, uncomment this line
 				// b.cppCompiler.args "/FS"		// for DEBUG, uncomment this line
 				// b.linker.args "/DEBUG"		// for DEBUG, uncomment this line
+				b.link.args "/LTCG"
 				if (b.targetPlatform.operatingSystem.windows) {
 					b.cppCompiler.define "WINDOWS"
 					b.cppCompiler.define "_WINDOWS"
@@ -246,6 +251,7 @@ model {
 				b.cCompiler.args "/W3"
 				b.cCompiler.args "/O2"
 				b.cCompiler.args "/Oy"			// Omit frame pointer
+				b.cCompiler.args "/GL"
 				b.cCompiler.define "_CRT_SECURE_NO_DEPRECATE"
 				b.cCompiler.define "_CRT_NONSTDC_NO_DEPRECATE"
 				b.cCompiler.define "ZLIB_WINAPI"


### PR DESCRIPTION
C++ files are compiled without optimization (default for MSVC). Optimizing them results in a 50+% reduction in decompile time. Also enable LTCG/LTO for good measure.