### PR TITLE
Add an Arm v8M+coprocessor variant, disabling the CDE extention

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARM.ldefs
+++ b/Ghidra/Processors/ARM/data/languages/ARM.ldefs
@@ -233,6 +233,24 @@
     <external_name tool="DWARF.register.mapping.file" name="ARMneon.dwarf"/>
   </language>
   <language processor="ARM"
+            endian="little"
+            size="32"
+            variant="v8-m"
+            version="1.107"
+            slafile="ARM8m_cp_le.sla"
+            processorspec="ARMCortex.pspec"
+            manualindexfile="../manuals/ARM.idx"
+            id="ARM:LE:32:v8-m-cp">
+    <description>ARM Cortex v8-m little endian, with co-processor</description>
+    <compiler name="default" spec="ARM.cspec" id="default"/>
+    <compiler name="APCS" spec="ARM_apcs.cspec" id="apcs"/>
+    <external_name tool="gnu" name="armv8-m.base"/>
+    <external_name tool="gnu" name="armv8-m.main"/>
+    <external_name tool="gnu" name="armv8.1-m.main"/>
+    <external_name tool="gdis.disassembler.options.file" name="ARM.gdis"/>
+    <external_name tool="DWARF.register.mapping.file" name="ARMneon.dwarf"/>
+  </language>
+  <language processor="ARM"
             endian="big"
             size="32"
             variant="v8-m"
@@ -250,7 +268,25 @@
     <external_name tool="gdis.disassembler.options.file" name="ARM.gdis"/>
     <external_name tool="DWARF.register.mapping.file" name="ARMneon.dwarf"/>
   </language>
-  
+  <language processor="ARM"
+            endian="big"
+            size="32"
+            variant="v8-m"
+            version="1.107"
+            slafile="ARM8m_cp_be.sla"
+            processorspec="ARMCortex.pspec"
+            manualindexfile="../manuals/ARM.idx"
+            id="ARM:BE:32:v8-m-cp">
+    <description>ARM Cortex v8-m big endian, with co-processor</description>
+    <compiler name="default" spec="ARM.cspec" id="default"/>
+    <compiler name="APCS" spec="ARM_apcs.cspec" id="apcs"/>
+    <external_name tool="gnu" name="armv8-m.base"/>
+    <external_name tool="gnu" name="armv8-m.main"/>
+    <external_name tool="gnu" name="armv8.1-m.main"/>
+    <external_name tool="gdis.disassembler.options.file" name="ARM.gdis"/>
+    <external_name tool="DWARF.register.mapping.file" name="ARMneon.dwarf"/>
+  </language>
+
   <language processor="ARM"
             endian="little"
             size="32"

--- a/Ghidra/Processors/ARM/data/languages/ARM8m_cp_be.slaspec
+++ b/Ghidra/Processors/ARM/data/languages/ARM8m_cp_be.slaspec
@@ -1,0 +1,19 @@
+
+@define ENDIAN "big"
+@define T_VARIANT ""
+@define VERSION_5 ""
+@define VERSION_5E ""
+@define VERSION_6 ""
+@define VERSION_6K ""
+@define VERSION_6T2 ""
+@define VERSION_7 ""
+@define VERSION_7M ""
+@define VERSION_8 ""
+@define SIMD ""
+# https://github.com/NationalSecurityAgency/ghidra/issues/8391
+@define CORTEX ""
+@define VFPv3 ""
+@define VFPv4 ""
+
+@include "ARM.sinc"
+@include "ARM_CDE.sinc"

--- a/Ghidra/Processors/ARM/data/languages/ARM8m_cp_le.slaspec
+++ b/Ghidra/Processors/ARM/data/languages/ARM8m_cp_le.slaspec
@@ -1,0 +1,19 @@
+
+@define ENDIAN "little"
+@define T_VARIANT ""
+@define VERSION_5 ""
+@define VERSION_5E ""
+@define VERSION_6 ""
+@define VERSION_6K ""
+@define VERSION_6T2 ""
+@define VERSION_7 ""
+@define VERSION_7M ""
+@define VERSION_8 ""
+@define SIMD ""
+# https://github.com/NationalSecurityAgency/ghidra/issues/8391
+@define CORTEX ""
+@define VFPv3 ""
+@define VFPv4 ""
+
+@include "ARM.sinc"
+@include "ARM_CDE.sinc"


### PR DESCRIPTION
Fixes #8391

Adds two new language ids:
* `ARM:LE:32:v8-m-cp`
* `ARM:BE:32:v8-m-cp`

These disable the CDE extension, using the co-processor instruction decoding instead.

I've been using these extensively on the Cortex-M33 Raspberry Pi RP2350.