### PR TITLE
Fix getDestinationFunctions

### DIFF
--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/AbstractGhidraVersionTrackingScript.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/AbstractGhidraVersionTrackingScript.java
@@ -195,7 +195,7 @@ public abstract class AbstractGhidraVersionTrackingScript extends GhidraScript {
 		if (vtSession == null) {
 			throw new RuntimeException("You must have an open vt session");
 		}
-		return getFunctionNames(vtSession.getSourceProgram());
+		return getFunctionNames(vtSession.getDestinationProgram());
 	}
 
 	private Set<String> getFunctionNames(Program program) {


### PR DESCRIPTION
Updated the `getDestinationFunction` method in the Version Tracking API to use `getDestinationProgram` instead of `getSourceProgram` to correctly reference the destination program when retrieving function information.