### PR TITLE
Annotations: Generalise programmatic modification

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/AnnotatedStringHandler.java
@@ -115,7 +115,7 @@ public interface AnnotatedStringHandler extends ExtensionPoint {
 	 * @return the example of how this is used.
 	 */
 	String getPrototypeString();
-	
+
 	/**
 	 * Returns an example string of how the annotation is used
 	 * @param displayText The text that may be wrapped, cannot be null
@@ -123,6 +123,16 @@ public interface AnnotatedStringHandler extends ExtensionPoint {
 	 */
 	default String getPrototypeString(String displayText) {
 		return getPrototypeString();
+	}
+
+	/**
+	 * Returns an array with modifications by the annotation; null otherwise.
+	 * @param  text An array of strings to modify.
+	 * @param  program The program with which the returned string is associated.
+	 * @return The modified array; null otherwise.
+	 */
+	default String[] modify(String[] test, Program program) {
+		return null;
 	}
 
 }

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/EolCommentFieldFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/EolCommentFieldFactory.java
@@ -401,7 +401,7 @@ public class EolCommentFieldFactory extends FieldFactory {
 			RowColLocation startRowCol = commentElement.getDataLocationForCharacterIndex(0);
 			int encodedRow = startRowCol.row();
 			int encodedCol = startRowCol.col();
-			Annotation annotation = new Annotation(refAddrComment, program);
+			Annotation annotation = new Annotation(refAddrComment);
 			FieldElement addressElement =
 				new AnnotatedTextFieldElement(annotation, currentPrefixString, program, encodedRow,
 					encodedCol);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/SymbolAnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/SymbolAnnotatedStringHandler.java
@@ -16,6 +16,7 @@
 package ghidra.app.util.viewer.field;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import docking.widgets.fieldpanel.field.AttributedString;
 import generic.theme.GThemeDefaults.Colors.Messages;
@@ -125,4 +126,31 @@ public class SymbolAnnotatedStringHandler implements AnnotatedStringHandler {
 		return "{@symbol " + displayText.trim() + "}";
 	}
 
+	@Override
+	public String[] modify(String[] text, Program program) {
+		if (text.length <= 1) {
+			return null;
+		}
+
+		if (program == null) { // this can happen during merge operations
+			return null;
+		}
+
+		Address address = program.getAddressFactory().getAddress(text[1]);
+		if (address != null) {
+			return null; // nothing to do
+		}
+
+		String originalValue = text[1];
+		List<Symbol> symbols = CommentUtils.getSymbols(originalValue, program);
+		if (symbols.size() != 1) {
+			// no unique symbol, so leave it as string name
+			return null;
+		}
+
+		Address symbolAddress = symbols.get(0).getAddress();
+		text[1] = symbolAddress.toString();
+
+		return text;
+	}
 }


### PR DESCRIPTION
Currently symbol annotations get their symbol name modified to its corresponding address if it's unique.

This pull request generalises this pattern so that annotation handlers can modify their contents as required via the `modify` function added to the AnnotatedStringHandler interface.

A default implementation for `modify` is included to allow plugins containing annotation handlers to continue to work.
The old instantiator for Annotation has been marked as deprecated.