### PR TITLE
GhidraProject: fix root path in docs

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/base/project/GhidraProject.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/base/project/GhidraProject.java
@@ -288,7 +288,7 @@ public class GhidraProject {
 	 * Opens a program.
 	 *
 	 * @param folderPath
-	 *            the path of the program within the project. ("\" is root)
+	 *            the path of the program within the project. ("/" is root)
 	 * @param programName
 	 *            the name of the program to open.
 	 * @param readOnly


### PR DESCRIPTION
While following the [GhidraProject `openProgram` API docs](https://ghidra.re/ghidra_docs/api/ghidra/base/project/GhidraProject.html#openProgram(java.lang.String,java.lang.String,boolean)), I got this error when trying to call `openProgram` on Windows like this:

```scala
program = project.openProgram("\\", domainFile.getName(), true)
```

```
java.lang.IllegalArgumentException: Absolute path must begin with '/'
        at ghidra.framework.data.DefaultProjectData.getFile(DefaultProjectData.java:663)
        at ghidra.base.project.GhidraProject.openProgram(GhidraProject.java:303)
```

So turns out it should be "/" under both Linux and Windows. I also tested it in both cases and it works.