### PR TITLE
Correct winsock.h headers in CreateExampleGDTArchiveScript.java

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/CreateExampleGDTArchiveScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/CreateExampleGDTArchiveScript.java
@@ -252,8 +252,6 @@ public class CreateExampleGDTArchiveScript extends GhidraScript {
 				"af_irda.h",
 				"in6addr.h",
 				"mstcpip.h",
-				"ws2def.h",
-				"winsock.h",
 				"winsock2.h",
 				"nsemail.h",
 				"nspapi.h",


### PR DESCRIPTION
There is a compile error if you include both winsock.h and winsock2.h. It says you should only include winsock2.h.