### PR TITLE
Fixing analysis fail with function entryPoint may not be created on defined data

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/ControlFlowGuard.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/ControlFlowGuard.java
@@ -150,7 +150,13 @@ public class ControlFlowGuard {
 		}
 
 		for (Address target : getFunctionAddressesFromTable(program, tableData)) {
-			AbstractProgramLoader.markAsFunction(program, null, target);
+			if (program.getListing().getDefinedDataAt(target) == null) {
+				AbstractProgramLoader.markAsFunction(program, null, target);
+			}
+			else {
+				log.appendMsg("Unable to mark Control Flow Guard function at " + target + 
+					". Data is already defined there.");
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi everyone,

I was analyzing a binary and couldn’t make further progress without patching Ghidra, as it was failing on load. Could you please take a look if these changes make sense?

```
Function entryPoint may not be created on defined data
java.lang.IllegalArgumentException: Function entryPoint may not be created on defined data
	at ghidra.program.database.function.FunctionManagerDB.createFunction(FunctionManagerDB.java:250)
	at ghidra.program.database.function.FunctionManagerDB.createFunction(FunctionManagerDB.java:201)
	at ghidra.app.util.opinion.AbstractProgramLoader.markAsFunction(AbstractProgramLoader.java:446)
	at ghidra.app.util.bin.format.pe.ControlFlowGuard.createCfgFunctions(ControlFlowGuard.java:153)
	at ghidra.app.util.bin.format.pe.ControlFlowGuard.markupCfgFunctionTable(ControlFlowGuard.java:138)
	at ghidra.app.util.bin.format.pe.ControlFlowGuard.markup(ControlFlowGuard.java:65)
	at ghidra.app.util.bin.format.pe.LoadConfigDataDirectory.markup(LoadConfigDataDirectory.java:66)
	at ghidra.app.util.opinion.PeLoader.load(PeLoader.java:141)
	at ghidra.app.util.opinion.AbstractLibrarySupportLoader.doLoad(AbstractLibrarySupportLoader.java:864)
	at ghidra.app.util.opinion.AbstractLibrarySupportLoader.loadProgram(AbstractLibrarySupportLoader.java:107)
	at ghidra.app.util.opinion.AbstractProgramLoader.load(AbstractProgramLoader.java:129)
	at ghidra.plugin.importer.ImporterUtilities.importSingleFile(ImporterUtilities.java:424)
	at ghidra.plugin.importer.ImporterDialog.lambda$okCallback$7(ImporterDialog.java:339)
	at ghidra.util.task.TaskBuilder$TaskBuilderTask.run(TaskBuilder.java:306)
	at ghidra.util.task.Task.monitoredRun(Task.java:134)
	at ghidra.util.task.TaskRunner.lambda$startTaskThread$0(TaskRunner.java:106)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

---------------------------------------------------
Build Date: 2025-May-15 0134 CEST
Ghidra Version: 11.3.2
Java Home: /opt/openjdk-bin-21.0.6_p7
JVM Version: Eclipse Adoptium 21.0.6
OS: Linux 6.12.16-gentoo-x86_64 amd64
```

[malware.zip](https://github.com/user-attachments/files/20623471/malware.zip)
password: infected