### PR TITLE
Fix spelling and grammar mistakes in the manual index documentation

### DIFF
--- a/GhidraDocs/languages/manual_index.txt
+++ b/GhidraDocs/languages/manual_index.txt
@@ -2,12 +2,12 @@
 How to Create a Processor Language Manual Index File
 ----------------------------------------------------
 
-The processor manual index file (*.idx) contains list of instructions mnemonic and page
-numbers into an identified PDF manual.  These files along with the corresponding PDF files
+The processor manual index file (*.idx) contains a list of instruction mnemonics and page
+numbers in an identified PDF manual.  These files, along with the corresponding PDF files,
 are generally located within the data/manuals directory of a Ghidra module
 (e.g., Ghidra/Processors/x86/data/manuals/x86.idx).
 
-The first line of the .idx file must be a PDF manual selector preceeded by the @ character.
+The first line of the .idx file must be a PDF manual selector preceded by the @ character.
 
 Example:
 
@@ -17,7 +17,7 @@ The manual selector specifies the PDF file name followed by the manual descripti
 brackets [ ].  The ".pdf" file extension is assumed if not specified, and the file path is
 relative to the directory containing the index file.  If the manual is omitted from the
 distribution due to copyright or other restrictions, the bracketed text will be helpful
-in allowing the user to obtain the manual on there own.
+in allowing the user to obtain the manual on their own.
 
 The PDF manual selector is immediately followed by lines containing instruction
 mnemonic, page number pairs which are contained within the specified PDF manual.
@@ -34,9 +34,9 @@ NEG, 4
 NOP, 7
 NOT, 9
 
-The AAA and AAD instructions will be found in Intel64_IA32_vol2a.pdf manual on
+The AAA and AAD instructions will be found in Intel64_IA32_vol2a.pdf manual
 on page 74 and 76, respectively.  Moreover, the NEG and NOP instructions
-will be found in Intel64_IA32_vol2b.pdf on page 4 and 7 respectively. Also, the
+will be found in Intel64_IA32_vol2b.pdf on page 4 and 7, respectively. Also, the
 remainder of the instructions will be found under Intel64_IA32_vol2b.pdf unless
 another section is defined with the "@" symbol.
 
@@ -51,4 +51,4 @@ its respective section. The instruction mnemonic may only specify the start of a
 mnemonic if appropriate.  For example a conditional branch instruction may include
 a condition suffix on the mnemonic, but for simplification the suffix may be omitted
 within the index file if all condition cases are handled together (e.g., index could
-a mnemonic 'B' instead of listing all the condition cases BLT, BGT, BEQ, etc.).
+have a mnemonic 'B' instead of listing all the condition cases BLT, BGT, BEQ, etc.).


### PR DESCRIPTION
Found some typos/incorrect grammar as I was reading the documentation describing the manual index format. This pull request fixes the issues I found. Also, I trimmed the blank space from the ends of lines that had it.