### PR TITLE
Add API to change/anonymize the username field of comment history and label history

### DIFF
--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramViewListing.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramViewListing.java
@@ -69,4 +69,16 @@ public class DBTraceProgramViewListing extends AbstractDBTraceProgramViewListing
 			throw new AssertionError(e);
 		}
 	}
+
+	@Override
+	public int anonymizeCommentHistory(String anonymousName) {
+		// Trace programs don't support comment history anonymization
+		return 0;
+	}
+
+	@Override
+	public int anonymizeCommentHistory(String anonymousName, Address addr) {
+		// Trace programs don't support comment history anonymization
+		return 0;
+	}
 }

--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramViewSymbolTable.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramViewSymbolTable.java
@@ -557,4 +557,16 @@ public class DBTraceProgramViewSymbolTable implements SymbolTable {
 		}
 	}
 
+	@Override
+	public int anonymizeLabelHistory(String anonymousName) {
+		// Trace programs don't support label history anonymization
+		return 0;
+	}
+
+	@Override
+	public int anonymizeLabelHistory(String anonymousName, Address addr) {
+		// Trace programs don't support label history anonymization
+		return 0;
+	}
+
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ListingDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ListingDB.java
@@ -15,6 +15,7 @@
  */
 package ghidra.program.database;
 
+import java.io.IOException;
 import java.util.*;
 
 import ghidra.program.database.code.CodeManager;
@@ -466,6 +467,16 @@ class ListingDB implements Listing {
 	@Override
 	public CommentHistory[] getCommentHistory(Address addr, CommentType commentType) {
 		return codeMgr.getCommentHistory(addr, commentType);
+	}
+
+	@Override
+	public int anonymizeCommentHistory(String anonymousName) throws IOException {
+		return codeMgr.anonymizeCommentHistory(anonymousName);
+	}
+
+	@Override
+	public int anonymizeCommentHistory(String anonymousName, Address addr) throws IOException {
+		return codeMgr.anonymizeCommentHistory(anonymousName, addr);
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
@@ -3409,6 +3409,56 @@ public class CodeManager implements ErrorHandler, ManagerDB {
 		return new CommentHistory[0];
 	}
 
+	/**
+	 * Anonymize all comment history records by replacing usernames with a given identifier.
+	 *
+	 * @param anonymousName the replacement name (e.g., "anonymous" or "user")
+	 * @return the number of records updated
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	public int anonymizeCommentHistory(String anonymousName) throws IOException {
+		lock.acquire();
+		try {
+			if (historyAdapter == null) {
+				return 0;
+			}
+			historyAdapter.anonymizeAllRecords(anonymousName);
+			return historyAdapter.getRecordCount();
+		}
+		finally {
+			lock.release();
+		}
+	}
+
+	/**
+	 * Anonymize comment history records for a specific address by replacing usernames with a given identifier.
+	 *
+	 * @param addr the address to anonymize
+	 * @param anonymousName the replacement name
+	 * @return the number of records updated
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	public int anonymizeCommentHistory(String anonymousName, Address addr) throws IOException {
+		lock.acquire();
+		try {
+			if (historyAdapter == null) {
+				return 0;
+			}
+			historyAdapter.anonymizeRecordsByAddress(anonymousName, addr);
+			// Count records for this address
+			int count = 0;
+			RecordIterator it = historyAdapter.getRecordsByAddress(addr);
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			return count;
+		}
+		finally {
+			lock.release();
+		}
+	}
+
 	// note: you must have the lock when calling this method
 	private List<DBRecord> getHistoryRecords(Address addr, CommentType commentType)
 			throws IOException {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CommentHistoryAdapter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CommentHistoryAdapter.java
@@ -177,4 +177,20 @@ abstract class CommentHistoryAdapter {
 	 * @throws IOException if there was a problem accessing the database
 	 */
 	abstract RecordIterator getAllRecords() throws IOException;
+
+	/**
+	 * Anonymize all comment history records by replacing the userName field with the given anonymousName.
+	 * @param anonymousName the name to replace the userName field with
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	abstract void anonymizeAllRecords(String anonymousName) throws IOException;
+
+	/**
+	 * Anonymize comment history records for a specific address by replacing the userName field with the given anonymousName.
+	 * @param anonymousName the name to replace the userName field with
+	 * @param addr the address of the records to anonymize
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	abstract void anonymizeRecordsByAddress(String anonymousName, Address addr) throws IOException;
+
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CommentHistoryAdapterNoTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CommentHistoryAdapterNoTable.java
@@ -58,4 +58,14 @@ class CommentHistoryAdapterNoTable extends CommentHistoryAdapter {
 	int getRecordCount() {
 		return 0;
 	}
+
+	@Override
+	void anonymizeAllRecords(String anonymousName) throws IOException {
+		// No-op: no table to anonymize
+	}
+
+	@Override
+	void anonymizeRecordsByAddress(String anonymousName, Address addr) throws IOException {
+		// No-op: no table to anonymize
+	}
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CommentHistoryAdapterV0.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CommentHistoryAdapterV0.java
@@ -100,4 +100,26 @@ class CommentHistoryAdapterV0 extends CommentHistoryAdapter {
 	int getRecordCount() {
 		return table.getRecordCount();
 	}
+
+	@Override
+	void anonymizeAllRecords(String anonymousName) throws IOException {
+		// Use table.iterator() instead of getAllRecords() to avoid issues
+		// with AddressKeyRecordIterator when modifying records during iteration
+		RecordIterator iter = table.iterator();
+		while (iter.hasNext()) {
+			DBRecord rec = iter.next();
+			rec.setString(HISTORY_USER_COL, anonymousName);
+			table.putRecord(rec);
+		}
+	}
+
+	@Override
+	void anonymizeRecordsByAddress(String anonymousName, Address addr) throws IOException {
+		RecordIterator iter = getRecordsByAddress(addr);
+		while (iter.hasNext()) {
+			DBRecord rec = iter.next();
+			rec.setString(HISTORY_USER_COL, anonymousName);
+			table.putRecord(rec);
+		}
+	}
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/LabelHistoryAdapter.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/LabelHistoryAdapter.java
@@ -142,4 +142,21 @@ abstract class LabelHistoryAdapter {
 			Set<Address> doNotDeleteSet, TaskMonitor monitor)
 			throws CancelledException, IOException;
 
+	/**
+	 * Anonymize all label history records by replacing the userName field with the given anonymousName.
+	 * @param anonymousName the name to replace the userName field with
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	abstract void anonymizeAllRecords(String anonymousName)
+			throws IOException;
+
+	/**
+	 * Anonymize label history records for a specific address by replacing the userName field with the given username.
+	 * @param anonymousName the name to replace the userName field with
+	 * @param addr the address key of the records to anonymize
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	abstract void anonymizeRecordsByAddress(String anonymousName, long addr)
+			throws IOException;
+
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/LabelHistoryAdapterNoTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/LabelHistoryAdapterNoTable.java
@@ -99,4 +99,20 @@ class LabelHistoryAdapterNoTable extends LabelHistoryAdapter {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @see ghidra.program.database.symbol.LabelHistoryAdapter#anonymizeAllRecords(java.lang.String)
+	 */
+	@Override
+	void anonymizeAllRecords(String anonymousName) throws IOException {
+		// No-op: no table to anonymize
+	}
+
+	/**
+	 * @see ghidra.program.database.symbol.LabelHistoryAdapter#anonymizeRecordsByAddress(java.lang.String, long)
+	 */
+	@Override
+	void anonymizeRecordsByAddress(String anonymousName, long addr) throws IOException {
+		// No-op: no table to anonymize
+	}
+
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/LabelHistoryAdapterV0.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/LabelHistoryAdapterV0.java
@@ -192,4 +192,29 @@ class LabelHistoryAdapterV0 extends LabelHistoryAdapter {
 			filter);
 	}
 
+	/**
+	 * @see ghidra.program.database.symbol.LabelHistoryAdapter#anonymizeAllRecords(java.lang.String)
+	 */
+	@Override
+	void anonymizeAllRecords(String anonymousName) throws IOException {
+		RecordIterator iter = getAllRecords();
+		while (iter.hasNext()) {
+			DBRecord rec = iter.next();
+			rec.setString(HISTORY_USER_COL, anonymousName);
+			table.putRecord(rec);
+		}
+	}
+
+	/**
+	 * @see ghidra.program.database.symbol.LabelHistoryAdapter#anonymizeRecordsByAddress(java.lang.String, long)
+	 */
+	@Override
+	void anonymizeRecordsByAddress(String anonymousName, long addr) throws IOException {
+		RecordIterator iter = getRecordsByAddress(addr);
+		while (iter.hasNext()) {
+			DBRecord rec = iter.next();
+			rec.setString(HISTORY_USER_COL, anonymousName);
+			table.putRecord(rec);
+		}
+	}
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/SymbolManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/symbol/SymbolManager.java
@@ -1507,6 +1507,52 @@ public class SymbolManager implements SymbolTable, ManagerDB {
 	}
 
 	@Override
+	public int anonymizeLabelHistory(String anonymousName) throws IOException {
+		lock.acquire();
+		try {
+			if (historyAdapter == null) {
+				return 0;
+			}
+			historyAdapter.anonymizeAllRecords(anonymousName);
+			return historyAdapter.getRecordCount();
+		}
+		catch (IOException e) {
+			program.dbError(e);
+			throw e;
+		}
+		finally {
+			lock.release();
+		}
+	}
+
+	@Override
+	public int anonymizeLabelHistory(String anonymousName, Address addr) throws IOException {
+		lock.acquire();
+		try {
+			if (historyAdapter == null) {
+				return 0;
+			}
+			long addrKey = addrMap.getKey(addr, false);
+			historyAdapter.anonymizeRecordsByAddress(anonymousName, addrKey);
+			// Count records for this address
+			int count = 0;
+			RecordIterator it = historyAdapter.getRecordsByAddress(addrKey);
+			while (it.hasNext()) {
+				it.next();
+				count++;
+			}
+			return count;
+		}
+		catch (IOException e) {
+			program.dbError(e);
+			throw e;
+		}
+		finally {
+			lock.release();
+		}
+	}
+
+	@Override
 	public void invalidateCache(boolean all) {
 		variableStorageMgr.invalidateCache(all);
 		lock.acquire();

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/Listing.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/Listing.java
@@ -15,6 +15,7 @@
  */
 package ghidra.program.model.listing;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
@@ -1038,5 +1039,26 @@ public interface Listing {
 	 * @return the number of addresses where at least one comment type has been applied
 	 */
 	public long getCommentAddressCount();
+
+	/**
+	 * Anonymize all comment history records by replacing usernames with a given identifier.
+	 *
+	 * @param anonymousName the replacement name
+	 * @return the number of records updated
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	public int anonymizeCommentHistory(String anonymousName)
+		throws IOException;
+
+	/**
+	 * Anonymize comment history records for a specific address and comment type by replacing usernames with a given identifier.
+	 *
+	 * @param anonymousName the replacement name
+	 * @param addr the address of the comment to anonymize
+	 * @return the number of records updated
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	public int anonymizeCommentHistory(String anonymousName, Address addr)
+		throws IOException;
 
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/StubListing.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/StubListing.java
@@ -476,4 +476,14 @@ public class StubListing implements Listing {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
+	public int anonymizeCommentHistory(String anonymousName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int anonymizeCommentHistory(String anonymousName, Address addr) {
+		throw new UnsupportedOperationException();
+	}
+
 }

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/SymbolTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/SymbolTable.java
@@ -15,6 +15,7 @@
  */
 package ghidra.program.model.symbol;
 
+import java.io.IOException;
 import java.util.*;
 
 import ghidra.program.database.symbol.*;
@@ -658,6 +659,25 @@ public interface SymbolTable {
 	 * @return true if a label history exists for specified address, otherwise false
 	 */
 	public boolean hasLabelHistory(Address addr);
+
+	/**
+	 * Anonymize all label history records by replacing usernames with a given identifier.
+	 *
+	 * @param anonymousName the replacement name (e.g., "anonymous" or "user")
+	 * @return the number of records updated
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	public int anonymizeLabelHistory(String anonymousName) throws IOException;
+
+	/**
+	 * Anonymize label history records for a specific address by replacing usernames with a given identifier.
+	 *
+	 * @param anonymousName the replacement name
+	 * @param addr the address to anonymize
+	 * @return the number of records updated
+	 * @throws IOException if there was a problem accessing the database
+	 */
+	public int anonymizeLabelHistory(String anonymousName, Address addr) throws IOException;
 
 	/**
 	 * Get the deepest namespace containing the given address

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/model/symbol/StubSymbolTable.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/model/symbol/StubSymbolTable.java
@@ -311,4 +311,14 @@ public class StubSymbolTable implements SymbolTable {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
+	public int anonymizeLabelHistory(String anonymousName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int anonymizeLabelHistory(String anonymousName, Address addr) {
+		throw new UnsupportedOperationException();
+	}
+
 }


### PR DESCRIPTION
When working on a Ghidra server with many users, local usernames often end up in the comment history and label history of programs.  This solution exposes an API to allow the username field of label history and comment history to be changed/anonymized.

Fixes [#8728](https://github.com/NationalSecurityAgency/ghidra/issues/8728)

## Example Usage (PyGhidra/Jython):

```
# Anonymize current program's label history
currentProgram.getSymbolTable().anonymizeLabelHistory("Anonymous")

# Anonymize label history at a specific address
currentProgram.getSymbolTable().anonymizeLabelHistory("Anonymous", toAddr(0x20000))

# Anonymize current program's comment history
currentProgram.getListing().anonymizeCommentHistory("Anonymous")

# Anonymize comment history at a specific address
currentProgram.getListing().anonymizeCommentHistory("Anonymous", toAddr(0x20000))
```

## Practical Example

<img width="781" height="514" alt="ghidra_script_console" src="https://github.com/user-attachments/assets/e9c7bbb0-7315-45dc-8fb0-a70653c098d0" />

<img width="707" height="349" alt="ghidra_label_history_small_after" src="https://github.com/user-attachments/assets/fa7687ae-3a6d-4a97-844f-ac90374534ab" />

<img width="526" height="326" alt="ghidra_comment_history_small_after" src="https://github.com/user-attachments/assets/2a9296dd-6ead-4e54-bc61-df5e9905da7d" />
