### PR TITLE
80251: Correct MOVZ to MOVS

### DIFF
--- a/Ghidra/Processors/8051/data/languages/80251.sinc
+++ b/Ghidra/Processors/8051/data/languages/80251.sinc
@@ -500,7 +500,7 @@ macro pop24(val) {
 :MOVH drk47,Data16x0	is $(GROUP3) & ophi=7 & oplo=14; $(DRK47) & s03=12; Data16x0  { drk47 = (drk47 & 0xffff0000) | (Data16x0 << 16); }
 
 # MOVS WRj,Rm
-:MOVZ wrj47,rm03  is $(GROUP3) & ophi=1 & oplo=10; wrj47 & rm03  { wrj47 = sext(rm03); }
+:MOVS wrj47,rm03  is $(GROUP3) & ophi=1 & oplo=10; wrj47 & rm03  { wrj47 = sext(rm03); }
 
 # MOVZ WRj,Rm
 :MOVZ wrj47,rm03  is $(GROUP3) & ophi=0 & oplo=10; wrj47 & rm03  { wrj47 = zext(rm03); }


### PR DESCRIPTION
This PR corrects a typo by replacing `MOVZ` with the correct `MOVS`.
