### PR TITLE
[fix] add support for little endian `VariableStorage`

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/VariableStorage.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/VariableStorage.java
@@ -431,14 +431,24 @@ public class VariableStorage implements Comparable<VariableStorage> {
 	 * @return first varnode within the ordered list of varnodes
 	 */
 	public Varnode getFirstVarnode() {
-		return (varnodes == null || varnodes.length == 0) ? null : varnodes[0];
+		Language language = programArch == null ? null : programArch.getLanguage();
+		if (language != null && !language.isBigEndian()) {
+			return (varnodes == null || varnodes.length == 0) ? null : varnodes[varnodes.length - 1];
+		} else {
+			return (varnodes == null || varnodes.length == 0) ? null : varnodes[0];
+		}
 	}
 
 	/**
 	 * @return last varnode within the ordered list of varnodes
 	 */
 	public Varnode getLastVarnode() {
-		return (varnodes == null || varnodes.length == 0) ? null : varnodes[varnodes.length - 1];
+		Language language = programArch == null ? null : programArch.getLanguage();
+		if (language != null && !language.isBigEndian()) {
+			return (varnodes == null || varnodes.length == 0) ? null : varnodes[0];
+		} else {
+			return (varnodes == null || varnodes.length == 0) ? null : varnodes[varnodes.length - 1];
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/ghidra/issues/8377

Allows `VariableStorage` to deal with little endian variable thus avoiding error around mixed space variable (e.g. register and stack) like: `Storage does not have a stack varnode`.

This fix checks if a language is linked to a variable and treats the variable accordingly to its specified endianess. Otherwise the variable is treated as big endian.