### PR TITLE
Decompiler: Add code folding

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangToken.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangToken.java
@@ -51,6 +51,15 @@ public class ClangToken implements ClangNode {
 	private int syntax_type;
 	private Color highlight; // Color to highlight with or null if no highlight
 	private boolean matchingToken;
+	private boolean collapsedToken;
+
+	public boolean getCollapsedToken() {
+		return collapsedToken;
+	}
+
+	public void setCollapsedToken(boolean collapsedToken) {
+		this.collapsedToken = collapsedToken;
+	}
 
 	public ClangToken(ClangNode par) {
 		parent = par;

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangToken.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/ClangToken.java
@@ -49,16 +49,21 @@ public class ClangToken implements ClangNode {
 	private ClangLine lineparent;
 	private String text;
 	private int syntax_type;
+	private int collapseLevel = 0;
 	private Color highlight; // Color to highlight with or null if no highlight
 	private boolean matchingToken;
-	private boolean collapsedToken;
 
 	public boolean getCollapsedToken() {
-		return collapsedToken;
+		return collapseLevel > 0;
 	}
 
 	public void setCollapsedToken(boolean collapsedToken) {
-		this.collapsedToken = collapsedToken;
+		if (collapsedToken) {
+			collapseLevel++;
+		}
+		else {
+			collapseLevel--;
+		}
 	}
 
 	public ClangToken(ClangNode par) {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/ClangLayoutController.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/ClangLayoutController.java
@@ -186,8 +186,10 @@ public class ClangLayoutController implements LayoutModel, LayoutModelListener {
 		int columnPosition = 0;
 		for (int i = 0; i < tokens.size(); ++i) {
 			ClangToken token = tokens.get(i);
+			if (token.getCollapsedToken()) {
+				continue;
+			}
 			Color color = getTokenColor(token);
-
 			if (token instanceof ClangCommentToken) {
 				AttributedString prototype = new AttributedString("prototype", color, metrics);
 				Program program = decompilerPanel.getProgram();
@@ -226,8 +228,8 @@ public class ClangLayoutController implements LayoutModel, LayoutModelListener {
 
 		// For now we have decided that any external function, linked or not, will be one color, as
 		// this makes it easy for the user to identify external function calls. Other functions will
-		// be colored according to the SymbolInspector.  If we use the SymbolInspector for all 
-		// colors, then some of the color values will be very close to some of the colors used by 
+		// be colored according to the SymbolInspector.  If we use the SymbolInspector for all
+		// colors, then some of the color values will be very close to some of the colors used by
 		// the Decompiler.  For example, non-linked external functions default to red and linked
 		// external functions default to green.
 		if (function.isExternal()) {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
@@ -813,6 +813,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 				return;
 			}
 
+			boolean isCollapsed = isBlockCollapsed(openingBrace);
 			List<ClangNode> list = new ArrayList<>();
 			openingBrace.Parent().flatten(list);
 
@@ -824,7 +825,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 						inSection = (!token.equals(closingBrace));
 					}
 					if (inSection) {
-						token.setCollapsedToken(!token.getCollapsedToken());
+						token.setCollapsedToken(!isCollapsed);
 					}
 				}
 				else if ((token instanceof ClangSyntaxToken)) {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
@@ -125,6 +125,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 
 		layoutController = new ClangLayoutController(options, this, metrics, hlFactory);
 		fieldPanel = new DecompilerFieldPanel(layoutController);
+		fieldPanel.addFieldInputListener(this);
 
 		scroller = new IndexedScrollPane(fieldPanel);
 		fieldPanel.addFieldSelectionListener(this);
@@ -788,8 +789,6 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 			toggleMiddleMouseHighlight(location, field);
 		}
 	}
-
-	public static final KeyStroke SELECT = KeyStroke.getKeyStroke(KeyEvent.VK_F7, 0);
 	public static final KeyStroke HIDE = KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, 0);
 	public static final KeyStroke SHOW = KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, 0);
 
@@ -799,7 +798,6 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		FieldLocation location = getCursorPosition();
 		ClangTextField textField = (ClangTextField) field;
 		ClangToken token = textField.getToken(location);
-
 		if (SHOW.equals(keyStroke)) {
 			if (token instanceof ClangSyntaxToken) {
 				toggleCollapseToken((ClangSyntaxToken) token, false);
@@ -849,7 +847,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		}
 	}
 
-	private void tryToGoto(FieldLocation location, Field field, MouseEvent event,
+	private void tryToGoto(FieldLocation location, Field field, InputEvent event,
 			boolean newWindow) {
 		if (!navigationEnabled) {
 			return;
@@ -874,7 +872,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		}
 	}
 
-	private void tryGoToComment(FieldLocation location, MouseEvent event, ClangTextField textField,
+	private void tryGoToComment(FieldLocation location, InputEvent event, ClangTextField textField,
 			boolean newWindow) {
 
 		// comments may use annotations; tell the annotation it was clicked

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
@@ -163,7 +163,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		setDecompileData(new EmptyDecompileData("No Function"));
 
 		if (options.isDisplayLineNumbers()) {
-			addMarginProvider(lineNumbersMargin = new LineNumberDecompilerMarginProvider());
+			addMarginProvider(lineNumbersMargin = new LineNumberDecompilerMarginProvider(this));
 		}
 	}
 
@@ -847,7 +847,23 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		}
 	}
 
-	private void tryToGoto(FieldLocation location, Field field, InputEvent event,
+	public boolean containsOpeningBrace(int lineNumber) {
+		List<ClangLine> lines = layoutController.getLines();
+		if (lineNumber < 0 || lineNumber > lines.size()) {
+			Msg.showError(this, this, "Invalid Line Number",
+				"Line number " + lineNumber + " is out of range");
+			return false; // Line number out of range
+		}
+		ClangLine line = lines.get(lineNumber);
+		for (ClangToken token : line.getAllTokens()) {
+			if (token.getText().contains("{")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void tryToGoto(FieldLocation location, Field field, MouseEvent event,
 			boolean newWindow) {
 		if (!navigationEnabled) {
 			return;
@@ -872,7 +888,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		}
 	}
 
-	private void tryGoToComment(FieldLocation location, InputEvent event, ClangTextField textField,
+	private void tryGoToComment(FieldLocation location, MouseEvent event, ClangTextField textField,
 			boolean newWindow) {
 
 		// comments may use annotations; tell the annotation it was clicked
@@ -1369,7 +1385,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 
 		if (options.isDisplayLineNumbers()) {
 			if (lineNumbersMargin == null) {
-				addMarginProvider(lineNumbersMargin = new LineNumberDecompilerMarginProvider());
+				addMarginProvider(lineNumbersMargin = new LineNumberDecompilerMarginProvider(this));
 			}
 		}
 		else {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerPanel.java
@@ -37,7 +37,6 @@ import docking.widgets.fieldpanel.field.FieldElement;
 import docking.widgets.fieldpanel.listener.*;
 import docking.widgets.fieldpanel.support.*;
 import docking.widgets.indexedscrollpane.IndexedScrollPane;
-import generic.stl.Pair;
 import generic.theme.GColor;
 import ghidra.app.decompiler.*;
 import ghidra.app.decompiler.component.hover.DecompilerHoverService;
@@ -56,9 +55,6 @@ import ghidra.util.*;
 import ghidra.util.bean.field.AnnotatedTextFieldElement;
 import ghidra.util.task.SwingUpdateManager;
 
-
-import javax.swing.KeyStroke;
-import java.awt.event.KeyEvent;
 
 /**
  * Class to handle the display of a decompiled function
@@ -771,6 +767,7 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		if (!decompileData.hasDecompileResults()) {
 			return;
 		}
+
 		int clickCount = ev.getClickCount();
 		int buttonState = ev.getButton();
 		if (buttonState == MouseEvent.BUTTON1) {
@@ -861,20 +858,20 @@ public class DecompilerPanel extends JPanel implements FieldMouseListener, Field
 		return false;
 	}
 
-	public List<Pair<BigInteger, Boolean>> getLinesIndexesWithOpeningBraces() {
-		List<Pair<BigInteger, Boolean>> lineNumbers = new ArrayList<>();
+	public Map<Integer, Boolean> getLinesWithOpeningBraces() {
+		Map<Integer, Boolean> lineNumbers = new HashMap<>();
 		List<ClangLine> lines = getLines();
 
-        for (int i = 0; i < lines.size(); i++) {
-            List<ClangToken> lineTokens = lines.get(i).getAllTokens();
-            for (ClangToken token : lineTokens) {
-                if (token.getText().contains("{") && token instanceof ClangSyntaxToken) {
+		for (int i = 0; i < lines.size(); i++) {
+			List<ClangToken> lineTokens = lines.get(i).getAllTokens();
+			for (ClangToken token : lineTokens) {
+				if (token.getText().contains("{") && token instanceof ClangSyntaxToken) {
 					List<ClangNode> list = new ArrayList<>();
 					token.Parent().flatten(list);
-					lineNumbers.add(new Pair<>(BigInteger.valueOf(i), isBlockCollapsed((ClangSyntaxToken) token)));
-                }
-            }
-        }
+					lineNumbers.put(i, isBlockCollapsed((ClangSyntaxToken) token));
+				}
+			}
+		}
 		return lineNumbers;
 	}
 

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerUtils.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerUtils.java
@@ -818,6 +818,7 @@ public class DecompilerUtils {
 
 		StringBuilder commentBuilder = new StringBuilder();
 		for (; i < alltoks.size(); ++i) {
+
 			ClangToken tok = (ClangToken) alltoks.get(i);
 			if (tok.getCollapsedToken()) {
 				continue;

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerUtils.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/DecompilerUtils.java
@@ -818,8 +818,10 @@ public class DecompilerUtils {
 
 		StringBuilder commentBuilder = new StringBuilder();
 		for (; i < alltoks.size(); ++i) {
-
 			ClangToken tok = (ClangToken) alltoks.get(i);
+			if (tok.getCollapsedToken()) {
+				continue;
+			}
 			if (tok instanceof ClangBreak) {
 				lines.add(current);
 				brk = (ClangBreak) tok;

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.math.BigInteger;
-import java.util.List;
 import java.util.Map;
 
 import javax.swing.BorderFactory;
@@ -29,11 +28,9 @@ import docking.util.GraphicsUtils;
 import docking.widgets.fieldpanel.LayoutModel;
 import docking.widgets.fieldpanel.listener.IndexMapper;
 import docking.widgets.fieldpanel.listener.LayoutModelListener;
-import generic.stl.Pair;
 import ghidra.app.decompiler.DecompileOptions;
 import ghidra.app.decompiler.component.DecompilerPanel;
 import ghidra.program.model.listing.Program;
-import ghidra.util.Msg;
 
 /**
  * The built-in provider for the Decompiler's line number margin
@@ -47,7 +44,7 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 
 	public LineNumberDecompilerMarginProvider(DecompilerPanel decompilerPanel) {
 		this.decompilerPanel = decompilerPanel;
-        setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 2));
+		setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 2));
 		addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
@@ -130,8 +127,8 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 		super.paint(g);
 
 		Insets insets = getInsets();
-		int leftEdge = insets.left;
 		int rightEdge = getWidth() - insets.right - getFontMetrics(getFont()).stringWidth(" ");
+		int leftEdge = insets.left;
 		Rectangle visible = getVisibleRect();
 		BigInteger startIdx = pixmap.getIndex(visible.y);
 		BigInteger endIdx = pixmap.getIndex(visible.y + visible.height);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
@@ -19,6 +19,7 @@ import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Objects;
 
 import javax.swing.BorderFactory;
@@ -28,6 +29,7 @@ import docking.util.GraphicsUtils;
 import docking.widgets.fieldpanel.LayoutModel;
 import docking.widgets.fieldpanel.listener.IndexMapper;
 import docking.widgets.fieldpanel.listener.LayoutModelListener;
+import generic.stl.Pair;
 import ghidra.app.decompiler.DecompileOptions;
 import ghidra.app.decompiler.component.DecompilerPanel;
 import ghidra.program.model.listing.Program;
@@ -134,7 +136,7 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 		BigInteger endIdx = pixmap.getIndex(visible.y + visible.height);
 		int ascent = g.getFontMetrics().getMaxAscent();
 		int arrowSize = ascent / 2;
-		var linesIndexes = decompilerPanel.getLinesIndexesWithOpeningBraces();
+		List<Pair<BigInteger, Boolean>> linesIndexes = decompilerPanel.getLinesIndexesWithOpeningBraces();
 		int ind = 0;
 
 		for (BigInteger i = startIdx; i.compareTo(endIdx) <= 0; i = i.add(BigInteger.ONE)) {

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
@@ -102,8 +102,9 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 			return;
 		}
 		int lastLine = model.getNumIndexes().intValueExact();
-		int width = getFontMetrics(getFont()).stringWidth(Integer.toString(lastLine)) +
-				getFontMetrics(getFont()).stringWidth(" ∇");
+		int width = getFontMetrics(getFont()).stringWidth(Integer.toString(lastLine));
+		int widthForArrows = getFontMetrics(getFont()).stringWidth(" ") * 2;
+		width += widthForArrows;
 		Insets insets = getInsets();
 		width += insets.left + insets.right;
 		setPreferredSize(new Dimension(Math.max(32, width), 0));
@@ -115,7 +116,7 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 		int y = e.getY() - insets.top;
 		int x = e.getX() - insets.left;
 
-		if (x >= getWidth() - getFontMetrics(getFont()).stringWidth("∇") - insets.right) {
+		if (x >= getWidth() - getFontMetrics(getFont()).stringWidth(" ") * 2 - insets.right) {
 			decompilerPanel.onClickAction(y);
 		}
 	}
@@ -127,16 +128,24 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 		List<BigInteger> linesIndex = decompilerPanel.linesWithOpeningBraces();
 		Insets insets = getInsets();
 		int leftEdge = insets.left;
-		int rightEdge = getWidth() - insets.right - getFontMetrics(getFont()).stringWidth("∇");
+		int rightEdge = getWidth() - insets.right - getFontMetrics(getFont()).stringWidth(" ");
 		Rectangle visible = getVisibleRect();
 		BigInteger startIdx = pixmap.getIndex(visible.y);
 		BigInteger endIdx = pixmap.getIndex(visible.y + visible.height);
 		int ascent = g.getFontMetrics().getMaxAscent();
+		int arrowSize = ascent / 2; // Size of the arrow
+
 		for (BigInteger i = startIdx; i.compareTo(endIdx) <= 0; i = i.add(BigInteger.ONE)) {
 			String text = i.add(BigInteger.ONE).toString();
 			GraphicsUtils.drawString(this, g, text, leftEdge, pixmap.getPixel(i) + ascent);
 			if (linesIndex.contains(i)) {
-				GraphicsUtils.drawString(this, g, "∇", rightEdge, pixmap.getPixel(i) + ascent);
+				int y = pixmap.getPixel(i) + ascent;
+                int arrowY = y - arrowSize;
+				g.setColor(Color.DARK_GRAY);
+				g.drawLine(rightEdge, arrowY, rightEdge - arrowSize / 2, arrowY + arrowSize / 2);
+
+				g.drawLine(rightEdge, arrowY, rightEdge + arrowSize / 2, arrowY + arrowSize / 2);
+				g.setColor(Color.BLACK);
 			}
 		}
 	}

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
@@ -133,7 +133,6 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 		BigInteger startIdx = pixmap.getIndex(visible.y);
 		BigInteger endIdx = pixmap.getIndex(visible.y + visible.height);
 		int ascent = g.getFontMetrics().getMaxAscent();
-		int arrowSize = ascent / 2;
 		Map<Integer, Boolean> linesIndexes = decompilerPanel.getLinesWithOpeningBraces();
 
 
@@ -142,17 +141,11 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 			GraphicsUtils.drawString(this, g, text, leftEdge, pixmap.getPixel(i) + ascent);
 
 			if (linesIndexes.containsKey(i.intValue())) {
-				int y = pixmap.getPixel(i) + ascent;
-				g.setColor(Color.GRAY);
 				if (linesIndexes.get(i.intValue())) {
-					y -= arrowSize / 2;
-					g.drawLine(rightEdge, y, rightEdge - arrowSize / 2, y - arrowSize / 2);
-					g.drawLine(rightEdge, y, rightEdge - arrowSize / 2, y + arrowSize / 2);
+					GraphicsUtils.drawString(this, g, "+", rightEdge, pixmap.getPixel(i) + ascent);
 				} else {
-					g.drawLine(rightEdge, y, rightEdge - arrowSize / 2, y - arrowSize / 2);
-					g.drawLine(rightEdge, y, rightEdge + arrowSize / 2, y - arrowSize / 2);
+					GraphicsUtils.drawString(this, g, "-", rightEdge, pixmap.getPixel(i) + ascent);
 				}
-				g.setColor(Color.BLACK);
 			}
 		}
 	}

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/component/margin/LineNumberDecompilerMarginProvider.java
@@ -20,7 +20,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
@@ -33,6 +33,7 @@ import generic.stl.Pair;
 import ghidra.app.decompiler.DecompileOptions;
 import ghidra.app.decompiler.component.DecompilerPanel;
 import ghidra.program.model.listing.Program;
+import ghidra.util.Msg;
 
 /**
  * The built-in provider for the Decompiler's line number margin
@@ -118,7 +119,7 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 		int y = e.getY() - insets.top;
 		int x = e.getX() - insets.left;
 
-        if (x >= getWidth() - getFontMetrics(getFont()).stringWidth(" ") * 2 - insets.right) {
+		if (x >= getWidth() - getFontMetrics(getFont()).stringWidth(" ") * 2 - insets.right) {
 			decompilerPanel.arrowClickAction(y);
 			repaint();
 		}
@@ -136,19 +137,17 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 		BigInteger endIdx = pixmap.getIndex(visible.y + visible.height);
 		int ascent = g.getFontMetrics().getMaxAscent();
 		int arrowSize = ascent / 2;
-		List<Pair<BigInteger, Boolean>> linesIndexes = decompilerPanel.getLinesIndexesWithOpeningBraces();
-		int ind = 0;
+		Map<Integer, Boolean> linesIndexes = decompilerPanel.getLinesWithOpeningBraces();
+
 
 		for (BigInteger i = startIdx; i.compareTo(endIdx) <= 0; i = i.add(BigInteger.ONE)) {
 			String text = i.add(BigInteger.ONE).toString();
 			GraphicsUtils.drawString(this, g, text, leftEdge, pixmap.getPixel(i) + ascent);
-			if (linesIndexes.size() <= ind) {
-				continue;
-			}
-			if (Objects.equals(linesIndexes.get(ind).first, i)) {
+
+			if (linesIndexes.containsKey(i.intValue())) {
 				int y = pixmap.getPixel(i) + ascent;
 				g.setColor(Color.GRAY);
-				if (linesIndexes.get(ind).second) {
+				if (linesIndexes.get(i.intValue())) {
 					y -= arrowSize / 2;
 					g.drawLine(rightEdge, y, rightEdge - arrowSize / 2, y - arrowSize / 2);
 					g.drawLine(rightEdge, y, rightEdge - arrowSize / 2, y + arrowSize / 2);
@@ -157,7 +156,6 @@ public class LineNumberDecompilerMarginProvider extends JPanel
 					g.drawLine(rightEdge, y, rightEdge + arrowSize / 2, y - arrowSize / 2);
 				}
 				g.setColor(Color.BLACK);
-				++ind;
 			}
 		}
 	}

--- a/gradlew
+++ b/gradlew
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 ##############################################################################
 #
@@ -55,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -84,7 +86,8 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
+' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -112,18 +115,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-#------------Ghidra Additions ----------------------------------------------------------------------
-
-# Set variables based on Production vs Dev environment
-if [ -f "${APP_HOME}/gradle-wrapper.jar" ]; then
-    # Production Environment
-    CLASSPATH="${APP_HOME}/gradle-wrapper.jar"
-    GHIDRA_HOME="${APP_HOME}/../.."
-else
-    # Development Environment (Eclipse classes or "gradle jar")
-    CLASSPATH="${APP_HOME}/Ghidra/RuntimeScripts/Common/support/gradle/gradle-wrapper.jar"
-    GHIDRA_HOME="${APP_HOME}"
-fi
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
 # Read application properties
 while IFS='=' read -r key value

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -16,6 +16,8 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 @rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
 
 @if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
@@ -71,38 +73,8 @@ goto fail
 :execute
 @rem Setup the command line
 
-@rem ------------Ghidra Additions ------------------------------------------------------------------
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
-@rem Set variables based on Production vs Dev environment
-if exist "%APP_HOME%\gradle-wrapper.jar" (
-    @rem Production Environment
-    set "CLASSPATH=%APP_HOME%gradle-wrapper.jar"
-    set "GHIDRA_HOME=%APP_HOME%..\..\"
-) else (
-    @rem Development Environment (Eclipse classes or "gradle jar")
-    set "CLASSPATH=%APP_HOME%Ghidra\RuntimeScripts\Common\support\gradle\gradle-wrapper.jar"
-    set "GHIDRA_HOME=%APP_HOME%"
-)
-
-@rem Read application properties
-for /f "tokens=1,2 delims==" %%g in (%GHIDRA_HOME%Ghidra\application.properties) DO (set %%g=%%h)
-
-@rem Only proceed with wrapper if we are in single-repo PUBLIC/DEV mode
-set PROCEED=1
-if exist "%GHIDRA_HOME%..\ghidra.bin" (
-    set PROCEED=0
-)
-if not "%application.release.name%" == "PUBLIC" (
-    if not "%application.release.name%" == "DEV" (
-        set PROCEED=0
-    )
-)
-
-if %PROCEED% == 0 (
-    echo Please install Gradle %application.gradle.min% or later and put it on your PATH.
-    goto fail
-)
-@rem -----------------------------------------------------------------------------------------------
 
 @rem Execute Gradle
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*


### PR DESCRIPTION
Closes #1294 

This PR copies over https://github.com/spbu-se/ghidra/pull/1 to the main repo. So thanks to @Gr-i-niy, @Wall-AF and @KirillSmirnov for writing the code and reviewing the original PR. I had no involvement in that PR - I just applied the PR's commits to the latest master, and made some small adjustments to fix merge conflicts.

-----

This PR increases the left margin of the decompiler view and uses it to display "+" and "-" symbols at the start of code blocks. You can click those to fold/unfold code sections.

**Before**
<img width="623" height="508" alt="Screenshot showing decompiler view without PR applied" src="https://github.com/user-attachments/assets/756386a2-379f-4067-aa0c-ccaef5782968" />


**After**
<img width="623" height="410" alt="Screenshot showing decompiler view with PR applied, clearly showing - characters in the extra large left margin" src="https://github.com/user-attachments/assets/99df0d33-54b1-4874-968b-3d7354927b4b" />

**After (folded)**
<img width="623" height="411" alt="image" src="https://github.com/user-attachments/assets/7c211524-4b36-42f9-a652-63961062a7af" />
