### PR TITLE
BSim: Add getmetadata subcommand to bsim

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
@@ -268,6 +268,7 @@
 <CODE class&nbsp;"computeroutput">
     bsim createdatabase  &lt;bsimURL&gt; &lt;config_template&gt; [--name|-n&nbsp;"&lt;name&gt;"] [--owner|-o&nbsp;"&lt;owner&gt;"] [--description|-d&nbsp;"&lt;text&gt;"] [--nocallgraph]
     bsim setmetadata     &lt;bsimURL&gt; [--name|-n&nbsp;"&lt;name&gt;"] [--owner|-o&nbsp;"&lt;owner&gt;"] [--description|-d&nbsp;"&lt;text&gt;"]\n" + 
+    bsim getmetadata     &lt;bsimURL&gt;
     bsim addexecategory  &lt;bsimURL&gt; &lt;category_name&gt; [--date]
     bsim addfunctiontag  &lt;bsimURL&gt; &lt;tag_name&gt;
     bsim dropindex       &lt;bsimURL&gt;
@@ -371,6 +372,16 @@
 
                 <P><SPAN class="command"><STRONG>--description|-d</STRONG></SPAN> - specifies a short
                 string describing the intended contents of the new repository.</P>
+              </DD>
+
+              <DT><SPAN class="term"><SPAN class=
+              "bold"><STRONG>getmetadata</STRONG></SPAN></SPAN></DT>
+
+              <DD>
+                <P>Show the global <SPAN class="emphasis"><EM>name</EM></SPAN>, <SPAN class=
+                "emphasis"><EM>owner</EM></SPAN>, and <SPAN class=
+                "emphasis"><EM>description</EM></SPAN> metadata associated with a BSim server. A
+                BSim server URL is required.</P>
               </DD>
 
               <DT><SPAN class="term"><SPAN class=

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BSimLaunchable.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BSimLaunchable.java
@@ -60,6 +60,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 	 */
 	private static final String COMMAND_CREATE_DATABASE = defineCommand("createdatabase");
 	private static final String COMMAND_SET_METADATA = defineCommand("setmetadata");
+	private static final String COMMAND_GET_METADATA = defineCommand("getmetadata");
 	private static final String COMMAND_ADD_EXE_CATEGORY = defineCommand("addexecategory");
 	private static final String COMMAND_ADD_FUNCTION_TAG = defineCommand("addfunctiontag");
 	private static final String COMMAND_DROP_INDEX = defineCommand("dropindex");
@@ -146,6 +147,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 	private static final Set<String> PREWARM_OPTIONS = Set.of();
 	private static final Set<String> SET_METADATA_OPTIONS = 
 			Set.of(NAME_OPTION, OWNER_OPTION, DESCRIPTION_OPTION);
+	private static final Set<String> GET_METADATA_OPTIONS = Set.of();
 	private static final Set<String> ADD_EXE_CATEGORY_OPTIONS = Set.of(CATEGORY_DATE_OPTION);
 	private static final Set<String> ADD_FUNCTION_TAG_OPTIONS = Set.of();
 	private static final Set<String> DUMP_SIGS_OPTIONS = 
@@ -166,6 +168,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 	static {
 		ALLOWED_OPTION_MAP.put(COMMAND_CREATE_DATABASE, CREATE_DATABASE_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_SET_METADATA, SET_METADATA_OPTIONS);
+		ALLOWED_OPTION_MAP.put(COMMAND_GET_METADATA, GET_METADATA_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_ADD_EXE_CATEGORY, ADD_EXE_CATEGORY_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_ADD_FUNCTION_TAG, ADD_FUNCTION_TAG_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_DROP_INDEX, DROP_INDEX_OPTIONS);
@@ -400,6 +403,10 @@ public class BSimLaunchable implements GhidraLaunchable {
 		else if (COMMAND_SET_METADATA.equals(command)) {
 			bsimURL = BSimClientFactory.deriveBSimURL(urlstring);
 			doInstallMetadata(subParams);
+		}
+		else if (COMMAND_GET_METADATA.equals(command)) {
+			bsimURL = BSimClientFactory.deriveBSimURL(urlstring);
+			doPrintMetadata(subParams);
 		}
 		else if (COMMAND_ADD_EXE_CATEGORY.equals(command)) {
 			bsimURL = BSimClientFactory.deriveBSimURL(urlstring);
@@ -853,6 +860,22 @@ public class BSimLaunchable implements GhidraLaunchable {
 	}
 
 	/**
+	 * Prints the BSim database metadata.
+	 * 
+	 * This variant of the print metadata method is intended for command-line
+	 * users.
+	 * 
+	 * @param params the command-line params
+	 * @throws IOException if there's an error establishing the database connection
+	 */
+	private void doPrintMetadata(List<String> params) throws IOException, LSHException {
+
+		try (BulkSignatures bsim = getBulkSignatures()) {
+			bsim.printMetadata();
+		}
+	}
+
+	/**
 	 * Inserts a new category name into the BSim database. 
 	 * 
 	 * This variant of the install category method is intended for command-line
@@ -949,6 +972,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 			"USAGE: bsim [command]       required-args... [OPTIONS...]\n" + 
 			"            createdatabase  <bsimURL> <config_template> [--name|-n \"<name>\"] [--owner|-o \"<owner>\"] [--description|-d \"<text>\"] [--nocallgraph]\n" + 
 			"            setmetadata     <bsimURL> [--name|-n \"<name>\"] [--owner|-o \"<owner>\"] [--description|-d \"<text>\"]\n" + 
+			"            getmetadata     <bsimURL>\n" + 
 			"            addexecategory  <bsimURL> <category_name> [--date]\n" + 
 			"            addfunctiontag  <bsimURL> <tag_name>\n" +  
 			"            dropindex       <bsimURL>\n" + 

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BulkSignatures.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BulkSignatures.java
@@ -759,6 +759,19 @@ public class BulkSignatures implements AutoCloseable {
 	}
 
 	/**
+	 * Prints the metadata.
+	 * 
+	 * @throws IOException if there's an error establishing the database connection
+	 */
+	public void printMetadata() throws IOException {
+		DatabaseInformation info = establishQueryServerConnection(false);
+		Msg.info(this, "BSim metadata: ");
+		Msg.info(this, "   Database:     " + info.databasename);
+		Msg.info(this, "   Owner:        " + info.owner);
+		Msg.info(this, "   Description:  " + info.description);
+	}
+
+	/**
 	 * Performs the work of installing a new category name. This will build the query
 	 * object, establish the database connection, and perform the query.
 	 * 


### PR DESCRIPTION
Fixes #8175 

Test with PostgreSQL:

```
$ ./support/bsim setmetadata postgresql://localhost/test2 -n "Test"     
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
Updated BSim metadata:  
   Database:     Test 
   Owner:        Example Owner 
   Description:  A medium sized (~10 million functions) database tuned for 64-bit executables

$ ./support/bsim getmetadata postgresql://localhost/test2        
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
BSim metadata:  
   Database:     Test 
   Owner:        Example Owner 
   Description:  A medium sized (~10 million functions) database tuned for 64-bit executables
```

Test with H2:

```
$ ./support/bsim createdatabase file:/home/gemesa/test.mv.db/test medium_64 -n Test
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
Created database: Test
   owner       = Example Owner
   description = A medium sized (~10 million functions) database tuned for 64-bit executables
   template    = medium_64

$ ./support/bsim getmetadata file:/home/gemesa/test.mv.db/test                  
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
BSim metadata:  
   Database:     Test 
   Owner:        Example Owner 
   Description:  A medium sized (~10 million functions) database tuned for 64-bit executables
```

Test with Elastic:

I have never used the Elastic backend.