### PR TITLE
Use importOptions instead of prog.getImportOptions()

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf/DWARFFunctionImporter.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf/DWARFFunctionImporter.java
@@ -189,7 +189,7 @@ public class DWARFFunctionImporter {
 
 		dfunc.runFixups();
 
-		String defaultCC = prog.getImportOptions().getDefaultCC();
+		String defaultCC = importOptions.getDefaultCC();
 		if (defaultCC != null && defaultCC.isBlank()) {
 			defaultCC = null;
 		}
@@ -339,7 +339,7 @@ public class DWARFFunctionImporter {
 						DWARFVariable localVar =
 							DWARFVariable.readLocalVariable(childDIEA, dfunc, offsetFromFuncStart);
 						if (!localVar.isMissingStorage()) {
-							if (prog.getImportOptions().isImportLocalVariables() ||
+							if (importOptions.isImportLocalVariables() ||
 								localVar.isRamStorage()) {
 								// only retain the local var if option is turned on, or global/static variable
 								dfunc.localVars.add(localVar);


### PR DESCRIPTION
Since the constructor already creates a reference to this which is used throughout the class, it's more uniform this way.