### PR TITLE
SuperH fix 'bclr' opcode

### DIFF
--- a/Ghidra/Processors/SuperH/data/languages/superh.sinc
+++ b/Ghidra/Processors/SuperH/data/languages/superh.sinc
@@ -2307,8 +2307,7 @@ define pcodeop Sleep_Standby;
 :bclr   "#"imm3_00_02, rn_04_07
     is opcode_08_15=0b10000110 & rn_04_07 & opcode_03_03=0b0 & imm3_00_02
 {
-    local b = *:1 (rn_04_07);
-    *:1 (rn_04_07) = b & (~(1 << imm3_00_02));
+    rn_04_07 = rn_04_07 & (~(1 << imm3_00_02));
 }
 
 # BLD.B       #imm3, @(disp12,Rn)      0011nnnn0iii1001 0011dddddddddddd        (imm of (disp+Rn)) → T 


### PR DESCRIPTION
I found a wrong decompilation near `bclr` instruction.

Real world code
```
                             FUN_00076d12 
        00076d12 04 90 3d f3     movi20     #-0x6c20d,r4
        00076d16 66 40           mov.b      @r4=>SBYTE_fff93df3,r6
        00076d18 65 63           mov        r6,r5
        00076d1a 86 50           bclr       #0x0,r5
        00076d1c 24 50           mov.b      r5,@r4=>SBYTE_fff93df3
        00076d1e 06 7b           rtv/n      r6
```

decompiled as
```
sbyte FUN_00076d12(void)
{
  *(byte *)(int)SBYTE_fff93df3 = *(byte *)(int)SBYTE_fff93df3 & 0xfe;
  return SBYTE_fff93df3;
}
```

after fix it works as it should:
```
sbyte FUN_00076d12(void)
{
  sbyte sVar1;
  
  sVar1 = SBYTE_fff93df3;
  SBYTE_fff93df3 = SBYTE_fff93df3 & 0xfe;
  return sVar1;
}
```

Similar instruction, `bset` doesn't contain such issue.