### PR TITLE
Fix incorrect overriding of showsyntaxerror in PyConsole

### DIFF
--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/internal/plugin/plugin.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/internal/plugin/plugin.py
@@ -291,9 +291,9 @@ class PyConsole(InteractiveConsole):
         finally:
             self._writer = self._out
 
-    def showsyntaxerror(self, filename=None):
+    def showsyntaxerror(self, filename=None, **kwargs):
         with self.redirect_writer():
-            super().showsyntaxerror(filename=filename)
+            super().showsyntaxerror(filename=filename, **kwargs)
 
     def showtraceback(self) -> None:
         with self.redirect_writer():


### PR DESCRIPTION
Fixes pyghidra interactive console restarting on any syntax error