### PR TITLE
Fix AVR32 SLEIGH semantics: CPC, ST.B{cond}, MOV

### DIFF
--- a/Ghidra/Processors/Atmel/data/languages/avr32a_arithmetic_operations.sinc
+++ b/Ghidra/Processors/Atmel/data/languages/avr32a_arithmetic_operations.sinc
@@ -38,7 +38,8 @@ macro cpcflags0(OP1, RES) {
         #    (OP2[31,1] && RES[31,1]) ||
         #    (!(OP1[31,1]) && RES[31,1]);
 
-        C = 0;
+        C = !(OP1[31,1]) && RES[31,1];
+        #C = 0;
         CZNVTOSR();
 }
 

--- a/Ghidra/Processors/Atmel/data/languages/avr32a_data_transfer.sinc
+++ b/Ghidra/Processors/Atmel/data/languages/avr32a_data_transfer.sinc
@@ -17,6 +17,11 @@
         rd0 = imm4_8;
 }
 
+:MOV rd0, imm4_8 is op13_3=0x1 & op12_1=1 & rd0 & rd0=0xf & imm4_8 {
+        PC = imm4_8;
+        goto [PC];
+}
+
 # MOV Format II
 # 111i iii0 011i dddd   iiii iiii iiii iiii
 
@@ -26,11 +31,23 @@
        rd0 = imm;
 }       
 
+:MOV rd0, imm is op13_3=0x7 & op5_4=0x3 & imm9_4 & imm4_1 & rd0 & rd0=0xf; imm16
+        [ imm = (imm9_4 << 17) | (imm4_1 << 16) | imm16; ]
+{
+        PC = imm;
+        goto [PC];
+}       
+
 # MOV Format III
 # 000s sss0 1001 dddd
 
 :MOV rd0, rs9 is op13_3=0x0 & op4_5=0x09 & rd0 & rs9 {
         rd0 = rs9;
+}
+
+:MOV rd0, rs9 is op13_3=0x0 & op4_5=0x09 & rd0 & rs9 & rd0=0xf {
+        PC = rs9;
+        goto [PC];
 }
 
 #---------------------------------------------------------------------
@@ -55,6 +72,14 @@
         rd0 = rs9;
 }
 
+:MOV^{ECOND_4_4} rd0, rs9 is op13_3=0x7 & op4_5=0 & rd0 & rs9 & rd0=0xf;
+        eop8_8=0x17 & eop0_4=0 & ECOND_4_4
+{
+        build ECOND_4_4;
+        PC = rs9;
+        goto [PC];
+}
+
 # MOV{cond4} Format II
 # Operation:  if (cond4)
 #                 Rd <- SE(imm8)
@@ -68,8 +93,21 @@
         rd0 = simm0_8;
 }
 
+:MOV^{ECOND_8_4} rd0, simm0_8 is op4_12=0xf9b & rd0 & rd0=0xf ;
+                                 eop12_4=0 & simm0_8 & ECOND_8_4
+{
+        build ECOND_8_4;
+        PC = simm0_8;
+        goto [PC];
+}
+
 :MOVH	rd0, imm16		is op4_12=0xfc1 & rd0 ; imm16 {
 	rd0 = imm16 << 16;
+}
+
+:MOVH	rd0, imm16		is op4_12=0xfc1 & rd0 & rd0=0xf ; imm16 {
+	PC = imm16 << 16;
+        goto [PC];
 }
 
 #---------------------------------------------------------------------

--- a/Ghidra/Processors/Atmel/data/languages/avr32a_data_transfer.sinc
+++ b/Ghidra/Processors/Atmel/data/languages/avr32a_data_transfer.sinc
@@ -609,10 +609,10 @@ LDSTSWPW: val		is disp0_12 [ val = disp0_12 << 2; ] { export *[const]:2 val; }
 # ST.B{cond4} Format I
 # 111p ppp1 1111 ssss   cccc 111n nnnn nnnn
 
-:ST.B^{COND_e12} RPwDisp9, rs0 is (op13_3=0x7 & op4_5=0x1f & rs0;
-                                      eop9_3=0x7 & COND_e12) & RPwDisp9 { 
+:ST.B^{COND_e12} RPbDisp9, rs0 is (op13_3=0x7 & op4_5=0x1f & rs0;
+                                      eop9_3=0x7 & COND_e12) & RPbDisp9 { 
         build COND_e12;
-        *:4 RPwDisp9 = rs0:1;
+        *:1 RPbDisp9 = rs0:1;
 }
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
This pull request fixes two issues in the AVR32A SLEIGH specifications:

- Correct CPC carry-flag behavior (avr32a_arithmetic_operations.sinc)
The cpcflags0 macro previously forced the carry flag (C) to 0, which produced incorrect carry flag updates. This change updates C to calculate properly.

- Fix ST.B{cond} operand selection to use byte displacement (avr32a_data_transfer.sinc)
The ST.B^{COND_e12} pattern was using RPwDisp9 (word displacement) even though ST.B stores a byte. This change switches the operand to RPbDisp9.