### PR TITLE
[docs] Remove references to `rom_space`

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
+++ b/Ghidra/Features/Decompiler/src/main/doc/sleigh.xml
@@ -696,7 +696,7 @@ and <emphasis>attributes</emphasis> looks like zero or more of the
 following lines:
 <informalexample>
 <programlisting>
-type=(ram_space|rom_space|register_space)
+type=(ram_space|register_space)
 size=<emphasis role="bold">integer</emphasis>
 default
 wordsize=<emphasis role="bold">integer</emphasis>
@@ -756,11 +756,6 @@ with <emphasis role="bold">register_space</emphasis>.
   </listitem>
 </itemizedlist>
 </informalexample>
-</para>
-<para>
-A space of type <emphasis role="bold">rom_space</emphasis> has seen
-little use so far but is intended to be the same as
-a <emphasis role="bold">ram_space</emphasis> that is not writable.
 </para>
 <para>
 At least one space needs to be labeled with

--- a/GhidraDocs/languages/html/sleigh_definitions.html
+++ b/GhidraDocs/languages/html/sleigh_definitions.html
@@ -86,7 +86,7 @@ and <span class="emphasis"><em>attributes</em></span> looks like zero or more of
 following lines:
 </p>
 <div class="informalexample"><pre class="programlisting">
-type=(ram_space|rom_space|register_space)
+type=(ram_space|register_space)
 size=<span class="bold"><strong>integer</strong></span>
 default
 wordsize=<span class="bold"><strong>integer</strong></span>
@@ -146,11 +146,6 @@ with <span class="bold"><strong>register_space</strong></span>.
   </li>
 </ul></div></div>
 <p>
-</p>
-<p>
-A space of type <span class="bold"><strong>rom_space</strong></span> has seen
-little use so far but is intended to be the same as
-a <span class="bold"><strong>ram_space</strong></span> that is not writable.
 </p>
 <p>
 At least one space needs to be labeled with


### PR DESCRIPTION
This PR removes references to a nonexistent space type `rom_space` in the Sleigh docs. All lines mentioning it come from the candidate release commit, so I'm guessing that if it did exist, it was removed before that, and the documentation wasn't updated.

This has caused some confusion (ctrl-f "rom_space"):
* https://github.com/NationalSecurityAgency/ghidra/issues/8382
* https://github.com/NationalSecurityAgency/ghidra/discussions/5144
* https://github.com/NationalSecurityAgency/ghidra/pull/7511