### PR TITLE
Add C23 enum type parsing

### DIFF
--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
@@ -2256,14 +2256,19 @@ DataType EnumSpecifier() : {
     DataType dt;
     ArrayList<EnumMember> list;
     Declaration dec = new Declaration();
+    Declaration tdec = null;
 }
 {
     <ENUM> 
     (
-        LOOKAHEAD(3)
-        [AttributeSpecList(dec)] [ t= <IDENTIFIER> ] "{" list= EnumeratorList() "}" 
+        LOOKAHEAD(5)
+        [AttributeSpecList(dec)] [ t= <IDENTIFIER> ] [ ":" tdec = TypeName() ] "{" list= EnumeratorList() "}" 
         {
             dt = allocateEnumDT(t, list);
+            if (tdec != null) {
+                // type provided
+                dt = tdec.getDataType();
+            }
         }
         |
         t= <IDENTIFIER>

--- a/Ghidra/Features/Base/src/test/resources/ghidra/app/util/cparser/CParserTest.h
+++ b/Ghidra/Features/Base/src/test/resources/ghidra/app/util/cparser/CParserTest.h
@@ -1248,3 +1248,5 @@ struct statcheck {
 typedef int test_before;
 static_assert(1 + 1 == 2, "That's true!");
 typedef int test_after;
+
+enum typedenum : unsigned char {};


### PR DESCRIPTION
Add C parser support for typed enums (C23).

Closes #8495 