### PR TITLE
BSim: Remove extra characters in CommandLineReference.html

### DIFF
--- a/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
+++ b/Ghidra/Features/BSim/src/main/help/help/topics/BSim/CommandLineReference.html
@@ -267,7 +267,7 @@
 <PRE>
 <CODE class&nbsp;"computeroutput">
     bsim createdatabase  &lt;bsimURL&gt; &lt;config_template&gt; [--name|-n&nbsp;"&lt;name&gt;"] [--owner|-o&nbsp;"&lt;owner&gt;"] [--description|-d&nbsp;"&lt;text&gt;"] [--nocallgraph]
-    bsim setmetadata     &lt;bsimURL&gt; [--name|-n&nbsp;"&lt;name&gt;"] [--owner|-o&nbsp;"&lt;owner&gt;"] [--description|-d&nbsp;"&lt;text&gt;"]\n" + 
+    bsim setmetadata     &lt;bsimURL&gt; [--name|-n&nbsp;"&lt;name&gt;"] [--owner|-o&nbsp;"&lt;owner&gt;"] [--description|-d&nbsp;"&lt;text&gt;"]
     bsim getmetadata     &lt;bsimURL&gt;
     bsim addexecategory  &lt;bsimURL&gt; &lt;category_name&gt; [--date]
     bsim addfunctiontag  &lt;bsimURL&gt; &lt;tag_name&gt;


### PR DESCRIPTION
Fixing a simple copy-paste error.