### PR TITLE
Decompiler support for typed pointer offsets

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -5568,6 +5568,7 @@ void ActionDatabase::universalAction(Architecture *conf)
 	actprop2->addRule( new RulePushPtr("typerecovery") );
 	actprop2->addRule( new RuleStructOffset0("typerecovery") );
 	actprop2->addRule( new RulePtrArith("typerecovery") );
+	actprop2->addRule( new RulePtrOffsetArith("typerecovery") );
 	//	actprop2->addRule( new RuleIndirectConcat("analysis") );
 	actprop2->addRule( new RuleLoadVarnode("stackvars") );
 	actprop2->addRule( new RuleStoreVarnode("stackvars") );

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
@@ -183,6 +183,7 @@ bool PrimitiveExtractor::extract(Datatype *dt,int4 max,int4 offset)
     case TYPE_FLOAT:
     case TYPE_PTR:
     case TYPE_PTRREL:
+    case TYPE_PTROFF:
       if (primitives.size() >= max)
 	return false;
       primitives.emplace_back(dt,offset);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -101,6 +101,7 @@ const string PrintC::KEYWORD_DEFAULT = "default";
 const string PrintC::KEYWORD_RETURN = "return";
 const string PrintC::KEYWORD_NEW = "new";
 const string PrintC::typePointerRelToken = "ADJ";
+const string PrintC::typePointerOffToken = "OFF";
 
 // Constructing this registers the capability
 PrintCCapability PrintCCapability::printCCapability;
@@ -882,10 +883,17 @@ void PrintC::opPtradd(const PcodeOp *op)
 {
   bool printval = isSet(print_load_value|print_store_value);
   uint4 m = mods & ~(print_load_value|print_store_value);
-  if (printval)			// Use array notation if we need value
-    pushOp(&subscript,op);
-  else				// just a '+'
-    pushOp(&binary_plus,op);
+  TypePointerOff *offptr = TypeOpPtradd::getPointerOffsetType(op);
+  if (offptr) {
+    pushOp(&function_call,op);
+    pushAtom(Atom(typePointerOffToken,optoken,EmitMarkup::funcname_color,op));
+    pushOp(&comma,(const PcodeOp *)0);
+  } else {
+    if (printval)                       // Use array notation if we need value
+      pushOp(&subscript,op);
+    else                                // just a '+'
+      pushOp(&binary_plus,op);
+  }
   // implied vn's pushed on in reverse order for efficiency
   // see PrintLanguage::pushVnImplied
   pushVn(op->getIn(1),op,m);
@@ -905,7 +913,10 @@ static bool isValueFlexible(const Varnode *vn)
       opc = invn->getDef()->code();
     }
     if (opc == CPUI_PTRSUB) return true;
-    if (opc == CPUI_PTRADD) return true;
+    if (opc == CPUI_PTRADD) {
+      if (TypeOpPtradd::getPointerOffsetType(def)) return false;
+      return true;
+    }
   }
   return false;
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.hh
@@ -142,6 +142,7 @@ public:
   static const string KEYWORD_RETURN;	///< "return" keyword
   static const string KEYWORD_NEW;	///< "new" keyword
   static const string typePointerRelToken;	///< The token to print indicating PTRSUB relative to a TypePointerRel
+  static const string typePointerOffToken;	///< The token to print indicating PTRADD+PTRSUB relative to a TypePointerOff
 protected:
   bool option_NULL;		///< Set to \b true if we should emit NULL keyword
   bool option_inplace_ops;	///< Set to \b true if we should use '+=' '&=' etc.

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
@@ -1069,6 +1069,16 @@ public:
   virtual int4 applyOp(PcodeOp *op,Funcdata &data);
   static int4 evaluatePointerExpression(PcodeOp *op,int4 slot);
 };
+class RulePtrOffsetArith : public Rule {
+public:
+  RulePtrOffsetArith(const string &g) : Rule(g, 0, "ptroffsetarith") {}	///< Constructor
+  virtual Rule *clone(const ActionGroupList &grouplist) const {
+    if (!grouplist.contains(getGroup())) return (Rule *)0;
+    return new RulePtrOffsetArith(getGroup());
+  }
+  virtual void getOpList(vector<uint4> &oplist) const;
+  virtual int4 applyOp(PcodeOp *op,Funcdata &data);
+};
 class RuleStructOffset0 : public Rule {
 public:
   RuleStructOffset0(const string &g) : Rule(g, 0, "structoffset0") {}	///< Constructor

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.hh
@@ -77,17 +77,18 @@ extern void print_data(ostream &s,uint1 *buffer,int4 size,const Address &baseadd
 /// The core meta-types supported by the decompiler. These are sizeless templates
 /// for the elements making up the type algebra.  Index is important for Datatype::base2sub array.
 enum type_metatype {
-  TYPE_VOID = 17,		///< Standard "void" type, absence of type
-  TYPE_SPACEBASE = 16,		///< Placeholder for symbol/type look-up calculations
-  TYPE_UNKNOWN = 15,		///< An unknown low-level type. Treated as an unsigned integer.
-  TYPE_INT = 14,		///< Signed integer. Signed is considered less specific than unsigned in C
-  TYPE_UINT = 13,		///< Unsigned integer
-  TYPE_BOOL = 12,		///< Boolean
-  TYPE_CODE = 11,		///< Data is actual executable code
-  TYPE_FLOAT = 10,		///< Floating-point
+  TYPE_VOID = 18,		///< Standard "void" type, absence of type
+  TYPE_SPACEBASE = 17,		///< Placeholder for symbol/type look-up calculations
+  TYPE_UNKNOWN = 16,		///< An unknown low-level type. Treated as an unsigned integer.
+  TYPE_INT = 15,		///< Signed integer. Signed is considered less specific than unsigned in C
+  TYPE_UINT = 14,		///< Unsigned integer
+  TYPE_BOOL = 13,		///< Boolean
+  TYPE_CODE = 12,		///< Data is actual executable code
+  TYPE_FLOAT = 11,		///< Floating-point
 
-  TYPE_PTR = 9,			///< Pointer data-type
-  TYPE_PTRREL = 8,		///< Pointer relative to another data-type (specialization of TYPE_PTR)
+  TYPE_PTR = 10,			///< Pointer data-type
+  TYPE_PTRREL = 9,		///< Pointer relative to another data-type (specialization of TYPE_PTR)
+  TYPE_PTROFF = 8,
   TYPE_ARRAY = 7,		///< Array data-type, made up of a sequence of "element" datatype
   TYPE_ENUM_UINT = 6,		///< Unsigned enumeration data-type (specialization of TYPE_UINT)
   TYPE_ENUM_INT = 5,		///< Signed enumeration data-type (specialization of TYPE_INT)
@@ -101,24 +102,26 @@ enum type_metatype {
 /// Specializations of the core meta-types.  Each enumeration is associated with a specific #type_metatype.
 /// Ordering is important: The lower the number, the more \b specific the data-type, affecting propagation.
 enum sub_metatype {
-  SUB_VOID = 23,		///< Compare as a TYPE_VOID
-  SUB_SPACEBASE = 22,		///< Compare as a TYPE_SPACEBASE
-  SUB_UNKNOWN = 21,		///< Compare as a TYPE_UNKNOWN
-  SUB_PARTIALSTRUCT = 20,	///< Compare as TYPE_PARTIALSTRUCT
-  SUB_INT_CHAR = 19,		///< Signed 1-byte character, sub-type of TYPE_INT
-  SUB_UINT_CHAR = 18,		///< Unsigned 1-byte character, sub-type of TYPE_UINT
-  SUB_INT_PLAIN = 17,		///< Compare as a plain TYPE_INT
-  SUB_UINT_PLAIN = 16,		///< Compare as a plain TYPE_UINT
-  SUB_INT_ENUM = 15,		///< Signed enum, sub-type of TYPE_INT
-  SUB_UINT_PARTIALENUM = 14,	///< Unsigned partial enum, sub-type of TYPE_UINT
-  SUB_UINT_ENUM = 13,		///< Unsigned enum, sub-type of TYPE_UINT
-  SUB_INT_UNICODE = 12,		///< Signed wide character, sub-type of TYPE_INT
-  SUB_UINT_UNICODE = 11,	///< Unsigned wide character, sub-type of TYPE_UINT
-  SUB_BOOL = 10,		///< Compare as TYPE_BOOL
-  SUB_CODE = 9,			///< Compare as TYPE_CODE
-  SUB_FLOAT = 8,		///< Compare as TYPE_FLOAT
-  SUB_PTRREL_UNK = 7,		///< Pointer to unknown field of struct, sub-type of TYPE_PTR
-  SUB_PTR = 6,			///< Compare as TYPE_PTR
+  SUB_VOID = 25,		///< Compare as a TYPE_VOID
+  SUB_SPACEBASE = 24,		///< Compare as a TYPE_SPACEBASE
+  SUB_UNKNOWN = 23,		///< Compare as a TYPE_UNKNOWN
+  SUB_PARTIALSTRUCT = 22,	///< Compare as TYPE_PARTIALSTRUCT
+  SUB_INT_CHAR = 21,		///< Signed 1-byte character, sub-type of TYPE_INT
+  SUB_UINT_CHAR = 20,		///< Unsigned 1-byte character, sub-type of TYPE_UINT
+  SUB_INT_PLAIN = 19,		///< Compare as a plain TYPE_INT
+  SUB_UINT_PLAIN = 18,		///< Compare as a plain TYPE_UINT
+  SUB_INT_ENUM = 17,		///< Signed enum, sub-type of TYPE_INT
+  SUB_UINT_PARTIALENUM = 16,	///< Unsigned partial enum, sub-type of TYPE_UINT
+  SUB_UINT_ENUM = 15,		///< Unsigned enum, sub-type of TYPE_UINT
+  SUB_INT_UNICODE = 14,		///< Signed wide character, sub-type of TYPE_INT
+  SUB_UINT_UNICODE = 13,	///< Unsigned wide character, sub-type of TYPE_UINT
+  SUB_BOOL = 12,		///< Compare as TYPE_BOOL
+  SUB_CODE = 11,			///< Compare as TYPE_CODE
+  SUB_FLOAT = 10,		///< Compare as TYPE_FLOAT
+  SUB_PTROFF_UNK = 9,
+  SUB_PTRREL_UNK = 8,		///< Pointer to unknown field of struct, sub-type of TYPE_PTR
+  SUB_PTR = 7,			///< Compare as TYPE_PTR
+  SUB_PTROFF = 6,
   SUB_PTRREL = 5,		///< Pointer relative to another data-type, sub-type of TYPE_PTR
   SUB_PTR_STRUCT = 4,		///< Pointer into struct, sub-type of TYPE_PTR
   SUB_ARRAY = 3,		///< Compare as TYPE_ARRAY
@@ -164,7 +167,7 @@ struct DatatypeCompare;
 /// Used for symbols, function prototypes, type propagation etc.
 class Datatype {
 protected:
-  static sub_metatype base2sub[18];
+  static sub_metatype base2sub[19];
   /// Boolean properties of datatypes
   enum {
     coretype = 1,		///< This is a basic type which will never be redefined
@@ -247,6 +250,8 @@ public:
   virtual Datatype *getSubType(int8 off,int8 *newoff) const; ///< Recover component data-type one-level down
   virtual Datatype *nearestArrayedComponentForward(int8 off,int8 *newoff,int8 *elSize) const;
   virtual Datatype *nearestArrayedComponentBackward(int8 off,int8 *newoff,int8 *elSize) const;
+
+  virtual bool isPointerOff(void) const { return false; }
 
   /// \brief Get number of bytes at the given offset that are padding
   ///
@@ -682,6 +687,30 @@ public:
   virtual bool isPtrsubMatching(int8 off,int8 extra,int8 multiplier) const;
   virtual Datatype *getStripped(void) const { return stripped; }	///< Get the plain form of the pointer
   static Datatype *getPtrToFromParent(Datatype *base,int4 off,TypeFactory &typegrp);
+};
+
+/// \brief Typed offset from BaseType to FieldType.
+///
+/// Adding a typed offset and a pointer of the offset's base type yields a new
+/// pointer of the offset's field type.
+class TypePointerOff : public TypePointer {
+protected:
+  friend class TypeFactory;
+  Datatype *ptrfrom;
+  TypePointer *plain;
+  void decode(Decoder &decoder,TypeFactory &typegrp);	///< Restore \b this pointer data-type from a stream
+  /// Internal constructor for decode
+  TypePointerOff(void) : TypePointer() { ptrfrom = (Datatype *)0; plain = (TypePointer *)0; submeta = SUB_PTROFF; }
+public:
+  /// Construct from another TypePointerOff
+  TypePointerOff(const TypePointerOff &op) : TypePointer((const TypePointer &)op) {
+    ptrfrom = op.ptrfrom; plain = op.plain; }
+
+  virtual Datatype *clone(void) const { return new TypePointerOff(*this); }
+  virtual Datatype *getStripped(void) const { return (Datatype*)0; }
+  TypePointer *getPlain(void) const { return plain; }
+  Datatype *getPtrFrom(void) const { return ptrfrom; }
+  virtual bool isPointerOff(void) const { return true; }
 };
 
 class FuncProto;		// Forward declaration

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.cc
@@ -2215,6 +2215,10 @@ TypeOpPtradd::TypeOpPtradd(TypeFactory *t) : TypeOp(t,CPUI_PTRADD,"+")
 Datatype *TypeOpPtradd::getInputLocal(const PcodeOp *op,int4 slot) const
 
 {
+  if (slot == 1) {
+    TypePointerOff *offptr = getPointerOffsetType(op);
+    if (offptr) return offptr;
+  }
   return tlst->getBase(op->getIn(slot)->getSize(),TYPE_INT);	// For type propagation, treat same as INT_ADD
 }
 
@@ -2227,6 +2231,8 @@ Datatype *TypeOpPtradd::getOutputLocal(const PcodeOp *op) const
 Datatype *TypeOpPtradd::getOutputToken(const PcodeOp *op,CastStrategy *castStrategy) const
 
 {
+  TypePointerOff *offptr = getPointerOffsetType(op);
+  if (offptr) return offptr->getPlain();
   return op->getIn(0)->getHighTypeReadFacing(op);		// Cast to the input data-type
 }
 
@@ -2255,6 +2261,16 @@ Datatype *TypeOpPtradd::propagateType(Datatype *alttype,PcodeOp *op,Varnode *inv
   else
     newtype = TypeOpIntAdd::propagateAddIn2Out(alttype,tlst,op,inslot);
   return newtype;
+}
+
+TypePointerOff *TypeOpPtradd::getPointerOffsetType(const PcodeOp *op) {
+  Datatype *base = op->getIn(0)->getTypeReadFacing(op);
+  Datatype *off = op->getIn(1)->getTypeReadFacing(op);
+  if (!off->isPointerOff() || base->getMetatype() != TYPE_PTR) return nullptr;
+  TypePointer *baseptr = (TypePointer*)base;
+  TypePointerOff *offptr = (TypePointerOff*)off;
+  if (baseptr->getPtrTo() != offptr->getPtrFrom()) return nullptr;
+  return offptr;
 }
 
 void TypeOpPtradd::printRaw(ostream &s,const PcodeOp *op)

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/typeop.hh
@@ -809,6 +809,7 @@ public:
   virtual Datatype *getInputCast(const PcodeOp *op,int4 slot,const CastStrategy *castStrategy) const;
   virtual Datatype *propagateType(Datatype *alttype,PcodeOp *op,Varnode *invn,Varnode *outvn,
 				  int4 inslot,int4 outslot);
+  static TypePointerOff *getPointerOffsetType(const PcodeOp *op);
   virtual void push(PrintLanguage *lng,const PcodeOp *op,const PcodeOp *readOp) const { lng->opPtradd(op); }
   virtual void printRaw(ostream &s,const PcodeOp *op);
 };


### PR DESCRIPTION
This adds a new `ptroff` metatype to the decompiler, which represents a typed pointer offset.

Given the following type definition:

```xml
<type metatype="ptroff" name="child-vtable-to-parent-a" id="0x1234500001" size="8">
  <typeref name="Child" id="0x100000000000015"/>
  <typeref name="Parent_A" id="0x100000000000013"/>
</type>
```

A `PTRADD(0: Child*, 1: child-vtable-to-parent-a)` op will have an output type of `Parent_A*`.

The new type allows the decompiler to better handle runtime field lookups, as seen in (for example) C++ virtual inheritance. More details and motivation in issue <https://github.com/NationalSecurityAgency/ghidra/issues/5855>.

Output of current `master/HEAD`:
```c
int __thiscall Child::Caller(Child *this)

{
  int iVar1;
  int iVar2;

  iVar1 = *(int *)(&this->field_0x8 + ADJ(this->vtable)->as_Parent_B);
  iVar2 = Parent_A::Callee_A((Parent_A *)((long)&this->vtable + ADJ(this->vtable)->as_Parent_A));
  return iVar2 + iVar1;
}
```

Output with typed pointer offsets -- note how the `parent_b_data` field is now correctly resolved relative to the offset target type:
```c
int __thiscall Child::Caller(Child *this)

{
  int iVar1;
  int iVar2;

  iVar1 = OFF(this,ADJ(this->vtable)->as_Parent_B)->parent_b_data[0];
  iVar2 = Parent_A::Callee_A(OFF(this,ADJ(this->vtable)->as_Parent_A));
  return iVar2 + iVar1;
}
```
