### PR TITLE
#8946 Fix CompareExecutablesScript Elastic BSim database does not exist

### DIFF
--- a/Ghidra/Features/BSim/ghidra_scripts/CompareExecutablesScript.java
+++ b/Ghidra/Features/BSim/ghidra_scripts/CompareExecutablesScript.java
@@ -58,6 +58,7 @@ public class CompareExecutablesScript extends GhidraScript {
 			askString("Enter name of executable to compare against database", "Name: ");
 		URL url = BSimClientFactory.deriveBSimURL(urlString);
 		try (FunctionDatabase database = BSimClientFactory.buildClient(url, true)) {
+			database.initialize();
 			QueryExeInfo exeInfo = new QueryExeInfo();
 			exeInfo.filterExeName = execName;
 			ResponseExe exeResult = exeInfo.execute(database);


### PR DESCRIPTION
This fixes #8946 by initializing the database connection before using it. This resolves the "database does not exist" error for databases that do in fact exist.