### PR TITLE
8586 Correctly decompile 1 indexing for globals

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.hh
@@ -192,6 +192,7 @@ class ActionConstantPtr : public Action {
   static bool checkCopy(PcodeOp *op,Funcdata &data);
   static SymbolEntry *isPointer(AddrSpace *spc,Varnode *vn,PcodeOp *op,int4 slot,
 				Address &rampoint,uintb &fullEncoding,Funcdata &data);
+  static int8 getConstOffsetBack(Varnode *vn,int8 &multiplier,int4 maxLevel);
 public:
   ActionConstantPtr(const string &g) : Action(0,"constantptr",g) {}	///< Constructor
   virtual void reset(Funcdata &data) { localcount = 0; }


### PR DESCRIPTION
This is the first draft of a solution to #8586. There are almost certainly some improvements that need to be made to code organization (first time contributor), but it solves most cases of global arrays with 1-indexing. 

Some improvements can be made to recognized arrays within structs, and further levels of nesting, but this was a massive improvement on my current project. Cross-refs work correctly and drastically improves decompile as shown in #8586.