### PR TITLE
Decompiler: Don't restrict long integer literals

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/cast.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/cast.cc
@@ -79,8 +79,6 @@ bool CastStrategy::markExplicitUnsigned(PcodeOp *op,int4 slot) const
 bool CastStrategy::markExplicitLongSize(PcodeOp *op,int4 slot) const
 
 {
-  if (!op->getOpcode()->isShiftOp()) return false;
-  if (slot != 0) return false;
   Varnode *vn = op->getIn(slot);
   if (!vn->isConstant()) return false;
   if (vn->getSize() <= promoteSize) return false;


### PR DESCRIPTION
Fixes #3587

This PR fixes a correctness issue in the decompiler ouput. Previously, `CastStrategy::markExplicitLongSize` only applied to the first input of shift operations. Using "L" suffixes is more widely useful, and sometimes even required for correct decompilation output: "-0x80000000" and "-0x80000000L" compile to very different constants. I'm not sure why `CastStrategy::markExplicitLongSize` was restricted to the first input of a shift operation, so I just removed the constraint. This might result in regressions somewhere else. If that is the case, please let me know.

The example below (copied from the linked issue) demonstrates a case where the lack of a `L` suffix resulted in different code when compiling the decompiler output.

**Before:**
```C
int main(void)

{
  long lVar1;
  undefined4 local_14;
  
  lVar1 = fake_function();
  if (lVar1 < -0x80000000)
  {
    local_14 = 0x7b;
  }
  else
  {
    local_14 = 0x457;
  }
  return local_14;
}
```

**After:**
```C
int main(void)

{
  long lVar1;
  undefined4 local_14;
  
  lVar1 = fake_function();
  if (lVar1 < -0x80000000L)
  {
    local_14 = 0x7b;
  }
  else
  {
    local_14 = 0x457;
  }
  return local_14;
}
```