### PR TITLE
#8914 Fix OOB exception being thrown when calling getTaskTimesString

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisManager.java
@@ -1249,9 +1249,7 @@ public class AutoAnalysisManager {
 			long taskTime = getTaskTime(timedTasks, element);
 			double totalTime = taskTime / 1000.00;
 
-			String partTime = (((int) (totalTime * 1000.0)) % 1000) + "";
-			String secString =
-				((int) totalTime) + "." + "000".substring(partTime.length()) + partTime + " secs";
+			String secString = String.format("%.3f secs", totalTime);
 			int testLen = element.length() + secString.length();
 			if (testLen > spacer.length()) {
 				testLen = spacer.length() - 5;


### PR DESCRIPTION
The exception occurs when `getTaskTime` returns a negative integer.

https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/AutoAnalysisManager.java#L1249
```
			long taskTime = getTaskTime(timedTasks, element);
			double totalTime = taskTime / 1000.00;

			String partTime = (((int) (totalTime * 1000.0)) % 1000) + "";
			String secString =
				((int) totalTime) + "." + "000".substring(partTime.length()) + partTime + " secs";
```			

 I added some debug logging and found that the following value caused the previously described exception to occur. I'm assuming it can be sometimes negative due to inaccuracies in recording the time taken for an individual analysis task to finish.

```
task=ELF Scalar Operand References taskTime=-1804 partTime=-804
```

Here's a small PoC you can run to see the bug in action:

```
public class GhidraBugTest {
    public static void main(String[] args) {
        long taskTime = -1804;
        double totalTime = taskTime / 1000.00;
        System.out.println("totalTime = " + totalTime);
        System.out.println("totalTime * 1000.0 = " + (totalTime * 1000.0));
        System.out.println("(int)(totalTime * 1000.0) = " + (int)(totalTime * 1000.0));
        System.out.println("% 1000 = " + ((int)(totalTime * 1000.0)) % 1000);
        String partTime = (((int) (totalTime * 1000.0)) % 1000) + "";
        System.out.println("partTime = \"" + partTime + "\" (length " + partTime.length() + ")");
        String secString = ((int) totalTime) + "." + "000".substring(partTime.length()) + partTime + " secs";
        System.out.println("secString = " + secString);
    }
}
```

and the output for the above code:
```
totalTime = -1.804
totalTime * 1000.0 = -1804.0
(int)(totalTime * 1000.0) = -1804
% 1000 = -804
partTime = "-804" (length 4)
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: Range [4, 3) out of bounds for length 3
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
        at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349)
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4865)
        at java.base/java.lang.String.substring(String.java:2834)
        at java.base/java.lang.String.substring(String.java:2807)
        at GhidraBugTest.main(GhidraBugTest.java:11)
```

The bug arises from trying to substring `"000"` from index 4 which causes the OOB exception to be raised. 