### PR TITLE
normalize username to lowercase on windows

### DIFF
--- a/Ghidra/Framework/Utility/src/main/java/ghidra/util/SystemUtilities.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/util/SystemUtilities.java
@@ -123,6 +123,13 @@ public class SystemUtilities {
 		if (slashIndex >= 0) {
 			uname = uname.substring(slashIndex + 1);
 		}
+
+		// on Windows, the username can come back in various cases if you're
+		// using AD or similar, this creates issues in the project file so we
+		// normalize to lowercase as it shouldn't impact anything else
+		if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+			uname = uname.toLowerCase();
+		}
 		return uname;
 	}
 


### PR DESCRIPTION
On windows systems, you can get usernames in various versions of casing which can cause problems because the username is stored case sensitively in the project file. this change normalizes windows usernames to the commonly accepted all lower case to try to mitigate most of these, but it won't solve any existing projects that are already messed up. In those cases, you can either do what's suggested in issue #43 if you have a lot OR you can update the <project>.rep/project.prp where the OWNER value=<whatever> you need as reported by the
`System.getProperty('user.name')` in Java.

Happy to adjust as needed, I've just hit this like 3 times this week due to different AD based systems returning the username in multiple casing formats.