### PR TITLE
Fix missing Altivec vadduws instruction

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/altivec.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/altivec.sinc
@@ -381,11 +381,10 @@ vaddubm_part2: is  vrA_8_8 & vrA_8_9 & vrA_8_10 & vrA_8_11 & vrA_8_12 & vrA_8_13
     vrD_32_3 = vrA_32_3 + vrB_32_3;
 }
 
-# Collides with vadduws
-# :vadduws vrD,vrA,vrB	is OP=4 & vrD & vrA & vrB & XOP_0_10=640
-# {   # TODO definition
-# 	vrD = vectorAddUnsignedWordSaturate(vrA,vrB);
-# }
+:vadduws vrD,vrA,vrB	is OP=4 & vrD & vrA & vrB & XOP_0_10=640
+{   # TODO definition
+	vrD = vectorAddUnsignedWordSaturate(vrA,vrB);
+}
 
 :vand vrD,vrA,vrB		is OP=4 & vrD & vrA & vrB & XOP_0_10=1028
 {   # TODO definition


### PR DESCRIPTION
I was trying to disassemble/decompile a PowerPC/Altivec binary and came across a `vadduws` instruction (instruction bytes `10 0b 02 80`), which failed to disassemble. After looking at the Altivec SLEIGH file, I found the cause: https://github.com/NationalSecurityAgency/ghidra/blob/dc5836119fb9864de2be156ce4af766614252ab9/Ghidra/Processors/PowerPC/data/languages/altivec.sinc#L384-L388

For some reason, `vadduws` is commented out. The comment says "Collides with vadduws", but that makes no sense to me. Seems like a mistake?