### PR TITLE
Decompiler: Fixed infinite loop if unexpected element found when decoding DecisionNode

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/slghsymbol.cc
@@ -2344,6 +2344,8 @@ void DecisionNode::decode(Decoder &decoder,DecisionNode *par,SubtableSymbol *sub
       subnode->decode(decoder,this,sub);
       children.push_back(subnode);
     }
+    else
+      throw DecoderError("Unexpected element " + std::to_string(subel));
     subel = decoder.peekElement();
   }
   decoder.closeElement(el);


### PR DESCRIPTION
When decoding `DecisionNode`, if the sub-element is neither `ELEM_PAIR` nor `ELEM_DECISION` then the `while` loop will repeatedly peek this invalid element and never terminate. Updated to throw an exception in this scenario. 