### PR TITLE
Fix symbol tree not updating on adding/removing symbols in namespace/class in a group

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/nodes/SymbolTreeNode.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/symboltree/nodes/SymbolTreeNode.java
@@ -263,6 +263,9 @@ public abstract class SymbolTreeNode extends GTreeSlowLoadingNode {
 			if (symbolNode.getSymbol() == searchSymbol) {
 				return symbolNode;
 			}
+			else if (symbolNode instanceof OrganizationNode) {
+				return findNode(symbolNode, key, loadChildren, monitor);
+			}
 		}
 
 		return null;


### PR DESCRIPTION
To reproduce:

1. Create lots of namespaces to trigger grouping:
```python
[createNamespace(currentProgram.getGlobalNamespace(), 'ns' + str(i)) for i in range(500)]
```
2. Namespace `ns0` should be in `Namespaces`, namespace `ns1` should be in the group `Namespaces/ns1`
3. Expand both namespaces `ns0` and `ns1`
4. Try creating namespaces in `ns0` and `ns1` using context menu - namespaces created in `ns0` appear, namespaces created in `ns1` don't

If you don't expand namespace `ns1`, first namespace created in it appears.

Reason: like `findNode`, its users don't expect `OrganizationNode`

commit that introduced `findNode`: 5f17963eba583b370cfec4e7437aece557dfc1c2