### PR TITLE
Use L as a default shortcut for renaming symbols in symbol tree

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/actions/RenameAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/actions/RenameAction.java
@@ -27,7 +27,7 @@ public class RenameAction extends SymbolTreeContextAction {
 		super("Rename Symbol", plugin.getName());
 		setPopupMenuData(
 			new MenuData(new String[] { "Rename" }, null, "xxx", MenuData.NO_MNEMONIC, "1"));
-		setKeyBindingData(new KeyBindingData(KeyEvent.VK_L, 0));
+		setKeyBindingData(new KeyBindingData("L"));
 	}
 
 	@Override

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/actions/RenameAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/actions/RenameAction.java
@@ -27,6 +27,7 @@ public class RenameAction extends SymbolTreeContextAction {
 		super("Rename Symbol", plugin.getName());
 		setPopupMenuData(
 			new MenuData(new String[] { "Rename" }, null, "xxx", MenuData.NO_MNEMONIC, "1"));
+		setKeyBindingData(new KeyBindingData(KeyEvent.VK_L, 0));
 	}
 
 	@Override


### PR DESCRIPTION
This new shortcut follows adds a missing one to rename symbols. It uses the same key as other renaming operations for consistency.