### PR TITLE
Fix narrowing conversion warning

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/address.cc
@@ -630,8 +630,8 @@ void RangeList::decode(Decoder &decoder)
 #ifdef UINTB4
 uintb uintbmasks[9] = { 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
 #else
-uintb uintbmasks[9] = { 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffffLL,
-			0xffffffffffffLL, 0xffffffffffffffLL, 0xffffffffffffffffLL };
+uintb uintbmasks[9] = { 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffffULL,
+			0xffffffffffffULL, 0xffffffffffffffULL, 0xffffffffffffffffULL };
 #endif
 
 /// Treat the given \b val as a constant of \b size bytes


### PR DESCRIPTION
error : constant expression evaluates to -1 which cannot be narrowed to type 'uintb' (aka 'unsigned long long') [-Wc++11-narrowing]

The value `0xffffffffffffffffLL` is signed long long (equivalent to `-1`) which causes a warning when narrowed. This happens when building with `clang-cl` on Windows.