### PR TITLE
decompiler: fix bit extractions with RuleShiftAnd and RuleShiftCompare

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -4951,8 +4951,7 @@ int4 RuleShiftAnd::applyOp(PcodeOp *op,Funcdata &data)
     mask &= fullmask;
   }
   if ((mask & nzm) != nzm) return 0;
-  data.opSetOpcode(andop,CPUI_COPY); // AND effectively does nothing, so we change it to a copy
-  data.opRemoveInput(andop,1);
+  data.opSetInput(op, invn, 0);	// Bypass the INT_AND
   return 1;
 }
 


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/ghidra/issues/8717

RuleShiftAnd previously replaced the AND opcode with COPY. This, however doesn't update the NZMask of the Varnode. As a result, following rules may assume the NZMask after the AND operation also applies to the Varnode being copied.

In combination with RuleShiftCompare, an expression of the form (a & bitmask) >> const != 0, wrongfully is reduced to a != 0. Instead of replacing the AND with COPY, we now replace the input of the shift operation instead. This way, future rules will see the correct NZMask.