### PR TITLE
Don't rewrite SBORROW(0, x) => 0

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/util/state/ResultsState.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/state/ResultsState.java
@@ -1090,12 +1090,16 @@ public class ResultsState {
 				return eillimnateCarryOp(pcodeOp, values, addrFactory, monitor);
 
 			case PcodeOp.INT_SCARRY:  		// TRUE if carry in signed addition of 2 ops 
+				if ((values[1].isConstant() && values[1].getOffset() == 0) ||
+					(values[0].isConstant() && values[0].getOffset() == 0)) {
+					result = new Varnode(addrFactory.getConstantAddress(0), 1);
+				}
+				break;
 
 // TODO: Implement constant case
 
 			case PcodeOp.INT_SBORROW:  		// TRUE if borrow in signed subtraction of 2 ops 
-				if ((values[1].isConstant() && values[1].getOffset() == 0) ||
-					(values[0].isConstant() && values[0].getOffset() == 0)) {
+				if (values[1].isConstant() && values[1].getOffset() == 0) {
 					result = new Varnode(addrFactory.getConstantAddress(0), 1);
 				}
 				break;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -3362,8 +3362,7 @@ int4 RuleSborrow::applyOp(PcodeOp *op,Funcdata &data)
   int4 zside;
 
 				// Check for trivial case
-  if ((op->getIn(1)->isConstant()&&op->getIn(1)->getOffset()==0)||
-      (op->getIn(0)->isConstant()&&op->getIn(0)->getOffset()==0)) {
+  if (op->getIn(1)->isConstant()&&op->getIn(1)->getOffset()==0) {
     data.opSetOpcode(op,CPUI_COPY);
     data.opSetInput(op,data.newConstant(1,0),0);
     data.opRemoveInput(op,1);


### PR DESCRIPTION
This optimization is unsound if x is the minimum signed integer value (of the appropriate width) - see #8396.

Only the change in `ruleaction.cc` seems to be needed to fix the bug, but I found the same logic in `ResultsState.java`, so I fixed both.

This doesn't look like it broke any tests, but I couldn't get some of the tests to run (because of missing dependencies, missing test data, etc).