### PR TITLE
Fix gradle wrapper name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ repository: `git clone https://github.com/NationalSecurityAgency/ghidra.git`
 
 ##### Download additional build dependencies into source repository:
 **NOTE:** If an Internet connection is available and you did not install Gradle, the following 
-`gradle` commands may be replaced with `./gradle(.bat)`.
+`gradle` commands may be replaced with `./gradlew(.bat)`.
 ```
 gradle -I gradle/support/fetchDependencies.gradle
 ```


### PR DESCRIPTION
This PR fixes the Gradle wrapper name in the setup guide.