### PR TITLE
Decompiler: Check WhileDo overflow syntax

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/block.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/block.cc
@@ -3313,7 +3313,17 @@ void BlockWhileDo::finalTransform(Funcdata &data)
 {
   BlockGraph::finalTransform(data);
   if (!data.getArch()->analyze_for_loops) return;
-  if (hasOverflowSyntax()) return;
+  if (hasOverflowSyntax()) {
+    // Maybe we have since been optimised so the condition is no longer too complex...
+    FlowBlock *check = getFrontLeaf();
+    if (check == (FlowBlock *)0) return;
+    BlockBasic *cond = (BlockBasic *)check->subBlock(0);
+    if (cond->isComplex()) return;
+
+    // Unmark this block as having overflow syntax
+    clearFlag(f_whiledo_overflow);
+    cond->negateCondition(true);
+  }
   FlowBlock *copyBl = getFrontLeaf();
   if (copyBl == (FlowBlock *)0) return;
   BlockBasic *head = (BlockBasic *)copyBl->subBlock(0);


### PR DESCRIPTION
Sometimes, BlockWhileDo blocks would be marked as using overflow syntax based on the unoptimised pcode, but when the pcode got optimised, the exit condition block no longer was complex. Still, the decision that the block uses overflow syntax is permanent, preventing for-loop recovery. This patch double-checks that BlockWhileDo blocks that have the overflow flag set really still are complex when attempting to recover the for loop.

----

The below comparison uses the xml contained inside this zip: [forfail.zip](https://github.com/user-attachments/files/20243921/forfail.zip)

Note how the **before** version has a `while(true)` loop with as first statement an `if` statement that can exit the loop. In the **after** version, this is simplified to a `for` loop.

**Before (11.3.1)**
```C
void FUN_00000000(undefined4 param_1,undefined4 param_2,uint param_3,uint param_4)

{

  int unaff_r2;
  undefined4 *puVar1;
  int iVar2;
  int unaff_r13;
  undefined4 *puVar3;
  undefined4 uVar4;
  undefined8 uVar5;
  undefined4 local_28;
  undefined4 local_24;
  undefined4 local_20;
  
  uVar5 = func_0x00266970();
  puVar1 = (undefined4 *)((ulonglong)uVar5 >> 0x20);
  local_20 = puVar1[2];
  local_24 = puVar1[1];
  local_28 = *puVar1;
  puVar3 = *(undefined4 **)(unaff_r13 + -0x58c0);
  uVar4 = 0;
  while( true )
  {
    if (puVar3 == NULL) break;
    if (((param_3 & *(byte *)((int)puVar3 + 0xdd)) != 0) &&
       (param_4 == *(byte *)((int)puVar3 + 0xde)) && (puVar3[0x35] == 0) &&
       (puVar3[0x33] - 5 > 4 && (iVar2 = func_0x0000a210(puVar3,puVar1,(int)uVar5,1), iVar2 != 0)))
    {
      iVar2 = func_0x00009f80((double)*(float *)(unaff_r2 + -0x7440),puVar3,&local_28);
      if (iVar2 != 0)
      {
        puVar1[3] = *puVar1;
        puVar1[4] = puVar1[1];
        puVar1[5] = puVar1[2];
      }
      uVar4 = *puVar3;
    }
    puVar3 = (undefined4 *)puVar3[1];
  }
  func_0x002669bc(uVar4);
  return;
}
```

**After**
```C
void FUN_00000000(undefined4 param_1, undefined4 param_2, uint param_3, uint param_4)

{
  float fVar1;
  int unaff_r2;
  undefined4 *puVar2;
  int unaff_r13;
  undefined4 *puVar3;
  undefined4 uVar4;
  undefined4 local_28;
  undefined4 local_24;
  undefined4 local_20;
  
  puVar2 = (undefined4 *)((ulonglong)func_0x00266970() >> 0x20);
  local_20 = puVar2[2];
  local_24 = puVar2[1];
  local_28 = *puVar2;
  uVar4 = 0;
  for (puVar3 = *(undefined4 **)(unaff_r13 + -0x58c0); puVar3 != NULL;
      puVar3 = (undefined4 *)puVar3[1])
  {
    if (((param_3 & *(byte *)((int)puVar3 + 0xdd)) != 0) &&
       (param_4 == *(byte *)((int)puVar3 + 0xde)) && (puVar3[0x35] == 0) &&
       (4 < puVar3[0x33] - 5 && (func_0x0000a210(puVar3, puVar2, (int)func_0x00266970(), 1) != 0)))
    {
      fVar1 = *(float *)(unaff_r2 + -0x7440);
      if (func_0x00009f80((double)fVar1, puVar3, &local_28) != 0)
      {
        puVar2[3] = *puVar2;
        puVar2[4] = puVar2[1];
        puVar2[5] = puVar2[2];
      }
      uVar4 = *puVar3;
    }
  }
  func_0x002669bc(uVar4);
  return;
}
```

**Cause**
Converting a `while` loop to a for-loop requires (among other things) that the loop has an exit condition that is not considered "complex". This is intended to capture that a block is emitted as a single statement in the pseudocode. In this example, you'd expect the check to not be considered "complex" - it's just a simple null check. However, when logging the pcode passed to `BlockBasic::isComplex` has not been completely optimised yet. This causes `BlockBasic::isComplex` to think the basic block requires 2 statements instead of 1.

Perhaps a better fix would be to recompute `isComplex` after all optimisations have been completed. However, to keep the patch as small as possible, I just recompute `isComplex` when `for` recovery is on and a `while` loop's exit condition is considered too complex.

I'm a bit suspicious about the `cond->negateCondition(true);` line. This is required because the exit condition has been (optionally?) negated before by `CollapseStructure::ruleBlockWhileDo`.