### PR TITLE
#8948 skip missing vectors in ExecutableComparison

### DIFF
--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/client/ExecutableComparison.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/client/ExecutableComparison.java
@@ -194,12 +194,19 @@ public class ExecutableComparison {
 		Iterator<FunctionDescription> iter = response.manage.listAllFunctions();
 		if (histogram == null) {
 			while (iter.hasNext()) {
-				baseIds.add(iter.next().getVectorId());
+				Long id = iter.next().getVectorId();
+				if (id == 0) {
+					continue;
+				}
+				baseIds.add(id);
 			}
 		}
 		else {
 			while (iter.hasNext()) {
 				Long id = iter.next().getVectorId();
+				if (id == 0) {
+					continue;
+				}
 				Count count = histogram.computeIfAbsent(id, key -> new Count());
 				count.value += 1;
 			}


### PR DESCRIPTION
This fixes #8948 by skipping missing vectors (those with ID == 0). This ensures the CompareExecutablesScript can finish with no errors, even if there are missing signature vectors in the database.