### PR TITLE
Fix: TaintAnalysis query use chosen file if none set in tool options

### DIFF
--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/taint/AngrTaintState.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/taint/AngrTaintState.java
@@ -55,10 +55,10 @@ public class AngrTaintState extends AbstractTaintState {
 	private Address start;
 
 	@Override
-	public void buildQuery(List<String> paramList, Path engine, File indexDBFile,
+	public void buildQuery(List<String> paramList, String engine_path, File indexDBFile,
 			String indexDirectory) {
 		paramList.add("python");
-		paramList.add(engine.toString());
+		paramList.add(engine_path);
 	}
 
 	@Override

--- a/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/plugin/core/decompiler/taint/AbstractTaintState.java
+++ b/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/plugin/core/decompiler/taint/AbstractTaintState.java
@@ -67,7 +67,7 @@ public abstract class AbstractTaintState implements TaintState {
 		this.plugin = plugin;
 	}
 
-	public abstract void buildQuery(List<String> param_list, Path engine, File indexDBFile,
+	public abstract void buildQuery(List<String> param_list, String engine_path, File indexDBFile,
 			String index_directory);
 
 	@Override
@@ -296,7 +296,7 @@ public abstract class AbstractTaintState implements TaintState {
 					plugin.consoleMessage("Unknown query type.");
 			}
 
-			buildQuery(paramList, engine, indexDBFile, indexDirectory.toString());
+			buildQuery(paramList, engineFile.toString(), indexDBFile, indexDirectory.toString());
 
 			if (queryType.equals(QueryType.SRCSINK) || queryType.equals(QueryType.CUSTOM)) {
 				// The datalog that specifies the query.

--- a/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/plugin/core/decompiler/taint/CreateTargetIndexTask.java
+++ b/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/plugin/core/decompiler/taint/CreateTargetIndexTask.java
@@ -125,7 +125,7 @@ public class CreateTargetIndexTask extends Task {
 			engineFile = getFilePath(enginePathName, "Select the engine binary");
 		}
 
-		consoleService.addMessage("Create Index", "using engine at: " + enginePath.toString());
+		consoleService.addMessage("Create Index", "using engine at: " + engineFile.toString());
 
 		Path factsPath = Path.of(factsDirectory);
 

--- a/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/plugin/core/decompiler/taint/ctadl/CTADLTaintState.java
+++ b/Ghidra/Features/DecompilerDependent/src/main/java/ghidra/app/plugin/core/decompiler/taint/ctadl/CTADLTaintState.java
@@ -42,9 +42,9 @@ public class CTADLTaintState extends AbstractTaintState {
 	}
 
 	@Override
-	public void buildQuery(List<String> paramList, Path engine, File indexDBFile,
+	public void buildQuery(List<String> paramList, String engine_path, File indexDBFile,
 			String indexDirectory) {
-		paramList.add(engine.toString());
+		paramList.add(engine_path);
 		paramList.add("--directory");
 		paramList.add(indexDirectory);
 		paramList.add("query");


### PR DESCRIPTION
These changes work on a fresh build, but if you would like to test, please see #8452 for the testing steps.

Changes:
- `buildQuery` in the `TaintState` classes now receives a `String engine_path` instead of a `Path engine`
- `queryIndex` now passes `engineFile.toString()` to `buildQuery` to pass chosen file
- Logging in `CreateTargetIndexTask` has been updated to `engineFile` instead of `enginePath` to pass chosen file