### PR TITLE
Fixed magic bytes to resolve Golang (v1.20+) functions.

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/GoPcHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/GoPcHeader.java
@@ -47,6 +47,7 @@ public class GoPcHeader {
 	public static final int GO_1_2_MAGIC = 0xfffffffb;
 	public static final int GO_1_16_MAGIC = 0xfffffffa;
 	public static final int GO_1_18_MAGIC = 0xfffffff0;
+	public static final int GO_1_20_MAGIC = 0xfffffff1;
 
 	/**
 	 * Returns the {@link Address} (if present) of the go pclntab section or symbol.
@@ -314,6 +315,7 @@ public class GoPcHeader {
 			case GO_1_2_MAGIC -> new GoVer(1, 2, 0);
 			case GO_1_16_MAGIC -> new GoVer(1, 16, 0);
 			case GO_1_18_MAGIC -> new GoVer(1, 18, 0);
+			case GO_1_20_MAGIC -> new GoVer(1, 20, 0);
 			default -> GoVer.INVALID;
 		};
 		


### PR DESCRIPTION
The current version of Ghidra was updated to detect binaries for Golang v1.20+, however the Auto Analysis could not resolve the function names. Below I'll attach an image of the broken example (Golang v1.20, Win_x64 PE format, from https://github.com/amidaware/rmmagent):
<img width="510" alt="broken" src="https://github.com/user-attachments/assets/6b249058-f410-4939-88c2-785a9c54c81e" />
The fixes were minor, it amounted to updating 2 lines in /ghidra/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/GoPcHeader.java
to include the Golang v1.20 magic bytes (0xfffffff1, pulled from https://github.com/golang/go/blob/master/src/debug/gosym/pclntab.go) and then correctly return the version in the file. This avoids returning null instead of a GoVerEndian type, and after building I was able to get these results:
<img width="555" alt="fixed" src="https://github.com/user-attachments/assets/d622b760-8aff-4fe1-826d-5c6740370191" />
