### PR TITLE
80251: Correct register mapping for rm47_d1

### DIFF
--- a/Ghidra/Processors/8051/data/languages/80251.sinc
+++ b/Ghidra/Processors/8051/data/languages/80251.sinc
@@ -58,7 +58,7 @@ attach variables  [ rm47 rm03 rm47_ rm03_ ] [
 ];
 
 attach variables  [ rm47_d1 ] [ 
-	R0  R0  R2  R2  R4  R3  R6  R6 
+	R0  R0  R2  R2  R4  R4  R6  R6 
 	R8  R8  B   B R12 R12 R14 R14 
 ];
 


### PR DESCRIPTION
This PR fixes a register mapping error affecting MUL and DIV instructions.

The sixth register in the operand list was incorrectly assigned to `R3`, which does not match the expected architecture behavior. It has been updated to `R4` to ensure correct decoding and operand selection.