### PR TITLE
CParser: Add upper case 'i' as part of an integer literal suffix.

### DIFF
--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
@@ -1079,11 +1079,11 @@ SKIP :
 TOKEN :
 {
     <INTEGER_LITERAL : 
-        <DECIMAL_LITERAL> (  "ull" | "ULL" | "ul" | "UL" | "ll" | "LL" | "l" | "L" | "U" | "u")? ("i")? ( ["0"-"9"] )*
+        <DECIMAL_LITERAL> (  "ull" | "ULL" | "ul" | "UL" | "ll" | "LL" | "l" | "L" | "U" | "u")? ("i" | "I")? ( ["0"-"9"] )*
         |
-        <HEX_LITERAL> ( "ull" | "ULL" | "ul" | "UL" | "ll" | "LL" | "l" | "L" | "U" | "u")? ("i")? ( ["0"-"9"] )*
+        <HEX_LITERAL> ( "ull" | "ULL" | "ul" | "UL" | "ll" | "LL" | "l" | "L" | "U" | "u")? ("i" | "I")? ( ["0"-"9"] )*
         |
-        <OCTAL_LITERAL> ( "ull" | "ULL" | "ul" | "UL" | "ll" | "LL" | "l" | "L" | "U" | "u")? ("i")? ( ["0"-"9"] )*
+        <OCTAL_LITERAL> ( "ull" | "ULL" | "ul" | "UL" | "ll" | "LL" | "l" | "L" | "U" | "u")? ("i" | "I")? ( ["0"-"9"] )*
     >
     |
     <#DECIMAL_LITERAL : [ "1"-"9" ] ( [ "0"-"9" ] )*> 


### PR DESCRIPTION
When trying to parse C header I got errors because it was not able to recognize `0x0000000000080000UI64` as an integer literal. Apparently the definition of the integer literal token it's just looking for lower case i in the suffix.