### PR TITLE
PowerPC: Add SPE floating point min/max instructions (efsmax, efsmin)

### DIFF
--- a/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
@@ -475,13 +475,10 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 #define pcodeop FloatingPointMaximum;
 :efsmax D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B0
 {
-   local result:4;
-   if ( A:4 f>= B:4 ) goto <use_a>;
-      result = B:4;
-      goto <done>;
-   <use_a>
-      result = A:4;
-   <done>
+   local inA:4 = A:4;
+   local inB:4 = B:4;
+   local cond:1 = inA f>= inB;
+   local result:4 = (zext(cond) * inA) + (zext(!cond) * inB);
    # assign to lower word of D
    D = ( D & 0xFFFFFFFF00000000 ) | zext( result );
    setFPRF( result );
@@ -492,13 +489,10 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 #define pcodeop FloatingPointMinimum;
 :efsmin D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B1
 {
-   local result:4;
-   if ( A:4 f<= B:4 ) goto <use_a>;
-      result = B:4;
-      goto <done>;
-   <use_a>
-      result = A:4;
-   <done>
+   local inA:4 = A:4;
+   local inB:4 = B:4;
+   local cond:1 = inA f<= inB;
+   local result:4 = (zext(cond) * inA) + (zext(!cond) * inB);
    # assign to lower word of D
    D = ( D & 0xFFFFFFFF00000000 ) | zext( result );
    setFPRF( result );

--- a/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
@@ -467,3 +467,40 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 {
   CRFD[2,1] = A:4 f< B:4;
 }
+
+# =================================================================
+# SPE Floating Point Single-Precision Min/Max
+
+# efsmax rT,rA,rB      010 1011 0000
+#define pcodeop FloatingPointMaximum;
+:efsmax D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B0
+{
+   local result:4;
+   if ( A:4 f>= B:4 ) goto <use_a>;
+      result = B:4;
+      goto <done>;
+   <use_a>
+      result = A:4;
+   <done>
+   # assign to lower word of D
+   D = ( D & 0xFFFFFFFF00000000 ) | zext( result );
+   setFPRF( result );
+   setSummaryFPSCR();
+}
+
+# efsmin rT,rA,rB      010 1011 0001
+#define pcodeop FloatingPointMinimum;
+:efsmin D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B1
+{
+   local result:4;
+   if ( A:4 f<= B:4 ) goto <use_a>;
+      result = B:4;
+      goto <done>;
+   <use_a>
+      result = A:4;
+   <done>
+   # assign to lower word of D
+   D = ( D & 0xFFFFFFFF00000000 ) | zext( result );
+   setFPRF( result );
+   setSummaryFPSCR();
+}

--- a/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
@@ -475,10 +475,12 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 #define pcodeop FloatingPointMaximum;
 :efsmax D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B0
 {
-   local inA:4 = A:4;
-   local inB:4 = B:4;
-   local cond:1 = inA f>= inB;
-   local result:4 = (zext(cond) * inA) + (zext(!cond) * inB);
+   local tmpA:4 = A:4;
+   local tmpB:4 = B:4;
+   local result:4 = tmpA;
+   if (tmpA f>= tmpB) goto <done>;
+   result = tmpB;
+   <done>
    # assign to lower word of D
    D = ( D & 0xFFFFFFFF00000000 ) | zext( result );
    setFPRF( result );
@@ -489,10 +491,12 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 #define pcodeop FloatingPointMinimum;
 :efsmin D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B1
 {
-   local inA:4 = A:4;
-   local inB:4 = B:4;
-   local cond:1 = inA f<= inB;
-   local result:4 = (zext(cond) * inA) + (zext(!cond) * inB);
+   local tmpA:4 = A:4;
+   local tmpB:4 = B:4;
+   local result:4 = tmpA;
+   if (tmpA f<= tmpB) goto <done>;
+   result = tmpB;
+   <done>
    # assign to lower word of D
    D = ( D & 0xFFFFFFFF00000000 ) | zext( result );
    setFPRF( result );


### PR DESCRIPTION
#6863 (partial)

Adds support for SPE floating-point min/max instructions (from e200z759CRM):
- efsmax: Floating-Point Single-Precision Maximum  
- efsmin: Floating-Point Single-Precision Minimum

Example:

Assembly:
  efsmin   r5,r3,r4         # r5 = min(r3, r4)
  efsmax   r5,r3,r4         # r5 = max(r3, r4)

Decompiles to:
  // efsmin
  result = fA;
  if (fB < fA) {
      result = fB;
  }

  // efsmax
  result = fA;
  if (fA < fB) {
      result = fB;
  }