### PR TITLE
Language: Add Nintendo e-Reader Z80 variant

### DIFF
--- a/Ghidra/Processors/Z80/data/languages/z80.ldefs
+++ b/Ghidra/Processors/Z80/data/languages/z80.ldefs
@@ -29,6 +29,18 @@
     <external_name tool="gnu" name="z80"/>
     <external_name tool="IDA-PRO" name="z80"/>
   </language>
+  <language processor="Z80e"
+			endian="little"
+			size="16"
+			variant="Z80e"
+			version="1.0"
+			slafile="z80e.sla"
+			processorspec="z80e.pspec"
+			manualindexfile="../manuals/Z80.idx"
+			id="z80e:LE:16:default">
+	<description>Nintendo e-Reader Z80</description>
+	<compiler name="default" spec="z80.cspec" id="default"/>
+  </language>
   <language processor="Z180"
             endian="little"
             size="16"

--- a/Ghidra/Processors/Z80/data/languages/z80.slaspec
+++ b/Ghidra/Processors/Z80/data/languages/z80.slaspec
@@ -44,12 +44,14 @@ define register offset=0xf0 size=4   contextreg;
 define token opbyte (8)
 	op0_8        = (0,7)
 	op6_2        = (6,7)
+	op4_4        = (4,7)
 	dRegPair4_2  = (4,5)
 	pRegPair4_2  = (4,5)
 	sRegPair4_2  = (4,5)
 	qRegPair4_2  = (4,5)
 	rRegPair4_2  = (4,5)
 	reg3_3       = (3,5)
+	bits3_1      = (3,3)
 	bits3_3      = (3,5)
 	bits0_4      = (0,3)
 	reg0_3       = (0,2)
@@ -349,7 +351,12 @@ Mem16: (imm16)  is imm16     { export *:2 imm16; }
 
 RelAddr8: loc  is simm8  [ loc = inst_next + simm8; ]        { export *:1 loc; }
 
+@if defined(Z80e)
+RstAddr: loc  is bits3_1 [ loc = bits3_1 << 3; ]       { export *:1 loc; }
+@else
 RstAddr: loc  is bits3_3 [ loc = bits3_3 << 3; ]       { export *:1 loc; }
+@endif
+
 @if defined(Z180)
 
 IOAddr8: (imm8)  is imm8       { export *[const]:2 imm8; }
@@ -563,6 +570,7 @@ cc2: "C"   is bits3_3=0x7   { c:1 = $(C_flag); export c; }
 	HL = tmp;	
 }
 
+@if not defined(Z80e)
 :EX AF, AF_         is op0_8=0x08 & AF & AF_ {
 	tmp:2 = AF;
 	AF = AF_;
@@ -580,6 +588,7 @@ cc2: "C"   is bits3_3=0x7   { c:1 = $(C_flag); export c; }
 	HL = HL_;
 	HL_ = tmp;
 }
+@endif
 
 :EX (SP),HL         is op0_8=0xe3 & SP & HL {
 	swap(HL);
@@ -1231,6 +1240,7 @@ local a_temp = A;
 	setResultFlags(val);
 }
 
+@if not defined(Z80e)
 :DAA                is op0_8=0x27 {
 	local a_temp = A;
 if (DECOMPILE_MODE) goto <forDecompilation>;
@@ -1327,6 +1337,7 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 
 <endDAA>
 }
+@endif
 
 :CPL                is op0_8=0x2f {
 	A = ~A;	
@@ -1360,6 +1371,7 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 	halt();
 }
 
+@if not defined(Z80e)
 :DI                 is op0_8=0xf3 {
 #	IFF1 = 0;
 #	IFF2 = 0;
@@ -1371,6 +1383,7 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 #	IFF2 = 1;
 	enableMaskableInterrupts();
 }
+@endif
 
 :IM 0               is op0_8=0xed; op0_8=0x46 {
 	setInterruptMode(0:1);
@@ -1485,6 +1498,7 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 	$(N_flag) = 0;
 }
 
+@if not defined(Z80e)
 :RLC reg0_3         is op0_8=0x0cb; op6_2=0x0 & bits3_3=0x0 & reg0_3 {
 	local val = reg0_3;
 	$(C_flag) = (val >> 7);
@@ -1928,6 +1942,7 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 	val:1 = iyMem8;
 	iyMem8 = val & mask;
 }
+@endif
 
 :JP Addr16          is op0_8=0xc3; Addr16 {
 	goto Addr16;	
@@ -2004,11 +2019,19 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 	return [ptr];
 }
 
+@if defined(Z80e)
+:RST RstAddr,imm8   is op4_4=0xC & RstAddr & bits0_3=0x7; imm8 {
+    push16(&:2 inst_next);
+	call RstAddr;
+}
+@else
 :RST RstAddr        is op6_2=0x3 & RstAddr & bits0_3=0x7 {
     push16(&:2 inst_next);
 	call RstAddr;
 }
+@endif
 
+@if not defined(Z80e)
 :IN A,IOAddr8a      is op0_8=0xdb & A; IOAddr8a {
 	ioRead(IOAddr8a, A);
 }
@@ -2124,6 +2147,8 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 	$(Z_flag) = 1;
 	$(N_flag) = 1;
 }
+@endif
+
 @if defined(Z180)
 
 :MLT qRegPair4_2    is op0_8=0xed; op6_2=0x1 & qRegPair4_2 & bits0_4=0xc {
@@ -2287,6 +2312,7 @@ if (DECOMPILE_MODE) goto <forDecompilation>;
 }
 
 
+@if not defined(Z80e)
 # CB range
 
 :SLL reg0_3         is op0_8=0x0cb; op6_2=0x0 & bits3_3=0x6 & reg0_3 {
@@ -2578,5 +2604,6 @@ ixl_iyl: IYL is op0_8=0xfd & IYL { export IYL; }
 	subtractionFlags(a_temp, r_temp);
 	setResultFlags(cmp);
 }
+@endif
 
 @endif

--- a/Ghidra/Processors/Z80/data/languages/z80e.pspec
+++ b/Ghidra/Processors/Z80/data/languages/z80e.pspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<processor_spec>
+  <programcounter register="PC"/>
+  
+  <segmentop space="ram" userop="segment" farpointer="yes">
+    <pcode>
+      <input name="base" size="2"/>
+      <input name="inner" size="2"/>
+      <output name="res" size="2"/>
+      <body><![CDATA[
+        res = (base << 12) + inner;
+      ]]></body>
+    </pcode>
+    <constresolve>
+      <register name="rBBR"/>
+    </constresolve>
+  </segmentop>
+  <context_data>
+    <tracked_set space="ram">
+      <set name="DECOMPILE_MODE" val="1"/>
+    </tracked_set>
+  </context_data>
+  
+  <default_symbols>
+    <symbol name="RST0" address="ram:0000" entry="true"/>
+    <symbol name="RST1" address="ram:0008" entry="true"/>
+  </default_symbols>
+</processor_spec>

--- a/Ghidra/Processors/Z80/data/languages/z80e.slaspec
+++ b/Ghidra/Processors/Z80/data/languages/z80e.slaspec
@@ -1,0 +1,3 @@
+@define Z80e ""
+
+@include "z80.slaspec"


### PR DESCRIPTION
The Nintendo e-Reader variant of the z80 processor does not run a any of the CB/DD/ED/FD prefix opcodes, along with a few other opcodes.   There is also no support for RST2-RST7.  And in the case of RST0 and RST1, the Nintendo e-reader treats those as two byte operations.

This implements all of those changes in a new .slaspec file along with the appropriate language definitions.