### PR TITLE
Add e200 VLE PowerPC language support

### DIFF
--- a/Ghidra/Processors/PowerPC/certification.manifest
+++ b/Ghidra/Processors/PowerPC/certification.manifest
@@ -26,6 +26,7 @@ data/languages/ppc_32_4xx_be.slaspec||GHIDRA||||END|
 data/languages/ppc_32_4xx_le.slaspec||GHIDRA||||END|
 data/languages/ppc_32_be.slaspec||GHIDRA||||END|
 data/languages/ppc_32_be_Mac.cspec||GHIDRA||||END|
+data/languages/ppc_32_e200.slaspec||GHIDRA||||END|
 data/languages/ppc_32_e500_be.cspec||GHIDRA||||END|
 data/languages/ppc_32_e500_be.slaspec||GHIDRA||||END|
 data/languages/ppc_32_e500_le.cspec||GHIDRA||||END|
@@ -53,6 +54,7 @@ data/languages/ppc_64_le.cspec||GHIDRA||||END|
 data/languages/ppc_64_le.slaspec||GHIDRA||||END|
 data/languages/ppc_a2.sinc||GHIDRA||||END|
 data/languages/ppc_common.sinc||GHIDRA||||END|
+data/languages/ppc_e200_ds.sinc||GHIDRA||||END|
 data/languages/ppc_embedded.sinc||GHIDRA||||END|
 data/languages/ppc_instructions.sinc||GHIDRA||||END|
 data/languages/ppc_isa.sinc||GHIDRA||||END|

--- a/Ghidra/Processors/PowerPC/data/languages/PowerPC.opinion
+++ b/Ghidra/Processors/PowerPC/data/languages/PowerPC.opinion
@@ -12,8 +12,10 @@
         <constraint primary="497"   processor="PowerPC" endian="little" size="32" />
     </constraint>
     <constraint loader="Executable and Linking Format (ELF)" compilerSpecID="default">
-        <constraint primary="20"   processor="PowerPC"                  size="32" />
-        <constraint primary="21"   processor="PowerPC"                  size="64" />
+        <constraint primary="20" processor="PowerPC" size="32">
+            <constraint secondary="0x80000000" endian="big" variant="e200" />
+        </constraint>
+        <constraint primary="21" processor="PowerPC" size="64" />
     </constraint>
     <constraint loader="Preferred Executable Format (PEF)" compilerSpecID="default">
         <constraint primary="pwpc" processor="PowerPC" endian="big" size="32" />

--- a/Ghidra/Processors/PowerPC/data/languages/SPE_FloatMulAdd.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/SPE_FloatMulAdd.sinc
@@ -19,83 +19,98 @@
 # Vector Floating-Point Single-Precision Multiply-Add
 :evfsmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x282
 {
-	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
-	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
-	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+	local tmpAL:$(HREGSIZE) = A:$(HREGSIZE); local tmpAH:$(HREGSIZE) = A[$(HREGBITS),$(HREGBITS)];
+	local tmpBL:$(HREGSIZE) = B:$(HREGSIZE); local tmpBH:$(HREGSIZE) = B[$(HREGBITS),$(HREGBITS)];
+	local tmpDL:$(HREGSIZE) = D:$(HREGSIZE); local tmpDH:$(HREGSIZE) = D[$(HREGBITS),$(HREGBITS)];
 
 	tmpDL = ((tmpAL f* tmpBL) f+ tmpDL);
 	tmpDH = ((tmpAH f* tmpBH) f+ tmpDH);
-	D = (zext(tmpDH) << 32) | zext(tmpDL);
+	D = (zext(tmpDH) << $(HREGBITS)) | zext(tmpDL);
 }
 
 # evfsmsub rD,rA,rB
 # Vector Floating-Point Single-Precision Multiply-Substract
 :evfsmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x283
 {
-	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
-	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
-	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+	local tmpAL:$(HREGSIZE) = A:$(HREGSIZE); local tmpAH:$(HREGSIZE) = A[$(HREGBITS),$(HREGBITS)];
+	local tmpBL:$(HREGSIZE) = B:$(HREGSIZE); local tmpBH:$(HREGSIZE) = B[$(HREGBITS),$(HREGBITS)];
+	local tmpDL:$(HREGSIZE) = D:$(HREGSIZE); local tmpDH:$(HREGSIZE) = D[$(HREGBITS),$(HREGBITS)];
 
 	tmpDL = ((tmpAL f* tmpBL) f- tmpDL);
 	tmpDH = ((tmpAH f* tmpBH) f- tmpDH);
-	D = (zext(tmpDH) << 32) | zext(tmpDL);
+	D = (zext(tmpDH) << $(HREGBITS)) | zext(tmpDL);
 }
 
 # evfsnmadd
 # Vector Floating-Point Single-Precision Negative Multiply-Add
 :evfsnmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x28A
 {
-	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
-	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
-	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+	local tmpAL:$(HREGSIZE) = A:$(HREGSIZE); local tmpAH:$(HREGSIZE) = A[$(HREGBITS),$(HREGBITS)];
+	local tmpBL:$(HREGSIZE) = B:$(HREGSIZE); local tmpBH:$(HREGSIZE) = B[$(HREGBITS),$(HREGBITS)];
+	local tmpDL:$(HREGSIZE) = D:$(HREGSIZE); local tmpDH:$(HREGSIZE) = D[$(HREGBITS),$(HREGBITS)];
 
 	tmpDL = f- ((tmpAL f* tmpBL) f+ tmpDL);
 	tmpDH = f- ((tmpAH f* tmpBH) f+ tmpDH);
-	D = (zext(tmpDH) << 32) | zext(tmpDL);
+	D = (zext(tmpDH) << $(HREGBITS)) | zext(tmpDL);
 }
 
 # evfsnmsub
 # Vector Floating-Point Single-Precision Negative Multiply-Substract
 :evfsnmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x28B
 {
-	local tmpAL:4 = A:4; local tmpAH:4 = A(4);
-	local tmpBL:4 = B:4; local tmpBH:4 = B(4);
-	local tmpDL:4 = D:4; local tmpDH:4 = D(4);
+	local tmpAL:$(HREGSIZE) = A:$(HREGSIZE); local tmpAH:$(HREGSIZE) = A[$(HREGBITS),$(HREGBITS)];
+	local tmpBL:$(HREGSIZE) = B:$(HREGSIZE); local tmpBH:$(HREGSIZE) = B[$(HREGBITS),$(HREGBITS)];
+	local tmpDL:$(HREGSIZE) = D:$(HREGSIZE); local tmpDH:$(HREGSIZE) = D[$(HREGBITS),$(HREGBITS)];
 
 	tmpDL = f- ((tmpAL f* tmpBL) f- tmpDL);
 	tmpDH = f- ((tmpAH f* tmpBH) f- tmpDH);
-	D = (zext(tmpDH) << 32) | zext(tmpDL);
+	D = (zext(tmpDH) << $(HREGBITS)) | zext(tmpDL);
 }
 
 # efsmadd rD,rA,rB
 # Floating-Point Single-Precision Multiply-Add
 :efsmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x2C2
 {
-	local lo:4 = (A:4 f* B:4) f+ D:4;
+	local lo:$(HREGSIZE) = (A:$(HREGSIZE) f* B:$(HREGSIZE)) f+ D:$(HREGSIZE);
+@if REGISTER_SIZE == "4"
+	D = (D & 0xFFFF0000) | zext(lo);
+@else
 	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+@endif
 }
 
 # efsmsub rD,rA,rB
 # Floating-Point Single-Precision Multiply-Substract
 :efsmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x2C3
 {
-	local lo:4 = (A:4 f* B:4) f- D:4;
+	local lo:$(HREGSIZE) = (A:$(HREGSIZE) f* B:$(HREGSIZE)) f- D:$(HREGSIZE);
+@if REGISTER_SIZE == "4"
+	D = (D & 0xFFFF0000) | zext(lo);
+@else
 	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+@endif
 }
 
 # efsnmadd rD,rA,rB
 # Floating-Point Single-Precision Negative Multiply-Add
 :efsnmadd D,A,B is OP=4 & D & A & B & XOP_0_10=0x2CA
 {
-	local lo:4 = f- ((A:4 f* B:4) f+ D:4);
+	local lo:$(HREGSIZE) = f- ((A:$(HREGSIZE) f* B:$(HREGSIZE)) f+ D:$(HREGSIZE));
+@if REGISTER_SIZE == "4"
+	D = (D & 0xFFFF0000) | zext(lo);
+@else
 	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+@endif
 }
 
 # efsnmsub rD,rA,rB
 # Floating-Point Single-Precision Negative Multiply-Substract
 :efsnmsub D,A,B is OP=4 & D & A & B & XOP_0_10=0x2CB
 {
-	local lo:4 = f- ((A:4 f* B:4) f- D:4);
+	local lo:$(HREGSIZE) = f- ((A:$(HREGSIZE) f* B:$(HREGSIZE)) f- D:$(HREGSIZE));
+@if REGISTER_SIZE == "4"
+	D = (D & 0xFFFF0000) | zext(lo);
+@else
 	D = (D & 0xFFFFFFFF00000000) | zext(lo);
+@endif
 }
-

--- a/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/Scalar_SPFP.sinc
@@ -434,6 +434,15 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
    setSummaryFPSCR();
 }
 
+# efssqrt rT,rA        010 1100 0111
+:efssqrt D,A is OP=4 & D & A & XOP_0_10=0x2C7 & BITS_11_15=0
+{
+   # assign to lower word of D
+   D = ( D & 0xFFFFFFFF00000000 ) | zext( sqrt( A:4 ) );
+   setFPRF( D:4 );
+   setSummaryFPSCR();
+}
+
 # efssub rT,rA,rB      010 1100 0001
 #define pcodeop FloatingPointSubtract;
 :efssub D,A,B is OP=4 & D & A & B & XOP_0_10=0x2C1
@@ -466,4 +475,39 @@ define pcodeop ConvertFloatingPointFromUnsignedFraction;
 :efststlt CRFD,A,B is OP=4 & CRFD & A & B & XOP_0_10=0x2DD & BITS_21_22=0
 {
   CRFD[2,1] = A:4 f< B:4;
+}
+
+# efsmin rT,rA,rB      010 1100 1010
+:efsmin D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B1
+{
+   local tmp:4 = B:4;
+   if (A:4 f<= B:4) goto <use_a>;
+   goto <done>;
+
+<use_a>
+   tmp = A:4;
+
+<done>
+   D = ( D & 0xFFFFFFFF00000000 ) | zext( tmp );
+   setSummaryFPSCR();
+}
+
+# efsmax rT,rA,rB      010 1100 1011
+:efsmax D,A,B is OP=4 & D & A & B & XOP_0_10=0x2B0
+{
+   local tmp:4 = B:4;
+   if (A:4 f>= B:4) goto <use_a>;
+   goto <done>;
+
+<use_a>
+   tmp = A:4;
+
+<done>
+   D = ( D & 0xFFFFFFFF00000000 ) | zext( tmp );
+   setSummaryFPSCR();
+}
+
+# mpusync 0x7c0008d8
+:mpusync is OP=31 & XOP_0_10=1132 & Rc=0 {
+	# e200 MPU synchronization barrier
 }

--- a/Ghidra/Processors/PowerPC/data/languages/ppc.ldefs
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc.ldefs
@@ -141,6 +141,21 @@
   <language processor="PowerPC"
             endian="big"
             size="32"
+            variant="e200"
+            version="1.7"
+            slafile="ppc_32_e200.sla"
+            processorspec="ppc_32.pspec"
+            manualindexfile="../manuals/PowerPC.idx"
+            id="PowerPC:BE:32:VLE-e200">
+    <description>Power ISA Embedded e200 32-bit big endian w/VLE</description>
+    <compiler name="default" spec="ppc_32.cspec" id="default"/>
+    <external_name tool="gnu" name="powerpc:e200"/>
+    <external_name tool="IDA-PRO" name="ppc"/>
+    <external_name tool="DWARF.register.mapping.file" name="ppc.dwarf"/>
+  </language>
+  <language processor="PowerPC"
+            endian="big"
+            size="32"
             variant="MPC8270"
             version="1.7"
             slafile="ppc_32_quicciii_be.sla"

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_32_e200.slaspec
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_32_e200.slaspec
@@ -6,6 +6,9 @@
 
 @define REGISTER_SIZE "4"
 
+@define HREGSIZE "2"
+@define HREGBITS "16"
+
 @define EATRUNC "ea"
 
 @define CTR_OFFSET "32"

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_32_e200.slaspec
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_32_e200.slaspec
@@ -1,0 +1,21 @@
+# SLA specification file for IBM PowerPC e200 series core
+
+@define E200 "1"
+
+@define ENDIAN "big"
+
+@define REGISTER_SIZE "4"
+
+@define EATRUNC "ea"
+
+@define CTR_OFFSET "32"
+
+@define NoLegacyIntegerMultiplyAccumulate "1"
+
+@include "ppc_common.sinc"
+@include "ppc_vle.sinc"
+@include "quicciii.sinc"
+@include "evx.sinc"
+@include "SPEF_SCR.sinc"
+@include "SPE_FloatMulAdd.sinc"
+@include "ppc_e200_ds.sinc"

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_64_isa_vle_be.slaspec
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_64_isa_vle_be.slaspec
@@ -7,6 +7,8 @@
 @define NoLegacyIntegerMultiplyAccumulate "1"
 
 @define REGISTER_SIZE "8"
+@define HREGSIZE "4"
+@define HREGBITS "32"
 @define BIT_64 "64"
 
 @define EATRUNC "ea"

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_e200_ds.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_e200_ds.sinc
@@ -1,0 +1,10 @@
+# e200 VLE variants need a small subset of device-synchronization instructions
+# without dragging in the full Power ISA table.
+
+# binutils-descr: "lbdx",	X(31,515),	X_MASK,      E500MC,	PPCNONE,	{RT, RA, RB}
+define pcodeop lbdxOp;
+# ISA-info: lbdx - Form "X" Page 708 Category "DS"
+# binutils: e500mc.d:   68:	7c 01 14 06 	lbdx    r0,r1,r2
+:lbdx RT,A,B is OP=31 & XOP_1_10=515 & RT & A & B & BIT_0=0  {
+	RT = lbdxOp(RT,A,B);
+}

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_instructions.sinc
@@ -3931,6 +3931,15 @@ define pcodeop TLBSynchronize; # Outputs/affect TBD
 	A = S ^ (UIMM << 16);
 }
 
+# isel r0,r0,r0	0x7c 00 00 1e
+:isel^CC_X_OPm D,RA_OR_ZERO,B,CC_X_OP  is OP=31 & D & RA_OR_ZERO & B & CC_X_OP & CC_X_OPm & XOP_1_5=15
+{
+	local tmp:$(REGISTER_SIZE) = RA_OR_ZERO;
+	D = B;
+	if (!CC_X_OP) goto inst_next;
+	D = tmp;
+}
+
 
 #TODO:
 # 2) Add simplified mnemonics for all instructions

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_vle.sinc
@@ -55,6 +55,69 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	call addrBD24;
 }
 
+# Certain 32-bit VLE encodings overlap with 16-bit forms. Define them before the
+# short-form rules so Sleigh gives the long-form decode higher priority.
+
+:e_stw S,dPlusRaOrZeroAddress	is $(ISVLE) & OP=21 & S & dPlusRaOrZeroAddress
+{
+@ifdef BIT_64
+	*:4(dPlusRaOrZeroAddress) = S:4;
+@else
+	*:4(dPlusRaOrZeroAddress) = S;
+@endif
+}
+
+:e_lwz	D,dPlusRaOrZeroAddress	is $(ISVLE) & OP=20 & D & dPlusRaOrZeroAddress
+{
+	D = zext(*:4(dPlusRaOrZeroAddress));
+}
+
+:e_li D,SIMM20					is $(ISVLE) & OP=28 & BIT_15=0 & D & SIMM20 {
+	D = sext(SIMM20);
+}
+
+:e_lis D,IMM16B					is $(ISVLE) & OP=28 & XOP_11_VLE=28 & D & IMM16B {
+	tmp:$(REGISTER_SIZE) = zext(IMM16B);
+	D = tmp << 16;
+}
+
+# The manual uses MB instead of MBL here, but because the "MB" symbol is already taken, MBL it is
+:e_rlwimi A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=0 & MBL & ME & A & SHL & S {
+	tmpS:4 = S:4;
+	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
+
+	tmpM1:4 = (~0:4) << MBL;
+	tmpM1   = tmpM1 >> ((31-ME) + MBL);
+	tmpM1   = tmpM1 << (31-ME);
+
+	tmpM2:4 = (~0:4) << ME;
+	tmpM2   = tmpM2 >> ((31-MBL) + ME);
+	tmpM2   = tmpM2 << (31-MBL);
+	tmpM2   = ~tmpM2;
+
+	local invert = (ME:1 < MBL:1);
+	tmpM:4 = (zext(invert == 0)*tmpM1) + (zext(invert == 1)*tmpM2);
+	A = zext(tmpA & tmpM) | (A & zext(~tmpM));
+}
+
+:e_rlwinm A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=1 & MBL & ME & A & SHL & S {
+	tmpS:4 = S:4;
+	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
+
+	tmpM1:4 = (~0:4) << MBL;
+	tmpM1   = tmpM1 >> ((31-ME) + MBL);
+	tmpM1   = tmpM1 << (31-ME);
+
+	tmpM2:4 = (~0:4) << ME;
+	tmpM2 = tmpM2 >> ((31-MBL) + ME);
+	tmpM2 = tmpM2 << (31-MBL);
+	tmpM2 = ~tmpM2;
+
+	local invert = (ME:1 < MBL:1);
+	tmpM:4 = (zext(invert == 0)*tmpM1) + (zext(invert == 1)*tmpM2);
+	A = zext(tmpA & tmpM);
+}
+
 :se_b addrBD8					is $(ISVLE) & OP6_VLE=58 & BIT9_VLE=0 & LK8_VLE=0 & addrBD8 {
 	goto addrBD8;
 }
@@ -320,11 +383,6 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	A = ea;
 }
 
-:e_lwz	D,dPlusRaOrZeroAddress	is $(ISVLE) & OP=20 & D & dPlusRaOrZeroAddress
-{
-	D = zext(*:4(dPlusRaOrZeroAddress));	
-}
-
 :se_lwz RZ_VLE,sd4WPlusRxAddr	is $(ISVLE) & OP4_VLE=12 & RZ_VLE & sd4WPlusRxAddr {	
 	RZ_VLE = zext(*:4(sd4WPlusRxAddr));	
 }
@@ -429,15 +487,6 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	tea = d8PlusRaOrZeroAddress;
 	storeReg(SRR0);
 	storeReg(SRR1);
-}
-
-:e_stw S,dPlusRaOrZeroAddress	is $(ISVLE) & OP=21 & S & dPlusRaOrZeroAddress
-{
-@ifdef BIT_64
-	*:4(dPlusRaOrZeroAddress) = S:4;
-@else
-	*:4(dPlusRaOrZeroAddress) = S;
-@endif
 }
 
 :se_stw RZ_VLE,sd4WPlusRxAddr	is $(ISVLE) & OP4_VLE=13 & RZ_VLE & sd4WPlusRxAddr {	
@@ -777,17 +826,8 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	RX_VLE = zext(RX_VLE:2);	
 }
 
-:e_li D,SIMM20					is $(ISVLE) & OP=28 & BIT_15=0 & D & SIMM20 {
-	D = sext(SIMM20);
-}
-
 :se_li RX_VLE,OIM7_VLE			is $(ISVLE) & OP5_VLE=9 & RX_VLE & OIM7_VLE {
 	RX_VLE = OIM7_VLE;
-}
-
-:e_lis D,IMM16B					is $(ISVLE) & OP=28 & XOP_11_VLE=28 & D & IMM16B {
-	tmp:$(REGISTER_SIZE) = zext(IMM16B);
-	D = tmp << 16;
 }
 
 :se_mfar RX_VLE,ARY_VLE			is $(ISVLE) & OP6_VLE=0 & BITS_8_9=3 & RX_VLE & ARY_VLE {
@@ -828,43 +868,6 @@ IMM16B: val						is IMM_0_10_VLE & IMM_16_20_VLE [ val = (IMM_16_20_VLE << 11) |
 	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
 	A = zext(tmpA);	
 	cr0flags(A); 							
-}
-
-# The manual uses MB instead of MBL here, but because the "MB" symbol is already taken, MBL it is
-:e_rlwimi A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=0 & MBL & ME & A & SHL & S {
-	tmpS:4 = S:4;
-	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
-
-	tmpM1:4 = (~0:4) << MBL;
-	tmpM1   = tmpM1 >> ((31-ME) + MBL);
-	tmpM1   = tmpM1 << (31-ME);
-
-	tmpM2:4 = (~0:4) << ME;
-	tmpM2   = tmpM2 >> ((31-MBL) + ME);
-	tmpM2   = tmpM2 << (31-MBL);
-	tmpM2   = ~tmpM2;
-
-	local invert = (ME:1 < MBL:1);
-	tmpM:4 = (zext(invert == 0)*tmpM1) + (zext(invert == 1)*tmpM2);
-	A = zext(tmpA & tmpM) | (A & zext(~tmpM));	
-}
-
-:e_rlwinm A,S,SHL,MBL,ME			is $(ISVLE) & OP=29 & BIT_0=1 & MBL & ME & A & SHL & S {
-	tmpS:4 = S:4;
-	tmpA:4 = (tmpS << SHL) | (tmpS >> (32 - SHL));
-
-	tmpM1:4 = (~0:4) << MBL;
-	tmpM1   = tmpM1 >> ((31-ME) + MBL);
-	tmpM1   = tmpM1 << (31-ME);
-
-	tmpM2:4 = (~0:4) << ME;
-	tmpM2 = tmpM2 >> ((31-MBL) + ME);
-	tmpM2 = tmpM2 << (31-MBL);
-	tmpM2 = ~tmpM2;
-
-	local invert = (ME:1 < MBL:1);
-	tmpM:4 = (zext(invert == 0)*tmpM1) + (zext(invert == 1)*tmpM2);
-	A = zext(tmpA & tmpM);		
 }
 
 :e_slwi A,S,SHL					is $(ISVLE) & OP=31 & BIT_0=0 & XOP_1_10=56 & A & SHL & S {

--- a/Ghidra/Processors/PowerPC/data/languages/quicciii.sinc
+++ b/Ghidra/Processors/PowerPC/data/languages/quicciii.sinc
@@ -60,15 +60,6 @@ define pcodeop invalidateTLB;
 	prefetchInstructionCacheBlockLockSetX(ea);
 }
 
-:isel^CC_X_OPm D,RA_OR_ZERO,B,CC_X_OP  is OP=31 & D & RA_OR_ZERO & B & CC_X_OP & CC_X_OPm & XOP_1_5=15
-{
-	local tmp:$(REGISTER_SIZE) = RA_OR_ZERO;
-	D = B;
-	if (!CC_X_OP) goto inst_next;
-	D = tmp;
-#        D = (zext(CC_X_OP) * RA_OR_ZERO) + (zext(!CC_X_OP) * B);
-}
-
 #mfapidi r0,r1  #FIXME
 :mfapidi D,A    is $(NOTVLE) & OP=31 & D & A & XOP_1_10=275
 { 

--- a/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/util/bin/format/elf/relocation/PowerPC_ElfRelocationHandler.java
+++ b/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/util/bin/format/elf/relocation/PowerPC_ElfRelocationHandler.java
@@ -35,6 +35,16 @@ public class PowerPC_ElfRelocationHandler extends
 	private static final int PPC_LOW14 = 0x0020FFFC;
 	private static final int PPC_HALF16 = 0xFFFF;
 
+	// VLE split-immediate field masks (per Power ISA VLE Extension / binutils elf32-ppc.c)
+	// split16a: UI[0:4] in instruction bits 20:16, UI[5:15] in bits 10:0
+	private static final int VLE_SPLIT16A_MASK = 0x001F07FF; // (0xF800 << 5) | 0x7FF
+	// split16d: UI[0:4] in instruction bits 25:21, UI[5:15] in bits 10:0
+	private static final int VLE_SPLIT16D_MASK = 0x03E007FF; // (0xF800 << 10) | 0x7FF
+	// BD24: 24-bit branch displacement, halfword-aligned, in bits 24:1
+	private static final int VLE_BD24_MASK = 0x01FFFFFE;
+	// BD15: 15-bit branch displacement in low halfword bits 15:1 (mask applied to full word)
+	private static final int VLE_BD15_MASK = 0x0000FFFE;
+
 	/**
 	 * Constructor
 	 */
@@ -56,6 +66,57 @@ public class PowerPC_ElfRelocationHandler extends
 	@Override
 	public int getRelrRelocationType() {
 		return PowerPC_ElfRelocationType.R_PPC_RELATIVE.typeId;
+	}
+
+	/**
+	 * Encode a 16-bit value into VLE split16a format (I16A form).
+	 * Per the Power ISA VLE Extension, the 16-bit immediate is split:
+	 *   UI[0:4]  -> instruction bits 20:16  (high 5 bits)
+	 *   UI[5:15] -> instruction bits 10:0   (low 11 bits)
+	 * Reference: binutils bfd/elf32-ppc.c ppc_elf_vle_split16()
+	 */
+	private static int encodeSplit16A(int instruction, int value16) {
+		instruction &= ~VLE_SPLIT16A_MASK;
+		instruction |= (value16 & 0xF800) << 5;   // high 5 bits shifted to bits 20:16
+		instruction |= (value16 & 0x7FF);          // low 11 bits at bits 10:0
+		return instruction;
+	}
+
+	/**
+	 * Encode a 16-bit value into VLE split16d format (D/I16D form).
+	 * Per the Power ISA VLE Extension, the 16-bit immediate is split:
+	 *   UI[0:4]  -> instruction bits 25:21  (high 5 bits)
+	 *   UI[5:15] -> instruction bits 10:0   (low 11 bits)
+	 * Reference: binutils bfd/elf32-ppc.c ppc_elf_vle_split16()
+	 */
+	private static int encodeSplit16D(int instruction, int value16) {
+		instruction &= ~VLE_SPLIT16D_MASK;
+		instruction |= (value16 & 0xF800) << 10;  // high 5 bits shifted to bits 25:21
+		instruction |= (value16 & 0x7FF);          // low 11 bits at bits 10:0
+		return instruction;
+	}
+
+	/**
+	 * Determine the SDA base value for a VLE SDAREL relocation based on the memory block
+	 * containing the target symbol.
+	 * @return SDA base offset, or null on failure (error already marked)
+	 */
+	private static Integer getSdaBaseForBlock(PowerPC_ElfRelocationContext elfRelocationContext,
+			MemoryBlock block, Program program, Address relocationAddress,
+			PowerPC_ElfRelocationType type, String symbolName, int symbolIndex) {
+		if (block != null) {
+			String blockName = block.getName();
+			if (".sdata".equals(blockName) || ".sbss".equals(blockName)) {
+				return elfRelocationContext.getSDABase();
+			}
+			if (".sdata2".equals(blockName) || ".sbss2".equals(blockName)) {
+				return elfRelocationContext.getSDA2Base();
+			}
+		}
+		markAsError(program, relocationAddress, type, symbolName, symbolIndex,
+			"Failed to identify SDA base for VLE SDAREL relocation",
+			elfRelocationContext.getLog());
+		return null;
 	}
 
 	@Override
@@ -225,6 +286,214 @@ public class PowerPC_ElfRelocationHandler extends
 					return RelocationResult.FAILURE;
 				}
 				break;
+			// =================================================================
+			// VLE (Variable-Length Encoding) Relocations (types 216-232)
+			// Per Power ISA VLE Extension and binutils bfd/elf32-ppc.c
+			// =================================================================
+
+			// --- VLE PC-relative branches ---
+
+			case R_PPC_VLE_REL8: {
+				// 8-bit PC-relative branch displacement (se_b, se_bc forms).
+				// 16-bit instruction; 8-bit signed displacement in bits 7:0,
+				// halfword-aligned (value includes implicit <<1).
+				// HOW: size=2, bitsize=8, mask=0xFF, rightshift=1
+				int displacement8 = (int) symbolValue + addend - offset;
+				short oldInsn16 = memory.getShort(relocationAddress);
+				short newInsn16 = (short) ((oldInsn16 & 0xFF00) |
+					((displacement8 >> 1) & 0xFF));
+				memory.setShort(relocationAddress, newInsn16);
+				byteLength = 2;
+				break;
+			}
+
+			case R_PPC_VLE_REL15:
+				// 15-bit PC-relative branch displacement (e_bc form).
+				// 32-bit instruction; displacement in bits 16:30 (ISA) = bits 15:1.
+				// Halfword-aligned; mask 0xFFFE on lower 16 bits.
+				newValue = (int) symbolValue + addend - offset;
+				newValue = (oldValue & ~VLE_BD15_MASK) | (newValue & VLE_BD15_MASK);
+				memory.setInt(relocationAddress, newValue);
+				break;
+
+			case R_PPC_VLE_REL24:
+				// 24-bit PC-relative branch displacement (e_b, e_bl forms).
+				// 32-bit instruction; 24-bit displacement in bits 1:24 (halfword-aligned).
+				// HOW: bitsize=25, mask=0x1FFFFFE
+				newValue = (int) symbolValue + addend - offset;
+				newValue = (oldValue & ~VLE_BD24_MASK) | (newValue & VLE_BD24_MASK);
+				memory.setInt(relocationAddress, newValue);
+				break;
+
+			// --- VLE absolute 16-bit (LO/HI/HA) ---
+
+			case R_PPC_VLE_LO16A:
+				// Low 16 bits of (S + A) in split16a (I16A) format.
+				newValue = (int) (symbolValue + addend);
+				memory.setInt(relocationAddress,
+					encodeSplit16A(oldValue, newValue & 0xFFFF));
+				break;
+
+			case R_PPC_VLE_LO16D:
+				// Low 16 bits of (S + A) in split16d (D) format.
+				newValue = (int) (symbolValue + addend);
+				memory.setInt(relocationAddress,
+					encodeSplit16D(oldValue, newValue & 0xFFFF));
+				break;
+
+			case R_PPC_VLE_HI16A:
+				// High 16 bits of (S + A) in split16a format.
+				newValue = (int) ((symbolValue + addend) >> 16);
+				memory.setInt(relocationAddress,
+					encodeSplit16A(oldValue, newValue & 0xFFFF));
+				break;
+
+			case R_PPC_VLE_HI16D:
+				// High 16 bits of (S + A) in split16d format.
+				newValue = (int) ((symbolValue + addend) >> 16);
+				memory.setInt(relocationAddress,
+					encodeSplit16D(oldValue, newValue & 0xFFFF));
+				break;
+
+			case R_PPC_VLE_HA16A:
+				// High adjusted 16 bits of (S + A) in split16a format.
+				// "Adjusted" means +0x8000 before shift to account for sign
+				// extension when the low 16 bits are later added via e_add16i.
+				newValue = (int) (symbolValue + addend);
+				newValue = (newValue >> 16) + ((newValue & 0x8000) != 0 ? 1 : 0);
+				memory.setInt(relocationAddress,
+					encodeSplit16A(oldValue, newValue & 0xFFFF));
+				break;
+
+			case R_PPC_VLE_HA16D:
+				// High adjusted 16 bits of (S + A) in split16d format.
+				newValue = (int) (symbolValue + addend);
+				newValue = (newValue >> 16) + ((newValue & 0x8000) != 0 ? 1 : 0);
+				memory.setInt(relocationAddress,
+					encodeSplit16D(oldValue, newValue & 0xFFFF));
+				break;
+
+			// --- VLE SDA21 ---
+
+			case R_PPC_VLE_SDA21:
+			case R_PPC_VLE_SDA21_LO: {
+				// VLE SDA21 relocation for e_add16i instruction.
+				// 16-bit displacement relative to SDA base in bits 16:31.
+				// Register base determined by section (.sdata→r13, .sdata2→r2).
+				MemoryBlock sdaBlock = memory.getBlock(symbolAddr);
+				Integer vleSdaBase = null;
+
+				if (sdaBlock != null) {
+					String sdaBlockName = sdaBlock.getName();
+					if (".sdata".equals(sdaBlockName) || ".sbss".equals(sdaBlockName)) {
+						vleSdaBase = elfRelocationContext.getSDABase();
+					}
+					else if (".sdata2".equals(sdaBlockName) ||
+						".sbss2".equals(sdaBlockName)) {
+						vleSdaBase = elfRelocationContext.getSDA2Base();
+					}
+				}
+				if (vleSdaBase == null) {
+					markAsError(program, relocationAddress, type, symbolName, symbolIndex,
+						"Failed to identify SDA base for VLE SDA21 relocation",
+						elfRelocationContext.getLog());
+					return RelocationResult.FAILURE;
+				}
+				newValue = (int) symbolValue + addend - vleSdaBase;
+				// Encode in low 16 bits of the instruction word
+				newValue = (oldValue & 0xFFFF0000) | (newValue & 0xFFFF);
+				memory.setInt(relocationAddress, newValue);
+				break;
+			}
+
+			// --- VLE SDA-relative 16-bit (split-immediate) ---
+
+			case R_PPC_VLE_SDAREL_LO16A: {
+				// Low 16 bits of (S + A - SDA_BASE) in split16a format.
+				MemoryBlock sdarelBlock = memory.getBlock(symbolAddr);
+				Integer sdarelBase = getSdaBaseForBlock(elfRelocationContext, sdarelBlock,
+					program, relocationAddress, type, symbolName, symbolIndex);
+				if (sdarelBase == null) {
+					return RelocationResult.FAILURE;
+				}
+				newValue = (int) (symbolValue + addend - sdarelBase);
+				memory.setInt(relocationAddress,
+					encodeSplit16A(oldValue, newValue & 0xFFFF));
+				break;
+			}
+
+			case R_PPC_VLE_SDAREL_LO16D: {
+				// Low 16 bits of (S + A - SDA_BASE) in split16d format.
+				MemoryBlock sdarelBlock = memory.getBlock(symbolAddr);
+				Integer sdarelBase = getSdaBaseForBlock(elfRelocationContext, sdarelBlock,
+					program, relocationAddress, type, symbolName, symbolIndex);
+				if (sdarelBase == null) {
+					return RelocationResult.FAILURE;
+				}
+				newValue = (int) (symbolValue + addend - sdarelBase);
+				memory.setInt(relocationAddress,
+					encodeSplit16D(oldValue, newValue & 0xFFFF));
+				break;
+			}
+
+			case R_PPC_VLE_SDAREL_HI16A: {
+				// High 16 bits of (S + A - SDA_BASE) in split16a format.
+				MemoryBlock sdarelBlock = memory.getBlock(symbolAddr);
+				Integer sdarelBase = getSdaBaseForBlock(elfRelocationContext, sdarelBlock,
+					program, relocationAddress, type, symbolName, symbolIndex);
+				if (sdarelBase == null) {
+					return RelocationResult.FAILURE;
+				}
+				newValue = (int) ((symbolValue + addend - sdarelBase) >> 16);
+				memory.setInt(relocationAddress,
+					encodeSplit16A(oldValue, newValue & 0xFFFF));
+				break;
+			}
+
+			case R_PPC_VLE_SDAREL_HI16D: {
+				// High 16 bits of (S + A - SDA_BASE) in split16d format.
+				MemoryBlock sdarelBlock = memory.getBlock(symbolAddr);
+				Integer sdarelBase = getSdaBaseForBlock(elfRelocationContext, sdarelBlock,
+					program, relocationAddress, type, symbolName, symbolIndex);
+				if (sdarelBase == null) {
+					return RelocationResult.FAILURE;
+				}
+				newValue = (int) ((symbolValue + addend - sdarelBase) >> 16);
+				memory.setInt(relocationAddress,
+					encodeSplit16D(oldValue, newValue & 0xFFFF));
+				break;
+			}
+
+			case R_PPC_VLE_SDAREL_HA16A: {
+				// High adjusted 16 bits of (S + A - SDA_BASE) in split16a format.
+				MemoryBlock sdarelBlock = memory.getBlock(symbolAddr);
+				Integer sdarelBase = getSdaBaseForBlock(elfRelocationContext, sdarelBlock,
+					program, relocationAddress, type, symbolName, symbolIndex);
+				if (sdarelBase == null) {
+					return RelocationResult.FAILURE;
+				}
+				newValue = (int) (symbolValue + addend - sdarelBase);
+				newValue = (newValue >> 16) + ((newValue & 0x8000) != 0 ? 1 : 0);
+				memory.setInt(relocationAddress,
+					encodeSplit16A(oldValue, newValue & 0xFFFF));
+				break;
+			}
+
+			case R_PPC_VLE_SDAREL_HA16D: {
+				// High adjusted 16 bits of (S + A - SDA_BASE) in split16d format.
+				MemoryBlock sdarelBlock = memory.getBlock(symbolAddr);
+				Integer sdarelBase = getSdaBaseForBlock(elfRelocationContext, sdarelBlock,
+					program, relocationAddress, type, symbolName, symbolIndex);
+				if (sdarelBase == null) {
+					return RelocationResult.FAILURE;
+				}
+				newValue = (int) (symbolValue + addend - sdarelBase);
+				newValue = (newValue >> 16) + ((newValue & 0x8000) != 0 ? 1 : 0);
+				memory.setInt(relocationAddress,
+					encodeSplit16D(oldValue, newValue & 0xFFFF));
+				break;
+			}
+
 			case R_PPC_EMB_SDA21:
 				// NOTE: PPC EABI V1.0 specifies this relocation on a 24-bit field address while 
 				// GNU assumes a 32-bit field address.  We cope with this difference by 

--- a/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/util/bin/format/elf/relocation/PowerPC_ElfRelocationHandler.java
+++ b/Ghidra/Processors/PowerPC/src/main/java/ghidra/app/util/bin/format/elf/relocation/PowerPC_ElfRelocationHandler.java
@@ -101,7 +101,7 @@ public class PowerPC_ElfRelocationHandler extends
 	 * containing the target symbol.
 	 * @return SDA base offset, or null on failure (error already marked)
 	 */
-	private static Integer getSdaBaseForBlock(PowerPC_ElfRelocationContext elfRelocationContext,
+	private Integer getSdaBaseForBlock(PowerPC_ElfRelocationContext elfRelocationContext,
 			MemoryBlock block, Program program, Address relocationAddress,
 			PowerPC_ElfRelocationType type, String symbolName, int symbolIndex) {
 		if (block != null) {


### PR DESCRIPTION
Fixes #6863.

This revives the separate-e200-language approach from #4952 and narrows it around the current PowerPC VLE/EVX gaps.

What this changes:
- adds a dedicated 32-bit e200 VLE language: `PowerPC:BE:32:VLE-e200`
- wires ELF opinion selection for e200 binaries
- adds missing SPFP instructions reported in #6863: `efsmin`, `efsmax`, `efssqrt`, `mpusync`
- adds an e200-only `lbdx` include without pulling the full `ppc_isa` table back into the new language
- moves `isel` into shared `ppc_instructions.sinc`, following the discussion on #4952
- keeps overlapping 32-bit VLE forms ahead of 16-bit `se_*` forms in `ppc_vle.sinc`

Why this shape:
- #6863 and its follow-up comments point to the core problem being the current 64-bit VLE model used for true 32-bit e200 firmware
- #4952 already established the direction of a separate e200 language, but later comments also called out `isel` placement and additional missing instructions
- the small `ppc_e200_ds.sinc` file is used to expose `lbdx` for the e200 language without reintroducing the broader 64-bit/full-ISA mismatch that caused false matches in the first place

Validation:
- all 19 PowerPC languages on this branch compile with the sleigh compiler from the Ghidra 12.0.3 release, exit 0, warnings only, including the new `ppc_32_e200.slaspec`; the same run over current `master` compiles its 18 languages, so this adds one and regresses none
- with these language files overlaid on that release, `analyzeHeadless` importing a raw binary as `PowerPC:BE:32:VLE-e200` decodes the byte cases from #6863 correctly: `efsmin r7,r7,r31`, `efsmax r0,r0,r30`, `efssqrt r3,r3`, `mpusync`, `iseleq r0,r7,r0,cr0`, `lbdx r31,r6,r30`
- independently, @MrsPeppu55 and @RealIndica reported this working on real e200 and SPC572L firmware

Not yet verified:
- no full gradle build of master was run, and only the language data files were overlaid onto the release, so the additions to `PowerPC_ElfRelocationHandler.java` are not exercised by the above
