### PR TITLE
Fix RISC-V minu and max instructions' definitions

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
@@ -52,13 +52,13 @@
 #TODO  fix op2026
 :grevi rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0xd & op2026 & rd & rs1 unimpl
 
-:max  rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x5 & rd & rs1 & rs2 unimpl
+:max  rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
 :maxu rd, rs1, rs2 is op0006=0x33 & op1214=0x7 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
 :min  rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
-:minu rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x5 & rd & rs1 & rs2 unimpl
+:minu rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
 :orn  rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x20 & rd & rs1 & rs2 unimpl
 


### PR DESCRIPTION
This PR fixes the definitions of the RISC-V `minu` and `max` instructions. The [specification](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf) provides the following encodings, where the two instructions are differentiated by bits 12 through 14:

```
max:  0000101 ????? ????? 110 ????? 0110011
minu: 0000101 ????? ????? 101 ????? 0110011
```

However, in Ghidra, the values of these bits are interchanged, resulting in incorrect disassembly.