### PR TITLE
Fix the semantics of eBPF byte swap instructions

### DIFF
--- a/Ghidra/Processors/eBPF/certification.manifest
+++ b/Ghidra/Processors/eBPF/certification.manifest
@@ -7,4 +7,5 @@ data/languages/eBPF.ldefs||GHIDRA||||END|
 data/languages/eBPF.opinion||GHIDRA||||END|
 data/languages/eBPF.pspec||GHIDRA||||END|
 data/languages/eBPF.sinc||GHIDRA||||END|
+data/languages/eBPF_be.slaspec||GHIDRA||||END|
 data/languages/eBPF_le.slaspec||GHIDRA||||END|

--- a/Ghidra/Processors/eBPF/data/languages/eBPF.ldefs
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.ldefs
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <language_definitions>
    <language processor="eBPF"
+            endian="big"
+            size="64"
+            variant="default"
+            version="1.0"
+            slafile="eBPF_be.sla"
+            processorspec="eBPF.pspec"
+            id="eBPF:BE:64:default">
+    <description>eBPF processor 64-bit big-endian</description>
+    <compiler name="default" spec="eBPF.cspec" id="default"/>
+    <external_name tool="DWARF.register.mapping.file" name="eBPF.dwarf"/>
+  </language>
+   <language processor="eBPF"
             endian="little"
             size="64"
             variant="default"
@@ -10,6 +22,6 @@
             id="eBPF:LE:64:default">
     <description>eBPF processor 64-bit little-endian</description>
     <compiler name="default" spec="eBPF.cspec" id="default"/>
-	<external_name tool="DWARF.register.mapping.file" name="eBPF.dwarf"/>
+    <external_name tool="DWARF.register.mapping.file" name="eBPF.dwarf"/>
   </language>
 </language_definitions>

--- a/Ghidra/Processors/eBPF/data/languages/eBPF.opinion
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.opinion
@@ -1,5 +1,6 @@
 <opinions>
     <constraint loader="Executable and Linking Format (ELF)" compilerSpecID="default">
+        <constraint primary="247" processor="eBPF" endian="big" size="64" />
         <constraint primary="247" processor="eBPF" endian="little" size="64" />
     </constraint>  
 </opinions>

--- a/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
@@ -2,6 +2,8 @@
 # eBPF Processor Specification for Ghidra
 ###############################################################################
 
+define endian=$(ENDIAN);
+
 #eBPF is a RISC register machine with a total of 11 64-bit registers, a program counter and a 512 byte fixed-size stack. 
 #9 registers are general purpose read-write, one is a read-only stack pointer and the program counter is implicit,
 #i.e. we can only jump to a certain offset from it. The eBPF registers are always 64-bit wide.
@@ -104,34 +106,55 @@ DST4: dst is dst { local tmp:4 = dst:4; export tmp; }
 
 #Bytewasp instructions
 ###############################################################################
+
+@if ENDIAN == "little"
 # BPF_ALU   | BPF_K   | BPF_END
-:LE16 dst  is imm=0x10 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 { dst=((dst) >> 8) | ((dst) << 8); }
-:LE32 dst  is imm=0x20 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 { dst=((dst) >> 24) | (((dst) & 0x00FF0000) >> 8)  | (((dst) & 0x0000FF00) << 8) | ((dst) << 24); }
+:LE16 dst  is imm=0x10 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 { dst = zext(dst:2); }
+:LE32 dst  is imm=0x20 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 { dst = zext(dst:4); }
+:LE64 dst  is imm=0x40 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 {}
+
+# BPF_ALU   | BPF_X   | BPF_END
+:BE16 dst  is imm=0x10 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 {
+    dst = ((dst & 0xff00) >> 8) | ((dst & 0x00ff) << 8);
+}
+:BE32 dst  is imm=0x20 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 {
+    dst = ((dst & 0xff000000) >> 24) | (((dst) & 0x00ff0000) >> 8) | (((dst) & 0x0000ff00) << 8) | ((dst & 0x000000ff) << 24);
+}
+:BE64 dst  is imm=0x40 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 {
+    dst = ((dst << 56) & 0xff00000000000000) |
+        ((dst << 40) & 0x00ff000000000000) |
+        ((dst << 24) & 0x0000ff0000000000) |
+        ((dst <<  8) & 0x000000ff00000000) |
+        ((dst >>  8) & 0x00000000ff000000) |
+        ((dst >> 24) & 0x0000000000ff0000) |
+        ((dst >> 40) & 0x000000000000ff00) |
+        ((dst >> 56) & 0x00000000000000ff);
+}
+@else # ENDIAN == "big"
+# BPF_ALU   | BPF_K   | BPF_END
+:LE16 dst  is imm=0x10 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 {
+    dst = ((dst & 0xff00) >> 8) | ((dst & 0x00ff) << 8);
+}
+:LE32 dst  is imm=0x20 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 {
+    dst = ((dst & 0xff000000) >> 24) | (((dst) & 0x00ff0000) >> 8) | (((dst) & 0x0000ff00) << 8) | ((dst & 0x000000ff) << 24);
+}
 :LE64 dst  is imm=0x40 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=0 & op_insn_class=0x4 {
-    dst=( (dst << 56) & 0xff00000000000000 ) |
-    ( (dst << 40) & 0x00ff000000000000 ) |
-    ( (dst << 24) & 0x0000ff0000000000 ) |
-    ( (dst <<  8) & 0x000000ff00000000 ) |
-    ( (dst >>  8) & 0x00000000ff000000 ) |
-    ( (dst >> 24) & 0x0000000000ff0000 ) |
-    ( (dst >> 40) & 0x000000000000ff00 ) |
-    ( (dst >> 56) & 0x00000000000000ff );
+    dst = ((dst << 56) & 0xff00000000000000) |
+        ((dst << 40) & 0x00ff000000000000) |
+        ((dst << 24) & 0x0000ff0000000000) |
+        ((dst <<  8) & 0x000000ff00000000) |
+        ((dst >>  8) & 0x00000000ff000000) |
+        ((dst >> 24) & 0x0000000000ff0000) |
+        ((dst >> 40) & 0x000000000000ff00) |
+        ((dst >> 56) & 0x00000000000000ff);
 }
 
 # BPF_ALU   | BPF_X   | BPF_END
-:BE16 dst  is imm=0x10 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 { dst=((dst) >> 8) | ((dst) << 8); }
-:BE32 dst  is imm=0x20 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 { dst=((dst) >> 24) | (((dst) & 0x00FF0000) >> 8)  | (((dst) & 0x0000FF00) << 8) | ((dst) << 24); }
-:BE64 dst  is imm=0x40 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 {
-    dst=( (dst << 56) & 0xff00000000000000 ) |
-    ( (dst << 40) & 0x00ff000000000000 ) |
-    ( (dst << 24) & 0x0000ff0000000000 ) |
-    ( (dst <<  8) & 0x000000ff00000000 ) |
-    ( (dst >>  8) & 0x00000000ff000000 ) |
-    ( (dst >> 24) & 0x0000000000ff0000 ) |
-    ( (dst >> 40) & 0x000000000000ff00 ) |
-    ( (dst >> 56) & 0x00000000000000ff );
-}
-    
+:BE16 dst  is imm=0x10 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 { dst = zext(dst:2); }
+:BE32 dst  is imm=0x20 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 { dst = zext(dst:4); }
+:BE64 dst  is imm=0x40 & dst & op_alu_jmp_opcode=0xd & op_alu_jmp_source=1 & op_insn_class=0x4 {}
+@endif # ENDIAN = "big"
+
 #Memory instructions - Load and Store
 ###############################################################################
 

--- a/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
@@ -15,6 +15,7 @@ define space syscall type=ram_space size=4;
 define register offset=0 size=8 [ R0  R1  R2  R3  R4  R5  R6  R7  R8  R9  R10  PC ];
 
 # Instruction encoding: Insop:8, dst_reg:4, src_reg:4, off:16, imm:32 - from lsb to msb
+@if ENDIAN == "little"
 define token instr(64)
     imm=(32, 63) signed
     off=(16, 31) signed
@@ -29,8 +30,25 @@ define token instr(64)
 
 #We'll need this token to operate with LDDW instruction, which has 64 bit imm value
 define token immtoken(64)
-    imm2=(32, 63)		
+    imm2=(32, 63)
 ;
+@else # ENDIAN == "big"
+define token instr(64)
+    imm=(0, 31) signed
+    off=(32, 47) signed
+    src=(48, 51)
+    dst=(52, 55)
+    op_insn_class=(56, 58)
+    op_ld_st_size=(59, 60)
+    op_ld_st_mode=(61, 63)
+    op_alu_jmp_source=(59, 59)
+    op_alu_jmp_opcode=(60, 63)
+;
+
+define token immtoken(64)
+    imm2=(0, 31)
+;
+@endif # ENDIAN = "big"
 
 #To operate with registers
 attach variables [ src dst ] [  R0  R1  R2  R3  R4  R5  R6  R7  R8  R9  R10  _  _  _  _  _  ];

--- a/Ghidra/Processors/eBPF/data/languages/eBPF_be.slaspec
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF_be.slaspec
@@ -1,0 +1,3 @@
+@define ENDIAN "big"
+
+@include "eBPF.sinc"

--- a/Ghidra/Processors/eBPF/data/languages/eBPF_le.slaspec
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF_le.slaspec
@@ -1,3 +1,3 @@
-define endian=little;
+@define ENDIAN "little"
 
 @include "eBPF.sinc"


### PR DESCRIPTION
Hello,

eBPF byte swap operations (`BE16`, `BE32`, `BE64`, `LE16`, `LE32`, `LE64`) have semantics that depend on the endianness of the host processor executing the eBPF program. For example, on a Little-Endian CPU, BE16 swaps the 2 lowest significant bytes of the given destination register.

The semantic section of BE16 contains:

    { dst=((dst) >> 8) | ((dst) << 8); }

This contains several issues:

- It assumes the instruction always swaps the bytes. This should only happen on Little-Endian host CPU.
- If `dst` does not contain a 16-bit value (meaning `dst >> 16 != 0`), the computed value is wrong. The value should be properly masked. For example the Linux kernel defines in https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/swab.h?h=v6.14#L14

  ```c
  #define ___constant_swab16(x) ((__u16)(               \
            (((__u16)(x) & (__u16)0x00ffU) << 8) |      \
            (((__u16)(x) & (__u16)0xff00U) >> 8)))
  ```

Add a new internal register to define whether the host CPU is Big Endian. This way:

- By default, p-code operations decoded from byte swap operations contain conditional statements depending on this register.
- By setting the internal register to 0 (for Little Endian host CPU) or 1 (for Big Endian host CPU) for the whole program, the conditional statements disappear from the decompiled code, making it clearer.

To test this in Ghidra, I wrote a C program with inline assembly statements with functions such as:

```c
unsigned short do_be16(unsigned short x) {
#ifdef __clang__
    __asm__("%0 = be16 %0" : "=r" (x) : "0" (x));
#else
    __asm__("endbe %0,16" : "=r" (x) : "0" (x));
#endif
    return x;
}
```

This program can be compiled both with gcc (`bpf-gcc -O2 -c byte_swap.c -o byte_swap.ebpf`) and clang (`clang -O2 -target bpf -mcpu=v4 -c byte_swap.c -o byte_swap_clang19.1_alpine3.21_O2.ebpf`). Here is an archive with the program compiled with clang: [byte_swap.zip](https://github.com/user-attachments/files/19609656/byte_swap.zip)

With this Pull Request, Ghidra decompiles `do_be16` with a conditional statement:

![image](https://github.com/user-attachments/assets/a87bdd54-f546-45ec-831b-e90c4949aa0a)

Setting register `big_endian_host` to 0 makes the function decompile to a usual byte swap:

![image](https://github.com/user-attachments/assets/67e17d7e-b1f5-4244-a3f7-eec7008d20f6)

Setting the register to 1 makes the function appear as a only returning a 16-bit `undefined2` value:

![image](https://github.com/user-attachments/assets/be04487c-62d1-4dba-b91d-7e82deb6f01b)
