### PR TITLE
RISC-V: Update Bit-Manipulation (B) extension to v1.0.0

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.ilp32d.slaspec
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.ilp32d.slaspec
@@ -1,5 +1,6 @@
 define endian=little;
 
+@define HXLEN 2
 @define XLEN 4
 @define XLEN2 8
 @define FLEN 8

--- a/Ghidra/Processors/RISCV/data/languages/riscv.ilp32d.slaspec
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.ilp32d.slaspec
@@ -1,6 +1,6 @@
 define endian=little;
 
-@define HXLEN 2
+@define HXLEN 2 # Half-XLEN 
 @define XLEN 4
 @define XLEN2 8
 @define FLEN 8

--- a/Ghidra/Processors/RISCV/data/languages/riscv.lp64d.slaspec
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.lp64d.slaspec
@@ -1,6 +1,6 @@
 define endian=little;
 
-@define HXLEN 4
+@define HXLEN 4 # Half-XLEN 
 @define XLEN 8
 @define XLEN2 16
 @define FLEN 8

--- a/Ghidra/Processors/RISCV/data/languages/riscv.lp64d.slaspec
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.lp64d.slaspec
@@ -1,5 +1,6 @@
 define endian=little;
 
+@define HXLEN 4
 @define XLEN 8
 @define XLEN2 16
 @define FLEN 8

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
@@ -134,6 +134,58 @@
 }
 
 # ==============================================================================
+# Zbs Instructions
+# ==============================================================================
+
+# 0100100 rs2 rs1 001 rd 0110011
+:bclr rd, rs1, rs2      is op2531=0x24 & rs2 & rs1 & op1214=0x1 & rd & op0006=0x33
+{
+    rd = rs1 & ~(1:$(XLEN) << (rs2 & (($(XLEN) << 3) - 1)));
+}
+
+# 0100100 shamt rs1 001 rd 0010011
+:bclri rd, rs1, op2024  is op2531=0x24 & op2024 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = rs1 & ~(1:$(XLEN) << op2024);
+}
+
+# 0100100 rs2 rs1 101 rd 0110011
+:bext rd, rs1, rs2      is op2531=0x24 & rs2 & rs1 & op1214=0x5 & rd & op0006=0x33
+{
+    rd = (rs1 >> (rs2 & (($(XLEN) << 3) - 1))) & 1;
+}
+
+# 0100100 shamt rs1 101 rd 0010011
+:bexti rd, rs1, op2024  is op2531=0x24 & op2024 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    rd = (rs1 >> op2024) & 1;
+}
+
+# 0110100 rs2 rs1 001 rd 0110011
+:binv rd, rs1, rs2      is op2531=0x34 & rs2 & rs1 & op1214=0x1 & rd & op0006=0x33
+{
+    rd = rs1 ^ (1:$(XLEN) << (rs2 & (($(XLEN) << 3) - 1)));
+}
+
+# 0110100 shamt rs1 001 rd 0010011
+:binvi rd, rs1, op2024  is op2531=0x34 & op2024 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = rs1 ^ (1:$(XLEN) << op2024);
+}
+
+# 0010100 rs2 rs1 001 rd 0110011
+:bset rd, rs1, rs2      is op2531=0x14 & rs2 & rs1 & op1214=0x1 & rd & op0006=0x33
+{
+    rd = rs1 | (1:$(XLEN) << (rs2 & (($(XLEN) << 3) - 1)));
+}
+
+# 0010100 shamt rs1 001 rd 0010011
+:bseti rd, rs1, op2024  is op2531=0x14 & op2024 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = rs1 | (1:$(XLEN) << op2024);
+}
+
+# ==============================================================================
 # Unimpl Instructions
 # ==============================================================================
 
@@ -197,26 +249,6 @@
 
 #TODO  fix op2026
 :rori rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0xc & op2026 & rd & rs1 unimpl
-
-:sbclr  rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:sbclri rd, rs1, op2026 is op0006=0x13 & op1214=0x1 & op2731=0x9 & op2026 & rd & rs1 unimpl
-
-:sbext  rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:sbexti rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0x9 & op2026 & rd & rs1 unimpl
-
-:sbinv  rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x34 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:sbinvi rd, rs1, op2026 is op0006=0x13 & op1214=0x1 & op2731=0xd & op2026 & rd & rs1 unimpl
-
-:sbset  rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x14 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:sbseti rd, rs1, op2026 is op0006=0x13 & op1214=0x1 & op2731=0x5 & op2026 & rd & rs1 unimpl
 
 :shfl    rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
@@ -2,7 +2,140 @@
 # NOTE: v1.0.0
 # Reference: https://docs.riscv.org/reference/isa/unpriv/b-st-ext.html
 
-:andn rd, rs1, rs2 is op0006=0x33 & op1214=0x7 & op2531=0x20 & rd & rs1 & rs2 unimpl
+# ==============================================================================
+# Zba Instructions
+# ==============================================================================
+
+# 0010000 rs2 rs1 010 rd 0110011
+:sh1add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x2 & rd & op0006=0x33
+{
+    rd = rs2 + (rs1 << 1);
+}
+
+# 0010000 rs2 rs1 100 rd 0110011
+:sh2add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x33
+{
+    rd = rs2 + (rs1 << 2);
+}
+
+# 0010000 rs2 rs1 110 rd 0110011
+:sh3add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x6 & rd & op0006=0x33
+{
+    rd = rs2 + (rs1 << 3);
+}
+
+# ==============================================================================
+# Zbb Instructions
+# ==============================================================================
+
+# 0100000 rs2 rs1 111 rd 0110011
+:andn rd, rs1, rs2      is op2531=0x20 & rs2 & rs1 & op1214=0x7 & rd & op0006=0x33
+{
+    rd = rs1 & ~rs2;
+}
+
+# 0100000 rs2 rs1 110 rd 0110011
+:orn rd, rs1, rs2       is op2531=0x20 & rs2 & rs1 & op1214=0x6 & rd & op0006=0x33
+{
+    rd = rs1 | ~rs2;
+}
+
+# 0100000 rs2 rs1 100 rd 0110011
+:xnor rd, rs1, rs2      is op2531=0x20 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x33
+{
+    rd = ~(rs1 ^ rs2);
+}
+
+# 0110000 00000 rs1 001 rd 0010011
+:clz rd, rs1            is op2531=0x30 & op2024=0x0 & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
+
+# 0110000 00001 rs1 001 rd 0010011
+:ctz rd, rs1            is op2531=0x30 & op2024=0x1 & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
+
+# 0110000 00010 rs1 001 rd 0010011
+:cpop rd, rs1           is op2531=0x30 & op2024=0x2 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = popcount(rs1);
+}
+
+# 0000101 rs2 rs1 110 rd 0110011
+:max rd, rs1, rs2       is op2531=0x5 & rs2 & rs1 & op1214=0x6 & rd & op0006=0x33
+{
+    if (rs1 s< rs2) goto <src2>;
+    rd = rs1;
+    goto <done>;
+    <src2>
+    rd = rs2;
+    <done>
+}
+
+# 0000101 rs2 rs1 111 rd 0110011
+:maxu rd, rs1, rs2      is op2531=0x5 & rs2 & rs1 & op1214=0x7 & rd & op0006=0x33
+{
+    if (rs1 < rs2) goto <src2>;
+    rd = rs1;
+    goto <done>;
+    <src2>
+    rd = rs2;
+    <done>
+}
+
+# 0000101 rs2 rs1 100 rd 0110011
+:min rd, rs1, rs2       is op2531=0x5 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x33
+{
+    if (rs1 s< rs2) goto <src1>;
+    rd = rs2;
+    goto <done>;
+    <src1>
+    rd = rs1;
+    <done>
+}
+
+# 0000101 rs2 rs1 101 rd 0110011
+:minu rd, rs1, rs2      is op2531=0x5 & rs2 & rs1 & op1214=0x5 & rd & op0006=0x33
+{
+    if (rs1 < rs2) goto <src1>;
+    rd = rs2;
+    goto <done>;
+    <src1>
+    rd = rs1;
+    <done>
+}
+
+# 0110000 00100 rs1 001 rd 0010011
+:sext.b rd, rs1         is op2531=0x30 & op2024=0x4 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = sext(rs1:1);
+}
+
+# 0110000 00101 rs1 001 rd 0010011
+:sext.h rd, rs1         is op2531=0x30 & op2024=0x5 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = sext(rs1:2);
+}
+
+# 0000100 00000 rs1 100 rd 0110011
+:zext.h rd, rs1         is op2531=0x4 & op2024=0x0 & rs1 & op1214=0x4 & rd & op0006=0x33
+{
+    rd = zext(rs1:2);
+}
+
+# 0010100 00111 rs1 101 rd 0010011
+:orc.b rd, rs1          is op2031=0x287 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    rd = (zext((rs1 & 0xFF) != 0) * 0xFF) |
+         (zext((rs1 & 0xFF00) != 0) * 0xFF00) |
+         (zext((rs1 & 0xFF0000) != 0) * 0xFF0000) |
+         (zext((rs1 & 0xFF000000) != 0) * 0xFF000000) |
+         (zext((rs1 & 0xFF00000000) != 0) * 0xFF00000000) |
+         (zext((rs1 & 0xFF0000000000) != 0) * 0xFF0000000000) |
+         (zext((rs1 & 0xFF000000000000) != 0) * 0xFF000000000000) |
+         (zext((rs1 & 0xFF00000000000000) != 0) * 0xFF00000000000000);
+}
+
+# ==============================================================================
+# Unimpl Instructions
+# ==============================================================================
 
 :bdep rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x24 & rd & rs1 & rs2 unimpl
 
@@ -15,8 +148,6 @@
 :clmulh rd, rs1, rs2 is op0006=0x33 & op1214=0x3 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
 :clmulr rd, rs1, rs2 is op0006=0x33 & op1214=0x2 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:clz rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x0 & op2531=0x30 & rd & rs1 unimpl
 
 :cmix rd, rs2, rs1, rs3 is op0006=0x33 & op1214=0x1 & op2526=0x3 & rd & rs1 & rs2 & rs3 unimpl
 
@@ -33,8 +164,6 @@
 :crc32c.h rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x19 & op2531=0x30 & rd & rs1 unimpl
 
 :crc32c.w rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x1a & op2531=0x30 & rd & rs1 unimpl
-
-:ctz rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x1 & op2531=0x30 & rd & rs1 unimpl
 
 :fsl  rd, rs1, rs3, rs2 is op0006=0x33 & op1214=0x1 & op2526=0x2 & rd & rs1 & rs2 & rs3 unimpl
 
@@ -53,16 +182,6 @@
 
 #TODO  fix op2026
 :grevi rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0xd & op2026 & rd & rs1 unimpl
-
-:max  rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:maxu rd, rs1, rs2 is op0006=0x33 & op1214=0x7 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:min  rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:minu rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:orn  rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x20 & rd & rs1 & rs2 unimpl
 
 :pack  rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x4 & rd & rs1 & rs2 unimpl
 
@@ -99,32 +218,6 @@
 #TODO  fix op2026
 :sbseti rd, rs1, op2026 is op0006=0x13 & op1214=0x1 & op2731=0x5 & op2026 & rd & rs1 unimpl
 
-:sext.b rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x4 & op2531=0x30 & rd & rs1 unimpl
-
-:sext.h rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x5 & op2531=0x30 & rd & rs1 unimpl
-
-# ==============================================================================
-# Zba Instructions
-# ==============================================================================
-
-# 0010000 rs2 rs1 010 rd 0110011
-:sh1add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x2 & rd & op0006=0x33
-{
-    rd = rs2 + (rs1 << 1);
-}
-
-# 0010000 rs2 rs1 100 rd 0110011
-:sh2add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x33
-{
-    rd = rs2 + (rs1 << 2);
-}
-
-# 0010000 rs2 rs1 110 rd 0110011
-:sh3add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x6 & rd & op0006=0x33
-{
-    rd = rs2 + (rs1 << 3);
-}
-
 :shfl    rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
 
 #TODO  fix op2025
@@ -144,6 +237,4 @@
 
 #TODO  fix op2025
 :unshfli rd, rs1, op2025 is op0006=0x13 & op1214=0x5 & op2631=0x2 & op2025 & rd & rs1 unimpl
-
-:xnor rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x20 & rd & rs1 & rs2 unimpl
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
@@ -46,12 +46,6 @@
     rd = ~(rs1 ^ rs2);
 }
 
-# 0110000 00000 rs1 001 rd 0010011
-:clz rd, rs1            is op2531=0x30 & op2024=0x0 & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
-
-# 0110000 00001 rs1 001 rd 0010011
-:ctz rd, rs1            is op2531=0x30 & op2024=0x1 & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
-
 # 0110000 00010 rs1 001 rd 0010011
 :cpop rd, rs1           is op2531=0x30 & op2024=0x2 & rs1 & op1214=0x1 & rd & op0006=0x13
 {
@@ -186,6 +180,59 @@
 }
 
 # ==============================================================================
+# Zbkb Instructions
+# ==============================================================================
+
+# 0110000 rs2 rs1 001 rd 0110011
+:rol rd, rs1, rs2       is op2531=0x30 & rs2 & rs1 & op1214=0x1 & rd & op0006=0x33
+{
+    rd = (rs1 << (rs2 & (($(XLEN) << 3) - 1))) |
+         (rs1 >> (($(XLEN) << 3) - (rs2 & (($(XLEN) << 3) - 1))));
+}
+
+# 0110000 rs2 rs1 101 rd 0110011
+:ror rd, rs1, rs2       is op2531=0x30 & rs2 & rs1 & op1214=0x5 & rd & op0006=0x33
+{
+    rd = (rs1 >> (rs2 & (($(XLEN) << 3) - 1))) |
+         (rs1 << (($(XLEN) << 3) - (rs2 & (($(XLEN) << 3) - 1))));
+}
+
+# 0110000 shamt rs1 101 rd 0010011
+:rori rd, rs1, op2024   is op2531=0x30 & op2024 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    rd = (rs1 >> op2024) | (rs1 << (($(XLEN) << 3) - op2024));
+}
+
+# 0110100 11000 rs1 101 rd 0010011
+:rev8 rd, rs1           is op2031=0x698 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    rd = ((rs1 & 0xFF) << 24) |
+         ((rs1 & 0xFF00) << 8) |
+         ((rs1 >> 8) & 0xFF00) |
+         ((rs1 >> 24) & 0xFF);
+}
+
+# 0000100 rs2 rs1 100 rd 0110011
+:pack rd, rs1, rs2      is op2531=0x4 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x33
+{
+    rd = (zext(rs2:$(HXLEN)) << ($(XLEN) << 2)) | zext(rs1:$(HXLEN));
+}
+
+# 0000100 rs2 rs1 111 rd 0110011
+:packh rd, rs1, rs2     is op2531=0x4 & rs2 & rs1 & op1214=0x7 & rd & op0006=0x33
+{
+    rd = (zext(rs2:1) << 8) | zext(rs1:1);
+}
+
+# 0110100 00111 rs1 101 rd 0010011
+:brev8 rd, rs1          is op2031=0x687 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    local tmp = ((rs1 & 0x5555555555555555) << 1) | ((rs1 >> 1) & 0x5555555555555555);
+    tmp =       ((tmp & 0x3333333333333333) << 2) | ((tmp >> 2) & 0x3333333333333333);
+    rd =        ((tmp & 0x0F0F0F0F0F0F0F0F) << 4) | ((tmp >> 4) & 0x0F0F0F0F0F0F0F0F);
+}
+
+# ==============================================================================
 # Unimpl Instructions
 # ==============================================================================
 
@@ -194,12 +241,6 @@
 :bext rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x4 & rd & rs1 & rs2 unimpl
 
 :bfp rd, rs1, rs2 is op0006=0x33 & op1214=0x7 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:clmul  rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:clmulh rd, rs1, rs2 is op0006=0x33 & op1214=0x3 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:clmulr rd, rs1, rs2 is op0006=0x33 & op1214=0x2 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
 :cmix rd, rs2, rs1, rs3 is op0006=0x33 & op1214=0x1 & op2526=0x3 & rd & rs1 & rs2 & rs3 unimpl
 
@@ -235,20 +276,7 @@
 #TODO  fix op2026
 :grevi rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0xd & op2026 & rd & rs1 unimpl
 
-:pack  rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-:packh rd, rs1, rs2 is op0006=0x33 & op1214=0x7 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
 :packu rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:pcnt rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x2 & op2531=0x30 & rd & rs1 unimpl
-
-:rol  rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x30 & rd & rs1 & rs2 unimpl
-
-:ror  rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x30 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:rori rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0xc & op2026 & rd & rs1 unimpl
 
 :shfl    rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
 
@@ -270,3 +298,23 @@
 #TODO  fix op2025
 :unshfli rd, rs1, op2025 is op0006=0x13 & op1214=0x5 & op2631=0x2 & op2025 & rd & rs1 unimpl
 
+# 0110000 00000 rs1 001 rd 0010011
+:clz rd, rs1            is op2531=0x30 & op2024=0x0 & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
+
+# 0110000 00001 rs1 001 rd 0010011
+:ctz rd, rs1            is op2531=0x30 & op2024=0x1 & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
+
+# 0000101 rs2 rs1 001 rd 0110011
+:clmul rd, rs1, rs2     is op2531=0x5 & rs2 & rs1 & op1214=0x1 & rd & op0006=0x33 unimpl
+
+# 0000101 rs2 rs1 011 rd 0110011
+:clmulh rd, rs1, rs2    is op2531=0x5 & rs2 & rs1 & op1214=0x3 & rd & op0006=0x33 unimpl
+
+# 0000101 rs2 rs1 010 rd 0110011
+:clmulr rd, rs1, rs2    is op2531=0x5 & rs2 & rs1 & op1214=0x2 & rd & op0006=0x33 unimpl
+
+# 0000100 01111 rs1 001 rd 0010011
+:zip rd, rs1            is op2531=0x4 & op2024=0xf & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
+
+# 0000100 01111 rs1 101 rd 0010011
+:unzip rd, rs1          is op2531=0x4 & op2024=0xf & rs1 & op1214=0x5 & rd & op0006=0x13 unimpl

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
@@ -1,4 +1,6 @@
-# RV32 Bitmanip Extension
+# RV32 Zb Extension (Bit Manipulation)
+# NOTE: v1.0.0
+# Reference: https://docs.riscv.org/reference/isa/unpriv/b-st-ext.html
 
 :andn rd, rs1, rs2 is op0006=0x33 & op1214=0x7 & op2531=0x20 & rd & rs1 & rs2 unimpl
 
@@ -101,11 +103,27 @@
 
 :sext.h rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x5 & op2531=0x30 & rd & rs1 unimpl
 
-:sh1add rd, rs1, rs2 is op0006=0x33 & op1214=0x2 & op2531=0x10 & rd & rs1 & rs2 unimpl
+# ==============================================================================
+# Zba Instructions
+# ==============================================================================
 
-:sh2add rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x10 & rd & rs1 & rs2 unimpl
+# 0010000 rs2 rs1 010 rd 0110011
+:sh1add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x2 & rd & op0006=0x33
+{
+    rd = rs2 + (rs1 << 1);
+}
 
-:sh3add rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x10 & rd & rs1 & rs2 unimpl
+# 0010000 rs2 rs1 100 rd 0110011
+:sh2add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x33
+{
+    rd = rs2 + (rs1 << 2);
+}
+
+# 0010000 rs2 rs1 110 rd 0110011
+:sh3add rd, rs1, rs2    is op2531=0x10 & rs2 & rs1 & op1214=0x6 & rd & op0006=0x33
+{
+    rd = rs2 + (rs1 << 3);
+}
 
 :shfl    rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32b.sinc
@@ -236,68 +236,6 @@
 # Unimpl Instructions
 # ==============================================================================
 
-:bdep rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:bext rd, rs1, rs2 is op0006=0x33 & op1214=0x6 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-:bfp rd, rs1, rs2 is op0006=0x33 & op1214=0x7 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:cmix rd, rs2, rs1, rs3 is op0006=0x33 & op1214=0x1 & op2526=0x3 & rd & rs1 & rs2 & rs3 unimpl
-
-:cmov rd, rs2, rs1, rs3 is op0006=0x33 & op1214=0x5 & op2526=0x3 & rd & rs1 & rs2 & rs3 unimpl
-
-:crc32.b rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x10 & op2531=0x30 & rd & rs1 unimpl
-
-:crc32.h rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x11 & op2531=0x30 & rd & rs1 unimpl
-
-:crc32.w rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x12 & op2531=0x30 & rd & rs1 unimpl
-
-:crc32c.b rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x18 & op2531=0x30 & rd & rs1 unimpl
-
-:crc32c.h rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x19 & op2531=0x30 & rd & rs1 unimpl
-
-:crc32c.w rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x1a & op2531=0x30 & rd & rs1 unimpl
-
-:fsl  rd, rs1, rs3, rs2 is op0006=0x33 & op1214=0x1 & op2526=0x2 & rd & rs1 & rs2 & rs3 unimpl
-
-:fsr  rd, rs1, rs3, rs2 is op0006=0x33 & op1214=0x5 & op2526=0x2 & rd & rs1 & rs2 & rs3 unimpl
-
-#TODO  fix op2025
-#TODO  this looks like a typo in 0.92
-:fsri rd, rs1, rs3, op2025 is op0006=0x33 & op1214=0x5 & op2626=0x1 & op2025 & rd & rs1 & rs3 unimpl
-
-:gorc  rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x14 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:gorci rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0x5 & op2026 & rd & rs1 unimpl
-
-:grev  rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x34 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:grevi rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0xd & op2026 & rd & rs1 unimpl
-
-:packu rd, rs1, rs2 is op0006=0x33 & op1214=0x4 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:shfl    rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2025
-:shfli   rd, rs1, op2025 is op0006=0x13 & op1214=0x1 & op2631=0x2 & op2025 & rd & rs1 unimpl
-
-:slo  rd, rs1, rs2 is op0006=0x33 & op1214=0x1 & op2531=0x10 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:sloi rd, rs1, op2026 is op0006=0x13 & op1214=0x1 & op2731=0x4 & op2026 & rd & rs1 unimpl
-
-:sro  rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x10 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:sroi rd, rs1, op2026 is op0006=0x13 & op1214=0x5 & op2731=0x4 & op2026 & rd & rs1 unimpl
-
-:unshfl  rd, rs1, rs2 is op0006=0x33 & op1214=0x5 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2025
-:unshfli rd, rs1, op2025 is op0006=0x13 & op1214=0x5 & op2631=0x2 & op2025 & rd & rs1 unimpl
-
 # 0110000 00000 rs1 001 rd 0010011
 :clz rd, rs1            is op2531=0x30 & op2024=0x0 & rs1 & op1214=0x1 & rd & op0006=0x13 unimpl
 
@@ -318,3 +256,9 @@
 
 # 0000100 01111 rs1 101 rd 0010011
 :unzip rd, rs1          is op2531=0x4 & op2024=0xf & rs1 & op1214=0x5 & rd & op0006=0x13 unimpl
+
+# 0010100 rs2 rs1 010 rd 0110011
+:xperm4 rd, rs1, rs2    is op2531=0x14 & rs2 & rs1 & op1214=0x2 & rd & op0006=0x33 unimpl
+
+# 0010100 rs2 rs1 100 rd 0110011
+:xperm8 rd, rs1, rs2    is op2531=0x14 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x33 unimpl

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
@@ -43,7 +43,8 @@
 # 0110000 00010 rs1 001 rd 0011011
 :cpopw rd, rs1          is op2531=0x30 & op2024=0x2 & rs1 & op1214=0x1 & rd & op0006=0x1b
 {
-    rd = zext(popcount(rs1:4));
+    local tmp:4 = popcount(rs1:4);
+    rd = zext(tmp);
 }
 
 # 0000100 00000 rs1 100 rd 0111011
@@ -96,7 +97,8 @@
 # 0000100 rs2 rs1 100 rd 0111011
 :packw rd, rs1, rs2     is op2531=0x4 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x3b
 {
-    rd = sext(((zext(rs2:2) << 16) | zext(rs1:2)):4);
+    local tmp:4 = (zext(rs2:2) << 16) | zext(rs1:2);
+    rd = sext(tmp);
 }
 
 # 0110000 rs2 rs1 001 rd 0111011

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
@@ -127,68 +127,6 @@
 # Unimpl Instructions
 # ==============================================================================
 
-#TODO  fix op2031
-:addiwu rd, rs1, op2031 is op0006=0x1b & op1214=0x4 & rd & op2031 & rs1 unimpl
-
-:addwu rd, rs1, rs2 is op0006=0x3b & op1214=0x0 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:bdepw rd, rs1, rs2 is op0006=0x3b & op1214=0x6 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:bextw rd, rs1, rs2 is op0006=0x3b & op1214=0x6 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-:bfpw rd, rs1, rs2 is op0006=0x3b & op1214=0x7 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:bmatflip rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x3 & op2531=0x30 & rd & rs1 unimpl
-
-:bmator rd, rs1, rs2 is op0006=0x33 & op1214=0x3 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-:bmatxor rd, rs1, rs2 is op0006=0x33 & op1214=0x3 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:clmulhw rd, rs1, rs2 is op0006=0x3b & op1214=0x3 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:clmulrw rd, rs1, rs2 is op0006=0x3b & op1214=0x2 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:clmulw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x5 & rd & rs1 & rs2 unimpl
-
-:crc32.d rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x13 & op2531=0x30 & rd & rs1 unimpl
-
-:crc32c.d rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x1b & op2531=0x30 & rd & rs1 unimpl
-
-:fslw  rd, rs1, rs3, rs2 is op0006=0x3b & op1214=0x1 & op2526=0x2 & rd & rs1 & rs2 & rs3 unimpl
-
-#TODO fix op2024
-:fsriw rd, rs1, rs3, op2024 is op0006=0x1b & op1214=0x5 & op2526=0x2 & op2024 & rd & rs1 & rs3 unimpl
-
-:fsrw  rd, rs1, rs3, rs2 is op0006=0x3b & op1214=0x5 & op2526=0x2 & rd & rs1 & rs2 & rs3 unimpl
-
-#TODO  fix op2024
-:gorciw rd, rs1, op2024 is op0006=0x1b & op1214=0x5 & op2531=0x14 & op2024 & rd & rs1 unimpl
-
-:gorcw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x14 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2024
-:greviw rd, rs1, op2024 is op0006=0x1b & op1214=0x5 & op2531=0x34 & op2024 & rd & rs1 unimpl
-
-:grevw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x34 & rd & rs1 & rs2 unimpl
-
-:shflw    rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2024
-:sloiw rd, rs1, op2024 is op0006=0x1b & op1214=0x1 & op2531=0x10 & op2024 & rd & rs1 unimpl
-
-:slow  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x10 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2024
-:sroiw rd, rs1, op2024 is op0006=0x1b & op1214=0x5 & op2531=0x10 & op2024 & rd & rs1 unimpl
-
-:srow  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x10 & rd & rs1 & rs2 unimpl
-
-:subu.w rd, rs1, rs2 is op0006=0x3b & op1214=0x0 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:subwu rd, rs1, rs2 is op0006=0x3b & op1214=0x0 & op2531=0x25 & rd & rs1 & rs2 unimpl
-
-:unshflw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
 # 0110000 00001 rs1 001 rd 0011011
 :ctzw rd, rs1           is op2531=0x30 & op2024=0x1 & rs1 & op1214=0x1 & rd & op0006=0x1b unimpl
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
@@ -1,9 +1,47 @@
-# RV64 Bitmanip Extension
+# RISC-V Zc & Zb Extensions (RV64 Specifics)
+# NOTE: v1.0.0
+# Reference: https://docs.riscv.org/reference/isa/unpriv/b-st-ext.html
+
+# ==============================================================================
+# Zba Instructions
+# ==============================================================================
+
+# 0000100 rs2 rs1 000 rd 0111011
+:add.uw rd, rs1, rs2    is op2531=0x4 & rs2 & rs1 & op1214=0x0 & rd & op0006=0x3b
+{
+    rd = rs2 + zext(rs1:4);
+}
+
+# 0010000 rs2 rs1 010 rd 0111011
+:sh1add.uw rd, rs1, rs2 is op2531=0x10 & rs2 & rs1 & op1214=0x2 & rd & op0006=0x3b
+{
+    rd = rs2 + (zext(rs1:4) << 1);
+}
+
+# 0010000 rs2 rs1 100 rd 0111011
+:sh2add.uw rd, rs1, rs2 is op2531=0x10 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x3b
+{
+    rd = rs2 + (zext(rs1:4) << 2);
+}
+
+# 0010000 rs2 rs1 110 rd 0111011
+:sh3add.uw rd, rs1, rs2 is op2531=0x10 & rs2 & rs1 & op1214=0x6 & rd & op0006=0x3b
+{
+    rd = rs2 + (zext(rs1:4) << 3);
+}
+
+# 000010 shamt rs1 001 rd 0011011
+:slli.uw rd, rs1, op2025 is op2631=0x2 & op2025 & rs1 & op1214=0x1 & rd & op0006=0x1b
+{
+    rd = zext(rs1:4) << op2025;
+}
+
+# ==============================================================================
+# Unimpl Instructions
+# ==============================================================================
 
 #TODO  fix op2031
 :addiwu rd, rs1, op2031 is op0006=0x1b & op1214=0x4 & rd & op2031 & rs1 unimpl
-
-:addu.w rd, rs1, rs2 is op0006=0x3b & op1214=0x0 & op2531=0x4 & rd & rs1 & rs2 unimpl
 
 :addwu rd, rs1, rs2 is op0006=0x3b & op1214=0x0 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
@@ -80,16 +118,7 @@
 
 :sbsetw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x14 & rd & rs1 & rs2 unimpl
 
-:sh1addu.w rd, rs1, rs2 is op0006=0x3b & op1214=0x2 & op2531=0x10 & rd & rs1 & rs2 unimpl
-
-:sh2addu.w rd, rs1, rs2 is op0006=0x3b & op1214=0x4 & op2531=0x10 & rd & rs1 & rs2 unimpl
-
-:sh3addu.w rd, rs1, rs2 is op0006=0x3b & op1214=0x6 & op2531=0x10 & rd & rs1 & rs2 unimpl
-
 :shflw    rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2026
-:slliu.w rd, rs1, op2026 is op0006=0x1b & op1214=0x1 & op2731=0x1 & op2026 & rd & rs1 unimpl
 
 #TODO  fix op2024
 :sloiw rd, rs1, op2024 is op0006=0x1b & op1214=0x1 & op2531=0x10 & op2024 & rd & rs1 unimpl

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
@@ -37,6 +37,22 @@
 }
 
 # ==============================================================================
+# Zbb Instructions
+# ==============================================================================
+
+# 0110000 00010 rs1 001 rd 0011011
+:cpopw rd, rs1          is op2531=0x30 & op2024=0x2 & rs1 & op1214=0x1 & rd & op0006=0x1b
+{
+    rd = zext(popcount(rs1:4));
+}
+
+# 0000100 00000 rs1 100 rd 0111011
+:zext.h rd, rs1         is op2531=0x4 & op2024=0x0 & rs1 & op1214=0x4 & rd & op0006=0x3b
+{
+    rd = zext(rs1:2);
+}
+
+# ==============================================================================
 # Unimpl Instructions
 # ==============================================================================
 
@@ -63,13 +79,9 @@
 
 :clmulw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x5 & rd & rs1 & rs2 unimpl
 
-:clzw rd, rs1 is op0006=0x1b & op1214=0x1 & op2024=0x0 & op2531=0x30 & rd & rs1 unimpl
-
 :crc32.d rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x13 & op2531=0x30 & rd & rs1 unimpl
 
 :crc32c.d rd, rs1 is op0006=0x13 & op1214=0x1 & op2024=0x1b & op2531=0x30 & rd & rs1 unimpl
-
-:ctzw rd, rs1 is op0006=0x1b & op1214=0x1 & op2024=0x1 & op2531=0x30 & rd & rs1 unimpl
 
 :fslw  rd, rs1, rs3, rs2 is op0006=0x3b & op1214=0x1 & op2526=0x2 & rd & rs1 & rs2 & rs3 unimpl
 
@@ -91,8 +103,6 @@
 :packuw rd, rs1, rs2 is op0006=0x3b & op1214=0x4 & op2531=0x24 & rd & rs1 & rs2 unimpl
 
 :packw  rd, rs1, rs2 is op0006=0x3b & op1214=0x4 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-:pcntw rd, rs1 is op0006=0x1b & op1214=0x1 & op2024=0x2 & op2531=0x30 & rd & rs1 unimpl
 
 :rolw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x30 & rd & rs1 & rs2 unimpl
 
@@ -136,3 +146,8 @@
 
 :unshflw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x4 & rd & rs1 & rs2 unimpl
 
+# 0110000 00001 rs1 001 rd 0011011
+:ctzw rd, rs1           is op2531=0x30 & op2024=0x1 & rs1 & op1214=0x1 & rd & op0006=0x1b unimpl
+
+# 0110000 00000 rs1 001 rd 0011011
+:clzw rd, rs1           is op2531=0x30 & op2024=0x0 & rs1 & op1214=0x1 & rd & op0006=0x1b unimpl

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
@@ -53,6 +53,34 @@
 }
 
 # ==============================================================================
+# Zbs Instructions
+# ==============================================================================
+
+# 010010 shamt rs1 001 rd 0010011
+:bclri rd, rs1, op2025  is op2631=0x12 & op2025 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = rs1 & ~(1:$(XLEN) << op2025);
+}
+
+# 010010 shamt rs1 101 rd 0010011
+:bexti rd, rs1, op2025  is op2531=0x12 & op2025 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    rd = (rs1 >> op2025) & 1;
+}
+
+# 011010 shamt rs1 001 rd 0010011
+:binvi rd, rs1, op2025  is op2531=0x1a & op2025 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = rs1 ^ (1:$(XLEN) << op2025);
+}
+
+# 001010 shamt rs1 001 rd 0010011
+:bseti rd, rs1, op2025  is op2531=0xa & op2025 & rs1 & op1214=0x1 & rd & op0006=0x13
+{
+    rd = rs1 | (1:$(XLEN) << op2025);
+}
+
+# ==============================================================================
 # Unimpl Instructions
 # ==============================================================================
 
@@ -110,23 +138,6 @@
 :roriw rd, rs1, op2024 is op0006=0x1b & op1214=0x5 & op2531=0x30 & op2024 & rd & rs1 unimpl
 
 :rorw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x30 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2024
-:sbclriw rd, rs1, op2024 is op0006=0x1b & op1214=0x1 & op2531=0x24 & op2024 & rd & rs1 unimpl
-
-:sbclrw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:sbextw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2024
-:sbinviw rd, rs1, op2024 is op0006=0x1b & op1214=0x1 & op2531=0x34 & op2024 & rd & rs1 unimpl
-
-:sbinvw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x34 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2024
-:sbsetiw rd, rs1, op2024 is op0006=0x1b & op1214=0x1 & op2531=0x14 & op2024 & rd & rs1 unimpl
-
-:sbsetw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x14 & rd & rs1 & rs2 unimpl
 
 :shflw    rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
 

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64b.sinc
@@ -81,6 +81,49 @@
 }
 
 # ==============================================================================
+# Zbkb Instructions
+# ==============================================================================
+
+# 011010 111000 rs1 101 rd 0010011
+:rev8 rd, rs1           is op2031=0x6b8 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    rd = ((rs1 & 0xFF) << 56) | ((rs1 & 0xFF00) << 40) |
+         ((rs1 & 0xFF0000) << 24) | ((rs1 & 0xFF000000) << 8) |
+         ((rs1 >> 8) & 0xFF000000) | ((rs1 >> 24) & 0xFF0000) |
+         ((rs1 >> 40) & 0xFF00) | ((rs1 >> 56) & 0xFF);
+}
+
+# 0000100 rs2 rs1 100 rd 0111011
+:packw rd, rs1, rs2     is op2531=0x4 & rs2 & rs1 & op1214=0x4 & rd & op0006=0x3b
+{
+    rd = sext(((zext(rs2:2) << 16) | zext(rs1:2)):4);
+}
+
+# 0110000 rs2 rs1 001 rd 0111011
+:rolw rd, rs1, rs2      is op2531=0x30 & rs2 & rs1 & op1214=0x1 & rd & op0006=0x3b
+{
+    rd = sext((rs1:4 << (rs2 & 0x1F)) | (rs1:4 >> (32 - (rs2 & 0x1F))));
+}
+
+# 0110000 rs2 rs1 101 rd 0111011
+:rorw rd, rs1, rs2      is op2531=0x30 & rs2 & rs1 & op1214=0x5 & rd & op0006=0x3b
+{
+    rd = sext( (rs1:4 >> (rs2 & 0x1F)) | (rs1:4 << (32 - (rs2 & 0x1F))) );
+}
+
+# 011000 shamt rs1 101 rd 0010011
+:rori rd, rs1, op2025   is op2631=0x18 & op2025 & rs1 & op1214=0x5 & rd & op0006=0x13
+{
+    rd = (rs1 >> op2025) | (rs1 << (($(XLEN) << 3) - op2025));
+}
+
+# 0110000 shamt rs1 101 rd 0011011
+:roriw rd, rs1, op2024  is op2531=0x30 & op2024 & rs1 & op1214=0x5 & rd & op0006=0x1b
+{
+    rd = sext((rs1:4 >> op2024) | (rs1:4 << (32 - op2024)));
+}
+
+# ==============================================================================
 # Unimpl Instructions
 # ==============================================================================
 
@@ -127,17 +170,6 @@
 :greviw rd, rs1, op2024 is op0006=0x1b & op1214=0x5 & op2531=0x34 & op2024 & rd & rs1 unimpl
 
 :grevw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x34 & rd & rs1 & rs2 unimpl
-
-:packuw rd, rs1, rs2 is op0006=0x3b & op1214=0x4 & op2531=0x24 & rd & rs1 & rs2 unimpl
-
-:packw  rd, rs1, rs2 is op0006=0x3b & op1214=0x4 & op2531=0x4 & rd & rs1 & rs2 unimpl
-
-:rolw  rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x30 & rd & rs1 & rs2 unimpl
-
-#TODO  fix op2024
-:roriw rd, rs1, op2024 is op0006=0x1b & op1214=0x5 & op2531=0x30 & op2024 & rd & rs1 unimpl
-
-:rorw  rd, rs1, rs2 is op0006=0x3b & op1214=0x5 & op2531=0x30 & rd & rs1 & rs2 unimpl
 
 :shflw    rd, rs1, rs2 is op0006=0x3b & op1214=0x1 & op2531=0x4 & rd & rs1 & rs2 unimpl
 


### PR DESCRIPTION
This PR updates the RISC-V Bit-Manipulation ('B') extension support to match the official v1.0.0 specification.
**Key Changes:**

- Updated Specification: Transitioned implementation from the draft v0.92 to the ratified v1.0.0 standard.
- Removed Deprecated Instructions: Cleaned up instructions that were present in v0.92 but removed or altered in the final specification.
- Full Implementation: Added all missing RV32 and RV64 instructions defined in v1.0.0.
- SLEIGH Refactoring: Introduced the `HXLEN` constant to simplify instruction semantics in SLEIGH files.

This ensures Ghidra correctly disassembles binaries compiled against the modern RISC-V B extension standard.