### PR TITLE
Fix Python type annotations in PyGhidra module for functions using `contextmanager`

### DIFF
--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/api.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/api.py
@@ -15,7 +15,7 @@
 ##
 import sys
 import contextlib
-from typing import Union, TYPE_CHECKING, Tuple, List, Callable, Any, Optional
+from typing import Union, TYPE_CHECKING, Tuple, List, Callable, Generator, Any, Optional
 
 from pyghidra.converters import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
@@ -142,7 +142,7 @@ def consume_program(
 def program_context(
         project: "Project", 
         path: Union[str, Path],
-    ) -> "Program":
+    ) -> Generator["Program", None, None]:
     """
     Gets the Ghidra program from the given project with the given project path. The returned
     program's resource cleanup is performed by a context manager.
@@ -256,7 +256,7 @@ def ghidra_script(
 def transaction(
         program: "Program",
         description: str = "Unnamed Transaction"
-    ):
+    ) -> Generator[int, None, None]:
     """
     Creates a context for running a Ghidra transaction.
 

--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/core.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/core.py
@@ -15,7 +15,7 @@
 ##
 import contextlib
 import warnings
-from typing import Union, TYPE_CHECKING, Tuple, ContextManager, List, Optional
+from typing import Union, TYPE_CHECKING, Tuple, Generator, List, Optional
 
 from pyghidra.converters import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
@@ -179,7 +179,7 @@ def open_program(
         loader: Union[str, JClass] = None,
         program_name: str = None,
         nested_project_location = True
-) -> ContextManager["FlatProgramAPI"]: # type: ignore
+) -> Generator["FlatProgramAPI", None, None]:
     """
     Opens given binary path (or optional program name) in Ghidra and returns FlatProgramAPI object.
 

--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/internal/plugin/plugin.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/internal/plugin/plugin.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import types
 from code import InteractiveConsole
+from typing import Generator
 
 from ghidra.app.script import ScriptControls
 from ghidra.framework import Application
@@ -276,7 +277,7 @@ class PyConsole(InteractiveConsole):
                 self.reset()
 
     @contextlib.contextmanager
-    def redirect_writer(self):
+    def redirect_writer(self) -> Generator[None, None, None]:
         self._writer = self._err
         try:
             yield
@@ -292,7 +293,7 @@ class PyConsole(InteractiveConsole):
             super().showtraceback()
 
     @contextlib.contextmanager
-    def _run_context(self):
+    def _run_context(self) -> Generator[None, None, None]:
         self._script.start()
         success = False
         try:

--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/launcher.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/launcher.py
@@ -29,7 +29,7 @@ import tempfile
 import threading
 from importlib.machinery import ModuleSpec
 from pathlib import Path
-from typing import List, NoReturn, Tuple, Union
+from typing import Generator, List, NoReturn, Tuple, Union
 
 import jpype
 from jpype import imports, _jpype
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
-def _silence_java_output(stdout=True, stderr=True):
+def _silence_java_output(stdout=True, stderr=True) -> Generator[None, None, None]:
     from java.io import OutputStream, PrintStream # type:ignore @UnresolvedImport
     from java.lang import System # type:ignore @UnresolvedImport
     out = System.out


### PR DESCRIPTION
Hello,

Verifying the type annotations used by PyGhidra with Mypy static type checker leads to the following error:

    core.py:171: error: Argument 1 to "contextmanager" has incompatible
    type "Callable[[str | Path, str | Path, str, Any, str, str, str |
    JClass, str, Any], AbstractContextManager[Any, bool | None]]";
    expected "Callable[[str | Path, str | Path, str, Any, str, str, str
    | JClass, str, Any], Iterator[Never]]"  [arg-type]

Indeed, in `Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/core.py`, function `open_program` was declared to return a `ContextManager["FlatProgramAPI"]`: https://github.com/NationalSecurityAgency/ghidra/blob/a8a07b148e464f93606c3177c3d65437034196cf/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/core.py#L171-L182

While this function indeed returns such a type, the implementation uses decorator `@contextlib.contextmanager` which expects the wrapped function to return an generator (with `yield`). Use `Generator["FlatProgramAPI", None, None]` to fix this.

While at it, fix other locations where the type annotation of the function wrapped with `contextmanager` was incorrect.