### PR TITLE
Support the microsoft-specific I64 integer suffix in CParser

### DIFF
--- a/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
+++ b/Ghidra/Features/Base/src/main/javacc/ghidra/app/util/cparser/C/C.jj
@@ -3079,7 +3079,7 @@ Object Constant() : {
     (
         t = <INTEGER_LITERAL>
         {
-            String sval = t.image.toLowerCase();
+            String sval = t.image.toLowerCase(Locale.ROOT);
             if (sval.endsWith("i8")) {
                 sval = sval.substring(0,sval.length()-2);
             }


### PR DESCRIPTION
As documented [here](https://learn.microsoft.com/en-us/cpp/c-language/c-integer-constants?view=msvc-170) MSVC supports an `I64` / `i64` suffix to indicate 64-bit values.

Closes #5564 