### PR TITLE
Make WAV detector more lenient so that first chunks such as "JUNK" are matched correctly

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/WAVEDataType.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/WAVEDataType.java
@@ -23,11 +23,11 @@ import ghidra.util.Msg;
 public class WAVEDataType extends BuiltIn implements Dynamic {
 	public static byte[] MAGIC = new byte[] { (byte) 'R', (byte) 'I', (byte) 'F', (byte) 'F',
 		(byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 'W', (byte) 'A', (byte) 'V',
-		(byte) 'E', (byte) 'f', (byte) 'm', (byte) 't' };
+		(byte) 'E' };
 
 	public static byte[] MAGIC_MASK = new byte[] { (byte) 0xff, (byte) 0xff, (byte) 0xff,
 		(byte) 0xff, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xff, (byte) 0xff,
-		(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+		(byte) 0xff, (byte) 0xff };
 
 	public WAVEDataType() {
 		this(null);


### PR DESCRIPTION
Currently, the WAVE audio data detector looks strictly for `RIFF....WAVEfmt`. This patch generalizes it to `RIFF....WAVE`, so that other common first chunks (such as `JUNK`, used for alignment) are matched. The new magic is still around the specificity of the JPEG data type, so false positives shouldn't be an issue.