### PR TITLE
Fix ignored arguments in ArrayMethods and remove unused parameter

### DIFF
--- a/Ghidra/Processors/JVM/src/main/java/ghidra/app/util/pcodeInject/ArrayMethods.java
+++ b/Ghidra/Processors/JVM/src/main/java/ghidra/app/util/pcodeInject/ArrayMethods.java
@@ -17,7 +17,6 @@ package ghidra.app.util.pcodeInject;
 
 import ghidra.javaclass.format.DescriptorDecoder;
 import ghidra.javaclass.format.JavaClassConstants;
-import ghidra.javaclass.format.constantpool.AbstractConstantPoolInfoJava;
 import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.DataTypeManager;
 
@@ -57,11 +56,9 @@ public class ArrayMethods {
 	 * and a dimension as its second argument.
 	 * @param pCode is the pcode accumulator
 	 * @param constantPoolIndex
-	 * @param constantPool
 	 * @param dimensions
 	 */
 	public static void getPcodeForMultiANewArray(PcodeOpEmitter pCode, int constantPoolIndex,
-			AbstractConstantPoolInfoJava[] constantPool,
 			int dimensions) {
 		//pop all of the dimensions off the stack
 		for (int i = dimensions; i >= 1; --i){
@@ -93,8 +90,7 @@ public class ArrayMethods {
 				multianewarrayOpArgs[i] = DIMENSION + Integer.toString(i);
 			}
 		}
-		pCode.emitAssignVarnodeFromPcodeOpCall(ARRAY_REF, 4, MULTIANEWARRAY, CLASS_NAME, "dim1",
-			"dim2");
+		pCode.emitAssignVarnodeFromPcodeOpCall(ARRAY_REF, 4, MULTIANEWARRAY, multianewarrayOpArgs);
 		
 
 

--- a/Ghidra/Processors/JVM/src/main/java/ghidra/app/util/pcodeInject/InjectMultiANewArray.java
+++ b/Ghidra/Processors/JVM/src/main/java/ghidra/app/util/pcodeInject/InjectMultiANewArray.java
@@ -16,7 +16,6 @@
 package ghidra.app.util.pcodeInject;
 
 import ghidra.app.plugin.processors.sleigh.SleighLanguage;
-import ghidra.javaclass.format.constantpool.AbstractConstantPoolInfoJava;
 import ghidra.program.model.lang.InjectContext;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.pcode.PcodeOp;
@@ -29,11 +28,10 @@ public class InjectMultiANewArray extends InjectPayloadJava {
 
 	@Override
 	public PcodeOp[] getPcode(Program program, InjectContext con) {
-		AbstractConstantPoolInfoJava[] constantPool = getConstantPool(program);
 		int constantPoolIndex = (int) con.inputlist.get(0).getOffset();
 		int dimensions = (int) con.inputlist.get(1).getOffset();
 		PcodeOpEmitter pCode = new PcodeOpEmitter(language, con.baseAddr, uniqueBase);
-		ArrayMethods.getPcodeForMultiANewArray(pCode, constantPoolIndex, constantPool, dimensions);
+		ArrayMethods.getPcodeForMultiANewArray(pCode, constantPoolIndex, dimensions);
 		return pCode.getPcodeOps();
 	}
 }


### PR DESCRIPTION
Corrected logic in ArrayMethods.getPcodeForMultiANewArray to use the dynamic `multianewarrayOpArgs` array instead of hardcoded strings. This previously caused incorrect Pcode generation for arrays with dimensions != 2.

Also removed the unused `constantPool` parameter from ArrayMethods and the corresponding data fetch in InjectMultiANewArray to reduce processing overhead.