### PR TITLE
BSim: Add dropdatabase subcommand to bsim

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
@@ -267,6 +267,7 @@
 <PRE>
 <CODE class&nbsp;"computeroutput">
     bsim createdatabase  &lt;bsimURL&gt; &lt;config_template&gt; [--name|-n&nbsp;"&lt;name&gt;"] [--owner|-o&nbsp;"&lt;owner&gt;"] [--description|-d&nbsp;"&lt;text&gt;"] [--nocallgraph]
+    bsim dropdatabase    &lt;bsimURL&gt;
     bsim setmetadata     &lt;bsimURL&gt; [--name|-n&nbsp;"&lt;name&gt;"] [--owner|-o&nbsp;"&lt;owner&gt;"] [--description|-d&nbsp;"&lt;text&gt;"]\n" + 
     bsim addexecategory  &lt;bsimURL&gt; &lt;category_name&gt; [--date]
     bsim addfunctiontag  &lt;bsimURL&gt; &lt;tag_name&gt;
@@ -351,6 +352,14 @@
 
                 <P><SPAN class="command"><STRONG>--nocallgraph</STRONG></SPAN> - disables storing call 
                 relationships between ingested functions. Default is to store call relationships.</P>
+              </DD>
+
+              <DT><SPAN class="term"><SPAN class=
+              "bold"><STRONG>dropdatabase</STRONG></SPAN></SPAN></DT>
+
+              <DD>
+                <P>Deletes the specified repository. A BSim server URL is required. The database name
+                is taken from the path element of the URL.
               </DD>
 
               <DT><SPAN class="term"><SPAN class=

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BSimLaunchable.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BSimLaunchable.java
@@ -59,6 +59,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 	 * bsim commands
 	 */
 	private static final String COMMAND_CREATE_DATABASE = defineCommand("createdatabase");
+	private static final String COMMAND_DROP_DATABASE = defineCommand("dropdatabase");
 	private static final String COMMAND_SET_METADATA = defineCommand("setmetadata");
 	private static final String COMMAND_ADD_EXE_CATEGORY = defineCommand("addexecategory");
 	private static final String COMMAND_ADD_FUNCTION_TAG = defineCommand("addfunctiontag");
@@ -136,6 +137,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 	// Populate ALLOWED_OPTION_MAP for each command
 	private static final Set<String> CREATE_DATABASE_OPTIONS = 
 			Set.of(NAME_OPTION, OWNER_OPTION, DESCRIPTION_OPTION, NO_CALLGRAPH_OPTION);
+	private static final Set<String> DROP_DATABASE_OPTIONS = Set.of();
 	private static final Set<String> COMMIT_SIGS_OPTIONS = 
 			Set.of(OVERRIDE_OPTION, MD5_OPTION); // url requires override param
 	private static final Set<String> COMMIT_UPDATES_OPTIONS = Set.of();
@@ -165,6 +167,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 	private static final Map<String, Set<String>> ALLOWED_OPTION_MAP = new HashMap<>();
 	static {
 		ALLOWED_OPTION_MAP.put(COMMAND_CREATE_DATABASE, CREATE_DATABASE_OPTIONS);
+		ALLOWED_OPTION_MAP.put(COMMAND_DROP_DATABASE, DROP_DATABASE_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_SET_METADATA, SET_METADATA_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_ADD_EXE_CATEGORY, ADD_EXE_CATEGORY_OPTIONS);
 		ALLOWED_OPTION_MAP.put(COMMAND_ADD_FUNCTION_TAG, ADD_FUNCTION_TAG_OPTIONS);
@@ -397,6 +400,10 @@ public class BSimLaunchable implements GhidraLaunchable {
 			bsimURL = BSimClientFactory.deriveBSimURL(urlstring);
 			doCreateDatabase(subParams);
 		}
+		else if (COMMAND_DROP_DATABASE.equals(command)) {
+			bsimURL = BSimClientFactory.deriveBSimURL(urlstring);
+			doDropDatabase(subParams);
+		}
 		else if (COMMAND_SET_METADATA.equals(command)) {
 			bsimURL = BSimClientFactory.deriveBSimURL(urlstring);
 			doInstallMetadata(subParams);
@@ -522,6 +529,18 @@ public class BSimLaunchable implements GhidraLaunchable {
 		try (BulkSignatures bsim = getBulkSignatures()) {
 			bsim.createDatabase(configTemplate, nameOption, ownerOption, descOption,
 				!noTrackCallGraph);
+		}
+	}
+
+	/**
+	 * Drops the current BSim database.
+	 * 
+	 * @param params the command-line parameters
+	 * @throws IOException if there's an error establishing the database connection
+	 */
+	private void doDropDatabase(List<String> params) throws IOException {
+		try (BulkSignatures bsim = getBulkSignatures()) {
+			bsim.dropDatabase();
 		}
 	}
 
@@ -948,6 +967,7 @@ public class BSimLaunchable implements GhidraLaunchable {
 		System.err.println("\n" +
 			"USAGE: bsim [command]       required-args... [OPTIONS...]\n" + 
 			"            createdatabase  <bsimURL> <config_template> [--name|-n \"<name>\"] [--owner|-o \"<owner>\"] [--description|-d \"<text>\"] [--nocallgraph]\n" + 
+			"            dropdatabase    <bsimURL> \n" + 
 			"            setmetadata     <bsimURL> [--name|-n \"<name>\"] [--owner|-o \"<owner>\"] [--description|-d \"<text>\"]\n" + 
 			"            addexecategory  <bsimURL> <category_name> [--date]\n" + 
 			"            addfunctiontag  <bsimURL> <tag_name>\n" +  

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BulkSignatures.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BulkSignatures.java
@@ -452,6 +452,30 @@ public class BulkSignatures implements AutoCloseable {
 	}
 
 	/**
+	 * Drops the current BSim database.
+	 * 
+	 * @throws IOException if there's an error establishing the database connection
+	 */
+	public void dropDatabase() throws IOException {
+		establishQueryServerConnection(false); // Set up client configuration
+		querydb.close(); // Database can't be in use when we try to drop it
+		DropDatabase command = new DropDatabase();
+		command.databaseName = bsimServerInfo.getDBName();
+		ResponseDropDatabase response = command.execute(querydb);
+		if (response == null) {
+			throw new IOException("Unable to drop database: " + querydb.getLastError().message);
+		}
+		else {
+			if (response.dropSuccessful) {
+				Msg.info(this, "Successfully dropped database \"" + command.databaseName + "\"");
+			}
+			else {
+				Msg.error(this, "Unable to drop database: " + response.errorMessage);
+			}
+		}
+	}
+
+	/**
 	 * Adds function signatures from the specified project to the BSim database
 	 * @param ghidraURL ghidra repository from which to pull files for signature generation
 	 * @param sigsLocation the location where signature files will be stored


### PR DESCRIPTION
Fixes #8178 

Test with PostgreSQL:

```
$ ./support/bsim createdatabase postgresql://localhost/test medium_32
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
Created database: Medium 32-bit
   owner       = Example Owner
   description = A medium sized (~10 million functions) database tuned for 32-bit executables
   template    = medium_32

$ ./support/bsim dropdatabase postgresql://localhost/test      
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
Successfully dropped database "test"

$ ./support/bsim dropdatabase postgresql://localhost/test
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
ERROR FATAL: database "test" does not exist (BSimLaunchable)
```

Test with H2:

```
$ ./support/bsim createdatabase file:/home/gemesa/test.mv.db/test medium_64 
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
Created database: Medium 64-bit
   owner       = Example Owner
   description = A medium sized (~10 million functions) database tuned for 64-bit executables
   template    = medium_64

$ ./support/bsim dropdatabase file:/home/gemesa/test.mv.db/test medium_64
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
Successfully dropped database "/home/gemesa/test.mv.db/test.mv.db"

$ ./support/bsim dropdatabase file:/home/gemesa/test.mv.db/test medium_64
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.4 GBytes
ERROR Database does not exist: /home/gemesa/test.mv.db/test.mv.db (BSimLaunchable)
```