### PR TITLE
BSim: Extend warning message for existing signature files

### DIFF
--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BulkSignatures.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/BulkSignatures.java
@@ -1106,7 +1106,8 @@ public class BulkSignatures implements AutoCloseable {
 			File file = new File(outdirectory, basename);
 			if ((!overwrite) && file.exists()) {
 				Msg.warn(this,
-					"Signature file already exists for: " + program.getDomainFile().getName());
+					"Signature file " + basename + " already exists for: " +
+						program.getDomainFile().getName());
 				return;
 			}
 			GenSignatures gensig = new GenSignatures(true);


### PR DESCRIPTION
Fixes #8754

Before:

```
$ ./support/bsim generatesigs ghidra://localhost/repo-test ~/git-repos/bsim-xml --bsim postgresql://localhost/repo
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.8 GBytes
Using configuration for:
 Database: repo
 Owner:    Example Owner

Repository Server: localhost
Password for gemesa:
Generating signatures for: obj1
WARN  Signature file already exists for: obj0 (SignatureRepository)
```

After:

```
$ ./support/bsim generatesigs ghidra://localhost/repo-test ~/git-repos/bsim-xml --bsim postgresql://localhost/repo
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
Max-Memory: 3.8 GBytes
Using configuration for:
 Database: repo
 Owner:    Example Owner

Repository Server: localhost
Password for gemesa:
Generating signatures for: obj1
WARN  Signature file sigs_0de541a97a4cb9648d45f81f293de764 already exists for: obj0 (SignatureRepository)
```
