### PR TITLE
Debugger/UI: Handle an unhandled exception when not setting the image path the first time

### DIFF
--- a/Ghidra/Debug/Debugger-rmi-trace/src/main/java/ghidra/app/plugin/core/debug/gui/tracermi/launcher/AbstractTraceRmiLaunchOffer.java
+++ b/Ghidra/Debug/Debugger-rmi-trace/src/main/java/ghidra/app/plugin/core/debug/gui/tracermi/launcher/AbstractTraceRmiLaunchOffer.java
@@ -410,7 +410,7 @@ public abstract class AbstractTraceRmiLaunchOffer implements TraceRmiLaunchOffer
 			}
 			catch(Exception e)
 			{
-				
+				Msg.warn(this, e);
 			}
 			if (fallback != null) {
 				args.put(param.name(), ValStr.from(fallback));


### PR DESCRIPTION
When launching a debugger:
  
![image](https://github.com/user-attachments/assets/a7f60052-82cf-429f-9afb-cef48a03276c)

and leaving "image" empty and then clicking "cancel":

![image](https://github.com/user-attachments/assets/bf5fd736-c12d-489b-ab83-cf669bae3286)


you will get this error the next time you launch the same debugger:

![image](https://github.com/user-attachments/assets/6931b5b2-e6df-49f7-80a5-94c4a0aff38f)
