### PR TITLE
Process more ELF relocation kinds for eBPF programs

### DIFF
--- a/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
@@ -207,20 +207,22 @@ DST4: dst is dst { local tmp:4 = dst:4; export tmp; }
 #Memory instructions - Load and Store
 ###############################################################################
 
-#LDDW is the only 16-byte eBPF instruction which consists of two consecutive 8-byte blocks ('struct bpf_insn') 
+#LDDW is the only 16-byte eBPF instruction which consists of two consecutive 8-byte blocks ('struct bpf_insn')
 #and interpreted as single instruction which loads 64-bit imm value into dst. Encoding of LDDW:
 #LSR                                                                                                MSR
 #           opcode      src     dst     offset      Low 8-byte imm      zero-block      High 8-byte imm
 #bits          8         4       4        16               32               32                 32
-# So, imm64 consists of concatination of high 8-byte imm and low 8-byte imm.
+# So, imm64 consists of concatenation of high 8-byte imm and low 8-byte imm.
+#As src is used to encode special instructions (BPF_PSEUDO_MAP_FD=1, BPF_PSEUDO_MAP_VALUE=2, BPF_PSEUDO_BTF_ID=3 or BPF_PSEUDO_FUNC=4), ensure it is zero for the base instruction.
 
-:LDDW dst, concat  is imm & dst &  op_ld_st_mode=0x0 & op_ld_st_size=0x3 & op_insn_class=0x0; imm2 [ concat= (imm2 << 32) | ((imm) & 0xFFFFFFFF); ] { dst = concat; }
+:LDDW dst, concat  is imm & src=0 & dst & op_ld_st_mode=0x0 & op_ld_st_size=0x3 & op_insn_class=0x0; imm2 [ concat= (imm2 << 32) | ((imm) & 0xFFFFFFFF); ] { dst = concat; }
 
-#BPF_LD_MAP_FD(DST, MAP_FD) -> second LDDW = pseudo LDDW insn used to refer to process-local map_fd 
-#For each instruction which needs relocation, it inject corresponding file descriptor to imm field. 
+#BPF_LD_MAP_FD(DST, MAP_FD) -> second LDDW = pseudo LDDW insn used to refer to process-local map_fd
+#For each instruction which needs relocation, it injects corresponding file descriptor to imm field.
 #As a part of protocol, src_reg is set to BPF_PSEUDO_MAP_FD (which defined as 1) to notify kernel this is a map loading instruction.
+#llvm-objdump decodes this instruction as "ld_pseudo dst, src, imm"
 
-:LDDW dst, imm  is imm & src=1 & dst & op_ld_st_mode=0x0 & op_ld_st_size=0x3 & op_insn_class=0x0; imm2 { dst = *:8 imm:8; }
+:LD_MAP_FD dst, imm  is imm & src=1 & dst & op_ld_st_mode=0x0 & op_ld_st_size=0x3 & op_insn_class=0x0; imm2 { dst = *:8 imm:8; }
 
 :LDABSW dst, imm  is imm & dst & op_ld_st_mode=0x1 & op_ld_st_size=0x0 & op_insn_class=0x0 { dst = zext(*:4 imm:8); }
 

--- a/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationHandler.java
+++ b/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationHandler.java
@@ -47,11 +47,53 @@ public class eBPF_ElfRelocationHandler
 		Program program = elfRelocationContext.getProgram();
 		Memory memory = program.getMemory();
 
-		ElfSectionHeader sectionToBeRelocated =
-		elfRelocationContext.relocationTable.getSectionToBeRelocated();
-		if (sectionToBeRelocated != null &&
-				sectionToBeRelocated.getNameAsString().startsWith(".debug")) {
-			return RelocationResult.SKIPPED;
+		// eBPF ELF files are using Elf64_Rel (not Elf64_Rela) so addend must be extracted.
+		// If this changes in the future, proper support for addend should be added.
+		if (!elfRelocationContext.extractAddend() || relocation.getAddend() != 0) {
+			return RelocationResult.FAILURE;
+		}
+
+		long addend;
+		long newValue;
+		int byteLength;
+
+		// Handle relative relocations that do not require symbolAddr or symbolValue
+		switch (type) {
+			case R_BPF_64_RELATIVE:
+				// R_BPF_64_RELATIVE does not exist in Linux's libbpf but was introduced in a LLVM fork:
+				// https://github.com/anza-xyz/llvm-project/blob/bpf-tools-v1.2/llvm/include/llvm/BinaryFormat/ELFRelocs/BPF.def#L8
+				// https://github.com/anza-xyz/llvm-project/blob/bpf-tools-v1.2/lld/ELF/Arch/BPF.cpp#L38
+				if (memory.getBlock(relocationAddress).isExecute()) {
+					if (memory.getByte(relocationAddress) == 0x18) {
+						// Adjust the value of instruction LDDW by program base
+						addend = getLddwImm64(memory, relocationAddress);
+						newValue = elfRelocationContext.getImageBaseWordAdjustmentOffset() + addend;
+						setLddwImm64(memory, relocationAddress, newValue);
+						byteLength = 16;
+					}
+					else {
+						return RelocationResult.UNSUPPORTED;
+					}
+				}
+				else {
+					// Adjust a pointer value in a non-executable section by program base
+					addend = memory.getLong(relocationAddress);
+					if ((addend & 0xffffffffL) == 0) {
+						// A known bug in a LLVM fork made the compiler produce data relocations shifted by 32 bits:
+						// https://github.com/anza-xyz/llvm-project/pull/35
+						// (https://github.com/anza-xyz/llvm-project/commit/fb7188bcf651fdaa2d2c522f4b7444e2c574a822).
+						// For more details, cf. this comment in the relevant eBPF virtual machine:
+						// https://github.com/solana-labs/rbpf/blob/v0.8.5/src/elf.rs#L1061-L1070
+						// This assumes R_BPF_64_RELATIVE relocations do not use addend above 4GB.
+						addend = (addend >> 32) & 0xffffffffL;
+					}
+					newValue = elfRelocationContext.getImageBaseWordAdjustmentOffset() + addend;
+					memory.setLong(relocationAddress, newValue);
+					byteLength = 8;
+				}
+				return new RelocationResult(Status.APPLIED, byteLength);
+			default:
+				break;
 		}
 
 		// Check for unresolved symbolAddr and symbolValue required by remaining relocation types handled below
@@ -59,57 +101,97 @@ public class eBPF_ElfRelocationHandler
 			return RelocationResult.FAILURE;
 		}
 
-		long new_value;
-		int byteLength;
-
 		switch (type) {
 			case R_BPF_64_64: {
-				byteLength = 12;
-				new_value = symbolAddr.getAddressableWordOffset();
-				Byte dst = memory.getByte(relocationAddress.add(0x1));
-				memory.setLong(relocationAddress.add(0x4), new_value);
-				memory.setByte(relocationAddress.add(0x1), (byte) (dst + 0x10));
+				if (memory.getBlock(relocationAddress).isExecute()) {
+					if (memory.getByte(relocationAddress) == 0x18) {
+						// Relocate the symbol used by instruction LDDW
+						// (instructions start with an opcode byte, in both Big Endian and Little Endian encodings)
+						addend = getLddwImm64(memory, relocationAddress);
+						newValue = symbolValue + addend;
+						setLddwImm64(memory, relocationAddress, newValue);
+						byteLength = 16;
+
+						String blockName = memory.getBlock(symbolAddr).getName();
+						if (blockName.equals(".maps") || blockName.startsWith("maps")) {
+							// libbpf loader transforms LDDW instructions targeting section .maps (MAPS_ELF_SEC) to use src=BPF_PSEUDO_MAP_FD
+							// cf. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/lib/bpf/libbpf.c?h=v6.16#n6106
+							// Legacy maps (without BTF) used dedicated sections starting with "maps". For example:
+							// https://github.com/vbpf/ebpf-samples/blob/65b12c682368e4030a683f60b959ff6b5f3b3d6e/src/map_in_map_legacy.c#L19
+							// More documentation is available on https://docs.ebpf.io/linux/concepts/maps/#legacy-maps
+							byte src_dst = memory.getByte(relocationAddress.add(0x1));
+							if (memory.isBigEndian()) {
+								src_dst = (byte) ((src_dst & 0xf0) | 1);
+							}
+							else {
+								src_dst = (byte) ((src_dst & 0x0f) | 0x10);
+							}
+							memory.setByte(relocationAddress.add(0x1), src_dst);
+						}
+					}
+					else {
+						return RelocationResult.UNSUPPORTED;
+					}
+				}
+				else {
+					// Relocate a pointer to symbol in a non-executable section.
+					// Using R_BPF_64_64 for such relocations was actually a bug in a LLVM fork, fixed in
+					// https://github.com/anza-xyz/llvm-project/pull/35
+					// (https://github.com/anza-xyz/llvm-project/commit/fb7188bcf651fdaa2d2c522f4b7444e2c574a822)
+					addend = memory.getLong(relocationAddress);
+					newValue = symbolValue + addend;
+					memory.setLong(relocationAddress, newValue);
+					byteLength = 8;
+				}
+				break;
+			}
+			case R_BPF_64_ABS64: {
+				// Relocate 64-bit addresses
+				addend = memory.getLong(relocationAddress);
+				newValue = symbolValue + addend;
+				memory.setLong(relocationAddress, newValue);
+				byteLength = 8;
+				break;
+			}
+			case R_BPF_64_ABS32:
+			case R_BPF_64_NODYLD32: {
+				// Relocate 32-bit addresses
+				// Relocate R_BPF_64_NODYLD32 too. This relocation type is used in sections .BTF and .BTF.ext.
+				addend = memory.getInt(relocationAddress);
+				newValue = symbolValue + addend;
+				memory.setInt(relocationAddress, (int) newValue);
+				byteLength = 4;
 				break;
 			}
 			case R_BPF_64_32: {
-				byteLength = 8;
-
-				// if we have, e.g, non-static function, it will be marked in the relocation table
-				// and indexed in the symbol table and it's easy to calculate the pc-relative offset
-				long instr_next = relocationAddress.add(0x8).getAddressableWordOffset();
-				if (symbol.isFunction()) {
-					new_value = symbolAddr.getAddressableWordOffset();
-					int offset = (int) ((new_value - instr_next) / 8);
+				if (memory.getBlock(relocationAddress).isExecute()) {
+					// Relocate the 32-bit displacement offset used by internal CALL.
+					// Linux kernel documents the formula in
+					// https://www.kernel.org/doc/html/v6.14/bpf/llvm_reloc.html#different-relocation-types
+					// (S + A) / 8 - 1
+					// To understand this formula:
+					// - The immediate operand of instruction CALL, called offset, encodes the number of 8-byte instructions from the end of the instruction (inst_next)
+					// - To call a function at address S + A, the offset is (S + A - inst_next) / 8
+					// - As inst_next = inst + 8, offset = (S + A - inst) / 8 - 1.
+					//
+					// As using inst_next is easier to understand than using the relocation address (inst), the code here uses (S + A - inst_next) / 8.
+					// The addend A is computed by decoding the existing offset of instruction CALL.
+					// Compilers usually write "-1" (the instruction bytes are 85 10 00 00 FF FF FF FF), to encode an instruction which calls itself.
+					// This offset is decoded as A = 0.
+					// If the encoded offset was -1 + value, the addend would be A = value * 8
+					// Therefore A = (encoded_offset + 1) * 8.
+					//
+					// By the way, memory.getInt and memory.setInt respect the endianness of the processor.
+					// This enables to support Little Endian and Big Endian eBPF at the same time.
+					long inst_next = relocationAddress.add(0x8).getAddressableWordOffset();
+					addend = (((long) memory.getInt(relocationAddress.add(0x4))) + 1) * 8;
+					int offset = (int) ((symbolValue + addend - inst_next) / 8);
 					memory.setInt(relocationAddress.add(0x4), offset);
+					byteLength = 8;
 				}
-				else if (symbol.isSection()) {
-					if (memory.getInt(relocationAddress) == 0x1085) {
-						ElfSectionHeader sectionHeader =
-							elfRelocationContext.getElfHeader().getSection(symbolName);
-						long section_start =
-							program.getImageBase().getOffset() + sectionHeader.getAddress();
-
-						// getting call instruction offset (current imm)
-						int current_imm = memory.getInt(relocationAddress.add(0x4));
-
-						// calculate the call target section offset  
-						// according to formula in "kernel.org" docs: https://www.kernel.org/doc/html/latest/bpf/llvm_reloc.html
-						int func_sec_offset = (current_imm + 1) * 8;
-						long func_addr = section_start + func_sec_offset;
-						int offset = (int) ((func_addr - instr_next) / 8);
-						memory.setInt(relocationAddress.add(0x4), offset);
-					}
-//					else {
-//						markAsUnhandled(program, relocationAddress, type, relocation.getSymbolIndex(), 
-//							symbolName, elfRelocationContext.getLog());
-//						return RelocationResult.UNSUPPORTED;
-//					}
+				else {
+					return RelocationResult.UNSUPPORTED;
 				}
-//				else {
-//					markAsUnhandled(program, relocationAddress, type, relocation.getSymbolIndex(), 
-//						symbolName, elfRelocationContext.getLog());
-//					return RelocationResult.UNSUPPORTED;
-//				}
 				break;
 			}
 			default: {
@@ -121,5 +203,32 @@ public class eBPF_ElfRelocationHandler
 			}
 		}
 		return new RelocationResult(Status.APPLIED, byteLength);
+	}
+
+	/**
+	 * Get the 64-bit immediate value of eBPF instruction LDDW
+	 *
+	 * @param memory memory
+	 * @param addr   address in memory
+	 * @return value from memory as a long
+	 * @throws MemoryAccessException if memory access failed
+	 */
+	private long getLddwImm64(Memory memory, Address addr) throws MemoryAccessException {
+		return (((long) memory.getInt(addr.add(0x4))) & 0xffffffffL) +
+			(((long) memory.getInt(addr.add(0xC))) << 32);
+	}
+
+	/**
+	 * Set the 64-bit immediate value of eBPF instruction LDDW
+	 *
+	 * @param memory memory
+	 * @param addr   address in memory
+	 * @param value  value
+	 * @throws MemoryAccessException if memory access failed
+	 */
+	private void setLddwImm64(Memory memory, Address addr, long value)
+			throws MemoryAccessException {
+		memory.setInt(addr.add(0x4), (int) value);
+		memory.setInt(addr.add(0xC), (int) (value >> 32));
 	}
 }

--- a/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationHandler.java
+++ b/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationHandler.java
@@ -135,7 +135,10 @@ public class eBPF_ElfRelocationHandler
 				}
 				else {
 					// Relocate a pointer to symbol in a non-executable section.
-					// Using R_BPF_64_64 for such relocations was actually a bug in a LLVM fork, fixed in
+					// Clang 13.0 introduced R_BPF_64_ABS64 and previous releases were using R_BPF_64_64:
+					// https://github.com/llvm/llvm-project/commit/6a2ea84600ba4bd3b2733bd8f08f5115eb32164b
+					//
+					// Using R_BPF_64_64 for such relocations was also a bug in a LLVM fork, fixed in
 					// https://github.com/anza-xyz/llvm-project/pull/35
 					// (https://github.com/anza-xyz/llvm-project/commit/fb7188bcf651fdaa2d2c522f4b7444e2c574a822)
 					addend = memory.getLong(relocationAddress);
@@ -190,7 +193,13 @@ public class eBPF_ElfRelocationHandler
 					byteLength = 8;
 				}
 				else {
-					return RelocationResult.UNSUPPORTED;
+					// Relocate a pointer to symbol in a non-executable section.
+					// Clang 13.0 introduced R_BPF_64_ABS32 and previous releases were using R_BPF_64_32:
+					// https://github.com/llvm/llvm-project/commit/6a2ea84600ba4bd3b2733bd8f08f5115eb32164b
+					addend = memory.getInt(relocationAddress);
+					newValue = symbolValue + addend;
+					memory.setInt(relocationAddress, (int) newValue);
+					byteLength = 4;
 				}
 				break;
 			}

--- a/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationType.java
+++ b/Ghidra/Processors/eBPF/src/main/java/ghidra/app/util/bin/format/elf/relocation/eBPF_ElfRelocationType.java
@@ -22,6 +22,7 @@ public enum eBPF_ElfRelocationType implements ElfRelocationType {
 	R_BPF_64_ABS64(2),		// S + A
 	R_BPF_64_ABS32(3),		// S + A
 	R_BPF_64_NODYLD32(4),	// S + A
+	R_BPF_64_RELATIVE(8),	// Adjust by program base
 
 	R_BPF_64_32(10),		// (S + A) / 8 - 1
 


### PR DESCRIPTION
Hello,

Only few relocation kinds were processed when loading eBPF programs.

`R_BPF_64_32` relocations to external functions were not processed (when `symbol.isExternal()` is true). In practice, this made code calling external functions look like the instructions were calling themselves (so the decompiler output was unusable).

Moreover, checking `memory.getInt(relocationAddress) == 0x1085`  in `eBPF_ElfRelocationHandler.java` does not work with Big Endian eBPF.

Fix these issues by reworking the way `R_BPF_64_32` relocations are processed. While at it, document the not-so-straightforward formula which is used.

`R_BPF_64_64` relocations to local data were not processed correctly, as the code considered them as if they targeted eBPF maps. This led to misleading `LDDW` instruction being decoded in the listing. Fix this by properly detecting whether the relocation target a map, using the same logic as libbpf: the section name of the target symbol is `.maps`. While at it, distinguish regular `LDDW` instructions from pseudo-load ones (in `eBPF.sinc`). Testing this led to identifying a regression with old eBPF programs compiled with legacy maps, using specific sections prefixed by `maps` (for example `maps/array_of_maps`). Adapt the condition to also modify `LDDW` instructions targeting such sections.

`R_BPF_64_ABS32` relocations used in debug sections (generated for example when compiling with option `-ggdb`, with gcc or clang) were not processed. This made DWARF information not applied correctly when loading programs with debug information. Implementing this kind of relocation enabled removing the logic which skipped debug sections.

`R_BPF_64_NODYLD32` relocations are used in sections `.BTF` and `.BTF.ext`. They are similar as `R_BPF_64_ABS32`, with the additional semantics that some tools do not process them. As Ghidra loads and relocates all sections, it makes sense to apply such relocations.

This was tested on sample programs from: https://github.com/vbpf/ebpf-samples/tree/f022799c04e21d16ff4f832d0c1e45625ab71b70/src and
https://github.com/vbpf/ebpf-samples/tree/f022799c04e21d16ff4f832d0c1e45625ab71b70/build

For example with [`packet_overflow.o`](https://github.com/vbpf/ebpf-samples/blob/f022799c04e21d16ff4f832d0c1e45625ab71b70/build/packet_overflow.o) ([source](https://github.com/vbpf/ebpf-samples/blob/f022799c04e21d16ff4f832d0c1e45625ab71b70/src/packet_overflow.c)), the decompilation changed from
<img width="1067" height="587" alt="image" src="https://github.com/user-attachments/assets/1112e7a3-7a15-4fd1-a2c9-ac164e1f8f4f" />
to
<img width="1138" height="906" alt="image" src="https://github.com/user-attachments/assets/7e74d63e-9255-4660-9fa5-24bf9a344b54" />
... due to the fact that debug symbols are properly relocated.

Moreover, when loading `packet_overflow.o` the current version of Ghidra creates 2 symbols `read_write_packet_start`, as shown by the Jython code:

```pyhon
for symbol in currentProgram.getSymbolTable().getSymbolIterator():
    print(symbol.getAddress(), symbol.getName())
```

```text
(ram:00000000, u'read_write_packet_start')
(ram:00100000, u'read_write_packet_start')
```

With this Pull Request, there is a single symbol `read_write_packet_start`:

```text
(ram:00100000, u'read_write_packet_start')
```

While testing the fixes, eBPF programs compiled with old buggy LLVM forks were discovered. As these relocations do not conflict with existing ones, add code to support them as well (with clear references to the forks and bugs). This makes analyzing these programs possible with Ghidra.