### PR TITLE
Fixes for SLA file parsing bugs uncovered during fuzzing

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
@@ -741,23 +741,24 @@ void Architecture::decodeDynamicRule(Decoder &decoder)
 ProtoModel *Architecture::decodeProto(Decoder &decoder)
 
 {
-  ProtoModel *res;
+  std::unique_ptr<ProtoModel> model;
   uint4 elemId = decoder.peekElement();
   if (elemId == ELEM_PROTOTYPE)
-    res = new ProtoModel(this);
+    model = std::make_unique<ProtoModel>(this);
   else if (elemId == ELEM_RESOLVEPROTOTYPE)
-    res = new ProtoModelMerged(this);
+    model = std::make_unique<ProtoModelMerged>(this);
   else
     throw LowlevelError("Expecting <prototype> or <resolveprototype> tag");
 
-  res->decode(decoder);
+  model->decode(decoder);
   
-  ProtoModel *other = getModel(res->getName());
+  ProtoModel *other = getModel(model->getName());
   if (other != (ProtoModel *)0) {
-    string errMsg = "Duplicate ProtoModel name: " + res->getName();
-    delete res;
+    string errMsg = "Duplicate ProtoModel name: " + model->getName();
     throw LowlevelError(errMsg);
   }
+
+  ProtoModel* res = model.release();
   protoModels[res->getName()] = res;
   return res;
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
@@ -23,6 +23,7 @@
 #ifdef CPUI_STATISTICS
 #include <cmath>
 #endif
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/architecture.cc
@@ -744,9 +744,9 @@ ProtoModel *Architecture::decodeProto(Decoder &decoder)
   std::unique_ptr<ProtoModel> model;
   uint4 elemId = decoder.peekElement();
   if (elemId == ELEM_PROTOTYPE)
-    model = std::make_unique<ProtoModel>(this);
+    model = std::unique_ptr<ProtoModel>(new ProtoModel(this));
   else if (elemId == ELEM_RESOLVEPROTOTYPE)
-    model = std::make_unique<ProtoModelMerged>(this);
+    model = std::unique_ptr<ProtoModel>(new ProtoModelMerged(this));
   else
     throw LowlevelError("Expecting <prototype> or <resolveprototype> tag");
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "funcdata.hh"
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
@@ -615,9 +615,9 @@ void Funcdata::decodeJumpTable(Decoder &decoder)
 {
   uint4 elemId = decoder.openElement(ELEM_JUMPTABLELIST);
   while(decoder.peekElement() != 0) {
-    JumpTable *jt = new JumpTable(glb);
+    std::unique_ptr<JumpTable> jt = std::make_unique<JumpTable>(glb);
     jt->decode(decoder);
-    jumpvec.push_back(jt);
+    jumpvec.push_back(jt.release());
   }
   decoder.closeElement(elemId);
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
@@ -615,7 +615,7 @@ void Funcdata::decodeJumpTable(Decoder &decoder)
 {
   uint4 elemId = decoder.openElement(ELEM_JUMPTABLELIST);
   while(decoder.peekElement() != 0) {
-    std::unique_ptr<JumpTable> jt = std::make_unique<JumpTable>(glb);
+    std::unique_ptr<JumpTable> jt = std::unique_ptr<JumpTable>(new JumpTable(glb));
     jt->decode(decoder);
     jumpvec.push_back(jt.release());
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.cc
@@ -1009,6 +1009,9 @@ AddrSpace *PackedDecode::readSpace(void)
   AddrSpace *spc;
   if (typeCode == TYPECODE_ADDRESSSPACE) {
     res = readInteger(readLengthCode(typeByte));
+    if (res >= spcManager->numSpaces())
+      throw DecoderError("Invalid address space index");
+
     spc = spcManager->getSpace(res);
     if (spc == (AddrSpace *)0)
       throw DecoderError("Unknown address space index");

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.cc
@@ -689,7 +689,10 @@ void PackedDecode::endIngest(int4 bufPos)
     }
     uint1 *buf = inStream.back().start;
     buf[bufPos] = ELEMENT_END;
+  } else {
+    throw DecoderError("Ended ingestion without any input");
   }
+
 }
 
 PackedDecode::~PackedDecode(void)

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.hh
@@ -536,7 +536,7 @@ private:
   uint1 getByte(Position &pos) { return *pos.current; }	///< Get the byte at the current position, do not advance
   uint1 getBytePlus1(Position &pos);	///< Get the byte following the current byte, do not advance position
   uint1 getNextByte(Position &pos);	///< Get the byte at the current position and advance to the next byte
-  void advancePosition(Position &pos,int4 skip);	///< Advance the position by the given number of bytes
+  void advancePosition(Position &pos,uint4 skip);	///< Advance the position by the given number of bytes
   uint8 readInteger(int4 len);		///< Read an integer from the \e current position given its length in bytes
   uint4 readLengthCode(uint1 typeByte) { return ((uint4)typeByte & PackedFormat::LENGTHCODE_MASK); }	///< Extract length code from type byte
   void findMatchingAttribute(const AttributeId &attribId);	///< Find attribute matching the given id in open element
@@ -631,7 +631,7 @@ inline uint1 PackedDecode::getNextByte(Position &pos)
 /// An exception is thrown of position is advanced past the end of the stream
 /// \param pos is the position being advanced
 /// \param skip is the number of bytes to advance
-inline void PackedDecode::advancePosition(Position &pos,int4 skip)
+inline void PackedDecode::advancePosition(Position &pos,uint4 skip)
 
 {
   while(pos.end - pos.current <= skip) {

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
@@ -451,18 +451,18 @@ void HomogeneousAggregate::decode(Decoder &decoder)
 QualifierFilter *QualifierFilter::decodeFilter(Decoder &decoder)
 
 {
-  QualifierFilter *filter;
+  std::unique_ptr<QualifierFilter> filter;
   uint4 elemId = decoder.peekElement();
   if (elemId == ELEM_VARARGS)
-    filter = new VarargsFilter();
+    filter = std::make_unique<VarargsFilter>();
   else if (elemId == ELEM_POSITION)
-    filter = new PositionMatchFilter(-1);
+    filter = std::make_unique<PositionMatchFilter>(-1);
   else if (elemId == ELEM_DATATYPE_AT)
-    filter = new DatatypeMatchFilter();
+    filter = std::make_unique<DatatypeMatchFilter>();
   else
     return (QualifierFilter *)0;
   filter->decode(decoder);
-  return filter;
+  return filter.release();
 }
 
 /// The AndFilter assumes ownership of all the filters in the array and the original vector is cleared

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
@@ -256,15 +256,15 @@ DatatypeFilter *DatatypeFilter::decodeFilter(Decoder &decoder)
   uint4 elemId = decoder.openElement(ELEM_DATATYPE);
   string nm = decoder.readString(ATTRIB_NAME);
   if (nm == "any") {
-    filter = std::make_unique<SizeRestrictedFilter>();
+    filter = std::unique_ptr<DatatypeFilter>(new SizeRestrictedFilter());
   }
   else if (nm == "homogeneous-float-aggregate") {
-    filter = std::make_unique<HomogeneousAggregate>(TYPE_FLOAT,4,0,0);
+    filter = std::unique_ptr<DatatypeFilter>(new HomogeneousAggregate(TYPE_FLOAT,4,0,0));
   }
   else {
     // If no other name matches, assume this is a metatype
     type_metatype meta = string2metatype(nm);
-    filter = std::make_unique<MetaTypeFilter>(meta);
+    filter = std::unique_ptr<DatatypeFilter>(new MetaTypeFilter(meta));
   }
   filter->decode(decoder);
   decoder.closeElement(elemId);
@@ -454,11 +454,11 @@ QualifierFilter *QualifierFilter::decodeFilter(Decoder &decoder)
   std::unique_ptr<QualifierFilter> filter;
   uint4 elemId = decoder.peekElement();
   if (elemId == ELEM_VARARGS)
-    filter = std::make_unique<VarargsFilter>();
+    filter = std::unique_ptr<QualifierFilter>(new VarargsFilter());
   else if (elemId == ELEM_POSITION)
-    filter = std::make_unique<PositionMatchFilter>(-1);
+    filter = std::unique_ptr<QualifierFilter>(new PositionMatchFilter(-1));
   else if (elemId == ELEM_DATATYPE_AT)
-    filter = std::make_unique<DatatypeMatchFilter>();
+    filter = std::unique_ptr<QualifierFilter>(new DatatypeMatchFilter());
   else
     return (QualifierFilter *)0;
   filter->decode(decoder);
@@ -595,24 +595,24 @@ AssignAction *AssignAction::decodeAction(Decoder &decoder,const ParamListStandar
   std::unique_ptr<AssignAction> action;
   uint4 elemId = decoder.peekElement();
   if (elemId == ELEM_GOTO_STACK)
-    action = std::make_unique<GotoStack>(res,0);
+    action = std::unique_ptr<AssignAction>(new GotoStack(res,0));
   else if (elemId == ELEM_JOIN) {
-    action = std::make_unique<MultiSlotAssign>(res);
+    action = std::unique_ptr<AssignAction>(new MultiSlotAssign(res));
   }
   else if (elemId == ELEM_CONSUME) {
-    action = std::make_unique<ConsumeAs>(TYPECLASS_GENERAL,res);
+    action = std::unique_ptr<AssignAction>(new ConsumeAs(TYPECLASS_GENERAL,res));
   }
   else if (elemId == ELEM_CONVERT_TO_PTR) {
-    action = std::make_unique<ConvertToPointer>(res);
+    action = std::unique_ptr<AssignAction>(new ConvertToPointer(res));
   }
   else if (elemId == ELEM_HIDDEN_RETURN) {
-    action = std::make_unique<HiddenReturnAssign>(res,hiddenret_specialreg);
+    action = std::unique_ptr<AssignAction>(new HiddenReturnAssign(res,hiddenret_specialreg));
   }
   else if (elemId == ELEM_JOIN_PER_PRIMITIVE) {
-    action = std::make_unique<MultiMemberAssign>(TYPECLASS_GENERAL,false,res->isBigEndian(),res);
+    action = std::unique_ptr<AssignAction>(new MultiMemberAssign(TYPECLASS_GENERAL,false,res->isBigEndian(),res));
   }
   else if (elemId == ELEM_JOIN_DUAL_CLASS) {
-    action = std::make_unique<MultiSlotDualAssign>(res);
+    action = std::unique_ptr<AssignAction>(new MultiSlotDualAssign(res));
   }
   else
     throw DecoderError("Expecting model rule action");
@@ -657,13 +657,13 @@ AssignAction *AssignAction::decodeSideeffect(Decoder &decoder,const ParamListSta
   uint4 elemId = decoder.peekElement();
 
   if (elemId == ELEM_CONSUME_EXTRA) {
-    action = std::make_unique<ConsumeExtra>(res);
+    action = std::unique_ptr<AssignAction>(new ConsumeExtra(res));
   }
   else if (elemId == ELEM_EXTRA_STACK) {
-    action = std::make_unique<ExtraStack>(res);
+    action = std::unique_ptr<AssignAction>(new ExtraStack(res));
   }
   else if (elemId == ELEM_CONSUME_REMAINING) {
-	action = std::make_unique<ConsumeRemaining>(res);
+	action = std::unique_ptr<AssignAction>(new ConsumeRemaining(res));
   }
   else
     throw DecoderError("Expecting model rule sideeffect");

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
@@ -653,22 +653,22 @@ AssignAction *AssignAction::decodePrecondition(Decoder &decoder,const ParamListS
 AssignAction *AssignAction::decodeSideeffect(Decoder &decoder,const ParamListStandard *res)
 
 {
-  AssignAction *action;
+  std::unique_ptr<AssignAction> action;
   uint4 elemId = decoder.peekElement();
 
   if (elemId == ELEM_CONSUME_EXTRA) {
-    action = new ConsumeExtra(res);
+    action = std::make_unique<ConsumeExtra>(res);
   }
   else if (elemId == ELEM_EXTRA_STACK) {
-    action = new ExtraStack(res);
+    action = std::make_unique<ExtraStack>(res);
   }
   else if (elemId == ELEM_CONSUME_REMAINING) {
-	action = new ConsumeRemaining(res);
+	action = std::make_unique<ConsumeRemaining>(res);
   }
   else
     throw DecoderError("Expecting model rule sideeffect");
   action->decode(decoder);
-  return action;
+  return action.release();
 }
 
 /// \brief Truncate a tiling by a given number of bytes

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
@@ -592,32 +592,32 @@ bool AssignAction::fillinOutputMap(ParamActive *active) const
 AssignAction *AssignAction::decodeAction(Decoder &decoder,const ParamListStandard *res)
 
 {
-  AssignAction *action;
+  std::unique_ptr<AssignAction> action;
   uint4 elemId = decoder.peekElement();
   if (elemId == ELEM_GOTO_STACK)
-    action = new GotoStack(res,0);
+    action = std::make_unique<GotoStack>(res,0);
   else if (elemId == ELEM_JOIN) {
-    action = new MultiSlotAssign(res);
+    action = std::make_unique<MultiSlotAssign>(res);
   }
   else if (elemId == ELEM_CONSUME) {
-    action = new ConsumeAs(TYPECLASS_GENERAL,res);
+    action = std::make_unique<ConsumeAs>(TYPECLASS_GENERAL,res);
   }
   else if (elemId == ELEM_CONVERT_TO_PTR) {
-    action = new ConvertToPointer(res);
+    action = std::make_unique<ConvertToPointer>(res);
   }
   else if (elemId == ELEM_HIDDEN_RETURN) {
-    action = new HiddenReturnAssign(res,hiddenret_specialreg);
+    action = std::make_unique<HiddenReturnAssign>(res,hiddenret_specialreg);
   }
   else if (elemId == ELEM_JOIN_PER_PRIMITIVE) {
-    action = new MultiMemberAssign(TYPECLASS_GENERAL,false,res->isBigEndian(),res);
+    action = std::make_unique<MultiMemberAssign>(TYPECLASS_GENERAL,false,res->isBigEndian(),res);
   }
   else if (elemId == ELEM_JOIN_DUAL_CLASS) {
-    action = new MultiSlotDualAssign(res);
+    action = std::make_unique<MultiSlotDualAssign>(res);
   }
   else
     throw DecoderError("Expecting model rule action");
   action->decode(decoder);
-  return action;
+  return action.release();
 }
 
 /// \brief Read the next model rule precondition element from the stream

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
@@ -15,6 +15,7 @@
  */
 #include "modelrules.hh"
 #include "funcdata.hh"
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.cc
@@ -252,23 +252,23 @@ PrimitiveExtractor::PrimitiveExtractor(Datatype *dt,bool unionIllegal,int offset
 DatatypeFilter *DatatypeFilter::decodeFilter(Decoder &decoder)
 
 {
-  DatatypeFilter *filter;
+  std::unique_ptr<DatatypeFilter> filter;
   uint4 elemId = decoder.openElement(ELEM_DATATYPE);
   string nm = decoder.readString(ATTRIB_NAME);
   if (nm == "any") {
-    filter = new SizeRestrictedFilter();
+    filter = std::make_unique<SizeRestrictedFilter>();
   }
   else if (nm == "homogeneous-float-aggregate") {
-    filter = new HomogeneousAggregate(TYPE_FLOAT,4,0,0);
+    filter = std::make_unique<HomogeneousAggregate>(TYPE_FLOAT,4,0,0);
   }
   else {
     // If no other name matches, assume this is a metatype
     type_metatype meta = string2metatype(nm);
-    filter = new MetaTypeFilter(meta);
+    filter = std::make_unique<MetaTypeFilter>(meta);
   }
   filter->decode(decoder);
   decoder.closeElement(elemId);
-  return filter;
+  return filter.release();
 }
 
 /// Parse the given string as a comma or space separated list of decimal integers,

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/override.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/override.cc
@@ -367,10 +367,10 @@ void Override::decode(Decoder &decoder,Architecture *glb)
     }
     else if (subId == ELEM_PROTOOVERRIDE) {
       Address callpoint = Address::decode(decoder);
-      FuncProto *fp = new FuncProto();
+      std::unique_ptr<FuncProto> fp = std::make_unique<FuncProto>();
       fp->setInternal(glb->defaultfp,glb->types->getTypeVoid());
       fp->decode(decoder,glb);
-      insertProtoOverride(callpoint,fp);
+      insertProtoOverride(callpoint,fp.release());
     }
     else if (subId == ELEM_FORCEGOTO) {
       Address targetpc = Address::decode(decoder);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/override.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/override.cc
@@ -15,6 +15,7 @@
  */
 #include "override.hh"
 #include "funcdata.hh"
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/override.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/override.cc
@@ -367,7 +367,7 @@ void Override::decode(Decoder &decoder,Architecture *glb)
     }
     else if (subId == ELEM_PROTOOVERRIDE) {
       Address callpoint = Address::decode(decoder);
-      std::unique_ptr<FuncProto> fp = std::make_unique<FuncProto>();
+      std::unique_ptr<FuncProto> fp(new FuncProto());
       fp->setInternal(glb->defaultfp,glb->types->getTypeVoid());
       fp->decode(decoder,glb);
       insertProtoOverride(callpoint,fp.release());

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
@@ -15,6 +15,7 @@
  */
 #include "semantics.hh"
 #include "translate.hh"
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
@@ -720,7 +720,7 @@ void OpTpl::decode(Decoder &decoder)
     output->decode(decoder);
   }
   while(decoder.peekElement() != 0) {
-    std::unique_ptr<VarnodeTpl> vn = std::make_unique<VarnodeTpl>();
+    std::unique_ptr<VarnodeTpl> vn(new VarnodeTpl());
     vn->decode(decoder);
     input.push_back(vn.release());
   }
@@ -914,7 +914,7 @@ int4 ConstructTpl::decode(Decoder &decoder)
     result->decode(decoder);
   }
   while(decoder.peekElement() != 0) {
-    std::unique_ptr<OpTpl> op = std::make_unique<OpTpl>();
+    std::unique_ptr<OpTpl> op(new OpTpl());
     op->decode(decoder);
     vec.push_back(op.release());
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
@@ -720,9 +720,9 @@ void OpTpl::decode(Decoder &decoder)
     output->decode(decoder);
   }
   while(decoder.peekElement() != 0) {
-    VarnodeTpl *vn = new VarnodeTpl();
+    std::unique_ptr<VarnodeTpl> vn = std::make_unique<VarnodeTpl>();
     vn->decode(decoder);
-    input.push_back(vn);
+    input.push_back(vn.release());
   }
   decoder.closeElement(el);
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.cc
@@ -914,9 +914,9 @@ int4 ConstructTpl::decode(Decoder &decoder)
     result->decode(decoder);
   }
   while(decoder.peekElement() != 0) {
-    OpTpl *op = new OpTpl();
+    std::unique_ptr<OpTpl> op = std::make_unique<OpTpl>();
     op->decode(decoder);
-    vec.push_back(op);
+    vec.push_back(op.release());
   }
   decoder.closeElement(el);
   return sectionid;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/semantics.hh
@@ -142,7 +142,7 @@ class OpTpl {
   OpCode opc;
   vector<VarnodeTpl *> input;
 public:
-  OpTpl(void) {}
+  OpTpl(void) : output(nullptr) {}
   OpTpl(OpCode oc) { opc = oc; output = (VarnodeTpl *)0; }
   ~OpTpl(void);
   VarnodeTpl *getOut(void) const { return output; }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
@@ -503,7 +503,7 @@ PatternExpression *PatternExpression::decodeExpression(Decoder &decoder,Translat
   else if (el == sla::ELEM_NOT_EXP)
     res = new NotExpression();
   else
-    return (PatternExpression *)0;
+    throw DecoderError("Invalid pattern expression element");
 
   res->decode(decoder,trans);
   return res;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
@@ -505,8 +505,10 @@ PatternExpression *PatternExpression::decodeExpression(Decoder &decoder,Translat
   else
     throw DecoderError("Invalid pattern expression element");
 
-  res->decode(decoder,trans);
-  return res;
+  // Call PatternExpression::release on decoding failure
+  std::unique_ptr<PatternExpression, void(*)(PatternExpression *)> patexp(res, PatternExpression::release);
+  patexp->decode(decoder, trans);
+  return patexp.release();
 }
 
 static intb getInstructionBytes(ParserWalker &walker,int4 bytestart,int4 byteend,bool bigendian)

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
@@ -15,6 +15,7 @@
  */
 #include "slghpatexpress.hh"
 #include "sleighbase.hh"
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghpatexpress.cc
@@ -828,6 +828,9 @@ void OperandValue::decode(Decoder &decoder,Translate *trans)
   uintm ctid = decoder.readUnsignedInteger(sla::ATTRIB_CT);
   SleighBase *sleigh = (SleighBase *)trans;
   SubtableSymbol *tab = dynamic_cast<SubtableSymbol *>(sleigh->findSymbol(tabid));
+  if (ctid >= tab->getNumConstructors()) {
+    throw DecoderError("Invalid constructor id");
+  }
   ct = tab->getConstructor(ctid);
   decoder.closeElement(el);
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghpattern.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghpattern.cc
@@ -141,16 +141,16 @@ bool DisjointPattern::resolvesIntersect(const DisjointPattern *op1,const Disjoin
 DisjointPattern *DisjointPattern::decodeDisjoint(Decoder &decoder)
 
 {				// DisjointPattern factory
-  DisjointPattern *res;
+  std::unique_ptr<DisjointPattern> res;
   uint4 el = decoder.peekElement();
   if (el == sla::ELEM_INSTRUCT_PAT)
-    res = new InstructionPattern();
+    res = std::make_unique<InstructionPattern>();
   else if (el == sla::ELEM_CONTEXT_PAT)
-    res = new ContextPattern();
+    res = std::make_unique<ContextPattern>();
   else
-    res = new CombinePattern();
+    res = std::make_unique<CombinePattern>();
   res->decode(decoder);
-  return res;
+  return res.release();
 }
 
 void PatternBlock::normalize(void)

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghpattern.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghpattern.cc
@@ -15,6 +15,7 @@
  */
 #include "slghpattern.hh"
 #include "slaformat.hh"
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghpattern.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghpattern.cc
@@ -144,11 +144,11 @@ DisjointPattern *DisjointPattern::decodeDisjoint(Decoder &decoder)
   std::unique_ptr<DisjointPattern> res;
   uint4 el = decoder.peekElement();
   if (el == sla::ELEM_INSTRUCT_PAT)
-    res = std::make_unique<InstructionPattern>();
+    res = std::unique_ptr<InstructionPattern>(new InstructionPattern());
   else if (el == sla::ELEM_CONTEXT_PAT)
-    res = std::make_unique<ContextPattern>();
+    res = std::unique_ptr<ContextPattern>(new ContextPattern());
   else
-    res = std::make_unique<CombinePattern>();
+    res = std::unique_ptr<CombinePattern>(new CombinePattern());
   res->decode(decoder);
   return res.release();
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
@@ -533,6 +533,9 @@ void ValueSymbol::encodeHeader(Encoder &encoder) const
 void ValueSymbol::decode(Decoder &decoder,SleighBase *trans)
 
 {
+  if (patval)
+    throw DecoderError("Already decoded symbol");
+
   patval = (PatternValue *) PatternExpression::decodeExpression(decoder,trans);
   patval->layClaim();
   decoder.closeElement(sla::ELEM_VALUE_SYM.getId());
@@ -614,6 +617,9 @@ void ValueMapSymbol::encodeHeader(Encoder &encoder) const
 void ValueMapSymbol::decode(Decoder &decoder,SleighBase *trans)
 
 {
+  if (patval)
+    throw DecoderError("Already decoded symbol");
+
   patval = (PatternValue *) PatternExpression::decodeExpression(decoder,trans);
   patval->layClaim();
   while(decoder.peekElement() != 0) {
@@ -693,6 +699,9 @@ void NameSymbol::encodeHeader(Encoder &encoder) const
 void NameSymbol::decode(Decoder &decoder,SleighBase *trans)
 
 {
+  if (patval)
+    throw DecoderError("Already decoded symbol");
+
   patval = (PatternValue *) PatternExpression::decodeExpression(decoder,trans);
   patval->layClaim();
   while(decoder.peekElement() != 0) {
@@ -827,6 +836,10 @@ void ContextSymbol::decode(Decoder &decoder,SleighBase *trans)
   if (lowMissing || highMissing) {
     throw DecoderError("Missing high/low attributes");
   }
+
+  if (patval)
+    throw DecoderError("Already decoded symbol");
+
   patval = (PatternValue *) PatternExpression::decodeExpression(decoder,trans);
   patval->layClaim();
   decoder.closeElement(sla::ELEM_CONTEXT_SYM.getId());
@@ -931,6 +944,9 @@ void VarnodeListSymbol::encodeHeader(Encoder &encoder) const
 void VarnodeListSymbol::decode(Decoder &decoder,SleighBase *trans)
 
 {
+  if (patval)
+    throw DecoderError("Already decoded symbol");
+
   patval = (PatternValue *) PatternExpression::decodeExpression(decoder,trans);
   patval->layClaim();
   while(decoder.peekElement() != 0) {
@@ -1075,6 +1091,9 @@ void OperandSymbol::encodeHeader(Encoder &encoder) const
 void OperandSymbol::decode(Decoder &decoder,SleighBase *trans)
 
 {
+  if (defexp || localexp)
+    throw DecoderError("Already decoded symbol");
+
   defexp = (PatternExpression *)0;
   triple = (TripleSymbol *)0;
   flags = 0;
@@ -1101,6 +1120,7 @@ void OperandSymbol::decode(Decoder &decoder,SleighBase *trans)
   localexp = (OperandValue *)PatternExpression::decodeExpression(decoder,trans);
   localexp->layClaim();
   if (decoder.peekElement() != 0) {
+
     defexp = PatternExpression::decodeExpression(decoder,trans);
     defexp->layClaim();
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
@@ -16,6 +16,7 @@
 #include "slghsymbol.hh"
 #include "sleighbase.hh"
 #include <cmath>
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
@@ -2375,9 +2375,9 @@ void DecisionNode::decode(Decoder &decoder,DecisionNode *par,SubtableSymbol *sub
       decoder.closeElement(subel);
     }
     else if (subel == sla::ELEM_DECISION) {
-      DecisionNode *subnode = new DecisionNode();
+      std::unique_ptr<DecisionNode> subnode = std::make_unique<DecisionNode>();
       subnode->decode(decoder,this,sub);
-      children.push_back(subnode);
+      children.push_back(subnode.release());
     }
     subel = decoder.peekElement();
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
@@ -219,31 +219,31 @@ void SymbolTable::decodeSymbolHeader(Decoder &decoder)
   std::unique_ptr<SleighSymbol> sym;
   uint4 el = decoder.peekElement();
   if (el == sla::ELEM_USEROP_HEAD)
-    sym = std::make_unique<UserOpSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new UserOpSymbol());
   else if (el == sla::ELEM_EPSILON_SYM_HEAD)
-    sym = std::make_unique<EpsilonSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new EpsilonSymbol());
   else if (el == sla::ELEM_VALUE_SYM_HEAD)
-    sym = std::make_unique<ValueSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new ValueSymbol());
   else if (el == sla::ELEM_VALUEMAP_SYM_HEAD)
-    sym = std::make_unique<ValueMapSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new ValueMapSymbol());
   else if (el == sla::ELEM_NAME_SYM_HEAD)
-    sym = std::make_unique<NameSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new NameSymbol());
   else if (el == sla::ELEM_VARNODE_SYM_HEAD)
-    sym = std::make_unique<VarnodeSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new VarnodeSymbol());
   else if (el == sla::ELEM_CONTEXT_SYM_HEAD)
-    sym = std::make_unique<ContextSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new ContextSymbol());
   else if (el == sla::ELEM_VARLIST_SYM_HEAD)
-    sym = std::make_unique<VarnodeListSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new VarnodeListSymbol());
   else if (el == sla::ELEM_OPERAND_SYM_HEAD)
-    sym = std::make_unique<OperandSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new OperandSymbol());
   else if (el == sla::ELEM_START_SYM_HEAD)
-    sym = std::make_unique<StartSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new StartSymbol());
   else if (el == sla::ELEM_END_SYM_HEAD)
-    sym = std::make_unique<EndSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new EndSymbol());
   else if (el == sla::ELEM_NEXT2_SYM_HEAD)
-    sym = std::make_unique<Next2Symbol>();
+    sym = std::unique_ptr<SleighSymbol>(new Next2Symbol());
   else if (el == sla::ELEM_SUBTABLE_SYM_HEAD)
-    sym = std::make_unique<SubtableSymbol>();
+    sym = std::unique_ptr<SleighSymbol>(new SubtableSymbol());
   else
     throw SleighError("Bad symbol xml");
 
@@ -1685,17 +1685,17 @@ void Constructor::decode(Decoder &decoder,SleighBase *trans)
       decoder.closeElement(subel);
     }
     else if (subel == sla::ELEM_CONTEXT_OP) {
-      std::unique_ptr<ContextOp> c_op = std::make_unique<ContextOp>();
+      std::unique_ptr<ContextOp> c_op = std::unique_ptr<ContextOp>(new ContextOp());
       c_op->decode(decoder,trans);
       context.push_back(c_op.release());
     }
     else if (subel == sla::ELEM_COMMIT) {
-      std::unique_ptr<ContextCommit> c_op = std::make_unique<ContextCommit>();
+      std::unique_ptr<ContextCommit> c_op = std::unique_ptr<ContextCommit>(new ContextCommit());
       c_op->decode(decoder,trans);
       context.push_back(c_op.release());
     }
     else {
-      std::unique_ptr<ConstructTpl> cur = std::make_unique<ConstructTpl>();
+      std::unique_ptr<ConstructTpl> cur = std::unique_ptr<ConstructTpl>(new ConstructTpl());
       int4 sectionid = cur->decode(decoder);
       if (sectionid < 0) {
         if (templ != (ConstructTpl *)0)
@@ -2398,7 +2398,7 @@ void DecisionNode::decode(Decoder &decoder,DecisionNode *par,SubtableSymbol *sub
       decoder.closeElement(subel);
     }
     else if (subel == sla::ELEM_DECISION) {
-      std::unique_ptr<DecisionNode> subnode = std::make_unique<DecisionNode>();
+      std::unique_ptr<DecisionNode> subnode = std::unique_ptr<DecisionNode>(new DecisionNode());
       subnode->decode(decoder,this,sub);
       children.push_back(subnode.release());
     }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
@@ -2369,6 +2369,9 @@ void DecisionNode::decode(Decoder &decoder,DecisionNode *par,SubtableSymbol *sub
     if (subel == sla::ELEM_PAIR) {
       decoder.openElement();
       uintm id = decoder.readSignedInteger(sla::ATTRIB_ID);
+      if (id >= sub->getNumConstructors()) {
+        throw DecoderError("Invalid constructor id");
+      }
       Constructor *ct = sub->getConstructor(id);
       DisjointPattern *pat = DisjointPattern::decodeDisjoint(decoder);
       list.push_back(pair<DisjointPattern *,Constructor *>(pat,ct));

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.hh
@@ -448,8 +448,8 @@ class ContextOp : public ContextChange {
   int4 shift;			// Number of bits to shift value into place
 public:
   ContextOp(int4 startbit,int4 endbit,PatternExpression *pe);
-  ContextOp(void) {}		// For use with decode
-  virtual ~ContextOp(void) { PatternExpression::release(patexp); }
+  ContextOp(void) : patexp(nullptr) {}		// For use with decode
+  virtual ~ContextOp(void) { if (patexp) PatternExpression::release(patexp); }
   virtual void validate(void) const;
   virtual void encode(Encoder &encoder) const;
   virtual void decode(Decoder &decoder,SleighBase *trans);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.hh
@@ -326,7 +326,7 @@ private:
   void setVariableLength(void) { flags |= variable_len; }
   bool isVariableLength(void) const { return ((flags&variable_len)!=0); }
 public:
-  OperandSymbol(void) {}	// For use with decode
+  OperandSymbol(void) : localexp(nullptr), defexp(nullptr) {}	// For use with decode
   OperandSymbol(const string &nm,int4 index,Constructor *ct);
   uint4 getRelativeOffset(void) const { return reloffset; }
   int4 getOffsetBase(void) const { return offsetbase; }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "translate.hh"
+#include <memory>
 
 namespace ghidra {
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
@@ -260,15 +260,15 @@ AddrSpace *AddrSpaceManager::decodeSpace(Decoder &decoder,const Translate *trans
   uint4 elemId = decoder.peekElement();
   std::unique_ptr<AddrSpace> res;
   if (elemId == ELEM_SPACE_BASE)
-    res = std::make_unique<SpacebaseSpace>(this,trans);
+    res = std::unique_ptr<SpacebaseSpace>(new SpacebaseSpace(this,trans));
   else if (elemId == ELEM_SPACE_UNIQUE)
-    res = std::make_unique<UniqueSpace>(this,trans);
+    res = std::unique_ptr<UniqueSpace>(new UniqueSpace(this,trans));
   else if (elemId == ELEM_SPACE_OTHER)
-    res = std::make_unique<OtherSpace>(this,trans);
+    res = std::unique_ptr<OtherSpace>(new OtherSpace(this,trans));
   else if (elemId == ELEM_SPACE_OVERLAY)
-    res = std::make_unique<OverlaySpace>(this,trans);
+    res = std::unique_ptr<OverlaySpace>(new OverlaySpace(this,trans));
   else
-    res = std::make_unique<AddrSpace>(this,trans,IPTR_PROCESSOR);
+    res = std::unique_ptr<AddrSpace>(new AddrSpace(this,trans,IPTR_PROCESSOR));
 
   res->decode(decoder);
   return res.release();

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/translate.cc
@@ -258,20 +258,20 @@ AddrSpace *AddrSpaceManager::decodeSpace(Decoder &decoder,const Translate *trans
 
 {
   uint4 elemId = decoder.peekElement();
-  AddrSpace *res;
+  std::unique_ptr<AddrSpace> res;
   if (elemId == ELEM_SPACE_BASE)
-    res = new SpacebaseSpace(this,trans);
+    res = std::make_unique<SpacebaseSpace>(this,trans);
   else if (elemId == ELEM_SPACE_UNIQUE)
-    res = new UniqueSpace(this,trans);
+    res = std::make_unique<UniqueSpace>(this,trans);
   else if (elemId == ELEM_SPACE_OTHER)
-    res = new OtherSpace(this,trans);
+    res = std::make_unique<OtherSpace>(this,trans);
   else if (elemId == ELEM_SPACE_OVERLAY)
-    res = new OverlaySpace(this,trans);
+    res = std::make_unique<OverlaySpace>(this,trans);
   else
-    res = new AddrSpace(this,trans,IPTR_PROCESSOR);
+    res = std::make_unique<AddrSpace>(this,trans,IPTR_PROCESSOR);
 
   res->decode(decoder);
-  return res;
+  return res.release();
 }
 
 /// This routine initializes (almost) all the address spaces used


### PR DESCRIPTION
## Why is this change being proposed?

I was fuzzing the .sla parser in the decompiler and resolved a number of issues uncovered. I've included all of the fixes in this PR, but if preferred I can split this into multiple PRs. I tried to keep each commit self-contained to the issue I was resolving for easier reviewing.

### Heap buffer overflows

These all triggered Address Sanitizer bug reports prior to being fixed:

1. There is a buffer overflow in `PackedDecode::advancePosition` due to the signed skip parameter, which is read from the `.sla` file. If negative, can result in a read out of bounds. This was changed to unsigned.
2. Identifiers read from the file and used as indexes should be validated to not exceed the container size. These included the symbol list, symbol scope table, address spaces, and constructors.

### Null pointer dereferences

1. If `endIngest` is called without any additional data, calls to `decode` will result in null deref when `getByte` tries to deref `endPos.current` which isn't set to point to the input stream (since there isn't one allocated). This can be triggered by an `.sla` file with just the header. I changed `endIngest` here to throw an exception in this case.
2. Symbol list and symbol scope tables updated to ensure their entries are non-null before deleting in destructor.
3. Pattern expression decoder returned null if invalid, but none of the callers checked for it. Changed this to an exception.

### Memory leaks

These were issues identified by Leak Sanitizer and largely followed the pattern

```cpp
TypeToDecode * localVar = new TypeToDecode();
localVar->decode(...);
owner->var = localVar;
```

If an issue occurred in `decode`, the `localVar` type would never be destroyed. These were largely mitigated with the use of `std::unique_ptr` locally to ensure the value would be destroyed on exception. The unique pointer is released prior to returning to prevent unwanted destruction on success.

The other common memory leak was overwriting the same value if decoding the same id multiple times. These scenarios were turned into exceptions. However, if there is a usecase for these, can update to change to free the previous value and allow overwriting instead.

## Additional changes

The following files were not technically a part of the fuzz run but exhibited the same decoding pattern that resulted in the memory leaks elsewhere. I've included patches for these that should resolve the same style of memory leaks on decoding failure.

* architecture.cc
* funcdata.cc
* modelrules.cc