### PR TITLE
decompiler: Fix extreme value checks in Funcdata::replaceLessequal

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/address.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/address.hh
@@ -498,6 +498,18 @@ inline bool Range::contains(const Address &addr) const {
 /// \return a value appropriate for masking off the first \e size bytes
 inline uintb calc_mask(int4 size) { return uintbmasks[((uint4)size) < 8  ? size : 8]; }
 
+/// \param size of the integer in bytes
+/// \return largest unsigned integer value for given size
+inline uintb calc_uint_max(int4 size) { return calc_mask(size); }
+
+/// \param size of the integer in bytes
+/// \return largest signed integer value for given size
+inline uintb calc_int_max(int4 size) { return calc_mask(size) >> 1; }
+
+/// \param size of the integer in bytes
+/// \return smallest signed integer value for given size
+inline uintb calc_int_min(int4 size) { return (uintb)1 << (size * 8 - 1); }
+
 /// Perform a CPUI_INT_RIGHT on the given val
 /// \param val is the value to shift
 /// \param sa is the number of bits to shift


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/ghidra/issues/8696

The checks for extreme values when transforming <= to < were incomplete and relied on undefined behavior, making compilers optimize them out.

Specifically, for SLESS_EQUAL, the decompiler relied on integer overflows. For integers smaller than 8 bytes, no overflow will occur when adding 1, resulting in a missed case and, thus, x <= INT_MAX will become x < INT_MIN. For the signed case when subtracting one, the compiler removes the check due to undefined behavior, resulting in another missed case.

To fix this, add helper functions for computing maximum and minimum values for signed and unsigned varnodes and directly check for them.