### PR TITLE
Fix short unaligned UniqueMemoryBank::setChunk calls.

### DIFF
--- a/Ghidra/Framework/Emulation/src/main/java/ghidra/pcode/memstate/UniqueMemoryBank.java
+++ b/Ghidra/Framework/Emulation/src/main/java/ghidra/pcode/memstate/UniqueMemoryBank.java
@@ -132,7 +132,7 @@ public class UniqueMemoryBank extends MemoryBank {
 				word = new WordInfo();
 				map.put(offset & ALIGNMENT_MASK, word);
 			}
-			for (int i = adjustment; i < WORD_SIZE; ++i) {
+			for (int i = adjustment; i < WORD_SIZE && size > currentPosition; ++i) {
 				word.setByte(src[currentPosition], i);
 				offset += 1;
 				currentPosition += 1;

--- a/Ghidra/Framework/Emulation/src/test/java/ghidra/pcode/memstate/UniqueMemoryBankTest.java
+++ b/Ghidra/Framework/Emulation/src/test/java/ghidra/pcode/memstate/UniqueMemoryBankTest.java
@@ -153,6 +153,16 @@ public class UniqueMemoryBankTest extends AbstractGenericTest {
 	}
 
 	@Test
+	public void testOneByteNonAlignedWrite() {
+		byte[] oneByte = new byte[] { 0x11 };
+		uniqueBank.setChunk(0x1001, 1, oneByte);
+		byte[] dest = new byte[1];
+		int numBytes = uniqueBank.getChunk(0x1001, 1, dest, true);
+		assertEquals(1, numBytes);
+		assertTrue(Arrays.equals(oneByte, dest));
+	}
+
+	@Test
 	public void testOverlappingReadWrite() {
 		uniqueBank.setChunk(0x1000, 16, sixteenTestBytes);
 		uniqueBank.setChunk(0x1004, 8, eightZeroBytes);


### PR DESCRIPTION
This fixes #8886, by avoiding overrunning the src buffer on unaligned setChunk calls.