### PR TITLE
decompiler: fix INT_LEFT for constant bitshift by 0 and varnodes > 8

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -3698,6 +3698,8 @@ void ActionDeadCode::propagateConsumed(vector<Varnode *> &worklist)
       if (sz > sizeof(uintb)) {	// If there exists bits beyond the precision of the consume field
 	if (sa >= 8*sizeof(uintb))
 	  a = ~((uintb)0);	// Make sure we assume one bits where we shift in unrepresented bits
+	else if (!sa)		// Special case to avoid undefined behavior caused by shifting too many bits
+	  a = outc;
 	else
 	  a = (outc >> sa) ^ ( (~((uintb)0)) << (8*sizeof(uintb)-sa));
 	sz = 8*sz -sa;


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/ghidra/issues/8705

In case of a 0-bitshift, the mask computation was performing a 64-bit shift, assuming the result will be 0. However, such a bitshift is undefined and will be equal to a NOP on some architectures.

This is fixed by explicitly checking for a shift-amount of 0.