### PR TITLE
fix(doc): Program names in README

### DIFF
--- a/GhidraDocs/GettingStarted.md
+++ b/GhidraDocs/GettingStarted.md
@@ -216,7 +216,7 @@ binaries for your platform, you will need the following installed on your system
     App Store while _Command Line Tools for Xcode_ may be installed using the command:
     `xcode-select --install`.
   * __Linux/FreeBSD:__ the 64-bit versions of the following packages should installed:
-    * gcc/g++ or clang
+    * GCC or Clang
     * make
   * __Windows:__
       [Microsoft Visual Studio](https://visualstudio.microsoft.com/vs/community) 2017 or later, or 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To create the latest development build for your platform from this source reposi
 * [JDK 21 64-bit][jdk]
 * [Gradle 8.5+][gradle] (or provided Gradle wrapper if Internet connection is available)
 * [Python3][python3] (version 3.9 to 3.13) with bundled pip
-* make, GCC or Clang (Linux/macOS-only)
+* GCC or Clang, and make (Linux/macOS-only)
 * [Microsoft Visual Studio][vs] 2017+ or [Microsoft C++ Build Tools][vcbuildtools] with the
   following components installed (Windows-only):
   - MSVC


### PR DESCRIPTION
The rest of the build dependencies/programs are named by their official names, with the exception of the Linux and macOS dependencies/programs; instead, they use their command names. For consistency across the documentation, it makes sense to use the actual names rather than the command names.

`g++` is also included in GCC, so it can be omitted in the context of this change.