### PR TITLE
Fix two crashes in decompiler

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/condexe.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/condexe.cc
@@ -336,7 +336,7 @@ void ConditionalExecution::doReplacement(PcodeOp *op)
       if (readop->code() == CPUI_MULTIEQUAL) {
 	rvn = getMultiequalRead(op, readop, slot);
       }
-      else if (readop->code() == CPUI_RETURN) {		// Cannot replace input of RETURN directly, create COPY to hold input
+      else if (readop->code() == CPUI_RETURN && readop->numInput() > 1) {		// Cannot replace input of RETURN directly, create COPY to hold input
 	Varnode *retvn = readop->getIn(1);
 	PcodeOp *newcopyop = fd->newOp(1,readop->getAddr());
 	fd->opSetOpcode(newcopyop,CPUI_COPY);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
@@ -453,7 +453,7 @@ void DisassemblyCache::initialize(int4 min,int4 hashsize)
   hashtable = new ParserContext *[hashsize];
   for(int4 i=0;i<minimumreuse;++i) {
     ParserContext *pos = new ParserContext(contextcache,translate);
-    pos->initialize(75,20,constspace);
+    pos->initialize(256,20,constspace);
     list[i] = pos;
   }
   ParserContext *pos = list[0];


### PR DESCRIPTION
See #9018 for details. 

This increases the available state space from an arbitrary `75` entries to a much larger and still arbitrary `256` entries. fixing the first crash mentioned in that issue. This should probably be either resized dynamically or calculated, but seeing as no-one has ran into this yet I'm not certain the extra complexity is worth it.

This also adds a guard to prevent against an out of bounds access to the inputs of a `RETURN` that has no inputs.

Closes #9018 