### PR TITLE
fix the printed value of a hovered register in the 32-bit static listing while debugging under a 64-bit host

### DIFF
--- a/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/stack/vars/VariableValueHoverService.java
+++ b/Ghidra/Debug/Debugger/src/main/java/ghidra/app/plugin/core/debug/gui/stack/vars/VariableValueHoverService.java
@@ -339,9 +339,14 @@ public class VariableValueHoverService extends AbstractConfigurableHover
 		}
 
 		public VariableValueTable fillRegisterNoFrame(Register register) {
-			TraceData data = eval.getRegisterUnit(register);
+			// Getting a register by name from the default view, is to fix its offset when
+			// the register is of a program which uses a different platform than the host.
+			// This should be easier than mapping Guest to Host addresses, and vice-versa.
+			String registerName = register.getName();
+			Register registerFromView = current.getTrace().getProgramView().getRegister(registerName);
+			TraceData data = eval.getRegisterUnit(registerFromView);
 			if (data != null) {
-				table.add(new NameRow(register.getName()));
+				table.add(new NameRow(registerName));
 				table.add(new TypeRow(data.getDataType()));
 				IntegerRow intRow = IntegerRow.fromCodeUnit(data, current.getSnap());
 				table.add(intRow);
@@ -349,8 +354,8 @@ public class VariableValueHoverService extends AbstractConfigurableHover
 				return table;
 			}
 			// Just display the raw register value
-			table.add(new NameRow(register.getName()));
-			WatchValue raw = eval.getRawRegisterValue(register);
+			table.add(new NameRow(registerName));
+			WatchValue raw = eval.getRawRegisterValue(registerFromView);
 			table.add(new IntegerRow(raw));
 			return table;
 		}


### PR DESCRIPTION
Hello,

While debugging, a 32-bit static listing could disagree with the 64-bit dynamic listing about the address for the same hovered register.  For instance, hovering a register in a 32-bit static listing could end up printing a misleading value by looking at the wrong address in the 64-bit host.

This PR, as stated in the title, is an attempt to fix the printed value of a hovered register in the 32-bit static listing while debugging under a 64-bit host.

A trivial change to the function `fillRegisterNoFrame()` would fetch a hovered 32-bit static listing register by its name, and not address, in the 64-bit host, as if a _guest_ had been mapped to the _host_.

Thank you very much for your precious time ;)

The image attached below is a summary of the result corrected by this PR while debugging Ghidra's `WinHelloCPP.exe` 32-bit example application under a 64-bit host.

<img width="1194" height="1454" alt="WinHelloCPP_hovering_registers_20260220" src="https://github.com/user-attachments/assets/ff8e1012-9307-44b1-b7f0-be8755976cbc" />
