### PR TITLE
Fix error when importing PE executable when NumberOfRvaAndSizes = 11.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/OptionalHeaderImpl.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/OptionalHeaderImpl.java
@@ -394,7 +394,7 @@ public class OptionalHeaderImpl implements OptionalHeader {
 				throw re;
 			}
 		}
-		if (ndata++ == numberOfRvaAndSizes) {
+		if (++ndata == numberOfRvaAndSizes) {
 			return;
 		}
 


### PR DESCRIPTION
### Overview
This pr fixes #7973. The issue is cause by line 397, where nData is post-incremented instead of pre-incremented. I came across this bug when I trying to import vgc.exe (from Vanguard) into a new project. I uploaded the executable [here](https://drive.google.com/file/d/1Gzp32ixTAYkbxEqztJwH6xB3W4rrupqv/view?usp=sharing) for anyone interested.