### PR TITLE
fix unbounded recursion in Varnode::eraseDescend

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varnode.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varnode.cc
@@ -316,13 +316,19 @@ void Varnode::printInfo(ostream &s) const
 void Varnode::eraseDescend(PcodeOp *op)
 
 {
-  list<PcodeOp *>::iterator iter;
+  list<PcodeOp *>::iterator iter = descend.begin();
 
-  iter = descend.begin();
-  while (*iter != op)		// Find this op in list of vn's descendants
-    iter++;
-  descend.erase(iter);		// Remove it from list
-  setFlags(Varnode::coverdirty);
+  while(iter != descend.end()) {	// Find this op in list of vn's descendants
+    if (*iter == op) {
+      descend.erase(iter);		// Remove it from list
+      setFlags(Varnode::coverdirty);
+      return;
+    }
+    ++iter;
+  }
+#ifdef OPACTION_DEBUG
+  throw LowlevelError("Attempted to erase non-existent PcodeOp descendant");
+#endif
 }
 
 /// Put a new operator in the descendant list and set the cover dirty flag


### PR DESCRIPTION
Moved to a bounds-checked search in Varnode::eraseDescend (Ghidra/Features/Decompiler/src/decompile/cpp/varnode.cc:316) so the descendant list is only mutated when the requested PcodeOp is actually present, preventing invalid std::list::erase calls that previously corrupted the allocator and triggered the segfault.

Builds compiled with OPACTION_DEBUG will now throw a LowlevelError if an unexpected removal is attempted, preserving diagnostics without crashing release builds.

Fixes issue #7321

Note: the sample provided in #7321 and the one described in https://github.com/NationalSecurityAgency/ghidra/issues/7321#issuecomment-3531903007 do not reliably trigger a segfault. Not sure how to to unit-test / integration-test this one.