### PR TITLE
Documentation Corrections and Script Updates

### DIFF
--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/help/help/topics/gdb/gdb.html
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/help/help/topics/gdb/gdb.html
@@ -140,7 +140,7 @@ python3 -m pip install --no-index -f Debugger-rmi-trace/pypkg/dist -f Debugger-a
     comprising our plugin for GDB and its dependencies. Copy all of the Python packages from
     <TT>Ghidra/Debug/Debugger-rmi-trace/pypkg/dist/</TT> and
     <TT>Ghidra/Debug/Debugger-agent-gdb/pypkg/dist/</TT> to the remote system. It is easiest to put
-    them all in one directory, e.g., <TT>~/ghidra-pypgk/</TT>. Then install them:</P>
+    them all in one directory, e.g., <TT>~/ghidra-pypkg/</TT>. Then install them:</P>
 
     <UL style="list-style-type: none">
       <LI>

--- a/Ghidra/Features/Base/ghidra_scripts/CreateExampleGDTArchiveScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/CreateExampleGDTArchiveScript.java
@@ -110,11 +110,10 @@ public class CreateExampleGDTArchiveScript extends GhidraScript {
 		};
 		
 		String includeFiles[] = {
-			headerFilePath+"/VC/VS22/10.0.190141.0",
-			headerFilePath+"/VC/VS22/10.0.19041.0/um",
+			headerFilePath+"/VC/VS22/Community/VC/Tools/MSVC/14.29.30133/include",
 			headerFilePath+"/VC/VS22/10.0.19041.0/shared",
 			headerFilePath+"/VC/VS22/10.0.19041.0/ucrt",
-			headerFilePath+"/VC/VS22/Community/VC/Tools/MSVC/14.30.30705/include",			
+			headerFilePath+"/VC/VS22/10.0.19041.0/um",
 		};
 		
 		String args[] = {


### PR DESCRIPTION
Documentation correction:

* Corrected a typo in the example directory name from `ghidra-pypgk` to `ghidra-pypkg` in the GDB setup documentation (`gdb.html`).

Script updates for include paths:

* Updated the `includeFiles` array in `CreateExampleGDTArchiveScript.java` to use the unified MSVC version '14.29.30133'.