### PR TITLE
Fix links to Sleigh docs

### DIFF
--- a/GhidraDocs/GhidraClass/Debugger/A4-MachineState.html
+++ b/GhidraDocs/GhidraClass/Debugger/A4-MachineState.html
@@ -448,7 +448,7 @@ databases in your expression. For example, to see how far a return
 address is into <code>main</code>, you could use
 <code>*:8 RSP - main</code>.</p>
 <p>For the complete specification, see the Semantic Section in the <a
-href="../../../Ghidra/Features/Decompiler/src/main/doc/sleigh.xml">Sleigh
+href="../../../docs/languages/html/sleigh.html">Sleigh
 documentation</a>.</p>
 <p>Sleigh is a bit unconventional in that its operators are typed rather
 than its variables. All variables are fixed-length bit vectors. Their

--- a/GhidraDocs/GhidraClass/Debugger/A4-MachineState.md
+++ b/GhidraDocs/GhidraClass/Debugger/A4-MachineState.md
@@ -241,7 +241,7 @@ If you already know this language, then there is little more to learn.
 Of note, you may use labels from mapped program databases in your expression.
 For example, to see how far a return address is into `main`, you could use `*:8 RSP - main`.
 
-For the complete specification, see the Semantic Section in the [Sleigh documentation](../../../Ghidra/Features/Decompiler/src/main/doc/sleigh.xml).
+For the complete specification, see the Semantic Section in the [Sleigh documentation](../../../docs/languages/html/sleigh.html).
 
 Sleigh is a bit unconventional in that its operators are typed rather than its variables.
 All variables are fixed-length bit vectors.

--- a/GhidraDocs/GhidraClass/Debugger/B2-Emulation.html
+++ b/GhidraDocs/GhidraClass/Debugger/B2-Emulation.html
@@ -650,7 +650,7 @@ of the <code>CALL</code> instruction, we tell the emulator to skip the
 current instruction.</p>
 <p>For the complete specification of Sleigh, see the Semantic Section in
 the <a
-href="../../../Ghidra/Features/Decompiler/src/main/doc/sleigh.xml">Sleigh
+href="../../../docs/languages/html/sleigh.html">Sleigh
 documentation</a>. The emulator adds a few userops:</p>
 <ul>
 <li><code>emu_skip_decoded()</code>: Skip the current instruction.</li>

--- a/GhidraDocs/GhidraClass/Debugger/B2-Emulation.md
+++ b/GhidraDocs/GhidraClass/Debugger/B2-Emulation.md
@@ -357,7 +357,7 @@ We initialize RAX to 0, and then check if the current character is NULL, or the 
 If so, we are done; if not, we increment RAX and repeat.
 Finally, because we are *replacing* the semantics of the `CALL` instruction, we tell the emulator to skip the current instruction.
 
-For the complete specification of Sleigh, see the Semantic Section in the [Sleigh documentation](../../../Ghidra/Features/Decompiler/src/main/doc/sleigh.xml).
+For the complete specification of Sleigh, see the Semantic Section in the [Sleigh documentation](../../../docs/languages/html/sleigh.html).
 The emulator adds a few userops:
 
 * `emu_skip_decoded()`: Skip the current instruction.


### PR DESCRIPTION
Fixes links to the Sleigh documentation in documentation files such as `docs/GhidraClass/Debugger/A4-MachineState.html#sleigh-expressions` in the distribution. They currently point to `Ghidra/Features/Decompiler/src/main/doc/sleigh.xml` which doesn't exist, at least in my Windows 11.4.2 distribution. I presume that the intent is to point to `docs/languages/html/sleigh.html` instead which does exist.

I couldn't find any contribution guidelines for docs so I hope this PR is properly made. For instance I'm unsure why there's both an `html` and `md` version of each page, and if both need to be updated. Not clear either how `docs/languages/html/sleigh.html` appears as part of the build.

I'll put this in bold to make it clear: **I haven't tested building the docs with this change**.

