### PR TITLE
BSim: fix malformed arguments to ./configure on macOS

### DIFF
--- a/Ghidra/Features/BSim/support/make-postgres.sh
+++ b/Ghidra/Features/BSim/support/make-postgres.sh
@@ -92,8 +92,8 @@ if [ "$OS" = "Darwin" ]; then
 		OSDIR="mac_arm_64"
 		HOMEBREW="/opt/homebrew"
 	fi
-	POSTGRES_CONFIG_OPTIONS+="--with-includes=${HOMEBREW}/include"
-	POSTGRES_CONFIG_OPTIONS+="--with-libraries=${HOMEBREW}/lib"
+	POSTGRES_CONFIG_OPTIONS+=" --with-includes=${HOMEBREW}/include"
+	POSTGRES_CONFIG_OPTIONS+=" --with-libraries=${HOMEBREW}/lib"
 elif [ "$ARCH" = "x86_64" ]; then
 	OSDIR="linux_x86_64"
 elif [ "$ARCH" = "aarch64" ]; then


### PR DESCRIPTION
The `make-postgres.sh` script fails to build PostgreSQL with OpenSSL enabled on macOS even when OpenSSL is present due to the script passing malformed arguments to `./configure`.
The script tries to automatically specify Homebrew's `include` and `lib` directories but without spaces between the arguments, which results in the following warning from `./configure`:
```
configure: WARNING: unrecognized options: --with-openssl--with-includes
```
This PR simply adds a space right before each argument.

You can check if PostgreSQL is built with SSL enabled by running `postgres -c ssl=on`.
If your build doesn't support SSL, you will get something like this:
```
FATAL: SSL is not supported by this build
```