### PR TITLE
pyghidra: Remove print from ghidra_builtins

### DIFF
--- a/GhidraBuild/BuildFiles/Doclets/src/main/java/ghidra/doclets/typestubs/GhidraBuiltinsBuilder.java
+++ b/GhidraBuild/BuildFiles/Doclets/src/main/java/ghidra/doclets/typestubs/GhidraBuiltinsBuilder.java
@@ -247,7 +247,7 @@ class GhidraBuiltinsBuilder {
 	 * @return A new {@link List} of filtered methods
 	 */
 	private List<PythonTypeStubMethod> filter(List<PythonTypeStubMethod> methods) {
-		final Set<String> EXCLUDES = Set.of("set");
+		final Set<String> EXCLUDES = Set.of("set", "print");
 		return methods.stream().filter(m -> !EXCLUDES.contains(m.getName())).toList();
 	}
 }


### PR DESCRIPTION
Starting with [1] there is still technically a print override applied in pyghidra/script.py

        printer = _build_script_print(self._script.writer)
        super().__setitem__("print", printer)

but its interface is the same as the builtin print:

    def _build_script_print(stdout):
        @functools.wraps(print)
        def wrapper(*objects, sep=' ', end='\n', file=None, flush=False):
            ...
        return wrapper

and very much incompatible with the interface that the stubs used to declare:

    @typing.overload
    def print(message: typing.Union[java.lang.String, str], color: java.awt.Color):
        ...

    @typing.overload
    def print(message: typing.Union[java.lang.String, str]):
        ...

This is similar to [2] and [3].

[1] 92d0f1dacfb0 ("Python3 support")
[2] cc15fdf691b9 ("GP-0: ghidra_builtins stubs no longer hides the python set type (Closes #7222)")
[3] https://github.com/NationalSecurityAgency/ghidra/issues/7222