### PR TITLE
Fix off-by-one in ElfHeader.getSectionLoadHeaderContaining

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java
@@ -1606,14 +1606,13 @@ public class ElfHeader implements StructConverter {
 	 * @return the section header that contains the address
 	 */
 	public ElfSectionHeader getSectionLoadHeaderContaining(long address) {
-// FIXME: verify 
 		for (ElfSectionHeader sectionHeader : sectionHeaders) {
 			if (!sectionHeader.isAlloc()) {
 				continue;
 			}
 			long start = sectionHeader.getAddress();
 			long end = start + sectionHeader.getSize();
-			if (start <= address && address <= end) {
+			if (start <= address && address < end) {
 				return sectionHeader;
 			}
 		}


### PR DESCRIPTION
**Description:**
The method getSectionLoadHeaderContaining in /ghidra/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfHeader.java checks whether a given address belongs to a section using:
```if (start <= address && address <= end)```

```java
public ElfSectionHeader getSectionLoadHeaderContaining(long address) {
    // FIXME: verify 
    for (ElfSectionHeader sectionHeader : sectionHeaders) {
        if (!sectionHeader.isAlloc()) {
            continue;
        }
        long start = sectionHeader.getAddress();
        long end = start + sectionHeader.getSize();
        if (start <= address && address <= end) { // <-- bug here
            return sectionHeader;
        }
    }
    return null;
}
```


Here, `end` is computed as `start + size`. This value represents the first address after the section,
so it should not be considered part of the section. The valid address range is `[start, end)`,
meaning the last valid address is `end - 1`

**Bug:**
Using `address <= end` incorrectly matches the address at exactly end as being inside the section,
even though it lies just past the section boundary.

**Fix:**
```java
public ElfSectionHeader getSectionLoadHeaderContaining(long address) {
    for (ElfSectionHeader sectionHeader : sectionHeaders) {
        if (!sectionHeader.isAlloc()) {
            continue;
        }
        long start = sectionHeader.getAddress();
        long end = start + sectionHeader.getSize();
        if (start <= address && address < end) { // fixed off-by-one
            return sectionHeader;
        }
    }
    return null;
}
```
- Updated the comparison to use `address < end` to correctly reflect the section bounds and prevent off-by-one inclusion.
- Removed `FIXME: verify` comment that was no longer needed.

**Testing:**
Ran `gradle Base:test` successfully to verify that no tests are broken.