### PR TITLE
V850: Add p-code emulation test classes

### DIFF
--- a/Ghidra/Processors/V850/build.gradle
+++ b/Ghidra/Processors/V850/build.gradle
@@ -20,3 +20,7 @@ apply from: "$rootProject.projectDir/gradle/jacocoProject.gradle"
 apply from: "$rootProject.projectDir/gradle/javaTestProject.gradle"
 apply plugin: 'eclipse'
 eclipse.project.name = 'Processors v850'
+
+dependencies {
+	api project(':Base')
+}

--- a/Ghidra/Processors/V850/src/test.processors/java/ghidra/test/processors/V850_O0_EmulatorTest.java
+++ b/Ghidra/Processors/V850/src/test.processors/java/ghidra/test/processors/V850_O0_EmulatorTest.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.test.processors;
+
+import ghidra.test.processors.support.ProcessorEmulatorTestAdapter;
+import junit.framework.Test;
+
+public class V850_O0_EmulatorTest extends ProcessorEmulatorTestAdapter {
+
+	private static final String LANGUAGE_ID = "V850:LE:32:default";
+	private static final String COMPILER_SPEC_ID = "default";
+
+	private static final String[] REG_DUMP_SET = new String[] {};
+
+	public V850_O0_EmulatorTest(String name) throws Exception {
+		super(name, LANGUAGE_ID, COMPILER_SPEC_ID, REG_DUMP_SET);
+	}
+
+	@Override
+	protected String getProcessorDesignator() {
+		return "V850_GCC_O0";
+	}
+
+	public static Test suite() {
+		return ProcessorEmulatorTestAdapter.buildEmulatorTestSuite(V850_O0_EmulatorTest.class);
+	}
+}

--- a/Ghidra/Processors/V850/src/test.processors/java/ghidra/test/processors/V850_O3_EmulatorTest.java
+++ b/Ghidra/Processors/V850/src/test.processors/java/ghidra/test/processors/V850_O3_EmulatorTest.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.test.processors;
+
+import ghidra.test.processors.support.ProcessorEmulatorTestAdapter;
+import junit.framework.Test;
+
+public class V850_O3_EmulatorTest extends ProcessorEmulatorTestAdapter {
+
+	private static final String LANGUAGE_ID = "V850:LE:32:default";
+	private static final String COMPILER_SPEC_ID = "default";
+
+	private static final String[] REG_DUMP_SET = new String[] {};
+
+	public V850_O3_EmulatorTest(String name) throws Exception {
+		super(name, LANGUAGE_ID, COMPILER_SPEC_ID, REG_DUMP_SET);
+	}
+
+	@Override
+	protected String getProcessorDesignator() {
+		return "V850_GCC_O3";
+	}
+
+	public static Test suite() {
+		return ProcessorEmulatorTestAdapter.buildEmulatorTestSuite(V850_O3_EmulatorTest.class);
+	}
+}


### PR DESCRIPTION
Fixes #8998

## Summary
- Add `EmulatorTest` JUnit classes for the V850 processor module
- Add `Base` dependency to `build.gradle` (required for `ProcessorEmulatorTestAdapter`)
- Enables `gradle :V850:pcodeTest` once pcodetest binaries are built via SleighDevTools

> **Note:** Depends on #8996 for full test pass. Without the SLEIGH fixes, `BIOPS2.u2_remainder_Main` fails in both O0 and O3 due to the `DIVHU` bug (`sext` instead of `zext` on the unsigned halfword operand).

## Details
Test classes target `V850:LE:32:default` with O0 and O3 optimization variants, matching the V850 entry already defined in `pcode_defs.py`.

Locally verified with binaries built using `v850-elf-gcc` 13.3.0 (newlib 4.4.0):

**With #8996 SLEIGH fixes applied:**

| Test Suite | Groups | Assertions | Failures |
|---|---|---|---|
| V850_O0_EmulatorTest | 18 | 1,249 | 0 |
| V850_O3_EmulatorTest | 18 | 1,249 | 0 |

**Without #8996 (on master):**

| Test Suite | Groups | Assertions | Failures |
|---|---|---|---|
| V850_O0_EmulatorTest | 18 | 1,249 | 1 (`u2_remainder_Main`) |
| V850_O3_EmulatorTest | 18 | 1,249 | 1 (`u2_remainder_Main`) |

## Files
- `Ghidra/Processors/V850/build.gradle` — add `api project(':Base')` dependency
- `Ghidra/Processors/V850/src/test.processors/java/ghidra/test/processors/V850_O0_EmulatorTest.java`
- `Ghidra/Processors/V850/src/test.processors/java/ghidra/test/processors/V850_O3_EmulatorTest.java`

## Test plan
- [x] `gradle :V850:pcodeTest` passes (36/36 groups, 2498/2498 assertions) with #8996 merged
- [x] Without #8996, only `u2_remainder_Main` fails (confirms the DIVHU fix is needed)