### PR TITLE
Less debugging for more speed

### DIFF
--- a/Ghidra/Features/WildcardAssembler/src/main/java/ghidra/asm/wild/sem/WildAssemblyNopStateGenerator.java
+++ b/Ghidra/Features/WildcardAssembler/src/main/java/ghidra/asm/wild/sem/WildAssemblyNopStateGenerator.java
@@ -39,7 +39,7 @@ public class WildAssemblyNopStateGenerator
 	public Stream<AssemblyGeneratedPrototype> generate(GeneratorContext gc) {
 		// TODO: Do we want to restrict the values?
 		// TODO: Is this the right place to generate "interesting values"?
-		gc.dbg("Generating WILD NOP for " + opSym);
+		// gc.dbg("Generating WILD NOP for " + opSym);
 		return Stream.of(new AssemblyGeneratedPrototype(
 			new WildAssemblyNopState(resolver, gc.path, gc.shift, opSym, wildcard), fromLeft));
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/AbstractSleighAssembler.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/AbstractSleighAssembler.java
@@ -150,7 +150,7 @@ public abstract class AbstractSleighAssembler<RP extends AssemblyResolvedPattern
 		for (String part : assembly) {
 			for (String line : part.split("\n")) {
 				RegisterValue rv = program.getProgramContext().getDisassemblyContext(at);
-				// dbg.println(rv);
+				if (dbg != DbgTimer.INACTIVE) dbg.println(rv);
 				AssemblyPatternBlock ctx = AssemblyPatternBlock.fromRegisterValue(rv);
 				ctx = ctx.fillMask();
 				byte[] insbytes = assembleLine(at, line, ctx);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/AbstractSleighAssembler.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/AbstractSleighAssembler.java
@@ -150,7 +150,7 @@ public abstract class AbstractSleighAssembler<RP extends AssemblyResolvedPattern
 		for (String part : assembly) {
 			for (String line : part.split("\n")) {
 				RegisterValue rv = program.getProgramContext().getDisassemblyContext(at);
-				dbg.println(rv);
+				// dbg.println(rv);
 				AssemblyPatternBlock ctx = AssemblyPatternBlock.fromRegisterValue(rv);
 				ctx = ctx.fillMask();
 				byte[] insbytes = assembleLine(at, line, ctx);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/expr/AbstractBinaryExpressionSolver.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/expr/AbstractBinaryExpressionSolver.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 
 import ghidra.app.plugin.assembler.sleigh.sem.*;
+import ghidra.app.plugin.assembler.sleigh.util.DbgTimer;
 import ghidra.app.plugin.processors.sleigh.expression.BinaryExpression;
 import ghidra.app.plugin.processors.sleigh.expression.PatternExpression;
 
@@ -43,13 +44,13 @@ public abstract class AbstractBinaryExpressionSolver<T extends BinaryExpression>
 
 		if (lval != null && !lval.isFullyDefined()) {
 			if (!lval.isFullyUndefined()) {
-				dbg.println("Partially-defined left value for binary solver: " + lval);
+				if (dbg != DbgTimer.INACTIVE) dbg.println("Partially-defined left value for binary solver: " + lval);
 			}
 			lval = null;
 		}
 		if (rval != null && !rval.isFullyDefined()) {
 			if (!rval.isFullyUndefined()) {
-				dbg.println("Partially-defined right value for binary solver: " + rval);
+				if (dbg != DbgTimer.INACTIVE) dbg.println("Partially-defined right value for binary solver: " + rval);
 			}
 			rval = null;
 		}
@@ -80,7 +81,7 @@ public abstract class AbstractBinaryExpressionSolver<T extends BinaryExpression>
 			return factory.newErrorBuilder().error(e.getMessage()).description(description).build();
 		}
 		catch (AssertionError e) {
-			dbg.println("While solving: " + exp + " (" + description + ")");
+			if (dbg != DbgTimer.INACTIVE) dbg.println("While solving: " + exp + " (" + description + ")");
 			throw e;
 		}
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/expr/RecursiveDescentSolver.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/expr/RecursiveDescentSolver.java
@@ -170,7 +170,7 @@ public class RecursiveDescentSolver {
 	protected <T extends PatternExpression> MaskedLong getValue(T exp, Map<String, Long> vals,
 			AssemblyResolvedPatterns cur) throws NeedsBackfillException {
 		MaskedLong value = getRegistered(exp.getClass()).getValue(exp, vals, cur);
-		DBG.println("Expression: " + value + " =: " + exp);
+		// DBG.println("Expression: " + value + " =: " + exp);
 		return value;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/expr/RecursiveDescentSolver.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/expr/RecursiveDescentSolver.java
@@ -123,7 +123,7 @@ public class RecursiveDescentSolver {
 				description);
 		}
 		catch (UnsupportedOperationException e) {
-			DBG.println("Error solving " + exp + " = " + goal);
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Error solving " + exp + " = " + goal);
 			throw e;
 		}
 	}
@@ -170,7 +170,7 @@ public class RecursiveDescentSolver {
 	protected <T extends PatternExpression> MaskedLong getValue(T exp, Map<String, Long> vals,
 			AssemblyResolvedPatterns cur) throws NeedsBackfillException {
 		MaskedLong value = getRegistered(exp.getClass()).getValue(exp, vals, cur);
-		// DBG.println("Expression: " + value + " =: " + exp);
+		if (DBG != DbgTimer.INACTIVE) DBG.println("Expression: " + value + " =: " + exp);
 		return value;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/parse/AssemblyParseMachine.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/parse/AssemblyParseMachine.java
@@ -206,7 +206,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 		c.accepted = accepted;
 		c.error = error;
 
-		// DBG.println("Copied " + id + " to " + c.id);
+		if (DBG != DbgTimer.INACTIVE) DBG.println("Copied " + id + " to " + c.id);
 		return c;
 	}
 
@@ -238,7 +238,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 				AssemblyParseBranch branch = new AssemblyParseBranch(parser.grammar, prod);
 				AssemblyParseMachine m = copy();
 				m.output.add(prod.getIndex());
-				// DBG.println("Prod: " + prod);
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Prod: " + prod);
 				for (@SuppressWarnings("unused")
 				AssemblySymbol sym : prod.getRHS()) {
 					m.stack.pop();
@@ -246,7 +246,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 				}
 				for (Action aa : m.parser.actions.get(m.stack.peek(), prod.getLHS())) {
 					GotoAction ga = (GotoAction) aa;
-					// DBG.println("Goto: " + ga);
+					if (DBG != DbgTimer.INACTIVE) DBG.println("Goto: " + ga);
 					AssemblyParseMachine n = m.copy();
 					n.stack.push(ga.newStateNum);
 					n.treeStack.push(branch);
@@ -274,7 +274,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 		try (DbgCtx dc = DBG.start("Matched " + t + " " + tok)) {
 			Collection<Action> as = parser.actions.get(stack.peek(), t);
 			assert !as.isEmpty();
-			// DBG.println("Actions: " + as);
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Actions: " + as);
 			for (Action a : as) {
 				doAction(a, tok, results, visited);
 			}
@@ -321,10 +321,10 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 	 */
 	protected void exhaust(Set<AssemblyParseMachine> results, Deque<AssemblyParseMachine> visited) {
 		try (DbgCtx dc = DBG.start("Exhausting machine " + id)) {
-			// DBG.println("Machine: " + this);
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Machine: " + this);
 			AssemblyParseMachine loop = findLoop(this, visited);
 			if (loop != null) {
-				// DBG.println("Pruned. Loop of " + loop.id);
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Pruned. Loop of " + loop.id);
 				return;
 			}
 			try (DequePush<?> push = DequePush.push(visited, this)) {
@@ -359,9 +359,11 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 						newExpected = new TreeSet<>();
 						newExpected.add(AssemblySentential.WHITE_SPACE);
 					}
-					// DBG.println("Syntax Error: ");
-					// DBG.println("  Expected: " + newExpected);
-					// DBG.println("  Got: " + buffer.substring(pos));
+					if (DBG != DbgTimer.INACTIVE) {
+						DBG.println("Syntax Error: ");
+						DBG.println("  Expected: " + newExpected);
+						DBG.println("  Got: " + buffer.substring(pos));
+					}
 					m.error = ERROR_SYNTAX;
 					m.got = buffer.substring(pos);
 					m.expected = newExpected;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/parse/AssemblyParseMachine.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/parse/AssemblyParseMachine.java
@@ -206,7 +206,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 		c.accepted = accepted;
 		c.error = error;
 
-		DBG.println("Copied " + id + " to " + c.id);
+		// DBG.println("Copied " + id + " to " + c.id);
 		return c;
 	}
 
@@ -238,7 +238,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 				AssemblyParseBranch branch = new AssemblyParseBranch(parser.grammar, prod);
 				AssemblyParseMachine m = copy();
 				m.output.add(prod.getIndex());
-				DBG.println("Prod: " + prod);
+				// DBG.println("Prod: " + prod);
 				for (@SuppressWarnings("unused")
 				AssemblySymbol sym : prod.getRHS()) {
 					m.stack.pop();
@@ -246,7 +246,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 				}
 				for (Action aa : m.parser.actions.get(m.stack.peek(), prod.getLHS())) {
 					GotoAction ga = (GotoAction) aa;
-					DBG.println("Goto: " + ga);
+					// DBG.println("Goto: " + ga);
 					AssemblyParseMachine n = m.copy();
 					n.stack.push(ga.newStateNum);
 					n.treeStack.push(branch);
@@ -274,7 +274,7 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 		try (DbgCtx dc = DBG.start("Matched " + t + " " + tok)) {
 			Collection<Action> as = parser.actions.get(stack.peek(), t);
 			assert !as.isEmpty();
-			DBG.println("Actions: " + as);
+			// DBG.println("Actions: " + as);
 			for (Action a : as) {
 				doAction(a, tok, results, visited);
 			}
@@ -321,10 +321,10 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 	 */
 	protected void exhaust(Set<AssemblyParseMachine> results, Deque<AssemblyParseMachine> visited) {
 		try (DbgCtx dc = DBG.start("Exhausting machine " + id)) {
-			DBG.println("Machine: " + this);
+			// DBG.println("Machine: " + this);
 			AssemblyParseMachine loop = findLoop(this, visited);
 			if (loop != null) {
-				DBG.println("Pruned. Loop of " + loop.id);
+				// DBG.println("Pruned. Loop of " + loop.id);
 				return;
 			}
 			try (DequePush<?> push = DequePush.push(visited, this)) {
@@ -359,9 +359,9 @@ public class AssemblyParseMachine implements Comparable<AssemblyParseMachine> {
 						newExpected = new TreeSet<>();
 						newExpected.add(AssemblySentential.WHITE_SPACE);
 					}
-					DBG.println("Syntax Error: ");
-					DBG.println("  Expected: " + newExpected);
-					DBG.println("  Got: " + buffer.substring(pos));
+					// DBG.println("Syntax Error: ");
+					// DBG.println("  Expected: " + newExpected);
+					// DBG.println("  Got: " + buffer.substring(pos));
 					m.error = ERROR_SYNTAX;
 					m.got = buffer.substring(pos);
 					m.expected = newExpected;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AbstractAssemblyTreeResolver.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AbstractAssemblyTreeResolver.java
@@ -107,7 +107,7 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 		if (DBG == DbgTimer.ACTIVE) {
 			try (DbgCtx dc = DBG.start("Prototypes:")) {
 				protStream = protStream.map(prot -> {
-					// DBG.println(prot);
+					if (DBG != DbgTimer.INACTIVE) DBG.println(prot);
 					return prot;
 				}).collect(Collectors.toList()).stream();
 			}
@@ -174,12 +174,12 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 				AssemblyPatternBlock src = context; // NOTE: This is only correct for "instruction"
 				String table = "instruction";
 
-				// DBG.println("Finding paths from " + src + " to " + ar.lineToString());
+				if (false) DBG.println("Finding paths from " + src + " to " + ar.lineToString());
 				Collection<Deque<AssemblyConstructorSemantic>> paths =
 					ctxGraph.computeOptimalApplications(src, table, dst, table);
-				// DBG.println("Found " + paths.size());
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Found " + paths.size());
 				for (Deque<AssemblyConstructorSemantic> path : paths) {
-					// DBG.println("  " + path);
+					if (DBG != DbgTimer.INACTIVE) DBG.println("  " + path);
 					result.absorb(applyRecursionPath(path, tree, rootRec, ar));
 				}
 			}
@@ -206,9 +206,9 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 			vals.put(INST_NEXT, at.add(rp.getInstructionLength()).getAddressableWordOffset());
 			// inst_next2 use not really supported
 			vals.put(INST_NEXT2, at.add(rp.getInstructionLength()).getAddressableWordOffset());
-			// DBG.println("Backfilling: " + rp);
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Backfilling: " + rp);
 			AssemblyResolution ar = rp.backfill(SOLVER, vals);
-			// DBG.println("Backfilled final: " + ar);
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Backfilled final: " + ar);
 			return ar;
 		}).apply(factory, rp -> {
 			if (rp.hasBackfills()) {
@@ -364,11 +364,11 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 	 */
 	protected AssemblyResolutionResults applyMutations(AssemblyConstructorSemantic sem,
 			AssemblyResolutionResults temp) {
-		// DBG.println("Applying context mutations:");
+		if (DBG != DbgTimer.INACTIVE) DBG.println("Applying context mutations:");
 		return temp.apply(factory, rp -> {
-			// DBG.println("Current: " + rp.lineToString());
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Current: " + rp.lineToString());
 			AssemblyResolution backctx = sem.solveContextChanges(rp, vals);
-			// DBG.println("Mutated: " + backctx.lineToString());
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Mutated: " + backctx.lineToString());
 			return backctx;
 		}).apply(factory, rp -> {
 			return rp.solveContextChangesForForbids(sem, vals);
@@ -381,7 +381,7 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 	 */
 	protected AssemblyResolutionResults applyPatterns(AssemblyConstructorSemantic sem, int shift,
 			AssemblyResolutionResults temp) {
-		// DBG.println("Applying patterns:");
+		if (false) DBG.println("Applying patterns:");
 		Collection<AssemblyResolution> patterns =
 			sem.getPatterns()
 					.stream()

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AbstractAssemblyTreeResolver.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AbstractAssemblyTreeResolver.java
@@ -107,7 +107,7 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 		if (DBG == DbgTimer.ACTIVE) {
 			try (DbgCtx dc = DBG.start("Prototypes:")) {
 				protStream = protStream.map(prot -> {
-					DBG.println(prot);
+					// DBG.println(prot);
 					return prot;
 				}).collect(Collectors.toList()).stream();
 			}
@@ -174,12 +174,12 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 				AssemblyPatternBlock src = context; // NOTE: This is only correct for "instruction"
 				String table = "instruction";
 
-				DBG.println("Finding paths from " + src + " to " + ar.lineToString());
+				// DBG.println("Finding paths from " + src + " to " + ar.lineToString());
 				Collection<Deque<AssemblyConstructorSemantic>> paths =
 					ctxGraph.computeOptimalApplications(src, table, dst, table);
-				DBG.println("Found " + paths.size());
+				// DBG.println("Found " + paths.size());
 				for (Deque<AssemblyConstructorSemantic> path : paths) {
-					DBG.println("  " + path);
+					// DBG.println("  " + path);
 					result.absorb(applyRecursionPath(path, tree, rootRec, ar));
 				}
 			}
@@ -206,9 +206,9 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 			vals.put(INST_NEXT, at.add(rp.getInstructionLength()).getAddressableWordOffset());
 			// inst_next2 use not really supported
 			vals.put(INST_NEXT2, at.add(rp.getInstructionLength()).getAddressableWordOffset());
-			DBG.println("Backfilling: " + rp);
+			// DBG.println("Backfilling: " + rp);
 			AssemblyResolution ar = rp.backfill(SOLVER, vals);
-			DBG.println("Backfilled final: " + ar);
+			// DBG.println("Backfilled final: " + ar);
 			return ar;
 		}).apply(factory, rp -> {
 			if (rp.hasBackfills()) {
@@ -364,11 +364,11 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 	 */
 	protected AssemblyResolutionResults applyMutations(AssemblyConstructorSemantic sem,
 			AssemblyResolutionResults temp) {
-		DBG.println("Applying context mutations:");
+		// DBG.println("Applying context mutations:");
 		return temp.apply(factory, rp -> {
-			DBG.println("Current: " + rp.lineToString());
+			// DBG.println("Current: " + rp.lineToString());
 			AssemblyResolution backctx = sem.solveContextChanges(rp, vals);
-			DBG.println("Mutated: " + backctx.lineToString());
+			// DBG.println("Mutated: " + backctx.lineToString());
 			return backctx;
 		}).apply(factory, rp -> {
 			return rp.solveContextChangesForForbids(sem, vals);
@@ -381,7 +381,7 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 	 */
 	protected AssemblyResolutionResults applyPatterns(AssemblyConstructorSemantic sem, int shift,
 			AssemblyResolutionResults temp) {
-		DBG.println("Applying patterns:");
+		// DBG.println("Applying patterns:");
 		Collection<AssemblyResolution> patterns =
 			sem.getPatterns()
 					.stream()

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AbstractAssemblyTreeResolver.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AbstractAssemblyTreeResolver.java
@@ -174,7 +174,7 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 				AssemblyPatternBlock src = context; // NOTE: This is only correct for "instruction"
 				String table = "instruction";
 
-				if (false) DBG.println("Finding paths from " + src + " to " + ar.lineToString());
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Finding paths from " + src + " to " + ar.lineToString());
 				Collection<Deque<AssemblyConstructorSemantic>> paths =
 					ctxGraph.computeOptimalApplications(src, table, dst, table);
 				if (DBG != DbgTimer.INACTIVE) DBG.println("Found " + paths.size());
@@ -381,7 +381,7 @@ public abstract class AbstractAssemblyTreeResolver<RP extends AssemblyResolvedPa
 	 */
 	protected AssemblyResolutionResults applyPatterns(AssemblyConstructorSemantic sem, int shift,
 			AssemblyResolutionResults temp) {
-		if (false) DBG.println("Applying patterns:");
+		if (DBG != DbgTimer.INACTIVE) DBG.println("Applying patterns:");
 		Collection<AssemblyResolution> patterns =
 			sem.getPatterns()
 					.stream()

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructState.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructState.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import ghidra.app.plugin.assembler.sleigh.util.DbgTimer;
 import ghidra.app.plugin.processors.sleigh.ConstructState;
 
 /**
@@ -142,8 +143,10 @@ public class AssemblyConstructState extends AbstractAssemblyState {
 		return sem.getPatterns()
 				.stream()
 				.map(pat -> {
-					DBG.println(path + ": Constructor pattern: " + pat.lineToString());
-					DBG.println(path + ": Current     pattern: " + fromMutations.lineToString());
+					if (DBG != DbgTimer.INACTIVE) {
+						DBG.println(path + ": Constructor pattern: " + pat.lineToString());
+						DBG.println(path + ": Current     pattern: " + fromMutations.lineToString());
+					}
 					AssemblyResolvedPatterns combined = fromMutations.combine(pat.shift(shift));
 					//DBG.println("Combined    pattern: " + combined);
 					return combined;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructStateGenerator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructStateGenerator.java
@@ -100,8 +100,8 @@ public class AssemblyConstructStateGenerator
 		Stream<AssemblyResolvedPatterns> applied = sem.applyPatternsForward(gc.shift, fromLeft)
 				.filter(pat -> {
 					if (pat == null) {
-						gc.dbg("Conflicting pattern. fromLeft=" + fromLeft + ",sem=" +
-							sem.getLocation());
+						// gc.dbg("Conflicting pattern. fromLeft=" + fromLeft + ",sem=" +
+						// 	sem.getLocation());
 						return false;
 					}
 					return true;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructorSemantic.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructorSemantic.java
@@ -304,28 +304,28 @@ public class AssemblyConstructorSemantic implements Comparable<AssemblyConstruct
 			Map<String, Long> vals) {
 		for (ContextChange chg : reversedChanges) {
 			if (chg instanceof ContextOp) {
-				// DBG.println("Current: " + res.lineToString());
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Current: " + res.lineToString());
 				// This seems backwards. That's because we're going backwards.
 				// This is the "write" location for disassembly.
 				ContextOp cop = (ContextOp) chg;
-				// DBG.println("Handling context change: " + cop);
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Handling context change: " + cop);
 
 				// TODO: Is this res or subres?
 				MaskedLong reqval = res.readContextOp(cop);
 				if (reqval.equals(MaskedLong.UNKS)) {
-					// DBG.println("Doesn't affect a current requirement");
+					if (DBG != DbgTimer.INACTIVE) DBG.println("Doesn't affect a current requirement");
 					continue; // this context change does not satisfy any requirement
 				}
-				// DBG.println("'read' " + reqval);
+				if (DBG != DbgTimer.INACTIVE) DBG.println("'read' " + reqval);
 
 				// Remove the requirement that we just read before trying to solve
 				res = res.maskOut(cop);
-				// DBG.println("Masked out: " + res.lineToString());
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Masked out: " + res.lineToString());
 
 				// Now, solve
 				AssemblyResolution sol = factory.solveOrBackfill(cop.getPatternExpression(), reqval,
 					vals, res, "Solution to " + cop);
-				// DBG.println("Solution: " + sol.lineToString());
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Solution: " + sol.lineToString());
 				if (sol.isError()) {
 					AssemblyResolvedError err = (AssemblyResolvedError) sol;
 					return factory.error(err.getError(), res);
@@ -344,7 +344,7 @@ public class AssemblyConstructorSemantic implements Comparable<AssemblyConstruct
 					AssemblyResolvedBackfill solbf = (AssemblyResolvedBackfill) sol;
 					res = res.combine(solbf);
 				}
-				// DBG.println("Combined: " + res.lineToString());
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Combined: " + res.lineToString());
 			}
 		}
 		return res;
@@ -386,8 +386,10 @@ public class AssemblyConstructorSemantic implements Comparable<AssemblyConstruct
 	public Stream<AssemblyResolvedPatterns> applyPatternsForward(int shift,
 			AssemblyResolvedPatterns fromLeft) {
 		if (patterns.isEmpty()) {
-			// DBG.println("No patterns for " + getLocation() + "?" + "(hash=" +
-			// 	System.identityHashCode(this) + ")");
+			if (DBG != DbgTimer.INACTIVE) {
+				DBG.println("No patterns for " + getLocation() + "?" + "(hash=" +
+					System.identityHashCode(this) + ")");
+			}
 		}
 		return patterns.stream().map(pat -> fromLeft.combine(pat.shift(shift)));
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructorSemantic.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyConstructorSemantic.java
@@ -304,28 +304,28 @@ public class AssemblyConstructorSemantic implements Comparable<AssemblyConstruct
 			Map<String, Long> vals) {
 		for (ContextChange chg : reversedChanges) {
 			if (chg instanceof ContextOp) {
-				DBG.println("Current: " + res.lineToString());
+				// DBG.println("Current: " + res.lineToString());
 				// This seems backwards. That's because we're going backwards.
 				// This is the "write" location for disassembly.
 				ContextOp cop = (ContextOp) chg;
-				DBG.println("Handling context change: " + cop);
+				// DBG.println("Handling context change: " + cop);
 
 				// TODO: Is this res or subres?
 				MaskedLong reqval = res.readContextOp(cop);
 				if (reqval.equals(MaskedLong.UNKS)) {
-					DBG.println("Doesn't affect a current requirement");
+					// DBG.println("Doesn't affect a current requirement");
 					continue; // this context change does not satisfy any requirement
 				}
-				DBG.println("'read' " + reqval);
+				// DBG.println("'read' " + reqval);
 
 				// Remove the requirement that we just read before trying to solve
 				res = res.maskOut(cop);
-				DBG.println("Masked out: " + res.lineToString());
+				// DBG.println("Masked out: " + res.lineToString());
 
 				// Now, solve
 				AssemblyResolution sol = factory.solveOrBackfill(cop.getPatternExpression(), reqval,
 					vals, res, "Solution to " + cop);
-				DBG.println("Solution: " + sol.lineToString());
+				// DBG.println("Solution: " + sol.lineToString());
 				if (sol.isError()) {
 					AssemblyResolvedError err = (AssemblyResolvedError) sol;
 					return factory.error(err.getError(), res);
@@ -344,7 +344,7 @@ public class AssemblyConstructorSemantic implements Comparable<AssemblyConstruct
 					AssemblyResolvedBackfill solbf = (AssemblyResolvedBackfill) sol;
 					res = res.combine(solbf);
 				}
-				DBG.println("Combined: " + res.lineToString());
+				// DBG.println("Combined: " + res.lineToString());
 			}
 		}
 		return res;
@@ -386,8 +386,8 @@ public class AssemblyConstructorSemantic implements Comparable<AssemblyConstruct
 	public Stream<AssemblyResolvedPatterns> applyPatternsForward(int shift,
 			AssemblyResolvedPatterns fromLeft) {
 		if (patterns.isEmpty()) {
-			DBG.println("No patterns for " + getLocation() + "?" + "(hash=" +
-				System.identityHashCode(this) + ")");
+			// DBG.println("No patterns for " + getLocation() + "?" + "(hash=" +
+			// 	System.identityHashCode(this) + ")");
 		}
 		return patterns.stream().map(pat -> fromLeft.combine(pat.shift(shift)));
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyDefaultContext.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyDefaultContext.java
@@ -110,17 +110,17 @@ public class AssemblyDefaultContext implements DisassemblerContext, DefaultProgr
 
 	@Override
 	public void setValue(Register register, BigInteger value) throws ContextChangeException {
-		dbg.println("Set " + register + " to " + value);
+		if (dbg != DbgTimer.INACTIVE) dbg.println("Set " + register + " to " + value);
 	}
 
 	@Override
 	public void setRegisterValue(RegisterValue value) throws ContextChangeException {
-		dbg.println("Set " + value);
+		if (dbg != DbgTimer.INACTIVE) dbg.println("Set " + value);
 	}
 
 	@Override
 	public void clearRegister(Register register) throws ContextChangeException {
-		dbg.println("Clear " + register);
+		if (dbg != DbgTimer.INACTIVE) dbg.println("Clear " + register);
 	}
 
 	@Override
@@ -165,12 +165,12 @@ public class AssemblyDefaultContext implements DisassemblerContext, DefaultProgr
 
 	@Override
 	public void setFutureRegisterValue(Address address, RegisterValue value) {
-		dbg.println("Set " + value + " at " + address);
+		if (dbg != DbgTimer.INACTIVE) dbg.println("Set " + value + " at " + address);
 	}
 
 	@Override
 	public void setFutureRegisterValue(Address fromAddr, Address toAddr, RegisterValue value) {
-		dbg.println("Set " + value + " for [" + fromAddr + ":" + toAddr + "]");
+		if (dbg != DbgTimer.INACTIVE) dbg.println("Set " + value + " for [" + fromAddr + ":" + toAddr + "]");
 	}
 
 	@Override
@@ -182,8 +182,10 @@ public class AssemblyDefaultContext implements DisassemblerContext, DefaultProgr
 			return;
 		}
 		defctx = defctx.combine(AssemblyPatternBlock.fromRegisterValue(registerValue));
-		dbg.println("Combining " + registerValue);
-		dbg.println("  " + defctx);
+		if (dbg != DbgTimer.INACTIVE) {
+			dbg.println("Combining " + registerValue);
+			dbg.println("  " + defctx);
+		}
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyNopStateGenerator.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyNopStateGenerator.java
@@ -47,7 +47,7 @@ public class AssemblyNopStateGenerator
 
 	@Override
 	public Stream<AssemblyGeneratedPrototype> generate(GeneratorContext gc) {
-		gc.dbg("Generating NOP for " + opSym);
+		// gc.dbg("Generating NOP for " + opSym);
 		return Stream.of(new AssemblyGeneratedPrototype(
 			new AssemblyNopState(resolver, gc.path, gc.shift, opSym), fromLeft));
 	}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyOperandState.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyOperandState.java
@@ -128,13 +128,13 @@ public class AssemblyOperandState extends AbstractAssemblyState {
 		if (symExp == null) {
 			symExp = opSym.getDefiningSymbol().getPatternExpression();
 		}
-		DBG.println("Equation: " + symExp + " = " + Long.toHexString(value));
+		// DBG.println("Equation: " + symExp + " = " + Long.toHexString(value));
 		String desc = "Solution to " + opSym + " in " + Long.toHexString(value) + " = " + symExp;
 		AssemblyResolution sol =
 			factory.solveOrBackfill(symExp, value, bitsize, resolver.vals, null, desc);
-		DBG.println("Solution: " + sol);
+		// DBG.println("Solution: " + sol);
 		AssemblyResolution shifted = sol.shift(shift);
-		DBG.println("Shifted: " + shifted);
+		// DBG.println("Shifted: " + shifted);
 		return shifted;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyOperandState.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyOperandState.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import ghidra.app.plugin.assembler.sleigh.symbol.AssemblyNumericTerminal;
 import ghidra.app.plugin.assembler.sleigh.symbol.AssemblyTerminal;
+import ghidra.app.plugin.assembler.sleigh.util.DbgTimer;
 import ghidra.app.plugin.assembler.sleigh.util.DbgTimer.DbgCtx;
 import ghidra.app.plugin.processors.sleigh.ConstructState;
 import ghidra.app.plugin.processors.sleigh.expression.PatternExpression;
@@ -128,13 +129,13 @@ public class AssemblyOperandState extends AbstractAssemblyState {
 		if (symExp == null) {
 			symExp = opSym.getDefiningSymbol().getPatternExpression();
 		}
-		// DBG.println("Equation: " + symExp + " = " + Long.toHexString(value));
+		if (DBG != DbgTimer.INACTIVE) DBG.println("Equation: " + symExp + " = " + Long.toHexString(value));
 		String desc = "Solution to " + opSym + " in " + Long.toHexString(value) + " = " + symExp;
 		AssemblyResolution sol =
 			factory.solveOrBackfill(symExp, value, bitsize, resolver.vals, null, desc);
-		// DBG.println("Solution: " + sol);
+		if (DBG != DbgTimer.INACTIVE) DBG.println("Solution: " + sol);
 		AssemblyResolution shifted = sol.shift(shift);
-		// DBG.println("Shifted: " + shifted);
+		if (DBG != DbgTimer.INACTIVE) DBG.println("Shifted: " + shifted);
 		return shifted;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyResolutionResults.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyResolutionResults.java
@@ -142,11 +142,11 @@ public class AssemblyResolutionResults extends AbstractSetDecorator<AssemblyReso
 				continue;
 			}
 			AssemblyResolvedPatterns rp = (AssemblyResolvedPatterns) res;
-			// DBG.println("Current: " + rp.lineToString());
+			if (false) DBG.println("Current: " + rp.lineToString());
 			for (AssemblyResolution ar : applicator.getPatterns(rp)) {
-				// DBG.println("Pattern: " + ar.lineToString());
+				if (false) DBG.println("Pattern: " + ar.lineToString());
 				AssemblyResolvedPatterns combined = applicator.combine(rp, ar);
-				// DBG.println("Combined: " + (combined == null ? "(null)" : combined.lineToString()));
+				if (false) DBG.println("Combined: " + (combined == null ? "(null)" : combined.lineToString()));
 				if (combined == null) {
 					results.add(factory.error(applicator.describeError(rp, ar), ar));
 					continue;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyResolutionResults.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyResolutionResults.java
@@ -142,11 +142,11 @@ public class AssemblyResolutionResults extends AbstractSetDecorator<AssemblyReso
 				continue;
 			}
 			AssemblyResolvedPatterns rp = (AssemblyResolvedPatterns) res;
-			DBG.println("Current: " + rp.lineToString());
+			// DBG.println("Current: " + rp.lineToString());
 			for (AssemblyResolution ar : applicator.getPatterns(rp)) {
-				DBG.println("Pattern: " + ar.lineToString());
+				// DBG.println("Pattern: " + ar.lineToString());
 				AssemblyResolvedPatterns combined = applicator.combine(rp, ar);
-				DBG.println("Combined: " + (combined == null ? "(null)" : combined.lineToString()));
+				// DBG.println("Combined: " + (combined == null ? "(null)" : combined.lineToString()));
 				if (combined == null) {
 					results.add(factory.error(applicator.describeError(rp, ar), ar));
 					continue;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyResolutionResults.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyResolutionResults.java
@@ -142,11 +142,11 @@ public class AssemblyResolutionResults extends AbstractSetDecorator<AssemblyReso
 				continue;
 			}
 			AssemblyResolvedPatterns rp = (AssemblyResolvedPatterns) res;
-			if (false) DBG.println("Current: " + rp.lineToString());
+			if (DBG != DbgTimer.INACTIVE) DBG.println("Current: " + rp.lineToString());
 			for (AssemblyResolution ar : applicator.getPatterns(rp)) {
-				if (false) DBG.println("Pattern: " + ar.lineToString());
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Pattern: " + ar.lineToString());
 				AssemblyResolvedPatterns combined = applicator.combine(rp, ar);
-				if (false) DBG.println("Combined: " + (combined == null ? "(null)" : combined.lineToString()));
+				if (DBG != DbgTimer.INACTIVE) DBG.println("Combined: " + (combined == null ? "(null)" : combined.lineToString()));
 				if (combined == null) {
 					results.add(factory.error(applicator.describeError(rp, ar), ar));
 					continue;

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/DefaultAssemblyResolvedError.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/DefaultAssemblyResolvedError.java
@@ -17,6 +17,8 @@ package ghidra.app.plugin.assembler.sleigh.sem;
 
 import java.util.List;
 
+import ghidra.app.plugin.assembler.sleigh.util.DbgTimer;
+
 /**
  * A {@link AssemblyResolution} indicating the occurrence of a (usually semantic) error
  * 
@@ -53,7 +55,8 @@ public class DefaultAssemblyResolvedError extends AbstractAssemblyResolution
 			String description, List<? extends AssemblyResolution> children,
 			AssemblyResolution right, String error) {
 		super(factory, description, children, right);
-		AbstractAssemblyTreeResolver.DBG.println(error);
+		if (AbstractAssemblyTreeResolver.DBG != DbgTimer.INACTIVE)
+			AbstractAssemblyTreeResolver.DBG.println(error);
 		this.error = error;
 	}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/DefaultAssemblyResolvedPatterns.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/DefaultAssemblyResolvedPatterns.java
@@ -28,6 +28,7 @@ import ghidra.app.plugin.assembler.sleigh.expr.MaskedLong;
 import ghidra.app.plugin.assembler.sleigh.expr.RecursiveDescentSolver;
 import ghidra.app.plugin.assembler.sleigh.sem.AbstractAssemblyResolutionFactory.AbstractAssemblyResolutionBuilder;
 import ghidra.app.plugin.assembler.sleigh.sem.AbstractAssemblyResolutionFactory.AbstractAssemblyResolvedPatternsBuilder;
+import ghidra.app.plugin.assembler.sleigh.util.DbgTimer;
 import ghidra.app.plugin.processors.sleigh.*;
 import ghidra.app.plugin.processors.sleigh.symbol.OperandSymbol;
 import ghidra.app.plugin.processors.sleigh.symbol.SubtableSymbol;
@@ -758,11 +759,11 @@ public class DefaultAssemblyResolvedPatterns extends AbstractAssemblyResolution
 			Set<Integer> printed =
 				Arrays.stream(cons.getOpsPrintOrder()).boxed().collect(Collectors.toSet());
 			if (!(opSym.getDefiningSymbol() instanceof SubtableSymbol)) {
-				AssemblyTreeResolver.DBG.println("Operand " + opSym + " is not a sub-table");
+				if (AssemblyTreeResolver.DBG != DbgTimer.INACTIVE) AssemblyTreeResolver.DBG.println("Operand " + opSym + " is not a sub-table");
 				continue;
 			}
 			if (!printed.contains(opIdx)) {
-				AssemblyTreeResolver.DBG.println("Operand " + opSym + " is hidden");
+				if (AssemblyTreeResolver.DBG != DbgTimer.INACTIVE) AssemblyTreeResolver.DBG.println("Operand " + opSym + " is hidden");
 				continue;
 			}
 			AssemblyResolvedPatterns child = (AssemblyResolvedPatterns) children.get(opIdx);


### PR DESCRIPTION
This is a naive attempt at addressing #8308. By simply commenting out these debug print lines we also prevent their arguments from being computed which makes the assembler 25-40% faster (at least in some use cases). 

There are certainly likely other ways to do this. I am not a Java expert to know if there's something like a `#define` in C which would let us fully disable these lines in a per-compile-configurable way. We could just add an "if" statement around each line, testing what `dbg` is... but that seems a bit messy.  Happy to adjust this to be done some other way if I can be pointed in the right direction! Thanks!