### PR TITLE
Text filter 

### DIFF
--- a/Ghidra/Framework/Docking/src/main/help/help/topics/Trees/GhidraTreeFilter.html
+++ b/Ghidra/Framework/Docking/src/main/help/help/topics/Trees/GhidraTreeFilter.html
@@ -42,11 +42,13 @@
       </BLOCKQUOTE>
 	  
 	  <BLOCKQUOTE>
-          <P><IMG alt="" src="help/shared/tip.png">While focus is in the filter you can press the 
-		  up and down arrow keys to change focus to the tree or table.  This allows you to enter 
+          <P><IMG alt="" src="help/shared/tip.png">While focus is in the filter you can press the
+		  up and down arrow keys to change focus to the tree or table.  This allows you to enter
 		  a filter and arrow through the results without using the mouse.   To get back to the
-		  filter easily, press the <A HREF="#Activate_Filter">activate filter</A> action (the 
-	      default key binding is <CODE>Ctrl-F</CODE>) to transfer focus back to the filter.</P>
+		  filter easily, press the <A HREF="#Activate_Filter">activate filter</A> action (the
+	      default key binding is <CODE>Ctrl-F</CODE>) to transfer focus back to the filter.
+		  Press <CODE>Escape</CODE> to clear the filter text; press <CODE>Escape</CODE> again
+		  (when the field is empty) to hide the filter.</P>
         </BLOCKQUOTE>
     </BLOCKQUOTE><BR>
      <BR>
@@ -61,16 +63,7 @@
 		  The default key binding for this action is <CODE>Ctrl-F</CODE>.
 		  </P>
 		</BLOCKQUOTE>
-	
-	
-	<H3><A name="Toggle_Filter"></A>Toggle Filter</H3>
-		<BLOCKQUOTE>
-	      <P>
-		  The <B>Toggle Filter</B> action will hide and show the filter field of the tree or table.
-		  To use this action you must first assign it a key binding from the tool options.
-		  </P>
-		</BLOCKQUOTE>
-		
+
 
     <H3>Clear Filter</H3>
 
@@ -96,6 +89,18 @@
           </TR>
         </TABLE>
       </CENTER>
+    </BLOCKQUOTE>
+
+    <H3><A name="Close_Filter"></A>Close Filter</H3>
+
+    <BLOCKQUOTE>
+      <P>The <B>Close Filter</B> button, located to the right of the Filter Options button,
+      will hide the filter panel when clicked. This can be useful to save screen space when
+      filtering is not needed. The filter can be shown again by pressing <CODE>Ctrl-F</CODE>.
+      You can also hide the filter by pressing <CODE>Escape</CODE> while the filter field has
+      focus and is empty (if the field contains text, the first <CODE>Escape</CODE> press will
+      clear the text, and the second press will hide the filter).
+      Ghidra will remember whether you prefer the filter shown or hidden.</P>
     </BLOCKQUOTE><BR>
      <BR>
 	</BLOCKQUOTE>		

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/filter/FilterTextField.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/filter/FilterTextField.java
@@ -303,6 +303,21 @@ public class FilterTextField extends JPanel {
 		return textField.requestFocusInWindow();
 	}
 
+	@Override
+	public void addKeyListener(java.awt.event.KeyListener listener) {
+		textField.addKeyListener(listener);
+	}
+
+	@Override
+	public void removeKeyListener(java.awt.event.KeyListener listener) {
+		textField.removeKeyListener(listener);
+	}
+
+	@Override
+	public java.awt.event.KeyListener[] getKeyListeners() {
+		return textField.getKeyListeners();
+	}
+
 	private void fireFilterChanged(String text) {
 		for (FilterListener l : listeners) {
 			l.filterChanged(text);

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/GTable.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/GTable.java
@@ -1530,38 +1530,8 @@ public class GTable extends JTable {
 		);
 		activateFilterAction.setKeyBindingData(new KeyBindingData(ACTIVATE_FILTER_KEY_STROKE));
 		activateFilterAction.setHelpLocation(new HelpLocation("Trees", "Activate_Filter"));
-		//@formatter:on
 
-		GTableAction toggleFilterAction = new GTableAction("Table/Tree Toggle Filter", owner) {
-
-			@Override
-			public boolean isEnabledForContext(ActionContext context) {
-				if (!super.isEnabledForContext(context)) {
-					return false;
-				}
-
-				GTable gTable = (GTable) context.getSourceComponent();
-				return gTable.getTableFilterPanel() != null;
-			}
-
-			@Override
-			public void actionPerformed(ActionContext context) {
-
-				GTable gTable = (GTable) context.getSourceComponent();
-				GTableFilterPanel<?> filterPanel = gTable.getTableFilterPanel();
-				filterPanel.toggleVisibility();
-			}
-		};
-		//@formatter:off
-		toggleFilterAction.setPopupMenuData(new MenuData(
-				new String[] { "Toggle Filter" },
-				null /*icon*/,
-				actionMenuGroup,
-				NO_MNEMONIC,
-				Integer.toString(subGroupIndex++)
-			)
-		);		
-		toggleFilterAction.setHelpLocation(new HelpLocation("Trees", "Toggle_Filter"));
+		// Removed Toggle Filter action - users can now use the Close Filter button or Escape key
 		//@formatter:on
 
 		toolActions.addGlobalAction(copyAction);
@@ -1571,7 +1541,6 @@ public class GTable extends JTable {
 		toolActions.addGlobalAction(exportColumnsAction);
 		toolActions.addGlobalAction(selectAllAction);
 		toolActions.addGlobalAction(activateFilterAction);
-		toolActions.addGlobalAction(toggleFilterAction);
 	}
 
 //==================================================================================================

--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/tree/GTree.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/tree/GTree.java
@@ -1978,22 +1978,9 @@ public class GTree extends JPanel implements BusyListener {
 			)
 		);
 		activateFilterAction.setKeyBindingData(new KeyBindingData("Control F"));
-		activateFilterAction.setHelpLocation(new HelpLocation("Trees", "Toggle_Filter"));
-		
-		GTreeAction toggleFilterAction = new GTreeAction("Table/Tree Toggle Filter", owner) {
-			@Override
-			public void actionPerformed(ActionContext context) {
-				GTree gTree = getTree(context);
-				gTree.filterProvider.toggleVisibility();				
-			}
-		};
+		activateFilterAction.setHelpLocation(new HelpLocation("Trees", "Activate_Filter"));
+
 		//@formatter:on
-		toggleFilterAction.setPopupMenuData(new MenuData(
-			new String[] { "Toggle Filter" },
-			null,
-			actionMenuGroup, NO_MNEMONIC,
-			Integer.toString(subGroupIndex++)));
-		toggleFilterAction.setHelpLocation(new HelpLocation("Trees", "Toggle_Filter"));
 
 		// these actions are self-explanatory and do need help
 		collapseAction.markHelpUnnecessary();
@@ -2007,7 +1994,6 @@ public class GTree extends JPanel implements BusyListener {
 		toolActions.addGlobalAction(expandTreeAction);
 		toolActions.addGlobalAction(copyFormattedAction);
 		toolActions.addGlobalAction(activateFilterAction);
-		toolActions.addGlobalAction(toggleFilterAction);
 	}
 
 	private static String generateFilterPreferenceKey() {


### PR DESCRIPTION
- Added "Close Filter" button (X icon) to filter panels in trees and tables for hiding the filter UI
- Added Escape key behavior: first press clears filter text, second press (when field is empty) hides the filter panel
- Removed "Toggle Filter" menu action from trees and tables (replaced by Close button and Escape key)


![python_SO0RSbprKk](https://github.com/user-attachments/assets/35bb0065-d439-4036-9e1b-c7b4b8b9c192)

