### PR TITLE
Decompiler: Support ZEXT when resolving pointer arithmetic

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -6220,6 +6220,8 @@ bool AddTreeState::checkTerm(Varnode *vn,uint8 treeCoeff)
     }
     if (def->code() == CPUI_INT_MULT)	// Check for constant coeff indicating size
       return checkMultTerm(vn, def, treeCoeff);
+    if (def->code() == CPUI_INT_ZEXT) // Recurse
+      return checkTerm(def->getIn(0), treeCoeff);
   }
   else if (vn->isFree()) {
     valid = false;


### PR DESCRIPTION
Currently the `RulePtrArith` rule cannot handle a zero extension Pcode-Op in the Add-Multiply chain.

This pull request adds support for the zero extension Pcode-Op to `AddTreeState::checkTerm`.

#### Before
```
uint get_u(s *ss,uint i)

{
  return *(uint *)(ss->pad1 + (i * 0x20 + 0x10) * 0x10);
}
```
#### After
```
uint get_u(s *ss,uint i)

{
  return ss[i].u;
}
```
#### Source Code
Contrived example to force the desired effect. Compiled via `gcc main.c`.
```
#include <stdio.h>
#include <stdint.h>

struct s {
  char pad1[0x100];
  unsigned u;
  char pad2[0xfc];
};

void set_u(struct s *ss, unsigned i, unsigned u) {
  ss[i].u = u;
}

unsigned get_u(struct s *ss, unsigned i) {
  unsigned volatile j = (i * 0x20) + 0x10;
  unsigned volatile k = j * 0x10;
  return *(unsigned *)((uintptr_t)ss + k);
}

#define LEN 10

int main(void) {
  struct s ss[LEN];

  for (unsigned i = 0; i < LEN; i++) {
    set_u(ss, i, i);
  }

  for (unsigned i = 0; i < LEN; i++) {
    printf("%u\n", get_u(ss, i));
  }

  return 0;
}
```