### PR TITLE
Decompiler: Add space after comma in function call

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -19,7 +19,7 @@
 namespace ghidra {
 
 // Operator tokens for expressions
-//                        token #in prec assoc   optype       space bump
+//                        token #in prec assoc   optype       space bump negate
 OpToken PrintC::hidden = { "", "", 1, 70, false, OpToken::hiddenfunction, 0, 0, (OpToken *)0 };
 OpToken PrintC::scope = { "::", "", 2, 70, true, OpToken::binary, 0, 0, (OpToken *)0 };
 OpToken PrintC::object_member = { ".", "", 2, 66, true, OpToken::binary, 0, 0, (OpToken *)0  };
@@ -54,7 +54,7 @@ OpToken PrintC::boolean_and = { "&&", "", 2, 22, false, OpToken::binary, 1, 0, (
 OpToken PrintC::boolean_xor = { "^^", "", 2, 20, false, OpToken::binary, 1, 0, (OpToken *)0 };
 OpToken PrintC::boolean_or = { "||", "", 2, 18, false, OpToken::binary, 1, 0, (OpToken *)0 };
 OpToken PrintC::assignment = { "=", "", 2, 14, false, OpToken::binary, 1, 5, (OpToken *)0 };
-OpToken PrintC::comma = { ",", "", 2, 2, true, OpToken::binary, 0, 0, (OpToken *)0 };
+OpToken PrintC::comma = { ",", "", 2, 2, true, OpToken::binary_trailspace, 1, 0, (OpToken *)0 };
 OpToken PrintC::new_op = { "", "", 2, 62, false, OpToken::space, 1, 0, (OpToken *)0 };
 
 // Inplace assignment operators
@@ -2229,8 +2229,10 @@ void PrintC::emitPrototypeInputs(const FuncProto *proto)
   else {
     bool printComma = false;
     for(int4 i=0;i<sz;++i) {
-      if (printComma)
+      if (printComma) {
 	emit->print(COMMA);
+	emit->spaces(1);
+      }
       ProtoParameter *param = proto->getParam(i);
       if (isSet(hide_thisparam) && param->isThisPointer())
 	continue;
@@ -2248,8 +2250,10 @@ void PrintC::emitPrototypeInputs(const FuncProto *proto)
     }
   }
   if (proto->isDotdotdot()) {
-    if (sz != 0)
+    if (sz != 0) {
       emit->print(COMMA);
+emit->spaces(1);
+    }
     emit->print(DOTDOTDOT);
   }
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
@@ -275,6 +275,7 @@ bool PrintLanguage::parentheses(const OpToken *op2)
   switch(topToken->type) {
   case OpToken::space:
   case OpToken::binary:
+  case OpToken::binary_trailspace:
     if (topToken->precedence > op2->precedence) return true;
     if (topToken->precedence < op2->precedence) return false;
     if (topToken->associative && (topToken == op2)) return false;
@@ -296,7 +297,7 @@ bool PrintLanguage::parentheses(const OpToken *op2)
     if (topToken->precedence < op2->precedence) return false;
     // If the precedences are equal, we know this postsurround
     // comes after, so op2 being first doesn't need parens
-    if ((op2->type==OpToken::postsurround)||(op2->type==OpToken::binary)) return false;
+    if ((op2->type==OpToken::postsurround)||(op2->type==OpToken::binary)||(op2->type==OpToken::binary_trailspace)) return false;
     //    if (associative && (this == &op2)) return false;
     return true;
   case OpToken::presurround:
@@ -310,7 +311,7 @@ bool PrintLanguage::parentheses(const OpToken *op2)
     if ((stage==0)&&(revpol.size() > 1)) {	// If there is an unresolved previous token
       // New token is printed next to the previous token.
       const OpToken *prevToken = revpol[revpol.size()-2].tok;
-      if (prevToken->type != OpToken::binary && prevToken->type != OpToken::unary_prefix)
+      if (prevToken->type != OpToken::binary && prevToken->type != OpToken::unary_prefix && prevToken->type != OpToken::binary_trailspace)
 	return false;
       if (prevToken->precedence < op2->precedence) return false;
       // If precedence is equal, make sure we don't treat two tokens as associative,
@@ -334,6 +335,11 @@ void PrintLanguage::emitOp(const ReversePolish &entry)
     emit->spaces(entry.tok->spacing,entry.tok->bump); // Spacing around operator
     emit->tagOp(entry.tok->print1,EmitMarkup::no_color,entry.op);
     emit->spaces(entry.tok->spacing,entry.tok->bump);
+    break;
+  case OpToken::binary_trailspace:
+    if (entry.visited!=1) return;
+    emit->tagOp(entry.tok->print1,EmitMarkup::no_color,entry.op);
+    emit->spaces(entry.tok->spacing,entry.tok->bump); // Spacing around operator
     break;
   case OpToken::unary_prefix:
     if (entry.visited!=0) return;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.hh
@@ -86,6 +86,7 @@ public:
   /// \brief The possible types of operator token
   enum tokentype {
     binary,			///< Binary operator form (printed between its inputs)
+    binary_trailspace,	///< Binary operator (printed between its inputs), only space after operator
     unary_prefix,		///< Unary operator form (printed before its input)
     postsurround,		///< Function or array operator form
     presurround,		///< Modifier form (like a cast operation)


### PR DESCRIPTION
Fixes #1299

This pull request adds a space after the commas in every function call in the pseudo-C emitted by the decompiler, as well as in the function prototype in the pseudo-C.

This patch is based on a [comment by](https://github.com/NationalSecurityAgency/ghidra/issues/1299#issuecomment-1868390971) @jonpalmisc in the linked issue. This patch also adds a new `OpToken` type for the comma token, that is treated like `OpToken::binary`, but instead of printing spaces both before and after the token, the spaces are only printed after the token.

**Before**
```C

void move_player(map_s *map,int dx,int dy)

{
  bool bVar1;
  int iVar2;
  int iVar3;
  
  iVar2 = dx + player_x;
  iVar3 = dy + player_y;
  bVar1 = can_move(map,iVar2,iVar3);
  if (bVar1)
  {
    player_x = iVar2;
    player_y = iVar3;
    pick_up_item(map);
  }
  else
  {
    builtin_strncpy(last_message,"Du kan ikke gå derhen!",0x18);
  }
  return;
}
```

**After**
```C

void move_player(map_s *map, int dx, int dy)

{
  bool bVar1;
  int iVar2;
  int iVar3;
  
  iVar2 = dx + player_x;
  iVar3 = dy + player_y;
  bVar1 = can_move(map, iVar2, iVar3);
  if (bVar1)
  {
    player_x = iVar2;
    player_y = iVar3;
    pick_up_item(map);
  }
  else
  {
    builtin_strncpy(last_message, "Du kan ikke gå derhen!", 0x18);
  }
  return;
}
```