### PR TITLE
Decompiler: Respect "rename" attribute in VarnodeData::decodeFromAttributes()

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.cc
@@ -1251,6 +1251,7 @@ AttributeId ATTRIB_TYPELOCK = AttributeId("typelock",23);
 AttributeId ATTRIB_VAL = AttributeId("val",24);
 AttributeId ATTRIB_VALUE = AttributeId("value",25);
 AttributeId ATTRIB_WORDSIZE = AttributeId("wordsize",26);
+AttributeId ATTRIB_RENAME = AttributeId("rename",27);
 AttributeId ATTRIB_STORAGE = AttributeId("storage",149);
 AttributeId ATTRIB_STACKSPILL = AttributeId("stackspill",150);
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/marshal.hh
@@ -737,6 +737,7 @@ extern AttributeId ATTRIB_VALUE;	///< Marshaling attribute "value"
 extern AttributeId ATTRIB_WORDSIZE;	///< Marshaling attribute "wordsize"
 extern AttributeId ATTRIB_STORAGE;	///< Marshaling attribute "storage"
 extern AttributeId ATTRIB_STACKSPILL;	///< Marshaling attribute "stackspill"
+extern AttributeId ATTRIB_RENAME;	///< Marshaling attribute "rename"
 
 extern ElementId ELEM_DATA;		///< Marshaling element \<data>
 extern ElementId ELEM_INPUT;		///< Marshaling element \<input>

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/pcoderaw.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/pcoderaw.cc
@@ -33,8 +33,11 @@ void VarnodeData::decode(Decoder &decoder)
 void VarnodeData::decodeFromAttributes(Decoder &decoder)
 
 {
+  string attribName, attribRename;
+
   space = (AddrSpace *)0;
   size = 0;
+
   for(;;) {
     uint4 attribId = decoder.getNextAttributeId();
     if (attribId == 0)
@@ -43,14 +46,24 @@ void VarnodeData::decodeFromAttributes(Decoder &decoder)
       space = decoder.readSpace();
       decoder.rewindAttributes();
       offset = space->decodeAttributes(decoder,size);
-      break;
+      return;
     }
     else if (attribId == ATTRIB_NAME) {
-      const Translate *trans = decoder.getAddrSpaceManager()->getDefaultCodeSpace()->getTrans();
-      const VarnodeData &point(trans->getRegister(decoder.readString()));
-      *this = point;
-      break;
+	  attribName = decoder.readString();
     }
+    else if (attribId == ATTRIB_RENAME) {
+	  attribRename = decoder.readString();
+	}
+  }
+
+  if (attribRename.size() > 0) {
+	attribName = attribRename;
+  }
+
+  if (attribName.size() > 0) {
+  	const Translate *trans = decoder.getAddrSpaceManager()->getDefaultCodeSpace()->getTrans();
+  	const VarnodeData &point(trans->getRegister(attribName));
+  	*this = point;
   }
 }
 


### PR DESCRIPTION
Without this volatile registers with a rename attribute will cause the decompiler to use a different name for a renamed register, and will cause the decompilation to fail.