### PR TITLE
Fix #8362: Set correct WM_CLASS for PyGhidra (ghidra-Ghidra window name)

### DIFF
--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/ghidra_launch.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/ghidra_launch.py
@@ -37,14 +37,14 @@ class GhidraLauncher(PyGhidraLauncher):
             if sys.platform == "win32":
                 appid = ctypes.c_wchar_p(self.app_info.name)
                 ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)  # @UndefinedVariable
-            Thread(lambda: Ghidra.main([self._class_name, *self.args])).start()
+            Thread(lambda: Ghidra.main(["ghidra.Ghidra", self._class_name, *self.args])).start()
             is_exiting = threading.Event()
             Runtime.getRuntime().addShutdownHook(Thread(is_exiting.set))
             if sys.platform == "darwin":
                 _run_mac_app()
             is_exiting.wait()
         else:
-            Ghidra.main([self._class_name, *self.args])
+            Ghidra.main(["ghidra.Ghidra", self._class_name, *self.args])
 
 
 class ParsedArgs(argparse.Namespace):


### PR DESCRIPTION
- Modified PyGhidra launcher to use ghidra.Ghidra as main class
- This ensures WM_CLASS is set to 'ghidra-Ghidra' instead of 'java-lang-Thread'
- Fixes issue where PyGhidra bypassed the WM_CLASS setting mechanism