### PR TITLE
Add OpenBSD support for x86_64 and arm_64.

### DIFF
--- a/GPL/DemanglerGnu/build.gradle
+++ b/GPL/DemanglerGnu/build.gradle
@@ -84,6 +84,8 @@ model {
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
 			targetPlatform "freebsd_arm_64"
+			targetPlatform "openbsd_x86_64"
+			targetPlatform "openbsd_arm_64"
 			sources {
 				c {
 					source {
@@ -108,6 +110,8 @@ model {
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
 			targetPlatform "freebsd_arm_64"
+			targetPlatform "openbsd_x86_64"
+			targetPlatform "openbsd_arm_64"
 			sources {
 				c {
 					source {

--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -49,6 +49,10 @@ model {
 			gcc(Gcc).target(current)
 			clang(Clang).target(current)
 		}
+		if (isOpenBSD(current)) {
+			gcc(Gcc).target(current)
+			clang(Clang).target(current)
+		}
 		if (isWindows(current) && VISUAL_STUDIO_INSTALL_DIR) {
 			// https://github.com/gradle/gradle-native/issues/617#issuecomment-575735288
 			visualCpp(VisualCpp) {

--- a/GPL/nativePlatforms.gradle
+++ b/GPL/nativePlatforms.gradle
@@ -27,7 +27,9 @@ project.ext.PLATFORMS = [
 	[name: "mac_x86_64", os: "osx", arch: "x86_64"],
 	[name: "mac_arm_64", os: "osx", arch: "arm64"],
 	[name: "freebsd_x86_64", os: "freebsd", arch: "x86_64"],
-	[name: "freebsd_arm_64", os: "freebsd", arch: "arm64"]
+	[name: "freebsd_arm_64", os: "freebsd", arch: "arm64"],
+	[name: "openbsd_x86_64", os: "openbsd", arch: "x86_64"],
+	[name: "openbsd_arm_64", os: "openbsd", arch: "arm64"]
 ]
 
 /*********************************************************************************
@@ -56,6 +58,9 @@ ext.getCurrentPlatformName = {
 			break
 		case ~/FreeBSD.*/:
 			os = "freebsd"
+			break
+		case ~/OpenBSD.*/:
+			os = "openbsd"
 			break
 		default:
 			throw new GradleException("Unrecognized platform operating system: $os")
@@ -130,6 +135,20 @@ ext.isFreeBSD = { platform_name ->
  *********************************************************************************/
 ext.isCurrentFreeBSD = {
 	return isFreeBSD(getCurrentPlatformName())
+}
+
+/*********************************************************************************
+ * Returns true if the given platform is OpenBSD.
+ *********************************************************************************/
+ext.isOpenBSD = { platform_name ->
+	return platform_name.startsWith("openbsd")
+}
+
+/*********************************************************************************
+ * Returns true if the current platform is OpenBSD.
+ *********************************************************************************/
+ext.isCurrentOpenBSD = {
+	return isOpenBSD(getCurrentPlatformName())
 }
 
 /*********************************************************************************

--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/arch.py
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/arch.py
@@ -103,6 +103,7 @@ data64_compiler_map: Dict[Optional[str], str] = {
 
 x86_compiler_map: Dict[Optional[str], str] = {
     'GNU/Linux': 'gcc',
+    'OpenBSD': 'gcc',
     'Windows': 'windows',
     # This may seem wrong, but Ghidra cspecs really describe the ABI
     'Cygwin': 'windows',
@@ -110,6 +111,7 @@ x86_compiler_map: Dict[Optional[str], str] = {
 
 riscv_compiler_map: Dict[Optional[str], str] = {
     'GNU/Linux': 'gcc',
+    'OpenBSD': 'gcc',
     'Cygwin': 'gcc',
 }
 

--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/util.py
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/util.py
@@ -19,6 +19,7 @@ import bisect
 from dataclasses import dataclass
 import re
 from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
+import platform
 
 import gdb
 
@@ -467,7 +468,7 @@ class RegisterDesc:
 
 def get_register_descs(arch: gdb.Architecture, group: str = 'all') -> List[
         Union[RegisterDesc, gdb.RegisterDescriptor]]:
-    if hasattr(arch, "registers"):
+    if hasattr(arch, "registers") and platform.system() != "OpenBSD":
         try:
             return list(arch.registers(group))
         except ValueError:  # No such group, or version too old
@@ -481,7 +482,7 @@ def get_register_descs(arch: gdb.Architecture, group: str = 'all') -> List[
             regset = gdb.execute(
                 f"info registers", to_string=True).strip().split('\n')
         for line in regset:
-            if not line.startswith(" "):
+            if not line.startswith(" ") and "<unavailable>" not in line:
                 tokens = line.strip().split()
                 descs.append(RegisterDesc(tokens[0]))
         return descs

--- a/Ghidra/Debug/Debugger-agent-lldb/src/main/py/src/ghidralldb/arch.py
+++ b/Ghidra/Debug/Debugger-agent-lldb/src/main/py/src/ghidralldb/arch.py
@@ -135,6 +135,7 @@ default_compiler_map: Dict[Optional[str], str] = {
     'freebsd': 'gcc',
     'linux': 'gcc',
     'netbsd': 'gcc',
+    'openbsd': 'gcc',
     'ps4': 'gcc',
     'ios': 'gcc',
     'macosx': 'gcc',

--- a/Ghidra/Features/Decompiler/buildNatives.gradle
+++ b/Ghidra/Features/Decompiler/buildNatives.gradle
@@ -45,6 +45,8 @@ model {
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
 			targetPlatform "freebsd_arm_64"
+			targetPlatform "openbsd_x86_64"
+			targetPlatform "openbsd_arm_64"
 			sources {
 				cpp {
 					// NOTE: The bison/flex generated files are assumed to be up-to-date.
@@ -157,6 +159,8 @@ model {
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
 			targetPlatform "freebsd_arm_64"
+			targetPlatform "openbsd_x86_64"
+			targetPlatform "openbsd_arm_64"
 			sources {
 				cpp {
 					// NOTE: The bison/flex generated files are assumed to be up-to-date.

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/Makefile
@@ -35,6 +35,13 @@ ifeq ($(OS),Darwin)
   OSDIR=mac_x86_64
 endif
 
+ifeq ($(OS),OpenBSD)
+ifeq ($(ARCH),amd64)
+  ARCH_TYPE=-m64
+  OSDIR=openbsd_x86_64
+endif
+endif
+
 CXX=g++ -std=c++11
 
 # Debug flags

--- a/Ghidra/Features/FileFormats/buildNatives.gradle
+++ b/Ghidra/Features/FileFormats/buildNatives.gradle
@@ -36,6 +36,8 @@ model {
 			targetPlatform "mac_arm_64"
 			targetPlatform "freebsd_x86_64"
 			targetPlatform "freebsd_arm_64"
+			targetPlatform "openbsd_x86_64"
+			targetPlatform "openbsd_arm_64"
 		
 			sources {
 				c {

--- a/Ghidra/Features/FunctionID/build.gradle
+++ b/Ghidra/Features/FunctionID/build.gradle
@@ -113,9 +113,10 @@ task buildFidHelpPdf(type: Exec) {
 	// Check the OS before executing command.
 	doFirst {
 		if ( !(org.gradle.internal.os.OperatingSystem.current().isLinux() 
-			|| org.gradle.internal.os.OperatingSystem.current().isMacOsX())) {
+			|| org.gradle.internal.os.OperatingSystem.current().isMacOsX()
+			|| org.gradle.internal.os.OperatingSystem.current().isOpenBSD())) {
 			throw new TaskExecutionException( it,
-				new Exception( "The '$it.name' task only works on Linux or Mac Os X" ))
+				new Exception( "The '$it.name' task only works on Linux, Mac Os X or OpenBSD" ))
 		}
 	}
 
@@ -177,8 +178,9 @@ task buildFidHelpHtml(type: Exec) {
 
 	// Check the OS before executing command.
 	doFirst {
-		if (!getCurrentPlatformName().startsWith("linux")) {
-			throw new TaskExecutionException( it, new Exception("The '$it.name' task only works on Linux."))
+		if (!(getCurrentPlatformName().startsWith("linux")
+		    || getCurrentPlatformName().startsWith("openbsd"))) {
+			throw new TaskExecutionException( it, new Exception("The '$it.name' task only works on Linux or OpenBSD."))
 		}
 	}
 

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/framework/Platform.java
@@ -81,6 +81,16 @@ public enum Platform {
 	FREEBSD_ARM_64(OperatingSystem.FREE_BSD, Architecture.ARM_64, "freebsd_arm_64", ".so", ""),
 
 	/**
+	 * Identifies a OpenBSD x86 64-bit OS.
+	 */
+	OPENBSD_X86_64(OperatingSystem.OPEN_BSD, Architecture.X86_64, "openbsd_x86_64", ".so", ""),
+
+	/**
+	 * Identifies a OpenBSD ARM 64-bit OS.
+	 */
+	OPENBSD_ARM_64(OperatingSystem.OPEN_BSD, Architecture.ARM_64, "openbsd_arm_64", ".so", ""),
+
+	/**
 	 * Identifies an unsupported OS.
 	 */
 	UNSUPPORTED(OperatingSystem.UNSUPPORTED, Architecture.UNKNOWN, null, null, ""),
@@ -233,6 +243,11 @@ public enum Platform {
 			paths.add("/System/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e");
 			paths.add("/System/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_x86_64");
 			paths.add("/System/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_x86_64h");
+		}
+		else if (operatingSystem == OperatingSystem.OPEN_BSD) {
+			paths.add("/usr/lib");
+			paths.add("/usr/X11R6/lib");
+			paths.add("/usr/local/lib");
 		}
 		else if (CURRENT_PLATFORM == WIN_X86_64) {
 			String windir = System.getenv("SystemRoot");

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/PtyFactory.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/PtyFactory.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import ghidra.framework.OperatingSystem;
 import ghidra.pty.linux.LinuxPtyFactory;
+import ghidra.pty.openbsd.OpenBSDPtyFactory;
 import ghidra.pty.macos.MacosPtyFactory;
 import ghidra.pty.windows.ConPtyFactory;
 
@@ -40,6 +41,8 @@ public interface PtyFactory {
 				return MacosPtyFactory.INSTANCE;
 			case LINUX:
 				return LinuxPtyFactory.INSTANCE;
+			case OPEN_BSD:
+				return OpenBSDPtyFactory.INSTANCE;
 			case WINDOWS:
 				return ConPtyFactory.INSTANCE;
 			default:

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDIoctls.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDIoctls.java
@@ -1,0 +1,38 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pty.openbsd;
+
+import ghidra.pty.unix.PosixC.Ioctls;
+import ghidra.pty.unix.UnixPtySessionLeader;
+
+public enum OpenBSDIoctls implements Ioctls {
+	INSTANCE;
+
+	@Override
+	public Class<? extends UnixPtySessionLeader> leaderClass() {
+		return OpenBSDPtySessionLeader.class;
+	}
+
+	@Override
+	public long TIOCSCTTY() {
+		return 0x20007461L;
+	}
+
+	@Override
+	public long TIOCSWINSZ() {
+		return 0x80087467L;
+	}
+}

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtyFactory.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtyFactory.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pty.openbsd;
+
+import java.io.IOException;
+
+import ghidra.pty.Pty;
+import ghidra.pty.PtyFactory;
+import ghidra.pty.unix.UnixPty;
+
+public enum OpenBSDPtyFactory implements PtyFactory {
+	INSTANCE;
+
+	@Override
+	public Pty openpty(short cols, short rows) throws IOException {
+		UnixPty pty = UnixPty.openpty(OpenBSDIoctls.INSTANCE);
+		if (cols != 0 && rows != 0) {
+			pty.getChild().setWindowSize(cols, rows);
+		}
+		return pty;
+	}
+
+	@Override
+	public String getDescription() {
+		return "local (OpenBSD)";
+	}
+}

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtySessionLeader.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtySessionLeader.java
@@ -1,0 +1,33 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pty.openbsd;
+
+import ghidra.pty.unix.PosixC.Ioctls;
+import ghidra.pty.unix.UnixPtySessionLeader;
+
+public class OpenBSDPtySessionLeader extends UnixPtySessionLeader {
+
+	public static void main(String[] args) throws Exception {
+		OpenBSDPtySessionLeader leader = new OpenBSDPtySessionLeader();
+		leader.parseArgs(args);
+		leader.run();
+	}
+
+	@Override
+	protected Ioctls ioctls() {
+		return OpenBSDIoctls.INSTANCE;
+	}
+}

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/framework/OperatingSystem.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/framework/OperatingSystem.java
@@ -20,6 +20,7 @@ public enum OperatingSystem {
 	LINUX("Linux"),
 	MAC_OS_X("Mac OS X"),
 	FREE_BSD("FreeBSD"),
+	OPEN_BSD("OpenBSD"),
 	UNSUPPORTED("Unsupported Operating System");
 
 	/**

--- a/Ghidra/Framework/Utility/src/main/java/utility/application/ApplicationUtilities.java
+++ b/Ghidra/Framework/Utility/src/main/java/utility/application/ApplicationUtilities.java
@@ -218,6 +218,7 @@ public class ApplicationUtilities {
 				case WINDOWS -> new File(getEnvFile("LOCALAPPDATA", true), appName);
 				case LINUX -> new File("/var/tmp/" + userDirName);
 				case FREE_BSD -> new File("/var/tmp/" + userDirName);
+				case OPEN_BSD -> new File("/var/tmp/" + userDirName);
 				case MAC_OS_X -> new File("/var/tmp/" + userDirName);
 				default -> throw new FileNotFoundException(
 					"Failed to find the user cache directory: Unsupported operating system.");
@@ -275,6 +276,7 @@ public class ApplicationUtilities {
 			case WINDOWS -> new File(getEnvFile("APPDATA", true), versionedSubdir);
 			case LINUX -> new File(userHomeDir, ".config/" + versionedSubdir);
 			case FREE_BSD -> new File(userHomeDir, ".config/" + versionedSubdir);
+			case OPEN_BSD -> new File(userHomeDir, ".config/" + versionedSubdir);
 			case MAC_OS_X -> new File(userHomeDir, "Library/" + versionedSubdir);
 			default -> throw new FileNotFoundException(
 				"Failed to find the user settings directory: Unsupported operating system.");

--- a/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/AppConfig.java
+++ b/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/AppConfig.java
@@ -453,6 +453,7 @@ public class AppConfig {
 					new File(localAppDataDirPath, appName + "/" + userSettingsDirName);
 				break;
 			case LINUX:
+			case OPEN_BSD:
 				userSettingsDir =
 					new File(userHomeDir, ".config/" + appName + "/" + userSettingsDirName);
 				break;

--- a/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/JavaFinder.java
+++ b/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/JavaFinder.java
@@ -36,7 +36,7 @@ public abstract class JavaFinder {
 	 * The different supported platforms (operating systems).
 	 */
 	public enum Platform {
-		WINDOWS, MACOS, LINUX;
+		WINDOWS, MACOS, LINUX, OPEN_BSD;
 	}
 
 	/**
@@ -54,6 +54,9 @@ public abstract class JavaFinder {
 			if (os.contains("mac")) {
 				return Platform.MACOS;
 			}
+			if (os.contains("openbsd")) {
+				return Platform.OPEN_BSD;
+			}
 		}
 		return Platform.LINUX;
 	}
@@ -69,6 +72,8 @@ public abstract class JavaFinder {
 				return new WindowsJavaFinder();
 			case MACOS:
 				return new MacJavaFinder();
+			case OPEN_BSD:
+				return new OpenBSDJavaFinder();
 			case LINUX:
 			default:
 				return new LinuxJavaFinder();

--- a/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/OpenBSDJavaFinder.java
+++ b/GhidraBuild/LaunchSupport/src/main/java/ghidra/launch/OpenBSDJavaFinder.java
@@ -1,0 +1,41 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.launch;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+
+/**
+ * Class responsible for finding Java installations on an OpenBSD system.
+ */
+public class OpenBSDJavaFinder extends LinuxJavaFinder {
+
+	@Override
+	protected List<File> getJavaRootInstallDirs() {
+		File localdir = new File("/usr/local");
+
+		File[] filteredFiles = localdir.listFiles((dir, name) ->
+        		name.toLowerCase().startsWith("jdk-")
+		);
+
+		return filteredFiles != null
+			? new ArrayList<>(Arrays.asList(filteredFiles))
+			: new ArrayList<>();
+	}
+}

--- a/gradle/hasProtobuf.gradle
+++ b/gradle/hasProtobuf.gradle
@@ -53,6 +53,9 @@ dependencies {
 			protocArtifact "com.google.protobuf:protoc:${version}:osx-aarch_64@exe"
 		}
 	}
+	if (isCurrentOpenBSD()) {
+		protocArtifact files('/usr/local/bin/protoc')
+	}
 }
 
 /*protobuf {


### PR DESCRIPTION
I recently update OpenBSD's port of ghidra to the latest version. This is based off of the prior work here: https://github.com/NationalSecurityAgency/ghidra/pull/490. I see that FreeBSD support has been accepted since then so I'm hoping these changes would be too.

Besides updating OpenBSD support to the current master code branch, I have implemented Pty support for OpenBSD and tested that that gdb can be launched and controlled by Ghidra. This requires using OpenBSD packages for jna and protobuf because native OpenBSD support for these are not included in the maven downloads of these packages.