### PR TITLE
Fix typo in Languages.htm regarding language change

### DIFF
--- a/Ghidra/Features/Base/src/main/help/help/topics/LanguageProviderPlugin/Languages.htm
+++ b/Ghidra/Features/Base/src/main/help/help/topics/LanguageProviderPlugin/Languages.htm
@@ -52,7 +52,7 @@ In addition, the program file may not be open in a tool when changing
 the assigned processor language.</p>
 <p> To change the processor language, right-click on the prorgam file
 within the <span style="font-style: italic;">Project Window</span>
-data tree, and setlect <span style="font-weight: bold;">Set Language...</span>
+data tree, and select <span style="font-weight: bold;">Set Language...</span>
 from the popup menu.&nbsp; Since setting the language is such a major
 change, the following warning will appear.</p>
 <p align="center"><img alt="" src="images/Warning.png"></p>


### PR DESCRIPTION
Corrected a typo in the instructions for changing the processor language.
`setlect` corrected to `select`