### PR TITLE
Decompiler: Fix inlining for call_return override

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
@@ -1170,15 +1170,16 @@ bool FlowInfo::testHardInlineRestrictions(Funcdata *inlinefd,PcodeOp *op,Address
 /// A function is in the EZ model if it is a straight-line leaf function. Note
 /// that we need to ensure that these instructions can all form a single basic
 /// block, since we cannot split a basic block in the middle of an address. As
-/// such, branches are disallowed, but CALL operations are allowed.
-/// \return \b true if this flow contains no BRANCH ops
+/// such, branches to different addresses (i.e. non-pcode relative branches) are
+/// disallowed, but CALL(IND) and p-code relative (C)BRANCH operations are allowed.
+/// \return \b true if this flow can be inlined using the EZ model
 bool FlowInfo::checkEZModel(void) const
 
 {
   list<PcodeOp *>::const_iterator iter = obank.beginDead();
   while(iter != obank.endDead()) {
     PcodeOp *op = *iter;
-    if (op->isCallOrBranch() && (op->code() != CPUI_CALL)) return false;
+    if (op->isBranch() && !(((op->code() == CPUI_BRANCH) || (op->code() == CPUI_CBRANCH)) && op->getIn(0)->isConstant())) return false;
     ++iter;
   }
   return true;


### PR DESCRIPTION
Previously, when decompiling a function with a call to an inlined function that is the result of a call_return flow override, the inline would fail with a `Return address prevents inlining here` warning. This was due to an overly restrictive check in
`FlowInfo::testHardInlineRestrictions`. With this PR applied, these function calls are inlined again.

This PR also allows `CALL` pcode-ops in EZ model functions, since `CALL` operations don't end basic blocks. This also significantly improves Ghidra's ability to inline functions with function calls inside (such as those generated by the call_return override).

This PR also makes the warning more explicit on why the return address prevents inlining.

**Sample**
[FUN_a7d3fb00_ret_addr_prevents_inline.xml](https://github.com/user-attachments/files/22872623/FUN_a7d3fb00_ret_addr_prevents_inline.xml) (manually edited to ensure the flow overrides are assigned to the correct function).

**Before**
Decompiler output without this PR applied:
```c
/* WARNING: This is an inlined function */

void FUN_a7d3fb00(undefined4 *param_1) {
  param_1[0x1c] = 0;
  memset(param_1 + 0x1e,0,800);
  *param_1 = 0;
                    /* WARNING: Return address prevents inlining here */
  FUN_a7d42a0c(param_1 + 1);
  return;
}
``` 

**After**
Decompiler output with this PR applied:
```c

/* WARNING: This is an inlined function */
/* WARNING: Inlined function: FUN_a7d42a0c */

void FUN_a7d3fb00(undefined4 *param_1) {
  param_1[0x1c] = 0;
  memset(param_1 + 0x1e,0,800);
  *param_1 = 0;
  memset(param_1 + 1,0,0x6c);
  return;
}
```
