### PR TITLE
Plan9 binaries

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutHeader.java
@@ -1,0 +1,387 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ghidra.app.util.bin.format.plan9aout;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.*;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.data.*;
+import ghidra.program.model.listing.Listing;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.util.CodeUnitInsertionException;
+import ghidra.util.exception.DuplicateNameException;
+
+public class Plan9AoutHeader implements StructConverter {
+
+	private BinaryReader reader;
+
+	private long binarySize;
+	private boolean machineTypeValid;
+	private String languageSpec;
+	private String compilerSpec = "default";
+	private long pageSize;
+	private int pointerSize;
+	private long hdrSize;
+
+	private long a_magic;
+	private long a_text;
+	private long a_data;
+	private long a_bss;
+	private long a_syms;
+	private long a_entry;
+	private long a_spsize;
+	private long a_pcsize;
+
+	private long strSize;
+
+	private long txtOffset;
+	private long datOffset;
+	private long symOffset;
+	private long spOffset;
+	private long pcOffset;
+	private long strOffset;
+
+	private long txtAddr;
+	private long txtEndAddr;
+	private long datAddr;
+	private long bssAddr;
+
+	// The Linux implementation of a.out appears to start the .text content at
+	// file offset 0x400 (rather than immediately after the 0x20 bytes of header
+	// data). It's possible that there exist Linux a.out executabLes with other
+	// (unintended?) header sizes caused by a mixture of 32- and 64-bit integers
+	// being padded out in the struct. The intended size is eight 32-bit words
+	// (32 bytes total.)
+	private static final int SIZE_OF_EXEC_HEADER = 0x20;
+	private static final int SIZE_OF_LONG_EXEC_HEADER = 0x400;
+
+	/**
+	 * Interprets binary data as an exec header from a Plan9-style a.out executable, and validates 
+	 * the contained fields.
+	 *
+	 * @param provider Source of header binary data
+	 * @throws IOException if an IO-related error occurred
+	 */
+	public Plan9AoutHeader(ByteProvider provider) throws IOException {
+		reader = new BinaryReader(provider, false);
+
+		a_magic = reader.readNextUnsignedInt();
+		a_text = reader.readNextUnsignedInt();
+		a_data = reader.readNextUnsignedInt();
+		a_bss = reader.readNextUnsignedInt();
+		a_syms = reader.readNextUnsignedInt();
+		a_entry = reader.readNextUnsignedInt();
+		a_spsize = reader.readNextUnsignedInt();
+		a_pcsize = reader.readNextUnsignedInt();
+		pointerSize = 4;
+		if ((a_magic & Plan9AoutMachineType.HDR_MAGIC) != 0) {
+			pointerSize = 8;
+			a_entry = reader.readNextUnsignedValue(pointerSize);
+		}
+		hdrSize = reader.getPointerIndex();
+		binarySize = reader.length();
+
+		checkMachineTypeValidity();
+
+		txtOffset = 0;
+		datOffset = txtOffset + hdrSize + a_text;
+		symOffset = datOffset + a_data;
+		spOffset = symOffset + a_syms;
+		pcOffset = spOffset + a_spsize;
+		strOffset = pcOffset + a_pcsize;
+
+		strSize = 0;
+		if (strOffset != 0 && (strOffset + 4) <= binarySize) {
+			strSize = reader.readUnsignedInt(strOffset);
+		}
+
+		determineTextAddr();
+		txtEndAddr = txtAddr + hdrSize + a_text;
+		datAddr = segmentRound(txtEndAddr);
+		bssAddr = datAddr + a_data;
+	}
+
+	public BinaryReader getReader() {
+		return reader;
+	}
+
+	/**
+	 * {@return the processor/language specified by this header.}
+	 */
+	public String getLanguageSpec() {
+		return languageSpec;
+	}
+
+	/**
+	 * {@return the compiler used by this executable. This is left as 'default' for
+	 * all machine types other than i386, where it is assumed to be plan9.}
+	 */
+	public String getCompilerSpec() {
+		return compilerSpec;
+	}
+
+	/**
+	 * {@return an indication of whether this header's fields are all valid; this
+	 * includes the machine type, executable type, and section offsets.}
+	 */
+	public boolean isValid() {
+		return isMachineTypeValid() &&
+			areOffsetsValid();
+	}
+
+	public long getTextSize() {
+		return a_text;
+	}
+
+	public long getDataSize() {
+		return a_data;
+	}
+
+	public long getBssSize() {
+		return a_bss;
+	}
+
+	public long getSymSize() {
+		return a_syms;
+	}
+
+	public long getStrSize() {
+		return strSize;
+	}
+
+	public int getPointerSize() {
+		return pointerSize;
+	}
+
+	public long getHeaderSize() {
+		return hdrSize;
+	}
+
+	public long getEntryPoint() {
+		return a_entry;
+	}
+
+	public long getTextRelocSize() {
+		return 0;
+	}
+
+	public long getDataRelocSize() {
+		return 0;
+	}
+
+
+	public long getTextOffset() {
+		return txtOffset;
+	}
+
+	public long getDataOffset() {
+		return datOffset;
+	}
+
+	public long getSymOffset() {
+		return symOffset;
+	}
+
+	public long getTextRelocOffset() {
+		return 0;
+	}
+
+	public long getDataRelocOffset() {
+		return 0;
+	}
+
+	public long getStrOffset() {
+		return strOffset;
+	}
+
+	public long getTextAddr() {
+		return txtAddr;
+	}
+
+	public long getDataAddr() {
+		return datAddr;
+	}
+
+	public long getBssAddr() {
+		return bssAddr;
+	}
+
+	/**
+	 * Checks the magic word in the header for a known machine type ID, and sets the
+	 * languageSpec string accordingly.
+	 */
+	private void checkMachineTypeValidity() {
+
+		machineTypeValid = true;
+		pageSize = (a_magic & Plan9AoutMachineType.HDR_MAGIC) != 0 ? 0x200000 : 4096;
+
+		switch ((int)a_magic) {
+			/**
+			 * Motorola 68K family
+			 */
+			case Plan9AoutMachineType.M_68020:
+				languageSpec = "68000:BE:32:MC68020";
+				break;
+
+			/**
+			 * SPARC family
+			 */
+			case Plan9AoutMachineType.M_SPARC:
+				languageSpec = "sparc:BE:32:default";
+				break;
+			case Plan9AoutMachineType.M_SPARC64:
+				languageSpec = "sparc:BE:64:default";
+				break;
+
+			/**
+			 * MIPS family
+			 */
+			case Plan9AoutMachineType.M_SPIM1:
+			case Plan9AoutMachineType.M_SPIM2:
+				languageSpec = "MIPS:LE:32:default";
+				break;
+			case Plan9AoutMachineType.M_MIPS1:
+			case Plan9AoutMachineType.M_MIPS2:
+				languageSpec = "MIPS:BE:32:default";
+				break;
+
+			/**
+			 * x86 family
+			 */
+			case Plan9AoutMachineType.M_386:
+				languageSpec = "x86:LE:32:default";
+				break;
+			case Plan9AoutMachineType.M_AMD64:
+				compilerSpec = "plan9";
+				languageSpec = "x86:LE:64:default";
+				break;
+
+			/**
+			 * ARM family
+			 */
+			case Plan9AoutMachineType.M_ARM:
+				languageSpec = "ARM:LE:32:default";
+				break;
+			case Plan9AoutMachineType.M_AARCH64:
+				languageSpec = "AARCH64:LE:64:default";
+				break;
+
+			/**
+			 * RISC family
+			 */
+			case Plan9AoutMachineType.M_RISCV:
+				languageSpec = "RISCV:LE:32:default";
+				break;
+
+			/**
+			 * PowerPC family
+			 */
+			case Plan9AoutMachineType.M_POWERPC:
+				languageSpec = "PowerPC:BE:32:default";
+				break;
+			case Plan9AoutMachineType.M_POWERPC64:
+				languageSpec = "PowerPC:BE:64:default";
+				break;
+
+			/**
+			 * Other
+			 */
+			case Plan9AoutMachineType.M_ALPHA:
+				languageSpec = "UNKNOWN:BE:64:default";
+				break;
+			case Plan9AoutMachineType.M_29K:
+				languageSpec = "UNKNOWN:LE:32:default";
+				break;
+			case Plan9AoutMachineType.M_UNKNOWN:
+				languageSpec = "UNKNOWN:LE:32:default";
+				break;
+			default:
+				machineTypeValid = false;
+		}
+	}
+
+	/**
+	 * Returns a flag indicating whether the header contains a known machine type
+	 * ID.
+	 */
+	private boolean isMachineTypeValid() {
+		return machineTypeValid;
+	}
+
+	/**
+	 * Uses the combination of executable type and architecture to set the
+	 * appropriate
+	 * base address of the .text segment when loaded.
+	 */
+	private void determineTextAddr() {
+		txtAddr = pageSize;
+	}
+
+	/**
+	 * Returns a flag indicating whether all the file offsets in the header
+	 * (for the segments of nonzero size) fall within the size of the file.
+	 */
+	private boolean areOffsetsValid() {
+		// Note that we can't check the string table validity because, if it
+		// doesn't exist, its offset will be computed to be beyond the end of
+		// the file. The string table is also not given an explicit size in
+		// the header.
+		boolean status = ((a_text == 0) || (txtOffset < binarySize) &&
+			((a_data == 0) || (datOffset < binarySize)) &&
+			((a_syms == 0) || (symOffset < binarySize)) &&
+			((a_spsize == 0) || (spOffset < binarySize)) &&
+			((a_pcsize == 0) || (pcOffset < binarySize)));
+		return status;
+	}
+
+	/**
+	 * Rounds the provided address up to the next page boundary.
+	 */
+	private long segmentRound(long addr) {
+		final long mask = pageSize - 1;
+		long rounded = ((addr + mask) & ~mask);
+		return rounded;
+	}
+
+	@Override
+	public DataType toDataType() throws DuplicateNameException, IOException {
+		Structure struct = new StructureDataType(new CategoryPath("/AOUT"), "exec", 0);
+		struct.add(DWORD, "a_midmag", "magic (network byte order)");
+		struct.add(DWORD, "a_text", "the size of the text segment in bytes");
+		struct.add(DWORD, "a_data", "the size of the data segment in bytes");
+		struct.add(DWORD, "a_bss", "the number of bytes in the bss segment");
+		struct.add(DWORD, "a_syms", "the size in bytes of the symbol table section");
+		struct.add(DWORD, "a_entry", "the address of the entry point");
+		struct.add(DWORD, "a_spsize", "the size in bytes of the SP/PC table");
+		struct.add(DWORD, "a_pcsize", "the size in bytes of the PC/lineno table");
+		if ((a_magic & Plan9AoutMachineType.HDR_MAGIC) != 0)
+			struct.add(QWORD, "a_entry64", "the address of the entry point");
+
+		return struct;
+	}
+
+	public void markup(Program program, Address headerAddress)
+			throws CodeUnitInsertionException, DuplicateNameException, IOException {
+		DataType dt = program.getDataTypeManager().addDataType(toDataType(), DataTypeConflictHandler.DEFAULT_HANDLER);
+		for (DataTypeComponent field : ((Composite)dt).getComponents()) {
+			field.getDefaultSettings().setLong("endian", EndianSettingsDefinition.BIG);
+		}
+		Listing listing = program.getListing();
+		listing.createData(headerAddress, dt);
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutMachineType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutMachineType.java
@@ -1,0 +1,49 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ghidra.app.util.bin.format.plan9aout;
+
+public class Plan9AoutMachineType {
+
+	// These values come from a combination of sources, including Plan 9's a.out.h and zl
+	// present in kencc-cross.
+
+	public final static int HDR_MAGIC = 0x00008000;
+
+	public final static int M_UNKNOWN = 0;
+	public final static int M_68020 = (((4*8)+0)*8)+7;	// retired
+	public final static int M_386 = (((4*11)+0)*11)+7;
+	public final static int M_960 = (((4*12)+0)*12)+7;	// intel (retired)
+	public final static int M_SPARC = (((4*13)+0)*13)+7;
+	public final static int M_MIPS1 = (((4*16)+0)*16)+7;	// MIPS 3000 BE
+	public final static int M_3210 = (((4*17)+0)*17)+7;	// att dsp (retired)
+	public final static int M_MIPS2 = (((4*18)+0)*18)+7;	// MIPS 4000 BE
+	public final static int M_29K = (((4*19)+0)*19)+7;	// AMD 29000 (retired)
+	public final static int M_ARM = (((4*20)+0)*20)+7;
+	public final static int M_POWERPC = (((4*21)+0)*21)+7;
+	public final static int M_SPIM2 = (((4*22)+0)*22)+7;	// MIPS 4000 LE
+	public final static int M_ALPHA = (((4*23)+0)*23)+7;	// DEC Alpha (retired)
+	public final static int M_SPIM1 = (((4*24)+0)*24)+7;	// MIPS 3000 LE
+	public final static int M_SPARC64 = (((4*25)+0)*25)+7;	// sparc64
+	public final static int M_AMD64 = HDR_MAGIC | (((4*26)+0)*26)+7;
+	public final static int M_POWERPC64 = HDR_MAGIC | (((4*27)+0)*27)+7;
+	public final static int M_AARCH64 = HDR_MAGIC | (((4*28)+0)*28)+7;  // arm64
+	public final static int M_RISCV = HDR_MAGIC | (((4*29)+0)*29)+7;	// riscv32
+
+	final static int _magic(int f, int b) {
+		return f|((((4*b)+0)*b)+7);
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutRelocation.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutRelocation.java
@@ -1,0 +1,85 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ghidra.app.util.bin.format.plan9aout;
+
+import ghidra.app.util.opinion.Plan9AoutProgramLoader;
+
+/**
+ * Represents the content of a single entry in the relocation table format used
+ * by the PLAN9 a.out executable.
+ */
+public class Plan9AoutRelocation {
+	public long address;
+	public int symbolNum;
+	public byte flags;
+	public boolean pcRelativeAddressing;
+	public byte pointerLength;
+	public boolean extern;
+	public boolean baseRelative;
+	public boolean jmpTable;
+	public boolean relative;
+	public boolean copy;
+
+	/**
+	 * 
+	 * @param address First of the two words in the table entry (a 32-bit address)
+	 * @param flags Second of the two words in the table entry (containing several bitfields)
+	 * @param bigEndian True if big endian; otherwise, false
+	 */
+	public Plan9AoutRelocation(long address, long flags, boolean bigEndian) {
+		this.address = (0xFFFFFFFF & address);
+
+		if (bigEndian) {
+			this.symbolNum = (int) ((flags & 0xFFFFFF00) >> 8);
+			this.flags = (byte) (flags & 0xFF);
+			this.pcRelativeAddressing = ((flags & 0x80) != 0);
+			this.pointerLength = (byte) (1 << ((flags & 0x60) >> 5));
+			this.extern = ((flags & 0x10) != 0);
+			this.baseRelative = ((flags & 0x8) != 0);
+			this.jmpTable = ((flags & 0x4) != 0);
+			this.relative = ((flags & 0x2) != 0);
+			this.copy = ((flags & 0x1) != 0);
+		}
+		else {
+			this.symbolNum = (int) (flags & 0x00FFFFFF);
+			this.flags = (byte) ((flags & 0xFF000000) >> 24);
+			this.pcRelativeAddressing = ((this.flags & 0x01) != 0);
+			this.pointerLength = (byte) (1 << ((this.flags & 0x06) >> 1));
+			this.extern = ((this.flags & 0x08) != 0);
+			this.baseRelative = ((this.flags & 0x10) != 0);
+			this.jmpTable = ((this.flags & 0x20) != 0);
+			this.relative = ((this.flags & 0x40) != 0);
+			this.copy = ((this.flags & 0x80) != 0);
+		}
+	}
+
+	public String getSymbolName(Plan9AoutSymbolTable symtab) {
+		if (extern && symbolNum < symtab.size()) {
+			return symtab.get(symbolNum).name;
+		}
+		else if (!extern) {
+			return switch (symbolNum) {
+				case 4 -> Plan9AoutProgramLoader.dot_text;
+				case 6 -> Plan9AoutProgramLoader.dot_data;
+				case 8 -> Plan9AoutProgramLoader.dot_bss;
+				default -> null;
+			};
+		}
+
+		return null;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutRelocationTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutRelocationTable.java
@@ -1,0 +1,102 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.plan9aout;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.apache.commons.lang3.StringUtils;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.StructConverter;
+import ghidra.program.model.data.*;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.util.CodeUnitInsertionException;
+import ghidra.util.exception.DuplicateNameException;
+
+public class Plan9AoutRelocationTable implements Iterable<Plan9AoutRelocation>, StructConverter {
+	private static final int ENTRY_SIZE = 8;
+
+	private final long fileSize;
+	private final List<Plan9AoutRelocation> relocations;
+	private final Plan9AoutSymbolTable symtab;
+
+	public Plan9AoutRelocationTable(BinaryReader reader, long fileOffset, long fileSize,
+			Plan9AoutSymbolTable symtab) throws IOException {
+		this.fileSize = fileSize;
+		this.relocations = new ArrayList<>();
+		this.symtab = symtab;
+
+		reader.setPointerIndex(fileOffset);
+
+		// read each relocation table entry
+		while (reader.getPointerIndex() < (fileOffset + fileSize)) {
+			long address = reader.readNextUnsignedInt();
+			long flags = reader.readNextUnsignedInt();
+
+			Plan9AoutRelocation relocation =
+				new Plan9AoutRelocation(address, flags, reader.isBigEndian());
+			relocations.add(relocation);
+		}
+	}
+
+	@Override
+	public Iterator<Plan9AoutRelocation> iterator() {
+		return relocations.iterator();
+	}
+
+	@Override
+	public DataType toDataType() throws DuplicateNameException, IOException {
+		String dtName = "relocation_info";
+		Structure struct = new StructureDataType(new CategoryPath("/AOUT"), dtName, 0);
+		struct.setPackingEnabled(true);
+		try {
+			struct.add(DWORD, "r_address", null);
+			struct.addBitField(DWORD, 24, "r_symbolnum", null);
+			struct.addBitField(BYTE, 1, "r_pcrel", null);
+			struct.addBitField(BYTE, 2, "r_length", null);
+			struct.addBitField(BYTE, 1, "r_extern", null);
+			struct.addBitField(BYTE, 1, "r_baserel", null);
+			struct.addBitField(BYTE, 1, "r_jmptable", null);
+			struct.addBitField(BYTE, 1, "r_relative", null);
+			struct.addBitField(BYTE, 1, "r_copy", null);
+		}
+		catch (InvalidDataTypeException e) {
+			throw new RuntimeException(e);
+		}
+
+		return new ArrayDataType(struct, (int) (fileSize / ENTRY_SIZE), ENTRY_SIZE);
+	}
+
+	public void markup(Program program, MemoryBlock block)
+			throws CodeUnitInsertionException, DuplicateNameException, IOException {
+		Listing listing = program.getListing();
+		Data array = listing.createData(block.getStart(), toDataType());
+
+		int idx = 0;
+		for (Plan9AoutRelocation relocation : this) {
+			String name = relocation.getSymbolName(symtab);
+
+			if (!StringUtils.isBlank(name)) {
+				Data structData = array.getComponent(idx);
+				structData.setComment(CommentType.EOL, name);
+			}
+
+			idx++;
+		}
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutStringTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutStringTable.java
@@ -1,0 +1,62 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.plan9aout;
+
+import java.io.IOException;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.StructConverter;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.data.TerminatedStringDataType;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.util.CodeUnitInsertionException;
+
+public class Plan9AoutStringTable {
+	private final BinaryReader reader;
+	private final long fileOffset;
+
+	public Plan9AoutStringTable(BinaryReader reader, long fileOffset, long fileSize) {
+		this.reader = reader;
+		this.fileOffset = fileOffset;
+	}
+
+	public String readString(long stringOffset) {
+		if (fileOffset < 0) {
+			return null;
+		}
+		try {
+			return reader.readUtf8String(fileOffset + stringOffset).trim();
+		}
+		catch (IOException e) {
+			// FIXME
+		}
+		return null;
+	}
+
+	public void markup(Program program, MemoryBlock block) throws CodeUnitInsertionException {
+		Listing listing = program.getListing();
+		Address address = block.getStart();
+		listing.createData(address, StructConverter.DWORD);
+
+		int strlen = 4;
+		while ((address.getOffset() + strlen) < block.getEnd().getOffset()) {
+			address = address.add(strlen);
+			Data str = listing.createData(address, TerminatedStringDataType.dataType, -1);
+			strlen = str.getLength();
+		}
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutSymbol.java
@@ -1,0 +1,52 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.plan9aout;
+
+/**
+ * Represents the content of a single entry in the symbol table format used by
+ * the PLAN9 a.out executable.
+ */
+public class Plan9AoutSymbol {
+
+	public enum SymbolType {
+		N_TEXT, N_LEAF, N_DATA, N_BSS, N_AUTO, N_PARAM, N_FRAME, N_FILE, N_PATH, N_LINE, UNKNOWN
+	}
+
+	public String name;
+	public SymbolType type;
+	public long value;
+	public boolean isExt;
+
+	public Plan9AoutSymbol(String name, byte typeByte, long value) {
+		this.name = name;
+		this.value = value;
+		this.isExt = (typeByte & 0x20) == 0;
+
+		this.type = switch (((int)typeByte) & 0xff) {
+			case 0x80+'t', 0x80+'T' -> SymbolType.N_TEXT;
+			case 0x80+'l', 0x80+'L' -> SymbolType.N_LEAF;
+			case 0x80+'d', 0x80+'D' -> SymbolType.N_DATA;
+			case 0x80+'b', 0x80+'B' -> SymbolType.N_BSS;
+			case 0x80+'a' -> SymbolType.N_AUTO;
+			case 0x80+'p' -> SymbolType.N_PARAM;
+			case 0x80+'m' -> SymbolType.N_FRAME;
+			case 0x80+'f' -> SymbolType.N_FILE;
+			case 0x80+'z' -> SymbolType.N_PATH;
+			case 0x80+'Z' -> SymbolType.N_LINE;
+			default -> SymbolType.UNKNOWN;
+		};
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutSymbolTable.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/plan9aout/Plan9AoutSymbolTable.java
@@ -1,0 +1,140 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.bin.format.plan9aout;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.StructConverter;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.app.util.opinion.Plan9AoutProgramLoader;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.data.*;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.util.CodeUnitInsertionException;
+import ghidra.util.InvalidNameException;
+import ghidra.util.exception.DuplicateNameException;
+
+public class Plan9AoutSymbolTable implements Iterable<Plan9AoutSymbol>, StructConverter {
+	private final long fileSize;
+	private final int pointerSize;
+	private List<Plan9AoutSymbol> symbols;
+	private Map<Long,String> files;
+
+	public Plan9AoutSymbolTable(BinaryReader reader, long fileOffset, long fileSize, int pointerSize,
+			Plan9AoutStringTable strtab, MessageLog log) throws IOException {
+		this.fileSize = fileSize;
+		this.pointerSize = pointerSize;
+		this.symbols = new ArrayList<>();
+		files = new HashMap<>();
+
+		reader.setPointerIndex(fileOffset);
+		int idx = 0;
+
+		// read each symbol table entry
+		while (reader.getPointerIndex() < (fileOffset + fileSize)) {
+			long value = reader.readNextUnsignedValue(pointerSize);
+			byte typeByte = reader.readNextByte();
+			String name = reader.readNextUtf8String();
+			if (name.isEmpty())
+				name = reader.readNextUnicodeString();
+
+			Plan9AoutSymbol symbol = new Plan9AoutSymbol(name, typeByte, value);
+			switch (symbol.type) {
+			case Plan9AoutSymbol.SymbolType.N_FILE:
+				files.put(symbol.value, symbol.name);
+				break;
+			case Plan9AoutSymbol.SymbolType.UNKNOWN:
+				log.appendMsg(Plan9AoutProgramLoader.dot_symtab,
+					String.format("Unknown symbol type 0x%02x at symbol index %d", typeByte, idx));
+			}
+			symbols.add(symbol);
+
+			idx++;
+		}
+	}
+
+	@Override
+	public Iterator<Plan9AoutSymbol> iterator() {
+		return symbols.iterator();
+	}
+
+	@Override
+	public DataType toDataType() throws DuplicateNameException, IOException {
+		// no uniform structure to be applied
+		return null;
+	}
+
+	public Plan9AoutSymbol get(int symbolNum) {
+		return symbols.get(symbolNum);
+	}
+
+	public long size() {
+		return symbols.size();
+	}
+
+	public void markup(Program program, MemoryBlock block)
+			throws CodeUnitInsertionException, DuplicateNameException, InvalidNameException, IOException {
+		Listing listing = program.getListing();
+		DataTypeManager dtmanager = program.getDataTypeManager();
+
+		DataType mword = (pointerSize == 8 ? QWORD : DWORD).clone(null);
+		DataType termUniBE = TerminatedUnicodeDataType.dataType.clone(null);
+		mword.setName("PWORD_BE");
+		termUniBE.setName("TerminatedUnicodeBE");
+		mword = dtmanager.addDataType(mword, DataTypeConflictHandler.DEFAULT_HANDLER);
+		mword.getDefaultSettings().setLong("endian", EndianSettingsDefinition.BIG);
+		termUniBE = dtmanager.addDataType(termUniBE, DataTypeConflictHandler.DEFAULT_HANDLER);
+		termUniBE.getDefaultSettings().setLong("endian", EndianSettingsDefinition.BIG);
+
+		Address addr = block.getStart();
+
+		int idx = 0;
+		for (Plan9AoutSymbol symbol : this) {
+			Data valData = listing.createData(addr, mword);
+			addr = addr.add(valData.getLength());
+			Data typeData = listing.createData(addr, BYTE);
+			addr = addr.add(typeData.getLength());
+			Data str = listing.createData(addr, TerminatedStringDataType.dataType);
+			addr = addr.add(str.getLength());
+			if (str.getLength() == 1) {
+				Data ustr = listing.createData(addr, termUniBE);
+				addr = addr.add(ustr.getLength());
+			}
+			switch (symbol.type) {
+				case N_PATH:
+					if (!StringUtils.isBlank(symbol.name)) {
+						String comm = symbol.name.codePoints()
+							.mapToObj(file -> files.getOrDefault((long)file, "(invalid)"))
+							.collect(Collectors.joining("/"));
+						valData.setComment(CommentType.EOL, comm);
+					}
+					break;
+				default:
+					if (!StringUtils.isBlank(symbol.name)) {
+						valData.setComment(CommentType.EOL, symbol.name);
+					}
+			}
+
+			idx++;
+		}
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Plan9AoutLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Plan9AoutLoader.java
@@ -1,0 +1,152 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.opinion;
+
+import java.io.IOException;
+import java.util.*;
+
+import ghidra.app.util.Option;
+import ghidra.app.util.OptionException;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.format.plan9aout.Plan9AoutHeader;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.framework.model.DomainObject;
+import ghidra.program.model.address.*;
+import ghidra.program.model.lang.LanguageCompilerSpecPair;
+import ghidra.program.model.listing.Program;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.task.TaskMonitor;
+
+/**
+ * A {@link Loader} for processing Plan9-style A.out executables
+ * <p>
+ * This style was also used by Plan9-like systems such as 9front, NIX and Inferno.
+ *
+ * @see <a href="https://9p.io/magic/man2html/6/a.out">Plan 9 manpage</a>
+ * @see <a href="https://9p.io/sources/plan9/sys/include/a.out.h">Plan 9 definition header</a>
+ */
+public class Plan9AoutLoader extends AbstractProgramWrapperLoader {
+
+	public final static String PLAN9_AOUT_NAME = "Plan 9 A.out";
+
+	public static final String OPTION_NAME_BASE_ADDR = "Base Address";
+
+	@Override
+	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
+		List<LoadSpec> loadSpecs = new ArrayList<>();
+
+		Plan9AoutHeader hdr = new Plan9AoutHeader(provider);
+
+		if (hdr.isValid()) {
+			final String lang = hdr.getLanguageSpec();
+			final String comp = hdr.getCompilerSpec();
+			// true means BE, maybe should detect?
+			loadSpecs.add(new LoadSpec(this, 0, new LanguageCompilerSpecPair(lang, comp), true));
+		}
+
+		return loadSpecs;
+	}
+
+	@Override
+	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
+			Program program, TaskMonitor monitor, MessageLog log)
+			throws CancelledException, IOException {
+		final Plan9AoutHeader header = new Plan9AoutHeader(provider);
+
+		final Plan9AoutProgramLoader loader =
+			new Plan9AoutProgramLoader(program, header, monitor, log);
+		loader.loadAout(getBaseAddrOffset(options));
+	}
+
+	@Override
+	public String validateOptions(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
+			Program program) {
+		Address baseAddr = null;
+
+		for (Option option : options) {
+			String optName = option.getName();
+			try {
+				if (optName.equals(OPTION_NAME_BASE_ADDR)) {
+					baseAddr = (Address) option.getValue();
+				}
+			}
+			catch (Exception e) {
+				if (e instanceof OptionException) {
+					return e.getMessage();
+				}
+				return "Invalid value for " + optName + " - " + option.getValue();
+			}
+		}
+		if (baseAddr == null) {
+			return "Invalid base address";
+		}
+
+		return super.validateOptions(provider, loadSpec, options, program);
+	}
+
+	@Override
+	public List<Option> getDefaultOptions(ByteProvider provider, LoadSpec loadSpec,
+			DomainObject domainObject, boolean loadIntoProgram) {
+		Address baseAddr = null;
+
+		if (domainObject instanceof Program) {
+			Program program = (Program) domainObject;
+			AddressFactory addressFactory = program.getAddressFactory();
+			if (addressFactory != null) {
+				AddressSpace defaultAddressSpace = addressFactory.getDefaultAddressSpace();
+				if (defaultAddressSpace != null) {
+					baseAddr = defaultAddressSpace.getAddress(0);
+				}
+			}
+		}
+
+		List<Option> list = new ArrayList<Option>();
+		list.add(new Option(OPTION_NAME_BASE_ADDR, baseAddr, Address.class,
+			Loader.COMMAND_LINE_ARG_PREFIX + "-baseAddr"));
+
+		list.addAll(super.getDefaultOptions(provider, loadSpec, domainObject, loadIntoProgram));
+		return list;
+	}
+
+	@Override
+	public String getName() {
+		return PLAN9_AOUT_NAME;
+	}
+
+	/**
+	 * Retrieves the Address offset given in the "Base Address" option.
+	 * Returns 0 if the option could not be found or contains an invalid value.
+	 */
+	private long getBaseAddrOffset(List<Option> options) {
+		Address baseAddr = null;
+
+		if (options != null) {
+			for (Option option : options) {
+				String optName = option.getName();
+				if (optName.equals(OPTION_NAME_BASE_ADDR)) {
+					baseAddr = (Address) option.getValue();
+				}
+			}
+		}
+
+		long offset = 0;
+		if (baseAddr != null) {
+			offset = baseAddr.getOffset();
+		}
+
+		return offset;
+	}
+}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Plan9AoutProgramLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/Plan9AoutProgramLoader.java
@@ -1,0 +1,402 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.opinion;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+import ghidra.app.util.MemoryBlockUtils;
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.format.plan9aout.*;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.database.function.OverlappingFunctionException;
+import ghidra.program.database.mem.FileBytes;
+import ghidra.program.model.address.*;
+import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.*;
+import ghidra.program.model.reloc.Relocation.Status;
+import ghidra.program.model.reloc.RelocationTable;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.util.CodeUnitInsertionException;
+import ghidra.util.DataConverter;
+import ghidra.util.MonitoredInputStream;
+import ghidra.util.InvalidNameException;
+import ghidra.util.exception.*;
+import ghidra.util.task.TaskMonitor;
+
+public class Plan9AoutProgramLoader {
+	private final int EXTERNAL_BLOCK_MIN_SIZE = 0x10000; // 64K
+
+	public final static String dot_text = ".text";
+	public final static String dot_data = ".data";
+	public final static String dot_bss = ".bss";
+	public final static String dot_rel_text = ".rel.text";
+	public final static String dot_rel_data = ".rel.data";
+	public final static String dot_strtab = ".strtab";
+	public final static String dot_symtab = ".symtab";
+
+	private final Program program;
+	private final TaskMonitor monitor;
+	private final MessageLog log;
+	private final Plan9AoutHeader header;
+
+	private FileBytes fileBytes;
+
+	private Plan9AoutRelocationTable relText;
+	private Plan9AoutRelocationTable relData;
+	private Plan9AoutSymbolTable symtab;
+	private Plan9AoutStringTable strtab;
+
+	private Map<String, Long> possibleBssSymbols = new HashMap<>();
+	private int extraBssSize = 0;
+	private int undefinedSymbolCount = 0;
+
+	public Plan9AoutProgramLoader(Program program, Plan9AoutHeader header, TaskMonitor monitor,
+			MessageLog log) {
+		this.program = program;
+		this.monitor = monitor;
+		this.log = log;
+		this.header = header;
+	}
+
+	public void loadAout(long baseAddr) throws IOException, CancelledException {
+		log.appendMsg(String.format("----- Loading %s -----",
+			header.getReader().getByteProvider().getAbsolutePath()));
+		log.appendMsg(String.format("Found Plan 9 a.out."));
+
+		ByteProvider byteProvider = header.getReader().getByteProvider();
+
+		try {
+			buildTables(byteProvider);
+			preprocessSymbolTable();
+			loadSections(baseAddr, byteProvider);
+			loadSymbols();
+			applyRelocations(baseAddr, program.getMemory().getBlock(dot_text), relText);
+			applyRelocations(baseAddr, program.getMemory().getBlock(dot_data), relData);
+			markupSections();
+		}
+		catch (AddressOverflowException | InvalidInputException | CodeUnitInsertionException
+				| DuplicateNameException | InvalidNameException
+				| MemoryAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void buildTables(ByteProvider byteProvider) throws IOException {
+		if (header.getStrSize() > 0) {
+			strtab = new Plan9AoutStringTable(header.getReader(), header.getStrOffset(),
+				header.getStrSize());
+		}
+		if (header.getSymSize() > 0) {
+			symtab = new Plan9AoutSymbolTable(header.getReader(), header.getSymOffset(),
+				header.getSymSize(), header.getPointerSize(),
+				strtab, log);
+		}
+		if (header.getTextRelocSize() > 0) {
+			relText = new Plan9AoutRelocationTable(header.getReader(), header.getTextRelocOffset(),
+				header.getTextRelocSize(), symtab);
+		}
+		if (header.getDataRelocSize() > 0) {
+			relData = new Plan9AoutRelocationTable(header.getReader(), header.getDataRelocOffset(),
+				header.getDataRelocSize(), symtab);
+		}
+	}
+
+	private void preprocessSymbolTable() {
+	}
+
+	private void loadSections(long baseAddr, ByteProvider byteProvider)
+			throws AddressOverflowException, IOException, CancelledException {
+		monitor.setMessage("Loading FileBytes...");
+
+		try (InputStream fileIn = byteProvider.getInputStream(0);
+				MonitoredInputStream mis = new MonitoredInputStream(fileIn, monitor)) {
+			// Indicate that cleanup is not neccessary for cancelled import operation.
+			mis.setCleanupOnCancel(false);
+			fileBytes = program.getMemory()
+					.createFileBytes(byteProvider.getName(), 0, byteProvider.length(), mis,
+						monitor);
+		}
+
+		final AddressSpace defaultAddressSpace =
+			program.getAddressFactory().getDefaultAddressSpace();
+		final Address otherAddress = AddressSpace.OTHER_SPACE.getMinAddress();
+		Address address;
+
+		address = defaultAddressSpace.getAddress(baseAddr + header.getTextAddr());
+		Address nextFreeAddress = address.add(header.getTextSize() + header.getHeaderSize());
+		MemoryBlockUtils.createInitializedBlock(program, false, dot_text, address, fileBytes,
+			header.getTextOffset(), header.getTextSize() + header.getHeaderSize(), null, null, true, true, true, log);
+
+		if (header.getDataSize() > 0) {
+			address = defaultAddressSpace.getAddress(baseAddr + header.getDataAddr());
+			nextFreeAddress = address.add(header.getDataSize());
+			MemoryBlockUtils.createInitializedBlock(program, false, dot_data, address, fileBytes,
+				header.getDataOffset(), header.getDataSize(), null, null, true, true, false, log);
+		}
+		if ((header.getBssSize() + extraBssSize) > 0) {
+			address = defaultAddressSpace.getAddress(baseAddr + header.getBssAddr());
+			nextFreeAddress = address.add(header.getBssSize() + extraBssSize);
+			MemoryBlockUtils.createUninitializedBlock(program, false, dot_bss, address,
+				header.getBssSize() + extraBssSize, null, null, true, true, false, log);
+		}
+		if (undefinedSymbolCount > 0) {
+			int externalSectionSize = undefinedSymbolCount * 4;
+			if (externalSectionSize < EXTERNAL_BLOCK_MIN_SIZE) {
+				externalSectionSize = EXTERNAL_BLOCK_MIN_SIZE;
+			}
+			MemoryBlock externalBlock = MemoryBlockUtils.createUninitializedBlock(program, false,
+				MemoryBlock.EXTERNAL_BLOCK_NAME, nextFreeAddress, externalSectionSize, null, null,
+				false, false, false, log);
+			if (externalBlock != null) {
+				externalBlock.setArtificial(true);
+			}
+		}
+		if (header.getStrSize() > 0) {
+			MemoryBlockUtils.createInitializedBlock(program, true, dot_strtab, otherAddress,
+				fileBytes, header.getStrOffset(), header.getStrSize(), null, null, false, false,
+				false, log);
+		}
+		if (header.getSymSize() > 0) {
+			MemoryBlockUtils.createInitializedBlock(program, true, dot_symtab, otherAddress,
+				fileBytes, header.getSymOffset(), header.getSymSize(), null, null, false, false,
+				false, log);
+		}
+		if (header.getTextRelocSize() > 0) {
+			MemoryBlockUtils.createInitializedBlock(program, true, dot_rel_text, otherAddress,
+				fileBytes, header.getTextRelocOffset(), header.getTextRelocSize(), null, null,
+				false, false, false, log);
+		}
+		if (header.getDataRelocSize() > 0) {
+			MemoryBlockUtils.createInitializedBlock(program, true, dot_rel_data, otherAddress,
+				fileBytes, header.getDataRelocOffset(), header.getDataRelocSize(), null, null,
+				false, false, false, log);
+		}
+	}
+
+	private void loadSymbols() throws InvalidInputException {
+		monitor.setMessage("Loading symbols...");
+
+		if (symtab == null) {
+			return;
+		}
+
+		SymbolTable symbolTable = program.getSymbolTable();
+		FunctionManager functionManager = program.getFunctionManager();
+		MemoryBlock textBlock = program.getMemory().getBlock(dot_text);
+		MemoryBlock dataBlock = program.getMemory().getBlock(dot_data);
+		MemoryBlock bssBlock = program.getMemory().getBlock(dot_bss);
+		MemoryBlock externalBlock = program.getMemory().getBlock(MemoryBlock.EXTERNAL_BLOCK_NAME);
+
+		int extraBssOffset = 0;
+		int undefinedSymbolIdx = 0;
+
+		for (Plan9AoutSymbol symbol : symtab) {
+			Address address = null;
+			MemoryBlock block = null;
+
+			switch (symbol.type) {
+				case N_TEXT:
+					address = textBlock != null ? textBlock.getStart().add(symbol.value - header.getTextAddr()) : null;
+					block = textBlock;
+					break;
+				case N_DATA:
+					address = dataBlock != null ? dataBlock.getStart().add(symbol.value - header.getDataAddr()) : null;
+					block = dataBlock;
+					break;
+				case N_BSS:
+					address = bssBlock != null ? bssBlock.getStart().add(symbol.value - header.getBssAddr()) : null;
+					block = bssBlock;
+					break;
+			}
+
+			if (address == null || block == null) {
+				continue;
+			}
+
+			switch (symbol.type) {
+				case N_LEAF:
+					try {
+						functionManager.createFunction(symbol.name, address,
+							new AddressSet(address),
+							SourceType.IMPORTED);
+					}
+					catch (OverlappingFunctionException e) {
+						log.appendMsg(block.getName(), String.format(
+							"Failed to create function %s @ %s, creating symbol instead.",
+							symbol.name, address));
+						symbolTable.createLabel(address, symbol.name, SourceType.IMPORTED);
+					}
+					break;
+				default:
+					Symbol label =
+						symbolTable.createLabel(address, symbol.name, SourceType.IMPORTED);
+					if (symbol.isExt) {
+						label.setPrimary();
+					}
+					break;
+			}
+		}
+	}
+
+	private void applyRelocations(long baseAddr, MemoryBlock targetBlock,
+			Plan9AoutRelocationTable relTable) throws MemoryAccessException {
+		if (targetBlock == null || relTable == null) {
+			return;
+		}
+
+		monitor.setMessage(
+			String.format("Applying relocations for section %s...", targetBlock.getName()));
+
+		DataConverter dc = DataConverter.getInstance(true);
+		SymbolTable symbolTable = program.getSymbolTable();
+		RelocationTable relocationTable = program.getRelocationTable();
+		Memory memory = program.getMemory();
+		MemoryBlock textBlock = memory.getBlock(dot_text);
+		MemoryBlock dataBlock = memory.getBlock(dot_data);
+		MemoryBlock bssBlock = memory.getBlock(dot_bss);
+
+		int idx = 0;
+		for (Plan9AoutRelocation relocation : relTable) {
+			Address targetAddress = targetBlock.getStart().add(relocation.address);
+
+			byte originalBytes[] = new byte[relocation.pointerLength];
+			targetBlock.getBytes(targetAddress, originalBytes);
+			long addend = dc.getValue(originalBytes, 0, relocation.pointerLength);
+
+			Long value = null;
+			Status status = Status.FAILURE;
+
+			if (relocation.baseRelative || relocation.jmpTable || relocation.relative ||
+				relocation.copy) {
+				status = Status.UNSUPPORTED;
+			}
+			else {
+				if (relocation.extern == true && relocation.symbolNum < symtab.size()) {
+					SymbolIterator symbolIterator =
+						symbolTable.getSymbols(symtab.get(relocation.symbolNum).name);
+					if (symbolIterator.hasNext()) {
+						value = symbolIterator.next().getAddress().getOffset();
+					}
+				}
+				else if (relocation.extern == false) {
+					switch (relocation.symbolNum) {
+						case 4:
+							value = textBlock.getStart().getOffset();
+							break;
+						case 6:
+							value = dataBlock.getStart().getOffset();
+							break;
+						case 8:
+							value = bssBlock.getStart().getOffset();
+							break;
+					}
+				}
+			}
+
+			if (value != null) {
+				if (relocation.pcRelativeAddressing) {
+					// Addend is relative to start of target section.
+					value -= targetBlock.getStart().getOffset();
+				}
+
+				// Apply relocation.
+				byte newBytes[] = new byte[relocation.pointerLength];
+				dc.putValue(value + addend, relocation.pointerLength, newBytes, 0);
+				targetBlock.putBytes(targetAddress, newBytes);
+
+				status = Status.APPLIED;
+			}
+
+			if (status != Status.APPLIED) {
+				log.appendMsg(targetBlock.getName(),
+					String.format("Failed to apply relocation entry %d with type 0x%02x @ %s.", idx,
+						relocation.flags, targetAddress));
+			}
+
+			relocationTable.add(targetAddress, status, relocation.flags,
+				new long[] { relocation.symbolNum },
+				originalBytes, relocation.getSymbolName(symtab));
+			idx++;
+		}
+	}
+
+	private void markupSections() throws InvalidInputException, CodeUnitInsertionException,
+			DuplicateNameException, InvalidNameException, IOException {
+		final AddressSpace defaultAddressSpace =
+			program.getAddressFactory().getDefaultAddressSpace();
+		final FunctionManager functionManager = program.getFunctionManager();
+		final SymbolTable symbolTable = program.getSymbolTable();
+
+		monitor.setMessage("Marking up header...");
+
+		// Markup header.
+		Address headerAddress = null;
+		MemoryBlock aoutHeader = program.getMemory().getBlock("_aoutHeader");
+		MemoryBlock textBlock = program.getMemory().getBlock(dot_text);
+		if (aoutHeader != null) {
+			headerAddress = aoutHeader.getStart();
+		}
+		else if (textBlock != null && header.getTextOffset() == 0) {
+			headerAddress = textBlock.getStart();
+		}
+		if (headerAddress != null) {
+			header.markup(program, headerAddress);
+		}
+
+		// Markup entrypoint.
+		if (header.getEntryPoint() != 0) {
+			Address address = defaultAddressSpace.getAddress(header.getEntryPoint());
+			try {
+				functionManager.createFunction("entry", address, new AddressSet(address),
+					SourceType.IMPORTED).setCallingConvention("processEntry");
+			}
+			catch (OverlappingFunctionException e) {
+				log.appendMsg(dot_text,
+					"Failed to create entrypoint function @ %s, creating symbol instead.");
+				symbolTable.createLabel(address, "entry", SourceType.IMPORTED);
+			}
+		}
+
+		monitor.setMessage("Marking up relocation tables...");
+
+		MemoryBlock relTextBlock = program.getMemory().getBlock(dot_rel_text);
+		if (relTextBlock != null) {
+			relText.markup(program, relTextBlock);
+		}
+
+		MemoryBlock relDataBlock = program.getMemory().getBlock(dot_rel_data);
+		if (relDataBlock != null) {
+			relData.markup(program, relDataBlock);
+		}
+
+		monitor.setMessage("Marking up symbol table...");
+
+		MemoryBlock symtabBlock = program.getMemory().getBlock(dot_symtab);
+		if (symtabBlock != null) {
+			symtab.markup(program, symtabBlock);
+		}
+
+		monitor.setMessage("Marking up string table...");
+
+		MemoryBlock strtabBlock = program.getMemory().getBlock(dot_strtab);
+		if (strtabBlock != null) {
+			strtab.markup(program, strtabBlock);
+		}
+	}
+}

--- a/Ghidra/Processors/x86/certification.manifest
+++ b/Ghidra/Processors/x86/certification.manifest
@@ -70,6 +70,7 @@ data/languages/x86-64-compat32.pspec||GHIDRA||||END|
 data/languages/x86-64-gcc.cspec||GHIDRA||||END|
 data/languages/x86-64-golang.cspec||GHIDRA||||END|
 data/languages/x86-64-golang.register.info||GHIDRA||||END|
+data/languages/x86-64-plan9.cspec||GHIDRA||||END|
 data/languages/x86-64-swift.cspec||GHIDRA||||END|
 data/languages/x86-64-win.cspec||GHIDRA||||END|
 data/languages/x86-64.dwarf||GHIDRA||||END|
@@ -89,6 +90,7 @@ data/patterns/patternconstraints.xml||GHIDRA||||END|
 data/patterns/prepatternconstraints.xml||GHIDRA||||END|
 data/patterns/x86-16_default_patterns.xml||GHIDRA||||END|
 data/patterns/x86-64gcc_patterns.xml||GHIDRA||||END|
+data/patterns/x86-64plan9_patterns.xml||GHIDRA||||END|
 data/patterns/x86-64win_patterns.xml||GHIDRA||||END|
 data/patterns/x86delphi_patterns.xml||GHIDRA||||END|
 data/patterns/x86gcc_patterns.xml||GHIDRA||||END|

--- a/Ghidra/Processors/x86/data/languages/x86-64-plan9.cspec
+++ b/Ghidra/Processors/x86/data/languages/x86-64-plan9.cspec
@@ -1,0 +1,462 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<compiler_spec>
+  <data_organization>
+     <machine_alignment value="2" />
+     <default_alignment value="1" />
+     <default_pointer_alignment value="8" />
+     <pointer_size value="8" />
+     <wchar_size value="4" />
+     <short_size value="2" />
+     <integer_size value="4" />
+     <long_size value="8" />
+     <long_long_size value="8" />
+     <float_size value="4" />
+     <double_size value="8" />
+     <long_double_size value="10" /> <!-- aligned-length=16 -->
+     <size_alignment_map>
+          <entry size="1" alignment="1" />
+          <entry size="2" alignment="2" />
+          <entry size="4" alignment="4" />
+          <entry size="8" alignment="8" />
+          <entry size="16" alignment="16" />
+     </size_alignment_map>
+  </data_organization>
+
+  <global>
+    <range space="ram"/>
+    <register name="MXCSR"/>
+  </global>
+  <stackpointer register="RSP" space="ram"/>
+  <returnaddress>
+    <varnode space="stack" offset="0" size="8"/>
+  </returnaddress>
+  <default_proto>
+    <prototype name="__stackcall" extrapop="8" stackshift="8">
+      <input pointermax="8">
+        <pentry minsize="1" maxsize="8">
+          <register name="RBP"/>
+        </pentry>
+        <pentry minsize="1" maxsize="500" align="8">
+          <addr offset="16" space="stack"/>
+        </pentry>
+      </input>
+      <output>
+        <pentry minsize="1" maxsize="8">
+          <register name="RAX"/>
+        </pentry>
+      </output>
+      <unaffected>
+        <register name="RSP"/>
+      </unaffected>
+      <killedbycall>
+        <register name="RAX"/>
+        <register name="RBX"/>
+        <register name="RCX"/>
+        <register name="RDX"/>
+        <register name="RSI"/>
+        <register name="RDI"/>
+        <register name="RBP"/>
+        <register name="R8"/>
+        <register name="R9"/>
+        <register name="R10"/>
+        <register name="R11"/>
+        <register name="R12"/>
+        <register name="R13"/>
+        <register name="XMM0"/>
+        <register name="XMM1"/>
+        <register name="XMM2"/>
+        <register name="XMM3"/>
+        <register name="XMM4"/>
+        <register name="XMM5"/>
+        <register name="XMM6"/>
+        <register name="XMM7"/>
+        <register name="XMM8"/>
+        <register name="XMM9"/>
+        <register name="XMM10"/>
+        <register name="XMM11"/>
+        <register name="XMM12"/>
+        <register name="XMM13"/>
+        <register name="XMM14"/>
+        <register name="XMM15"/>
+      </killedbycall>
+    </prototype>
+  </default_proto>
+  <prototype name="__stdcall" extrapop="8" stackshift="8">
+    <!-- Derived from "System V Application Binary Interface AMD64 Architecture Processor Supplement" April 2016 -->
+    <input>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM0_Qa"/>
+      </pentry>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM1_Qa"/>
+      </pentry>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM2_Qa"/>
+      </pentry>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM3_Qa"/>
+      </pentry>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM4_Qa"/>
+      </pentry>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM5_Qa"/>
+      </pentry>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM6_Qa"/>
+      </pentry>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM7_Qa"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="RDI"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="RSI"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="RDX"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="RCX"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="R8"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="R9"/>
+      </pentry>
+      <pentry minsize="1" maxsize="500" align="8">
+        <addr offset="8" space="stack"/>
+      </pentry>
+      <rule>
+        <datatype name="any" maxsize="16"/>
+        <join_dual_class/>		<!-- Bind from registers if possible-->
+      </rule>
+      <rule>
+        <datatype name="any"/>
+        <goto_stack/>
+      </rule>
+    </input>
+    <output>
+      <pentry minsize="1" maxsize="8" metatype="float">
+        <register name="XMM0_Qa"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8" metatype="float">
+        <register name="XMM1_Qa"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="RAX"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="RDX"/>
+      </pentry>
+      <rule>
+        <datatype name="any" maxsize="16"/>
+        <join_dual_class/>
+      </rule>
+      <rule>
+        <datatype name="any"/>
+        <hidden_return/>
+      </rule>
+    </output>
+    <killedbycall>
+      <register name="RAX"/>
+      <register name="RDX"/>
+      <register name="XMM0"/>
+    </killedbycall>
+    <unaffected>
+      <register name="RBX"/>
+      <register name="RSP"/>
+      <register name="RBP"/>
+      <register name="R12"/>
+      <register name="R13"/>
+      <register name="R14"/>
+      <register name="R15"/>
+    </unaffected>
+  </prototype>
+	<prototype name="MSABI" extrapop="8" stackshift="8">
+	  <input pointermax="8">
+	  <!--  Use same grouping setup as x86-64-win.cspec. If the nth general-purpose register is 
+	  		consumed, consume the nth floating point register, and vice-versa -->
+	  <group>
+        <pentry minsize="4" maxsize="8" metatype="float">
+          <register name="XMM0_Qa"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="RCX"/>
+        </pentry>
+      </group>
+      <group>
+        <pentry minsize="4" maxsize="8" metatype="float">
+          <register name="XMM1_Qa"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="RDX"/>
+        </pentry>
+      </group>
+      <group>
+        <pentry minsize="4" maxsize="8" metatype="float">
+          <register name="XMM2_Qa"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="R8"/>
+        </pentry>
+      </group>
+      <group>
+        <pentry minsize="4" maxsize="8" metatype="float">
+          <register name="XMM3_Qa"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="R9"/>
+        </pentry>
+      </group>
+      <pentry minsize="1" maxsize="500" align="8">
+        <addr offset="40" space="stack"/>
+      </pentry>
+      <!-- only structs of size 8,16,32,64 bits can be packed to register -->  
+      <rule>
+      	<datatype name="struct" sizes="3,5,6,7"/>
+      	<convert_to_ptr/>
+      </rule>
+    </input> 
+  	<output>
+      <pentry minsize="4" maxsize="8" metatype="float">
+        <register name="XMM0_Qa"/>
+      </pentry>
+      <pentry minsize="1" maxsize="8">
+        <register name="RAX"/>
+      </pentry>
+      <!-- only structs of size 8,16,32,64 bits can be returned via register -->
+      <rule>
+      	<datatype name="struct" sizes="3,5,6,7"/>
+      	<hidden_return/>
+      </rule>
+	</output>
+	  <unaffected>
+	    <varnode space="ram" offset="0" size="8"/>
+	    <register name="RBX"/>
+	    <register name="RBP"/>
+	    <register name="RDI"/>
+	    <register name="RSI"/>
+	    <register name="RSP"/>
+	    <register name="R12"/>
+	    <register name="R13"/>
+	    <register name="R14"/>
+	    <register name="R15"/>
+	    <register name="DF"/>
+	  </unaffected>
+      <killedbycall>
+        <register name="RAX"/>
+        <register name="XMM0"/>
+      </killedbycall>
+	  <localrange>
+	    <range space="stack" first="0xfffffffffff0bdc1" last="0xffffffffffffffff"/>
+	    <range space="stack" first="8" last="39"/>
+	  </localrange>
+	</prototype>
+	<prototype name="syscall" extrapop="8" stackshift="8">
+      <input pointermax="8">
+        <pentry minsize="1" maxsize="8">
+          <register name="RDI"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="RSI"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="RDX"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="R10"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="R8"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8">
+          <register name="R9"/>
+        </pentry>
+      </input>
+      <output killedbycall="true">
+        <pentry minsize="1" maxsize="8">
+          <register name="RAX"/>
+        </pentry>
+      </output>
+      <unaffected>
+        <varnode space="ram" offset="0" size="8"/>
+        <register name="RBX"/>
+        <register name="RDX"/>
+        <register name="RBP"/>
+        <register name="RDI"/>
+        <register name="RSI"/>
+        <register name="RSP"/>
+        <register name="R8"/>
+        <register name="R9"/>
+        <register name="R10"/>
+        <register name="R12"/>
+        <register name="R13"/>
+        <register name="R14"/>
+        <register name="R15"/>
+        <register name="DF"/>
+      </unaffected>
+      <killedbycall>
+        <register name="RCX"/>
+        <register name="R11"/>
+      </killedbycall>
+    </prototype>
+	<prototype name="processEntry" extrapop="0" stackshift="0">
+      <input pointermax="8">
+        <pentry minsize="1" maxsize="8">
+          <register name="RAX"/>
+        </pentry>
+	    <pentry minsize="1" maxsize="500" align="8">
+	      <addr offset="0" space="stack"/>
+	    </pentry>
+      </input>
+      <output killedbycall="true">
+        <pentry minsize="1" maxsize="8">
+          <register name="RAX"/>
+        </pentry>
+      </output>
+      <unaffected>
+          <register name="RSP"/>
+      </unaffected>
+      <!-- Functions with this prototype don't have a return address. But, if we don't specify one, this prototype will
+           use the default, which is to have the return address on the stack. That conflicts with how this prototype actually
+           uses the stack, so we set a fake return address at a RBP, which is unspecified at process entry --> 
+      <returnaddress>
+         <register name="RBP"/>
+      </returnaddress>
+    </prototype>
+    
+    <callfixup name="x86_return_thunk">
+      <target name="__x86_return_thunk"/>
+      <pcode>
+        <body><![CDATA[
+	  RIP = *:8 RSP;
+	  RSP = RSP + 8;
+	  return [RIP];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="fentry">
+      <target name="__fentry__"/>
+      <pcode>
+        <body><![CDATA[
+	  temp:1 = 0;
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="mcount">
+      <target name="mcount"/>
+      <pcode>
+        <body><![CDATA[
+	  temp:1 = 0;
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_rbp">
+      <target name="__x86_indirect_thunk_rbp"/>
+      <pcode>
+        <body><![CDATA[
+	  call [RBP];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_rax">
+      <target name="__x86_indirect_thunk_rax"/>
+      <pcode>
+        <body><![CDATA[
+	  call [RAX];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_rbx">
+      <target name="__x86_indirect_thunk_rbx"/>
+      <pcode>
+        <body><![CDATA[
+	  call [RBX];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_rcx">
+      <target name="__x86_indirect_thunk_rcx"/>
+      <pcode>
+        <body><![CDATA[
+	  call [RCX];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_rdx">
+      <target name="__x86_indirect_thunk_rdx"/>
+      <pcode>
+        <body><![CDATA[
+	  call [RDX];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r8">
+      <target name="__x86_indirect_thunk_r8"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R8];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r9">
+      <target name="__x86_indirect_thunk_r9"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R9];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r10">
+      <target name="__x86_indirect_thunk_r10"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R10];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r11">
+      <target name="__x86_indirect_thunk_r11"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R11];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r12">
+      <target name="__x86_indirect_thunk_r12"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R12];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r13">
+      <target name="__x86_indirect_thunk_r13"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R13];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r14">
+      <target name="__x86_indirect_thunk_r14"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R14];
+        ]]></body>
+      </pcode>
+    </callfixup>
+    <callfixup name="x86_indirect_thunk_r15">
+      <target name="__x86_indirect_thunk_r15"/>
+      <pcode>
+        <body><![CDATA[
+	  call [R15];
+        ]]></body>
+      </pcode>
+    </callfixup>
+</compiler_spec>

--- a/Ghidra/Processors/x86/data/languages/x86.ldefs
+++ b/Ghidra/Processors/x86/data/languages/x86.ldefs
@@ -94,6 +94,7 @@
     <compiler name="Visual Studio" spec="x86-64-win.cspec" id="windows"/>
     <compiler name="clang" spec="x86-64-win.cspec" id="clangwindows"/>
     <compiler name="gcc" spec="x86-64-gcc.cspec" id="gcc"/>
+    <compiler name="plan9" spec="x86-64-plan9.cspec" id="plan9"/>
     <compiler name="golang" spec="x86-64-golang.cspec" id="golang"/>
     <compiler name="Swift" spec="x86-64-swift.cspec" id="swift"/>
     <external_name tool="gnu" name="i386:x86-64:intel"/>

--- a/Ghidra/Processors/x86/data/languages/x86.opinion
+++ b/Ghidra/Processors/x86/data/languages/x86.opinion
@@ -73,8 +73,15 @@
         <constraint primary="332"    processor="x86"          endian="little" size="32" />
         <constraint primary="-31132" processor="x86"          endian="little" size="64"	variant="default" />
     </constraint>
-    <constraint loader="Assembler Output (AOUT)" compilerSpecID="gcc">
+    <constraint loader="UNIX A.out">
+      <constraint compilerSpecID="gcc">
         <constraint primary="134"  processor="x86"          endian="little" size="32" />
+      </constraint>
+    </constraint>
+    <constraint loader="Plan 9 A.out">
+      <constraint compilerSpecID="plan9">
+        <constraint primary="134"  secondary="plan9" processor="x86" endian="little" size="64"	variant="default" />
+      </constraint>
     </constraint>
     <constraint loader="Relocatable Object Module Format (OMF)">
       <constraint compilerSpecID="windows">

--- a/Ghidra/Processors/x86/data/patterns/patternconstraints.xml
+++ b/Ghidra/Processors/x86/data/patterns/patternconstraints.xml
@@ -21,6 +21,9 @@
     <compiler id="gcc">
       <patternfile>x86-64gcc_patterns.xml</patternfile>
     </compiler>
+    <compiler id="plan9">
+      <patternfile>x86-64plan9_patterns.xml</patternfile>
+    </compiler>
   </language>
   
   <language id="x86:LE:16:Real Mode">

--- a/Ghidra/Processors/x86/data/patterns/x86-64plan9_patterns.xml
+++ b/Ghidra/Processors/x86/data/patterns/x86-64plan9_patterns.xml
@@ -1,0 +1,146 @@
+<patternlist>
+  <patternpairs totalbits="40" postbits="24">
+    <prepatterns>
+      <data>0x90 0x90</data>               <!-- NOP NOP -->
+      <data>0xc3 0x90</data>               <!-- RET NOP -->
+      <data>0x6690</data>                  <!-- two-byte nop -->
+      <data>0xc9 0xc3</data>               <!-- LEAVE RET -->
+      <data>0xe9........</data>            <!-- JMP xxx - after a shared jump target -->
+      <data>0xe9........90</data>            <!-- JMP xxx, NOP - after a shared jump target -->
+      <data>0xeb..</data>                  <!-- JMP small -->
+      <data>0xeb..90</data>                <!-- JMP small , NOP -->
+      <data>0x5d 0xc3</data>               <!-- POP RBP, RET --> 
+      <data>0x5b 0xc3</data>               <!-- POP RBX, RET -->
+      <data>0x41 010111.. 0xc3</data>      <!-- POP R12-15, RET -->
+      <data>0x31c0 0xc3</data>             <!-- XOR(EAX,EAX), RET -->
+      <data>0x4883c4 .....000 0xc3</data>  <!-- ADD RSP, C; RET -->
+      <data>0x666690</data>                <!-- three-byte NOP -->
+      <data>0x0f1f00</data>                <!-- three-byte NOP -->
+      <data>0x0f1f4000</data>              <!-- four-byte NOP -->
+      <data>0x0f1f440000</data>            <!-- five-byte NOP -->
+      <data>0x660f1f440000</data>          <!-- six-byte NOP -->
+      <data>0x0f1f8000000000</data>        <!-- seven-byte NOP --> 
+      <data>0x0f1f840000000000</data>      <!-- eight-byte NOP -->
+      <data>0x660f1f840000000000</data>    <!-- nine-byte NOP -->
+    </prepatterns>
+    <postpatterns>
+      <!-- two-instruction sequences -->
+      <data>0x48 0x89 0x5c 0x24  11...000 0x48 0x89 0x6c 0x24  11...000</data>  <!-- MOV [RSP + C], RBX; MOV [RSP + C], RBP -->
+      <data>0x48 0x89 0x5c 0x24  11...000 0x4c 0x89 0x64 0x24  111..000</data>  <!-- MOV [RSP + C], RBX; MOV [RSP + C], R12 -->
+      <data>0x48 0x89 0x6c 0x24  11...000 0x4c 0x89 0x64 0x24  111..000</data>  <!-- MOV [RSP + C], RBP; MOV [RSP + C], R12 -->
+      <data>0x5589e5</data>                                                     <!-- PUSH RBP; MOV(EBP, ESP) (shared objects) -->
+      <data>0x554889e5</data>                                                   <!-- PUSH RBP; MOV(RBP, RSP) (shared objects) -->
+      <data>0x534889fb</data>                                                   <!-- PUSH RBX; MOV(RBX,RDI) (shared objects) --> 
+      <data>0x554889fd</data>                                                   <!-- PUSH (RBP); MOV(RBP, RDI) (kernel objects) -->
+      <data>0x534889fb</data>                                                   <!-- PUSH RBX; MOV(RBX,RDI)-->
+      <data>0x53   0x48 0x83 0xec  0....000 </data>                             <!-- PUSH RBX; SUB RSP, C -->
+      <data>0x53   0x48 0x81 0xec  .....000 00...... 0x00 </data>               <!-- PUSH RBX; SUB RSP, C -->
+      <!-- three-instruction sequences -->
+      <data>0x55 0x48 0x89 0xe5 0x48 100000.1 0xec  .....000</data>             <!-- PUSH RBP; MOV RBP, RSP; SUB RSP, C --> 
+      <data>0x554889e553</data>                                                 <!-- PUSH RBP; MOV RBP, RSP; PUSH RBX -->
+      <data>0x554889fd53</data>                                                 <!-- PUSH RBP; MOV RBP, RDI; PUSH RBX -->
+      <data>0x554889e548897df8</data>                                           <!-- PUSH RBP; MOV RBP, RSP; MOV [RBP -0x8], RDI -->
+      <data>0x53 0x48 0x89 0xfb 0xe8  ........  ........ 0xff 0xff</data>       <!-- PUSH RBX; MOV RBX,RDI; CALL -->
+      <data>0x4154 0x55 0100100. 0x89 11......</data>                           <!-- PUSH R12; PUSH RBP; MOV(R12/3/4/5/xX,RxX); -->
+      <data>0x4154 0x55 0x53 0100100. 0x89 11......</data>                      <!-- PUSH R12; PUSH RBP; PUSH RBX; MOV(R12/3/4/5/xX,RxX); -->
+      <!--  save registers start sequences -->
+      <data>0x415741564155</data>                                               <!-- PUSH R15; PUSH R14; PUSH R13-->
+      <data>0x41564155</data>                                                   <!-- PUSH R14; PUSH R13-->
+      <data>0x41554154</data>                                                   <!-- PUSH R13; PUSH R12-->
+      <data>0x41 010101.. 0100100. 0x89 11...... 0x55</data>                    <!-- PUSH R12/3/4/5; MOV(R12/3/4/5/xX,RxX); PUSH(RBP)-->
+      <data>0x41 010101.. 0x41 010101.. 0100100. 0x89 11...... </data>          <!-- PUSH R12/3/4/5; PUSH R12/3/4/5; MOV(R12/3/4/5/xX,RxX); -->
+      <funcstart/>
+    </postpatterns>
+  </patternpairs>
+  
+<pattern>
+     <data>0x5589e5</data>                                                     <!-- PUSH RBP; MOV(EBP, ESP) (shared objects) -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x55 0x53 0100100. 0x89 11......</data>                             <!-- PUSH RBP; PUSH RBX; MOV(R12/3/4/5/xX,RxX); -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x4154 0x55 0100100. 0x89 11......</data>                           <!-- PUSH R12; PUSH RBP; MOV(R12/3/4/5/xX,RxX); -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x4154 0x55 0x53 0100100. 0x89 11......</data>                      <!-- PUSH R12; PUSH RBP; PUSH RBX; MOV(R12/3/4/5/xX,RxX); -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x53    0x48 0x83 0xec  0....000 </data>                            <!-- PUSH RBX; SUB RSP, C -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x48 0x83 0xec  .....000 </data>                                    <!-- SUB RSP, C -->
+     <funcstart after="defined" validcode="10" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x48 0x81 0xec  .....000 00...... 0x00 </data>                      <!-- SUB RSP, big C -->
+     <funcstart after="defined" validcode="10" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x55 0x53  0x48 0x83 100000.1 0xec  .....000 </data>                <!-- PUSH RBP; PUSH RBX; SUB RSP, big/C -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+  
+<pattern>
+     <data>0x554889e5</data>                                                   <!-- PUSH RBP; MOV(RBP, RSP) (shared objects) -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x55 0x48 0x89 0xe5 0x48 100000.1 0xec  .....000</data>             <!-- PUSH RBP; MOV RBP, RSP; SUB RSP, big/C -->                                                 <!-- PUSH RBP; MOV(RBP, RSP) (shared objects) -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x554889e553</data>                                                 <!-- PUSH RBP; MOV RBP, RSP; PUSH RBX -->                                              <!-- PUSH RBP; MOV(RBP, RSP) (shared objects) -->
+     <funcstart after="defined" /> <!-- must be something defined right before this, or no memory -->
+</pattern>
+
+<pattern>
+     <data>0x4157 0x4156 0x4155</data>                                         <!-- PUSH R15; PUSH R14; PUSH R13-->
+     <funcstart after="defined" validcode="5" /> <!-- must be something defined right before this, or no memory, at least 5 FT instructions -->
+</pattern>
+
+<pattern>
+      <data>0x4157 0x4156</data>                                               <!-- PUSH R15; PUSH R14-->
+     <funcstart after="defined" validcode="5" /> <!-- must be something defined right before this, or no memory, at least 5 FT instructions -->
+</pattern>
+
+<pattern>
+      <data>0x4156 0x4155</data>                                               <!-- PUSH R14; PUSH R13-->
+     <funcstart after="defined" validcode="5" /> <!-- must be something defined right before this, or no memory, at least 5 FT instructions -->
+</pattern>
+
+<pattern>
+     <data>0x41554154</data>                                                   <!-- PUSH R13; PUSH R12-->
+     <funcstart after="defined" validcode="5" /> <!-- must be something defined right before this, or no memory, at least 5 FT instructions -->
+</pattern>
+
+<pattern>
+     <data>0x41 010101.. 0100100. 0x89 11...... 0x55</data>                    <!-- PUSH R12/3/4/5; MOV(R12/3/4/5/xX,RxX); PUSH(RBP)-->
+     <funcstart after="defined" validcode="5" /> <!-- must be something defined right before this, or no memory, at least 5 FT instructions -->
+</pattern>
+
+<pattern>
+     <data>0x41 010101.. 0x41 010101.. 0100100. 0x89 11...... </data>          <!-- PUSH R12/3/4/5; PUSH R12/3/4/5; MOV(R12/3/4/5/xX,RxX); -->
+     <funcstart after="defined" validcode="5" /> <!-- must be something defined right before this, or no memory, at least 5 FT instructions -->
+</pattern>
+
+<pattern>
+     <data>0x41 010101.. 0x41 010101.. 0100100. 0x89 11...... </data>          <!-- PUSH R12/3/4/5; PUSH R12/3/4/5; MOV(R12/3/4/5/xX,RxX); -->
+     <funcstart after="defined" validcode="5" /> <!-- must be something defined right before this, or no memory, at least 5 FT instructions -->
+</pattern>
+ 
+</patternlist>

--- a/Ghidra/RuntimeScripts/Linux/ghidraRun
+++ b/Ghidra/RuntimeScripts/Linux/ghidraRun
@@ -16,4 +16,4 @@ SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo
 SCRIPT_DIR="${SCRIPT_FILE%/*}"
 
 # Launch Ghidra
-"${SCRIPT_DIR}"/support/launch.sh bg jdk Ghidra "${MAXMEM}" "" ghidra.GhidraRun "$@"
+sh -x "${SCRIPT_DIR}"/support/launch.sh fg jdk Ghidra "${MAXMEM}" "" ghidra.GhidraRun "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/launch.sh
+++ b/Ghidra/RuntimeScripts/Linux/support/launch.sh
@@ -171,7 +171,7 @@ JAVA_CMD="${LS_JAVA_HOME}/bin/java"
 
 # Get the configurable VM arguments from the launch properties
 while IFS=$'\r\n' read -r line; do
-	VMARGS_FROM_LAUNCH_PROPS+=("$line")
+	VMARGS_FROM_LAUNCH_PROPS+=($line)
 done < <("${JAVA_CMD}" -cp "${LS_CPATH}" LaunchSupport "${INSTALL_DIR}" -vmargs)
 
 # Add extra macOS VM arguments


### PR DESCRIPTION
This is a sample loader for Plan 9 binaries, and its amd64 ABI. Please consider it just a starting point, I have not conformed particularly well to code style nor have I done any serious tests beyond loading a binary and seeing that it kind of works.
Probably too much code cargo-culted over from UNIX a.out binaries. No support for relocations (Plan 9 DLMs).

See #808