### PR TITLE
MIPS: Don't treat mips16 LI with imm > 0x1f as LUI

### DIFF
--- a/Ghidra/Processors/MIPS/data/languages/mips16.sinc
+++ b/Ghidra/Processors/MIPS/data/languages/mips16.sinc
@@ -883,7 +883,7 @@ E2_REGOFF: imm is ext_imm_2124 & m16_i_imm [ imm = m16_i_imm | (ext_imm_2124 << 
     lockload(tmp);
 }
 
-:lui m16_rx, EXT_LIU8				is ISA_MODE=1 & RELP=1 & ext_isjal=0 & m16_op=0b01101 & m16_rx & m16_ri_z=1 & EXT_LIU8 {
+:lui m16_rx, EXT_LIU8				is ISA_MODE=1 & RELP=1 & ext_isjal=0 & ext_is_ext=1 & m16_op=0b01101 & m16_rx & m16_ri_z=1 & EXT_LIU8 {
 	m16_rx = zext(EXT_LIU8) << 16;
 }
 


### PR DESCRIPTION
I annoyingly missed this one during #8406. It was reported to me that mips16 LI instructions with an immediate > 0x1f will be treated as a LUI, this is due to a missing `is_ext` check.

<details>
<summary>Example Source</summary>

```c
int main() {
	__asm__("nop");
	__asm__("nop");
	__asm__("nop");
	__asm__(".byte 0x6c");
	__asm__(".byte 0x2b");
	__asm__("nop");
	__asm__("nop");
	__asm__(".byte 0x6c");
	__asm__(".byte 0x18");
	__asm__("nop");
	__asm__("nop");
	__asm__("li $a0, 0x18");
	__asm__("li $a0, 0x19");
	__asm__("li $a0, 0x1a");
	__asm__("li $a0, 0x1b");
	__asm__("li $a0, 0x1c");
	__asm__("li $a0, 0x1d");
	__asm__("li $a0, 0x1e");
	__asm__("li $a0, 0x1f");
	__asm__("li $a0, 0x20");
	__asm__("li $a0, 0x21");
	__asm__("li $a0, 0x22");
	__asm__("li $a0, 0x23");
	__asm__("li $a0, 0x24");
	__asm__("li $a0, 0x25");
	__asm__("li $a0, 0x26");
	__asm__("li $a0, 0x27");
	__asm__("li $a0, 0x28");
	__asm__("li $a0, 0x29");
	__asm__("li $a0, 0x2a");
	__asm__("li $a0, 0x2b");
	__asm__("li $a0, 0x2c");
	__asm__("li $a0, 0x2d");
	__asm__("li $a0, 0x2e");
	__asm__("li $a0, 0x2f");
	__asm__("nop");
	__asm__("nop");
	__asm__("lui $a0, 0x18");
	__asm__("lui $a0, 0x19");
	__asm__("lui $a0, 0x1a");
	__asm__("lui $a0, 0x1b");
	__asm__("lui $a0, 0x1c");
	__asm__("lui $a0, 0x1d");
	__asm__("lui $a0, 0x1e");
	__asm__("lui $a0, 0x1f");
	__asm__("lui $a0, 0x20");
	__asm__("lui $a0, 0x21");
	__asm__("lui $a0, 0x22");
	__asm__("lui $a0, 0x23");
	__asm__("lui $a0, 0x24");
	__asm__("lui $a0, 0x25");
	__asm__("lui $a0, 0x26");
	__asm__("lui $a0, 0x27");
	__asm__("lui $a0, 0x28");
	__asm__("lui $a0, 0x29");
	__asm__("lui $a0, 0x2a");
	__asm__("lui $a0, 0x2b");
	__asm__("lui $a0, 0x2c");
	__asm__("lui $a0, 0x2d");
	__asm__("lui $a0, 0x2e");
	__asm__("lui $a0, 0x2f");
}
```
</details>

Example binary: [a.out.zip](https://github.com/user-attachments/files/24238378/a.out.zip)
