### PR TITLE
Fix lexing of directives with quoted strings in C headers

### DIFF
--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/CPP/CPP.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/CPP/CPP.jj
@@ -2699,7 +2699,8 @@ SKIP : {
     <_INCWSP: <WSP> > : INCDEF |
     <_INCCP: <CP> > : DIRECTIVE |
     <_INCOP: <OP> > : INCDEF |
-    <_INCSTANDARD:  <_LT> (~["\n","\r",">",")","("])* <_GT> > : INCDEF
+    <_INCSTANDARD:  <_LT> (~["\n","\r",">",")","("])* <_GT> > : INCDEF |
+    <_INCSTRING: <QUOTED_TEXT> > : INCDEF
 }
 
 //<INCDEF>


### PR DESCRIPTION
With this change, importing C header files containing lines like `# if __has_include ("linux/stat.h")` will no longer cause lexer errors.

Fixes #7032