### PR TITLE
Do not apply rule ptrsubundo for pointers targeting ARM Thumb functions

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
@@ -1268,9 +1268,17 @@ bool TypePointer::isPtrsubMatching(int8 off,int8 extra,int8 multiplier) const
     if (subType == (Datatype *)0 || newoff != 0)
       return false;
     extra = AddrSpace::addressToByteInt(extra,wordsize);
-    if (extra < 0 || extra >= subType->getSize()) {
-      if (!testForArraySlack(subType, extra))
+    if (subType->getMetatype() == TYPE_CODE) {
+      // When the pointer targets inside a function, consider PTRSUB to be suitable when
+      // the extra is non-negative, as subType->getSize() cannot be used (it is always 1).
+      if (extra < 0)
 	return false;
+    }
+    else {
+      if (extra < 0 || extra >= subType->getSize()) {
+	if (!testForArraySlack(subType, extra))
+	  return false;
+      }
     }
   }
   else if (meta == TYPE_ARRAY) {


### PR DESCRIPTION
Hello,
In ARM Thumb, function pointers are used with an offset. For example, let's consider this C program:

```c
static void fn(void) {}

__attribute__((noinline, optimize("O0")))
static void call_function(void (*callback)(void)) {
    callback();
}

void call_fn_through_reference(void) {
    call_function(fn);
}
```

Function `call_fn_through_reference` actually gives the address `fn + 1` in the first parameter of `call_function`, when this code is compiled in ARM Thumb mode. In such a situation, Ghidra's decompiler produced:

```c
void call_fn_through_reference(void)
{
  call_function((void *)0x10189);
  return;
}
```

The rules which were applied included both:

- rule `constantptr`, which converted the constant `0x10189` to `(#0x0 -> #0x10188) + #0x1` (opcodes `PTRSUB` and `INT_ADD`) ;
- rule `ptrsubundo`, which converted this expression to `(#0x0 + #0x10188) + #0x1` (later simplified to constant `#0x10189`).

The second rule cancelled the first one. In this case, rule `ptrsubundo` should not be applied as the expression involving PTRSUB targets a valid location.

Nevertheless, `TypePointer::isPtrsubMatching(off=0x10188, extra=1, multiplier=0)` returned `false`. This is due to the fact that even though the size of symbol `fn` was adjusted to be 2 (`diff + 1 = 2` in method `DecompileCallback::encodeFunction` in  https://github.com/NationalSecurityAgency/ghidra/blob/e3c1b6393becbddc4256f3d4b3cd566d3bd95903/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java#L906 ), the actual type is "pointer to a TypeCode which size is 1", so `extra >= subType->getSize()` and the method returned `false`: https://github.com/NationalSecurityAgency/ghidra/blob/e3c1b6393becbddc4256f3d4b3cd566d3bd95903/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc#L1271-L1273

Fix `TypePointer::isPtrsubMatching` to return `true` when a pointer to some code is encountered with `extra >= 0`. This makes Ghidra's decompiler now produce the expected output:

```c
void call_fn_through_reference(void)
{
  call_function(fn + 1);
  return;
}
```

After debugging this issue, I read the git history and identified this issue was actually a regression caused by commit 34adcff8308d2fce92424dcf817e5e3152dbce8c ("GP-4782 Refactor RulePtrsubUndo"):

- Ghidra 11.1.2 (before this commit) decompiled the program with `call_function(fn + 1);`
- Ghidra 11.2 (after this commit) decompiled the program with `call_function((void *)0x10189);`

As this commit introduced the notion of extra constant value being added to `PTRSUB` (through method `RulePtrsubUndo::getExtraOffset` in [`ruleaction.cc‎`](https://github.com/NationalSecurityAgency/ghidra/blob/e3c1b6393becbddc4256f3d4b3cd566d3bd95903/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc#L7011)), it seems it just did not consider the ARM Thumb corner case where `constantptr` may produce `PTRSUB` and `INT_ADD` opcodes to encode `fn + 1`.

Fixes: https://github.com/NationalSecurityAgency/ghidra/issues/8471