### PR TITLE
Fix Infinite Loops in `PtrSubUndo` Rule 

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -6255,7 +6255,7 @@ void AddTreeState::calcSubtype(void)
     }
     extra = AddrSpace::byteToAddress(extra, ct->getWordSize()); // Convert back to address units
     offset = (offset - extra) & ptrmask;
-    correct = (correct - extra) & ptrmask;
+    // Do NOT adjust 'correct' - it tracks double-counted constants only, not structural offsets
     isSubtype = true;
   }
   else if (baseType->getMetatype() == TYPE_STRUCT) {
@@ -6272,7 +6272,7 @@ void AddTreeState::calcSubtype(void)
     }
     extra = AddrSpace::byteToAddressInt(extra, ct->getWordSize()); // Convert back to address units
     offset = (offset - extra) & ptrmask;
-    correct = (correct - extra) & ptrmask;
+    // Do NOT adjust 'correct' - it tracks double-counted constants only, not structural offsets
     if (pRelType != (TypePointerRel *)0 && offset == pRelType->getAddressOffset()) {
       // offset falls within basic ptrto
       if (!pRelType->evaluateThruParent(0)) {	// If we are not representing offset 0 through parent
@@ -6284,7 +6284,7 @@ void AddTreeState::calcSubtype(void)
   }
   else if (baseType->getMetatype() == TYPE_ARRAY) {
     isSubtype = true;
-    correct = (correct - offset) & ptrmask;
+    // Do NOT adjust 'correct' - it tracks double-counted constants only, not structural offsets
     offset = 0;
   }
   else {
@@ -6294,7 +6294,7 @@ void AddTreeState::calcSubtype(void)
   if (pRelType != (const TypePointerRel *)0) {
     int4 ptrOff = ((TypePointerRel *)ct)->getAddressOffset();
     offset = (offset - ptrOff) & ptrmask;
-    correct = (correct - ptrOff) & ptrmask;
+    // Do NOT adjust 'correct' - it tracks double-counted constants only, not structural offsets
   }
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -7079,6 +7079,9 @@ int4 RulePtrsubUndo::applyOp(PcodeOp *op,Funcdata &data)
   if (basevn->getTypeReadFacing(op)->isPtrsubMatching(val,extra,multiplier))
     return 0;
 
+  // Don't undo PTRSUB with zero offset and no extra - these can be valid pointer operations (e.g., casts)
+  if (val == 0 && extra == 0)
+    return 0;
   data.opSetOpcode(op,CPUI_INT_ADD);
   op->clearStopTypePropagation();
   extra = removeLocalAdds(op->getOut(),data);


### PR DESCRIPTION
The [last refactor of the PtrSubUndo Rule](https://github.com/NationalSecurityAgency/ghidra/commit/aac3e5ad1ce70c5db136e17fd50ca17aff4e47cd) (part of the type inference action) seemingly introduced new infinite loops, as discussed in https://github.com/NationalSecurityAgency/ghidra/issues/7997.

My understanding of the semantics and interdependencies involved in the processing of these rules is still limited so I'm thankful for any insights and reviews.

I've traced the loops to two root causes:
1. The `calcSubtype` method seems to incorrectly adjust the `correct` variable when handling `TypePointerRel` offsets. The `correct` variable is meant to tarck double-counted constants (per a comment) in the pointer arithmetic expression, but it was also being modified by offsets (field offsets, array offsets, `TypePointerRel` offsets).
Example on processing a stack pointer access:
    ```C
    // Initial: correct = -0x418
    // Process constants from nonmult array:
    //   -0x418 is constant: correct -= (-0x418) = -0x418 - (-0x418) = 0
    //   0x418 is constant: correct -= 0x418 = 0 - 0x418 = -0x418
    // Final: correct = -0x418
    
    // Since correct != 0, add correction in `buildExtra`:
    correction = uintb_negate(-0x418 - 1) = uintb_negate(-0x419) = 0x419
    ```
    - `RulePtrArith` sees `PTRSUB(ptr, -0x418) + 0x419` and processes it: `nonmultsum = 0x419`
    - after `calcSubtype` with `TypePointerRel`: offset = 1, correct = 1
    - after `buildExtra`: adds correction of -1
    - result: `PTRSUB(ptr, 1) + (-1)`
    - => the incorrect `correct` adjustment keeps introducing new constants that need to be "corrected" in the next iteration
2. `RulePtrsubUndo` is converting `PTRSUB` operations with zero offset back to `INT_ADD`, which would then be converted back to `PTRSUB` by `RulePtrArith`, creating an infinite loop.
    - first iteration:
    ```
    RulePtrArith: INT_ADD(generic_buffer, 0) → PTRSUB(generic_buffer, 0)
    RulePtrsubUndo: 
    - Checks isPtrsubMatching(0, 0, 1) on void* → returns false
    - Converts back: PTRSUB(generic_buffer, 0) → INT_ADD(generic_buffer, 0)
    ```
    - second iteration
    ```
    RulePtrArith: Sees INT_ADD(generic_buffer, 0) again → PTRSUB(generic_buffer, 0)
    RulePtrsubUndo: Same as before → INT_ADD(generic_buffer, 0)
    ```
    - but from what I understand, a `PTRSUB` with offset `0` can be valid, e.g., this seems to be used on pointer casts to signal that something is the same pointer but we have new type information for it.
    
Any testing and feedback are very welcome. 