### PR TITLE
Fix PIC18 RLNCF and RRNCF instructions to use rotate instead of shift

### DIFF
--- a/Ghidra/Processors/PIC/data/languages/pic18_instructions.sinc
+++ b/Ghidra/Processors/PIC/data/languages/pic18_instructions.sinc
@@ -995,7 +995,7 @@ A: "BANKED"			is a=1										{ }
 	#  0100 0111 0000 0000  ->	RLNCF REG0x0, f, BANKED
 	#  0100 0110 1101 1000  ->	RLNCF STATUS, f, ACCESS
 	#  0100 0111 1101 1000  ->	RLNCF REG0xD8, f, BANKED
-	tmp:1 = srcREG << 1;
+	tmp:1 = srcREG << 1 | srcREG >> 7;
 	destREG = tmp;
 	setResultFlags(tmp);
 }
@@ -1028,7 +1028,7 @@ A: "BANKED"			is a=1										{ }
 	#  0100 0011 0000 0000  ->	RRNCF REG0x0, f, BANKED
 	#  0100 0010 1101 1000  ->	RRNCF STATUS, f, ACCESS
 	#  0100 0011 1101 1000  ->	RRNCF REG0xD8, f, BANKED
-	tmp:1 = srcREG >> 1;
+	tmp:1 = srcREG >> 1 | srcREG << 7;
 	destREG = tmp;
 	setResultFlags(tmp);
 }


### PR DESCRIPTION
**Summary**

This PR fixes incorrect behavior in the PIC18 processor module, specifically for the `RLNCF` and `RRNCF` instructions. The original implementation used logical bit shifts (`<<` and `>>`) instead of true 8-bit rotations, which contradicts the PIC18 instruction set documentation from Microchip. fixes #8269 

**Problem**

The current sleigh implementation in `pic18_instructions.sinc`:
```sleigh
tmp:1 = srcREG >> 1;
tmp:1 = srcREG << 1;
```
...is incorrect. It performs a shift and discards the rotated-out bit, rather than rotating it back in.

**Fix**

Replaced the shift logic with correct 8-bit rotation using bitwise OR:
```sleigh
tmp:1 = srcREG >> 1 | srcREG << 7;
tmp:1 = srcREG << 1 | srcREG >> 7;
```
**Why this matters**

This correction improves the accuracy of disassembly, decompilation, and emulation of PIC18 binaries in Ghidra, ensuring that these two commonly used instructions behave as expected.

