### PR TITLE
Prevent segfault from known bash expansion bug

### DIFF
--- a/Ghidra/RuntimeScripts/Linux/ghidraRun
+++ b/Ghidra/RuntimeScripts/Linux/ghidraRun
@@ -23,6 +23,6 @@ VMARG_LIST="${GHIDRA_JAVA_OPTIONS} ${GHIDRA_GUI_JAVA_OPTIONS} "
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch Ghidra
 "${SCRIPT_DIR}"/support/launch.sh bg jdk Ghidra "${GHIDRA_GUI_MAXMEM}" "${VMARG_LIST}" ghidra.GhidraRun "$@"

--- a/Ghidra/RuntimeScripts/Linux/server/ghidraSvr
+++ b/Ghidra/RuntimeScripts/Linux/server/ghidraSvr
@@ -75,7 +75,7 @@ WRAPPER_TMPDIR="${TMPDIR:-/tmp}"
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Ensure Ghidra path doesn't contain illegal characters
 if [[ "${SCRIPT_DIR}" = *"!"* ]]; then
 	echo "Ghidra path cannot contain a \"!\" character."

--- a/Ghidra/RuntimeScripts/Linux/server/svrAdmin
+++ b/Ghidra/RuntimeScripts/Linux/server/svrAdmin
@@ -31,7 +31,7 @@ MAXMEM=128M
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 if [ -d "${SCRIPT_DIR}/../Ghidra" ]; then
 	# Production Environment
 	CONFIG="${SCRIPT_DIR}/server.conf"

--- a/Ghidra/RuntimeScripts/Linux/support/GhidraGo/ghidraGo
+++ b/Ghidra/RuntimeScripts/Linux/support/GhidraGo/ghidraGo
@@ -10,6 +10,6 @@ LAUNCH_MODE=fg
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch Filesystem Conversion
 "${SCRIPT_DIR}"/../launch.sh $LAUNCH_MODE jdk GhidraGo "" "" ghidra.GhidraGo "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/analyzeHeadless
+++ b/Ghidra/RuntimeScripts/Linux/support/analyzeHeadless
@@ -36,7 +36,7 @@ DEBUG_ADDRESS=127.0.0.1:13002
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch HeadlessAnalyzer.
 # DEBUG_ADDRESS set via environment for launch.sh
 DEBUG_ADDRESS=${DEBUG_ADDRESS} "${SCRIPT_DIR}"/launch.sh "${LAUNCH_MODE}" jdk Ghidra-Headless "${GHIDRA_HEADLESS_MAXMEM}" "${VMARG_LIST}" ghidra.app.util.headless.AnalyzeHeadless "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/bsim
+++ b/Ghidra/RuntimeScripts/Linux/support/bsim
@@ -27,5 +27,5 @@ LAUNCH_MODE=fg
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 ${SCRIPT_DIR}/launch.sh $LAUNCH_MODE jdk "BSim" "${GHIDRA_BSIM_MAXMEM}" "${VMARG_LIST}" ghidra.features.bsim.query.ingest.BSimLaunchable "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/bsim_ctl
+++ b/Ghidra/RuntimeScripts/Linux/support/bsim_ctl
@@ -15,5 +15,5 @@ VMARG_LIST="-Djava.awt.headless=true "
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 ${SCRIPT_DIR}/launch.sh $LAUNCH_MODE jdk "BSimControl" $MAXMEM "${VMARG_LIST}" ghidra.features.bsim.query.BSimControlLaunchable "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/buildGhidraJar
+++ b/Ghidra/RuntimeScripts/Linux/support/buildGhidraJar
@@ -16,7 +16,7 @@ LAUNCH_MODE=fg
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 GHIDRA_ROOT_DIR="${SCRIPT_DIR}"/../Ghidra
 if [ ! -d "${GHIDRA_ROOT_DIR}" ]; then
 	echo "This script does not support development mode use"

--- a/Ghidra/RuntimeScripts/Linux/support/convertStorage
+++ b/Ghidra/RuntimeScripts/Linux/support/convertStorage
@@ -13,6 +13,6 @@ MAXMEM=128M
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch Filesystem Conversion
 "${SCRIPT_DIR}"/launch.sh fg jdk ConvertStorage "${MAXMEM}" "" ghidra.framework.data.ConvertFileSystem "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/gdbGADPServerRun
+++ b/Ghidra/RuntimeScripts/Linux/support/gdbGADPServerRun
@@ -13,6 +13,6 @@
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch Ghidra
 "${SCRIPT_DIR}"/launch.sh fg jdk GdbAgent "${MAXMEM}" "" agent.gdb.gadp.GdbGadpServerLaunchShim $@

--- a/Ghidra/RuntimeScripts/Linux/support/ghidraClean
+++ b/Ghidra/RuntimeScripts/Linux/support/ghidraClean
@@ -16,5 +16,5 @@ VMARG_LIST="-Djava.awt.headless=true "
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 "${SCRIPT_DIR}"/launch.sh fg jre Ghidra-Clean "$MAXMEM" "$VMARG_LIST" utility.application.AppCleaner Ghidra

--- a/Ghidra/RuntimeScripts/Linux/support/ghidraDebug
+++ b/Ghidra/RuntimeScripts/Linux/support/ghidraDebug
@@ -30,7 +30,7 @@ DEBUG_ADDRESS=127.0.0.1:18001
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch Ghidra in debug mode
 # DEBUG_ADDRESS set via environment for launch.sh
 DEBUG_ADDRESS=${DEBUG_ADDRESS} "${SCRIPT_DIR}"/launch.sh "${LAUNCH_MODE}" jdk Ghidra "${GHIDRA_GUI_MAXMEM}" "${VMARG_LIST}" ghidra.GhidraRun "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/jshellRun
+++ b/Ghidra/RuntimeScripts/Linux/support/jshellRun
@@ -23,6 +23,6 @@ VMARG_LIST="${GHIDRA_JAVA_OPTIONS} ${GHIDRA_JSHELL_JAVA_OPTIONS} "
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch Ghidra
 "${SCRIPT_DIR}"/launch.sh fg jdk Ghidra-JShell "${GHIDRA_JSHELL_MAXMEM}" "${VMARG_LIST}" ghidra.JShellRun "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/jythonRun
+++ b/Ghidra/RuntimeScripts/Linux/support/jythonRun
@@ -35,7 +35,7 @@ DEBUG_ADDRESS=127.0.0.1:13002
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Launch Ghidra Jython
 # DEBUG_ADDRESS set via environment for launch.sh
 DEBUG_ADDRESS=${DEBUG_ADDRESS} "${SCRIPT_DIR}"/launch.sh "${LAUNCH_MODE}" jdk "Ghidra-Jython" "${GHIDRA_JYTHON_MAXMEM}" "${VMARG_LIST}" ghidra.jython.JythonRun "$@"

--- a/Ghidra/RuntimeScripts/Linux/support/launch.sh
+++ b/Ghidra/RuntimeScripts/Linux/support/launch.sh
@@ -93,7 +93,7 @@ if [[ ${INDEX} -lt 6 ]]; then
 fi
 
 # Sets SUPPORT_DIR to the directory that contains this file (launch.sh)
-SUPPORT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUPPORT_DIR="$(dirname -- "$0")"
 # Ensure Ghidra path doesn't contain illegal characters
 if [[ "${SUPPORT_DIR}" = *"!"* ]]; then
 	echo "Ghidra path cannot contain a \"!\" character."

--- a/Ghidra/RuntimeScripts/Linux/support/pyghidraRun
+++ b/Ghidra/RuntimeScripts/Linux/support/pyghidraRun
@@ -9,7 +9,7 @@
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 # Since JPype doesn't seem to pick up JDK_JAVA_OPTIONS automatically, include it ourselves
 VMARG_LIST="${JDK_JAVA_OPTIONS}"
 

--- a/Ghidra/RuntimeScripts/Linux/support/sleigh
+++ b/Ghidra/RuntimeScripts/Linux/support/sleigh
@@ -15,5 +15,5 @@ VMARG_LIST="-Djava.awt.headless=true "
 # contains the link you are calling (which is the best we can do on macOS), and the "echo" is the 
 # fallback, which doesn't attempt to do anything with links.
 SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_FILE")" && pwd)"
+SCRIPT_DIR="$(dirname -- "$SCRIPT_FILE")"
 "${SCRIPT_DIR}"/launch.sh fg jdk Sleigh "$MAXMEM" "${VMARG_LIST}" ghidra.pcodeCPort.slgh_compile.SleighCompileLauncher "$@"


### PR DESCRIPTION
ghidraRun (and launch.sh) both seg fault in some macOS bash installations via the bash expansions performed in in ghidraRun, launch.sh, and a few other scripts. This happens on my macports bash installation and has been reported in homebrew bash installations as well
(https://github.com/orgs/Homebrew/discussions/6270)

My specific bash that seg faults: `GNU bash, version 5.3.9(1)-release (aarch64-apple-darwin24.6.0)`

We can avoid the expansion and use an alternate expansion method.

Scripts were updated via:
```sh
perl -pi -e 's~^(\w+)\s*=\s*"\$\{(\w+)%/\*\}"\s*$~$1="\$(cd "\$(dirname "\$$2")" && pwd)"~' `find Ghidra/RuntimeScripts/Linux/`
```