### PR TITLE
Fix a SymbolPath documentation typo

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/SymbolPath.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/util/SymbolPath.java
@@ -28,7 +28,7 @@ import ghidra.program.model.symbol.*;
  * name of a symbol in the "bar" namespace, which is in the "foo" namespace.
  * <UL>
  * <LI>{@link #getName()} will return "baz".</LI>
- * <LI>{@link #getParentPath()} will return "foo:bar".</LI>
+ * <LI>{@link #getParentPath()} will return "foo::bar".</LI>
  * <LI>{@link #getPath()} will return "foo::bar::baz".</LI>
  * </UL>
  *


### PR DESCRIPTION
One colon was missing from the example, the namespace delimiter is two colons.