### PR TITLE
add '+' (plus) as a possible character for project and file names, i.e. to debug notepad++.exe - any reason not to?

### DIFF
--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/util/NamingUtilities.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/util/NamingUtilities.java
@@ -37,7 +37,7 @@ public final class NamingUtilities {
 
 	public final static Set<Character> VALID_NAME_CHARSET =
 		Collections.unmodifiableSet(
-			Set.of('.', '-', '=', '@', ' ', '_', '(', ')', '[', ']'));
+			Set.of('.', '-', '+', '=', '@', ' ', '_', '(', ')', '[', ']'));
 
 	private NamingUtilities() {
 	}
@@ -50,7 +50,7 @@ public final class NamingUtilities {
 	 * <li>Name may not be blank (i.e., no characters or all space characters)</li>
 	 * <li>Name may not start with period</li>
 	 * <li>All characters must be a letter, digit (0..9), or within the allowed character set:
-	 *    '.', '-', '=', '@', ' ', '_', '(', ')', '[', ']' </li>
+	 *    '.', '-', '+', '=', '@', ' ', '_', '(', ')', '[', ']' </li>
 	 * </ul>
 	 * 
 	 * @param name name to validate
@@ -88,7 +88,7 @@ public final class NamingUtilities {
 	 * <li>Path element may not start with a '.' which may result in path traversal or hidden 
 	 *     file/folder use.</li>
 	 * <li>Path element may only contain the letters, numbers, or the following characters:
-	 *     '.', '-', '=', '@', ' ', '_', '(', ')', '[', ']'</li>
+	 *     '.', '-', '+', '=', '@', ' ', '_', '(', ')', '[', ']'</li>
 	 * </ul>
 	 * 
 	 * @param pathElement project or file path element (use of leading and trailing spaces should be 


### PR DESCRIPTION
Hello,

Is there any reason to not allow the plus `+` character for project and file names?

The file `notepad++.exe`, part of the archive `npp.8.9.1.portable.x64.7z`, cannot be mapped as module, unless `+` is inserted into the allowed characters set, for project and file names: https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.1/npp.8.9.1.portable.x64.7z (please, see also the attached image).

Thank you very much, warm regards ;)

<img width="956" height="934" alt="NamingUtilities_plus_character_not_allowed_20260227" src="https://github.com/user-attachments/assets/3e86fcdb-eb97-4716-95c2-d4f202e38140" />
