### PR TITLE
Zero extend XCHG on Reg32

### DIFF
--- a/Ghidra/Processors/x86/data/languages/lockable.sinc
+++ b/Ghidra/Processors/x86/data/languages/lockable.sinc
@@ -1245,7 +1245,7 @@
    UNLOCK();
 }
 
-:XCHG^xacq_xrel_prefx^alwaysLock  m32,Reg32   is vexMode=0 & xacq_xrel_prefx & alwaysLock & opsize=1 & byte=0x87; m32 & Reg32 ...        
+:XCHG^xacq_xrel_prefx^alwaysLock  m32,Reg32   is vexMode=0 & xacq_xrel_prefx & alwaysLock & opsize=1 & byte=0x87; m32 & Reg32 ... & check_Reg32_dest        
 { 
   build xacq_xrel_prefx;
   build alwaysLock;


### PR DESCRIPTION
Intel's Software Developer Manual (Vol. 1, Sec. 3.4.1.1):

*"32-bit operands generate a 32-bit result, zero-extended to a 64-bit result in the destination general-purpose register."*