### PR TITLE
[BitmapResource] Fix channel swaped and black icons

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/BitmapResource.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/BitmapResource.java
@@ -334,7 +334,7 @@ public class BitmapResource {
 		// create the color model
 		ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_sRGB);
 		int[] nBits = { 8, 8, 8, 8 };
-		int[] bOffs = { 0, 1, 2, 3 };
+		int[] bOffs = { 2, 1, 0, 3 };
 		ColorModel colorModel =
 			new ComponentColorModel(cs, nBits, true, false, Transparency.TRANSLUCENT,
 				DataBuffer.TYPE_BYTE);
@@ -422,11 +422,14 @@ public class BitmapResource {
 	 */
 	protected DataImage getOnePlaneImage(MemBuffer buf) {
 		// create the color model
+		int[] colormapData = getRGBData(buf);
+		IndexColorModel model =
+			new IndexColorModel(1, getClrUsed(), colormapData, 0, false, -1, DataBuffer.TYPE_BYTE);
 
 		// create the image
 
 		BufferedImage image =
-			new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_BYTE_BINARY);
+			new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_BYTE_BINARY, model);
 		byte[] dbuf = ((DataBufferByte) image.getRaster().getDataBuffer()).getData();
 		getPixelData(buf, dbuf);
 		return new BitmapDataImage(image);


### PR DESCRIPTION
Fixes #436

Icons that take the [`getOnePlaneImage`](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/BitmapResource.java#L425) path do not have their color map considered and appear black. Icons that take the [`get32PlaneImage`](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/BitmapResource.java#L337) path have their red and blue channels swapped; the swapping is done properly for [`get18PlaneImage`](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/BitmapResource.java#L364).

I made a sample executable with different icons of varying colors and bit depth to test with: https://github.com/widberg/ghidra-icon-resource-test/releases/download/v0.2.0/MyApp.exe. The `*_1bpp_1a_2p` icons are black, and the `*_32bpp_8a_0p` icons have the red and blue channels swapped. The PNG icons (`_c`) and icons with other bit depths are fine and can be used as a reference for how the icons are supposed to appear.

This change makes the icons appear in Ghidra as they do in Resource Hacker and GIMP.