### PR TITLE
Improve the ExportToHeader action

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AbstractFloatDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/AbstractFloatDataType.java
@@ -210,8 +210,8 @@ public abstract class AbstractFloatDataType extends BuiltIn {
 	@Override
 	public String getCTypeDeclaration(DataOrganization dataOrganization) {
 		// NOTE: There are a variety of naming conventions for fixed-length floats
-		// so we will just use our name and rely on user to edit to suit there needs.
-		return hasLanguageDependantLength() ? null : name;
+		// so we will just not provide a declaration and rely on the user to declare their own.
+		return null;
 	}
 
 	private static TreeMap<Integer, AbstractFloatDataType> floatTypes; // fixed-size float types

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/BooleanDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/BooleanDataType.java
@@ -75,8 +75,7 @@ public class BooleanDataType extends AbstractUnsignedIntegerDataType {
 	public Object getValue(MemBuffer buf, Settings settings, int length) {
 		try {
 			return buf.getByte(0) != 0;
-		}
-		catch (MemoryAccessException e) {
+		} catch (MemoryAccessException e) {
 			return null;
 		}
 	}
@@ -118,6 +117,15 @@ public class BooleanDataType extends AbstractUnsignedIntegerDataType {
 	public AbstractIntegerDataType getOppositeSignednessDataType() {
 		// TODO: only unsigned supported
 		return this;
+	}
+
+	private static final String EOL = System.getProperty("line.separator");
+
+	@Override
+	public String getCTypeDeclaration(DataOrganization dataOrganization) {
+		// In C++ and C23 and onwards bool is no longer a type that has to be declared first.
+		String declaration = super.getCTypeDeclaration(dataOrganization);
+		return "#if !defined(__cplusplus) && __STDC_VERSION__ < 202311L" + EOL + declaration + EOL + "#endif";
 	}
 
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DataTypeWriter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/DataTypeWriter.java
@@ -452,6 +452,8 @@ public class DataTypeWriter {
 		String compositeType = composite instanceof Structure ? "struct" : "union";
 
 		StringBuilder sb = new StringBuilder();
+		sb.append("#pragma pack(push, 1)").append(EOL);
+
 		sb.append(compositeType + " " + composite.getDisplayName() + " {");
 
 		String descrip = composite.getDescription();
@@ -466,7 +468,8 @@ public class DataTypeWriter {
 		}
 
 		sb.append(annotator.getSuffix(composite, null));
-		sb.append("};");
+		sb.append("};").append(EOL);
+		sb.append("#pragma pack(pop)").append(EOL);
 
 		writer.write(sb.toString());
 		writer.write(EOL);

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/FloatDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/FloatDataType.java
@@ -47,6 +47,11 @@ public class FloatDataType extends AbstractFloatDataType {
 	}
 
 	@Override
+	public String getCTypeDeclaration(DataOrganization dataOrganization) {
+		return null; // Standard C primitive
+	}
+
+	@Override
 	public boolean hasLanguageDependantLength() {
 		return true;
 	}


### PR DESCRIPTION
I recently wanted to make a cheat for a video game for educational purposes and the lolz of course.
I decided that I want to use Ghidras type system more than I used to, but realized that the ExportToHeaderAction has several flaws, for one there was a bogus float16 "declaration"
<img width="1504" height="240" alt="image" src="https://github.com/user-attachments/assets/801656cf-9eee-4d00-a278-3250846f405a" />
Bool was redefined and that made my C++ compiler unhappy and even a modern C23 compiler would choke on this
<img width="1474" height="128" alt="image" src="https://github.com/user-attachments/assets/c6fe2cf1-1a4d-4339-be5b-42de6af498f4" />
and by far the most annoying problem: structs were not packed.
This actually caused some frustration when I didn't realize why the offsets were different to what Ghidra reported.

These commits should fix these problems.
Bool is now only declared if you use an old C compiler.
Fixed-size floats are not redeclared at all, a comment correctly stated that the declaration is different on each platform, however it still emitted the name as the declaration which caused the bogus float16 typedef that literally just said the type name and nothing else. For now fixed-size floats don't get a declaration, someone who uses them can easily declare them manually.
And the structs are now packed. I use MSVC-style pragmas here, because GCC and LLVM/Clang both support MSVCs approach, but MSVC doesn't support the others (`[[gnu::packed]]` or `__attribute__((packed))`), which in a rare case of circumstances makes MSVCs approach the most portable. I believe that there should be export options to control this, but that would've probably made this PR a lot bigger than it would need to be.

This does not just allow GCC and Clang to parse Ghidras headers without modification but also allows Ghidra to parse its own headers. Although I should add that this is more or less anecdotal because I have not tried to feed a testset through it, so there may be edge cases that I haven't noticed.