### PR TITLE
Fix `java.awt.headless=true` inconsistently not being set in some bash scripts

### DIFF
--- a/Ghidra/RuntimeScripts/Linux/support/bsim
+++ b/Ghidra/RuntimeScripts/Linux/support/bsim
@@ -18,4 +18,4 @@ VMARG_LIST="-Djava.awt.headless=true "
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
 SCRIPT_DIR="${SCRIPT_FILE%/*}"
 
-${SCRIPT_DIR}/launch.sh $LAUNCH_MODE jdk "BSim" "${MAXMEM}" "" ghidra.features.bsim.query.ingest.BSimLaunchable "$@"
+${SCRIPT_DIR}/launch.sh $LAUNCH_MODE jdk "BSim" "${MAXMEM}" "${VMARG_LIST}" ghidra.features.bsim.query.ingest.BSimLaunchable "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/bsim_ctl
+++ b/Ghidra/RuntimeScripts/Linux/support/bsim_ctl
@@ -17,8 +17,4 @@ VMARG_LIST="-Djava.awt.headless=true "
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
 SCRIPT_DIR="${SCRIPT_FILE%/*}"
 
-# Some JVM's with class data sharing enabled have issues with BSim starting with Ghidra's custom 
-# classloader, so we will disable sharing
-VMARG_LIST+="-Xshare:off"
-
 ${SCRIPT_DIR}/launch.sh $LAUNCH_MODE jdk "BSimControl" $MAXMEM "${VMARG_LIST}" ghidra.features.bsim.query.BSimControlLaunchable "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/bsim_ctl
+++ b/Ghidra/RuntimeScripts/Linux/support/bsim_ctl
@@ -19,6 +19,6 @@ SCRIPT_DIR="${SCRIPT_FILE%/*}"
 
 # Some JVM's with class data sharing enabled have issues with BSim starting with Ghidra's custom 
 # classloader, so we will disable sharing
-VMARG_LIST="-Xshare:off"
+VMARG_LIST+="-Xshare:off"
 
 ${SCRIPT_DIR}/launch.sh $LAUNCH_MODE jdk "BSimControl" $MAXMEM "${VMARG_LIST}" ghidra.features.bsim.query.BSimControlLaunchable "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,7 +35,7 @@ elif [[ $MODE == "ghidra-server" ]] then
 elif [[ $MODE == "bsim" ]] then
 	LAUNCH_MODE=${LAUNCH_MODE:=fg}
 	VMARG_LIST=${VMARG_LIST:="-Djava.awt.headless=true "}
-	/ghidra/support/launch.sh $LAUNCH_MODE jdk "BSim" "${MAXMEM}" "" ghidra.features.bsim.query.ingest.BSimLaunchable "$@"
+	/ghidra/support/launch.sh $LAUNCH_MODE jdk "BSim" "${MAXMEM}" "${VMARG_LIST}" ghidra.features.bsim.query.ingest.BSimLaunchable "$@"
 elif [[ $MODE == "bsim-server" ]] then
 	LAUNCH_MODE=${LAUNCH_MODE:=fg}
 	VMARG_LIST=${VMARG_LIST:="-Djava.awt.headless=true -Xshare:off"}


### PR DESCRIPTION
In a few BSim related bash scripts, `java.awt.headless=true` is not set despite a clear intention to do so.
Setting this flag to true is beneficial for macOS users at the very least, because without it macOS's window manager takes the focus away from the terminal window when you run the script and puts it onto the Java runtime application, and the script doesn't terminate unless you manually move the focus away from the runtime.