### PR TITLE
Add more Program Starting Locations

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/navigation/ProgramStartingLocationOptions.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/navigation/ProgramStartingLocationOptions.java
@@ -60,7 +60,7 @@ public class ProgramStartingLocationOptions implements OptionsChangeListener {
 			"a newly discovered starting symbol, provided the user hasn't manually moved.";
 
 	private static final String DEFAULT_STARTING_SYMBOLS =
-		"main.main, main, WinMain, libc_start_main, WinMainStartup, start, entry";
+		"main.main, main, wmain, WinMain, wWinMain, DriverEntry, libc_start_main, WinMainStartup, start, entry";
 
 	public enum StartLocationType {
 		LOWEST_ADDRESS("Lowest Address"),


### PR DESCRIPTION
Add [wmain](https://learn.microsoft.com/en-us/cpp/c-language/using-wmain), [wWinMain](https://learn.microsoft.com/en-us/windows/win32/learnwin32/winmain--the-application-entry-point), and [DriverEntry](https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/writing-a-driverentry-routine) functions as starting locations for Windows PE files.