### PR TITLE
ghidra_launch.py: append JVM args in right order

### DIFF
--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/ghidra_launch.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/ghidra_launch.py
@@ -113,6 +113,6 @@ if __name__ == "__main__":
     _, remaining = parser.parse_known_args(namespace=args)
     
     launcher = GhidraLauncher(False, args.class_name, args.gui, install_dir=args.install_dir)
-    launcher.vm_args = args.jvm_args + launcher.vm_args
+    launcher.vm_args = launcher.vm_args + args.jvm_args
     launcher.args = remaining
     launcher.start()


### PR DESCRIPTION
when passing JVM args to the PyGhidra launcher, these get prepended to the default args:

https://github.com/NationalSecurityAgency/ghidra/blob/44510d1e84774a3add2741205b627f18171dce9f/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/ghidra_launch.py#L116

when the correct behavior would be to append them to the default args, as the default launcher does, so they take precedence:

https://github.com/NationalSecurityAgency/ghidra/blob/44510d1e84774a3add2741205b627f18171dce9f/Ghidra/RuntimeScripts/Linux/support/launch.sh#L225