### PR TITLE
add Coldfire MBAR control register

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -19,7 +19,7 @@ define register offset=0xb0 size=4   [ FPCR FPSR FPIAR ];
 define register offset=0xe0 size=8   [ CRP ];
 define register offset=0x100 size=4  [ ISP MSP VBR CACR CAAR AC0 AC1 USP TT0 TT1 ];
 define register offset=0x140 size=4  [ SFC DFC TC ITT0 ITT1 DTT0 DTT1 MMUSR URP SRP PCR CAC ];
-define register offset=0x180 size=4  [ BUSCR MBB RAMBAR0 RAMBAR1 ];
+define register offset=0x180 size=4  [ BUSCR MBB RAMBAR0 RAMBAR1 MBAR ];
 define register offset=0x200 size=2  [ SR ACUSR ];
 # NOTE that SR overlaps XF, ZF, VF, CF
 # NOTE that A7 refers to USP, ISP, or MSP depending on privilege level
@@ -631,6 +631,7 @@ ctlreg: SRP    is SRP & ctl=0x807    { export SRP; }
 ctlreg: PCR    is PCR & ctl=0x808    { export PCR; }
 ctlreg: RAMBAR0    is RAMBAR0 & ctl=0xc04    { export RAMBAR0; }
 ctlreg: RAMBAR1    is RAMBAR1 & ctl=0xc05    { export RAMBAR1; }
+ctlreg: MBAR   is MBAR & ctl=0xc0f    { export MBAR; }
 #  ctlreg: PCR    is PCR & ctl=0x808    { export PCR; }
 ctlreg: CAC    is CAC & ctl=0xffe    { export CAC; }
 ctlreg: MBB    is MBB & ctl=0xfff    { export MBB; }


### PR DESCRIPTION
On the Coldfire 5206 processor (and others?) the MBAR control register with index 0x0c0f is used to set the base address for the onboard peripherals.  It is missing from `68000.sinc`.