### PR TITLE
Improve ubfx lifting in 32-bit ARM

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -5221,13 +5221,13 @@ Pcrel: [pc,Rm0003]  is Rm0003 & thc0404=1 & pc
 
 :ubfx^ItCond Rd0811,Rn0003,thLsbImm,thWidthMinus1	is TMode=1 & ItCond & op4=0xf3c & Rn0003; thc1515=0 & Rd0811 & thLsbImm & thc0505=0 & thWidthMinus1
 {
-   build ItCond;
-	build thLsbImm;
-	build thWidthMinus1;
-	shift:4 = 31 - (thLsbImm + thWidthMinus1); # thMsbImm represents widthMinus1
-	Rd0811 = Rn0003 << shift;
-	shift = 31 - thWidthMinus1; # msbImm represents widthMinus1
-	Rd0811 = Rd0811 >> shift;
+  build ItCond;
+  build thLsbImm;
+  build thWidthMinus1;
+  shift:4 = 31 - (thLsbImm + thWidthMinus1); # thMsbImm represents widthMinus1
+  Rd0811 = Rn0003 << shift;
+  shift = 31 - thWidthMinus1; # msbImm represents widthMinus1
+  Rd0811 = Rd0811 >> shift;
 }
 
 :udiv^ItCond   Rd0811,Rn0003,Rm0003    is TMode=1 & ItCond & op4=0xfbb & Rn0003; op12=0xf & Rd0811 & thc0407=0xf & Rm0003

--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -5222,12 +5222,8 @@ Pcrel: [pc,Rm0003]  is Rm0003 & thc0404=1 & pc
 :ubfx^ItCond Rd0811,Rn0003,thLsbImm,thWidthMinus1	is TMode=1 & ItCond & op4=0xf3c & Rn0003; thc1515=0 & Rd0811 & thLsbImm & thc0505=0 & thWidthMinus1
 {
   build ItCond;
-  build thLsbImm;
-  build thWidthMinus1;
-  shift:4 = 31 - (thLsbImm + thWidthMinus1); # thMsbImm represents widthMinus1
-  Rd0811 = Rn0003 << shift;
-  shift = 31 - thWidthMinus1; # msbImm represents widthMinus1
-  Rd0811 = Rd0811 >> shift;
+  tmpmask:4 = ((1:4 << (1 + thWidthMinus1)) - 1);
+  Rd0811 = (Rn0003 >> thLsbImm) & tmpmask;
 }
 
 :udiv^ItCond   Rd0811,Rn0003,Rm0003    is TMode=1 & ItCond & op4=0xfbb & Rn0003; op12=0xf & Rd0811 & thc0407=0xf & Rm0003

--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -5945,12 +5945,8 @@ armEndianNess: "BE" is c0031=0xf1010200 { export 1:1; }
 :ubfx^COND Rd,Rm,lsbImm,widthMinus1	is $(AMODE) & ARMcond=1 & COND & c2127=0x3f & widthMinus1 & Rd & lsbImm & c0406=5 & Rm
 {
   build COND;
-  build lsbImm;
-  build widthMinus1;
-  shift:4 = 31 - (lsbImm + widthMinus1);
-  Rd = Rm << shift;
-  shift = 31 - widthMinus1;
-  Rd = Rd >> shift;
+  tmpmask:4 = ((1:4 << (1 + widthMinus1)) - 1);
+  Rd = (Rm >> lsbImm) & tmpmask;
 }
 
 @endif # VERSION_6T2

--- a/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMinstructions.sinc
@@ -5944,13 +5944,13 @@ armEndianNess: "BE" is c0031=0xf1010200 { export 1:1; }
 
 :ubfx^COND Rd,Rm,lsbImm,widthMinus1	is $(AMODE) & ARMcond=1 & COND & c2127=0x3f & widthMinus1 & Rd & lsbImm & c0406=5 & Rm
 {
-	build COND;
-	build lsbImm;
-	build widthMinus1;
-	shift:4 = 31 - (lsbImm + widthMinus1);
-	Rd = Rm << shift;
-	shift = 31 - widthMinus1;
-	Rd = Rd >> shift;
+  build COND;
+  build lsbImm;
+  build widthMinus1;
+  shift:4 = 31 - (lsbImm + widthMinus1);
+  Rd = Rm << shift;
+  shift = 31 - widthMinus1;
+  Rd = Rd >> shift;
 }
 
 @endif # VERSION_6T2


### PR DESCRIPTION
Currently, the way `ubfx r2, param_2, #0xa, #0x4` is lifted looks like this:

```
uVar1 = (param_2 << 0x12) >> 0x1c
```

However, the following equivalent form was preferred at my workplace by a vote of 14-0:

```
uVar1 = (param_2 >> 0xa) & 0xf
```

This PR could be considered a specific case of #5772 .  However, there's no need to even emit the double-shifts for UBFX in the first place, and this is both easier SLEIGH code to reason about and emits decompilation output that users prefer to reason about.

Here are some test binaries and the source code/Makefile used to generate them: [ubfx.zip](https://github.com/user-attachments/files/19822077/ubfx.zip)