### PR TITLE
Fix typo: "occured" -> "occurred" (46 instances across 35 files)

### DIFF
--- a/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.md
+++ b/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.md
@@ -606,7 +606,7 @@ Added `AbstractLocation/Selection/HighlightPluginEvent`.
 * _Search_. Corrected a problem with the Memory Search dialog which could prevent proper search of selected memory regions. (GP-5395)
 * _SourceMatching_. Corrected parsing of certain DWARF source file paths. (GP-5561, Issue #7963)
 * _Terminal_. Fixed issue with obtrusive scrolling when selecting text. (GP-5416)
-* _Version Tracking_. Fixed NullPointerException that occured when clicking on Version Tracking match where either source or destination address was not in current program memory. (GP-5549, Issue #7964)
+* _Version Tracking_. Fixed NullPointerException that occurred when clicking on Version Tracking match where either source or destination address was not in current program memory. (GP-5549, Issue #7964)
 
 ### Notable API Changes
 * _Debugger:Emulator_. (GP-5517) Added Stack and Frames to the `pure emulation` trace object schema.
@@ -979,7 +979,7 @@ Added API method `Structure.setLength(int length)` which allows the size of a no
 * _Importer:ELF_. Fixed ELF X86-64 GOT allocation bug which could cause exception during import. Also added unverified ELF relocation support for `R_X86_64_GOT64` and `R_X86_64_PLTOFF64`. (GP-4758, Issue #6691)
 * _Importer:Mach-O_. Fixed an issue with importing Mach-O binaries that have an empty `__chain_starts` section. (GP-4695)
 * _Importer:Mach-O_. Fixed a regression in the MachoLoader that prevented some KDK binaries from being loaded. (GP-4699)
-* _Multi-User:Merge_. Fixed assertion error which occured for multi-user merge of register context within overlay memory blocks. (GP-4508, Issue #6403)
+* _Multi-User:Merge_. Fixed assertion error which occurred for multi-user merge of register context within overlay memory blocks. (GP-4508, Issue #6403)
 * _Processors_. Fixed AARCH64 Windows stack alignment. (GP-4752, Issue #6680)
 
 # Ghidra 11.1.1 Change History (June 2024)

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/client/AbstractSQLFunctionDatabase.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/client/AbstractSQLFunctionDatabase.java
@@ -437,7 +437,7 @@ public abstract class AbstractSQLFunctionDatabase<VF extends LSHVectorFactory>
 
 	/**
 	 * Drop this database
-	 * @throws SQLException if a database error occured
+	 * @throws SQLException if a database error occurred
 	 */
 	abstract protected void dropDatabase() throws SQLException;
 

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/facade/SFResultsUpdateListener.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/facade/SFResultsUpdateListener.java
@@ -42,7 +42,7 @@ public interface SFResultsUpdateListener<R> {
 
 	/**
 	 * Callback to supply the final accumulated result.
-	 * @param result accumulated query result or null if a failure occured which prevented
+	 * @param result accumulated query result or null if a failure occurred which prevented
 	 * results from being returned.
 	 */
 	public void setFinalResult(R result);

--- a/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/IterateRepository.java
+++ b/Ghidra/Features/BSim/src/main/java/ghidra/features/bsim/query/ingest/IterateRepository.java
@@ -36,7 +36,7 @@ public abstract class IterateRepository {
 	 * Perform processing on program obtained from repository.
 	 * @param program program obtained from repository
 	 * @param monitor processing task monitor
-	 * @throws IOException if an error occured during processing.
+	 * @throws IOException if an error occurred during processing.
 	 * @throws CancelledException if processing was cancelled
 	 */
 	protected abstract void process(Program program, TaskMonitor monitor)

--- a/Ghidra/Features/Base/ghidra_scripts/CompareGDTs.java
+++ b/Ghidra/Features/Base/ghidra_scripts/CompareGDTs.java
@@ -60,7 +60,7 @@ public class CompareGDTs extends GhidraScript {
 		firstArchive = openDataTypeArchive(firstFile, false);
 		if (firstArchive.getWarning() != ArchiveWarning.NONE) {
 			popup(
-				"An architecture language error occured while opening archive (see log for details)\n" +
+				"An architecture language error occurred while opening archive (see log for details)\n" +
 					firstFile.getPath());
 			return;
 		}
@@ -68,7 +68,7 @@ public class CompareGDTs extends GhidraScript {
 		secondArchive = openDataTypeArchive(secondFile, false);
 		if (secondArchive.getWarning() != ArchiveWarning.NONE) {
 			popup(
-				"An architecture language error occured while opening archive (see log for details)\n" +
+				"An architecture language error occurred while opening archive (see log for details)\n" +
 					secondFile.getPath());
 			firstArchive.close();
 			return;

--- a/Ghidra/Features/Base/ghidra_scripts/FixElfExternalOffsetDataRelocationScript.java
+++ b/Ghidra/Features/Base/ghidra_scripts/FixElfExternalOffsetDataRelocationScript.java
@@ -75,7 +75,7 @@ public class FixElfExternalOffsetDataRelocationScript extends GhidraScript {
 					}
 				}
 				catch (Exception e) {
-					Msg.error(this, "Error occured while updating EXTERNAL relocation at " +
+					Msg.error(this, "Error occurred while updating EXTERNAL relocation at " +
 						b.getAddress() + ": " + e.getMessage());
 				}
 			}

--- a/Ghidra/Features/Base/ghidra_scripts/SynchronizeGDTCategoryPaths.java
+++ b/Ghidra/Features/Base/ghidra_scripts/SynchronizeGDTCategoryPaths.java
@@ -74,7 +74,7 @@ public class SynchronizeGDTCategoryPaths extends GhidraScript {
 					"\nIs it OK to proceed?");
 		}
 		popup(
-			"An architecture language error occured while opening archive (see log for details)\n" +
+			"An architecture language error occurred while opening archive (see log for details)\n" +
 				file.getPath());
 		return true;
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/misc/MyProgramChangesDisplayPlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/misc/MyProgramChangesDisplayPlugin.java
@@ -297,7 +297,7 @@ public class MyProgramChangesDisplayPlugin extends ProgramPlugin implements Doma
 			}
 
 			// Update conflict markers when forced by server version change,
-			// local version change (merge may have occured) or a transaction has ended
+			// local version change (merge may have occurred) or a transaction has ended
 			if (updateConflicts) {
 				AddressSet intersect = changeSet.getAddressSetCollectionSinceCheckout()
 						.getCombinedAddressSet()

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/progmgr/AbstractUndoRedoAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/progmgr/AbstractUndoRedoAction.java
@@ -115,7 +115,7 @@ public abstract class AbstractUndoRedoAction extends MultiActionDockingAction {
 		}
 		catch (IOException e) {
 			Msg.showError(this, null, getName() + " Error",
-				"Error occured while attempting " + getName() + "!", e);
+				"Error occurred while attempting " + getName() + "!", e);
 		}
 
 	}

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/extend/ElfLoadAdapter.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/extend/ElfLoadAdapter.java
@@ -554,7 +554,7 @@ public class ElfLoadAdapter {
 	 * 
 	 * @param section ELF section header which is specified by the ELF symbol
 	 * @param sectionBase memory address where section has been loaded.  Could be within overlay
-	 * space if load conflict occured.
+	 * space if load conflict occurred.
 	 * @param elfSymbol ELF symbol
 	 * @return section relative symbol offset or null if symbol value offset is absolute
 	 */

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/bytesearch/MatchAction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/bytesearch/MatchAction.java
@@ -27,7 +27,7 @@ public interface MatchAction {
 	 * Apply the match action to the program at the address.
 	 * 
 	 * @param program program in which the match occurred
-	 * @param addr where the match occured
+	 * @param addr where the match occurred
 	 * @param match information about the match that occurred
 	 */
 	public void apply(Program program, Address addr, Match<Pattern> match);

--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/CommandProcessor.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/CommandProcessor.java
@@ -266,7 +266,7 @@ public class CommandProcessor {
 					processCommand(repositoryMgr, cmdStr.trim());
 				}
 				catch (ArrayIndexOutOfBoundsException e) {
-					log.error("Error occured processing command: " + cmdStr);
+					log.error("Error occurred processing command: " + cmdStr);
 				}
 			}
 			file.delete();

--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/RepositoryManager.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/RepositoryManager.java
@@ -571,7 +571,7 @@ public class RepositoryManager {
 	/**
 	 * Callback when user removed from server.  Remove user from all repository access lists.
 	 * @param username user name
-	 * @throws IOException if error occured while updating repository access lists.
+	 * @throws IOException if error occurred while updating repository access lists.
 	 */
 	void userRemoved(String username) throws IOException {
 		for (String repName : getRepositoryNames()) {

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/db/VTSessionDB.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/db/VTSessionDB.java
@@ -258,7 +258,7 @@ public class VTSessionDB extends DomainObjectAdapterDB implements VTSession {
 	 * Open associated source and destination program files and complete session initialization.
 	 * @param projectData active project data
 	 * @throws IOException if source or destination program not found within specified project
-	 * or an error occured while opening them (e.g., upgrade required).
+	 * or an error occurred while opening them (e.g., upgrade required).
 	 */
 	private void openSourceAndDestinationPrograms(ProjectData projectData) throws IOException {
 		String sourceProgramID = getSourceProgramID();

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/client/ServerConnectTask.java
@@ -102,7 +102,7 @@ class ServerConnectTask extends Task {
 	 * if handle is null after running task.  If both the exception
 	 * and handle are null, it implies the connection attempt was cancelled
 	 * by the user.
-	 * @return exception which occured during a failed connection attempt, or null
+	 * @return exception which occurred during a failed connection attempt, or null
 	 */
 	Exception getException() {
 		return exc;
@@ -402,7 +402,7 @@ class ServerConnectTask extends Task {
 			// do nothing - connect occurs during instantiation
 		}
 		finally {
-			monitor.checkCancelled(); // circumvent any IOException which may have occured
+			monitor.checkCancelled(); // circumvent any IOException which may have occurred
 		}
 
 		// Perform secure socket test connection to prime keystore use without RMI involvement
@@ -416,7 +416,7 @@ class ServerConnectTask extends Task {
 			return socket.getSession().getPeerCertificates();
 		}
 		finally {
-			monitor.checkCancelled(); // circumvent any IOException which may have occured
+			monitor.checkCancelled(); // circumvent any IOException which may have occurred
 		}
 	}
 

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/FileSystemEventManager.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/FileSystemEventManager.java
@@ -187,7 +187,7 @@ public class FileSystemEventManager implements FileSystemListener {
 	 * @param timeout the maximum time to wait
 	 * @param unit the time unit of the {@code time} argument
 	 * @return true if the events were processed in the given timeout.  A false value will be
-	 * returned if either a timeout occured
+	 * returned if either a timeout occurred
 	 */
 	public boolean flushEvents(long timeout, TimeUnit unit) {
 		if (!asyncDispatchEnabled) {
@@ -196,7 +196,7 @@ public class FileSystemEventManager implements FileSystemListener {
 
 		MarkerEvent event = new MarkerEvent();
 		if (!queueEvent(event)) {
-			// events are not queuing since there are no listeners or dispose has occured
+			// events are not queuing since there are no listeners or dispose has occurred
 			return true;
 		}
 		try {

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/local/IndexedLocalFileSystem.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/local/IndexedLocalFileSystem.java
@@ -89,7 +89,7 @@ public class IndexedLocalFileSystem extends LocalFileSystem {
 	 * to notify listeners.  If false, blocking notification will be performed.
 	 * @param create if true a new folder will be created.
 	 * @throws FileNotFoundException if specified rootPath does not exist
-	 * @throws IndexReadException failure occured reading index file
+	 * @throws IndexReadException failure occurred reading index file
 	 * @throws IOException if error occurs while reading/writing index files
 	 */
 	IndexedLocalFileSystem(String rootPath, boolean isVersioned, boolean readOnly,

--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/local/IndexedV1LocalFileSystem.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/framework/store/local/IndexedV1LocalFileSystem.java
@@ -43,7 +43,7 @@ public class IndexedV1LocalFileSystem extends IndexedLocalFileSystem {
 	 * to notify listeners.  If false, blocking notification will be performed.
 	 * @param create if true a new folder will be created.
 	 * @throws FileNotFoundException if specified rootPath does not exist
-	 * @throws IndexReadException failure occured reading index file
+	 * @throws IndexReadException failure occurred reading index file
 	 * @throws IOException if error occurs while reading/writing index files
 	 */
 	protected IndexedV1LocalFileSystem(String rootPath, boolean isVersioned, boolean readOnly,

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/net/DefaultKeyManagerFactory.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/net/DefaultKeyManagerFactory.java
@@ -99,7 +99,7 @@ public class DefaultKeyManagerFactory {
 	 * 
 	 * @param path keystore file path or null to clear current key store and preference.
 	 * @param savePreference if true will be saved as user preference
-	 * @return true if successful else false if error occured (see log).
+	 * @return true if successful else false if error occurred (see log).
 	 */
 	public static synchronized boolean setDefaultKeyStore(String path, boolean savePreference) {
 

--- a/Ghidra/Framework/Generic/src/main/java/ghidra/net/PKIUtils.java
+++ b/Ghidra/Framework/Generic/src/main/java/ghidra/net/PKIUtils.java
@@ -85,7 +85,7 @@ public class PKIUtils {
 	 * @param caCertsFile CA certificates storage file
 	 * @return X509TrustManager
 	 * @throws CancelledException if password entry was cancelled
-	 * @throws GeneralSecurityException if error occured during truststore initialization
+	 * @throws GeneralSecurityException if error occurred during truststore initialization
 	 * @throws IOException if file read error occurs
 	 */
 	public static X509TrustManager getTrustManager(File caCertsFile)

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/GhidraFileData.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/GhidraFileData.java
@@ -777,7 +777,7 @@ public class GhidraFileData {
 	/**
 	 * Returns a new DomainObject that cannot be changed or saved to its original file.
 	 * NOTE: The use of this method should generally be avoided since it can't
-	 * handle version changes that may have occured and require a data upgrade
+	 * handle version changes that may have occurred and require a data upgrade
 	 * (e.g., DB schema change).
 	 * @param consumer consumer of the domain object which is responsible for
 	 * releasing it after use.
@@ -2202,7 +2202,7 @@ public class GhidraFileData {
 			mergeInProgress = false;
 			try {
 				if (tmpItem != null) {
-					// remove temporary merge file if error occured
+					// remove temporary merge file if error occurred
 					try {
 						tmpItem.delete(-1, ClientUtil.getUserName());
 					}

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/GhidraFolderData.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/GhidraFolderData.java
@@ -88,7 +88,7 @@ class GhidraFolderData {
 	 * Construct a folder instance with a specified name and a correpsonding parent folder
 	 * @param parent parent folder
 	 * @param name folder name
-	 * @throws FileNotFoundException if folder not found or error occured while checking
+	 * @throws FileNotFoundException if folder not found or error occurred while checking
 	 * for its existance
 	 */
 	GhidraFolderData(GhidraFolderData parent, String name) throws FileNotFoundException {

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/ProjectDataPasteLinkAction.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/main/projectdata/actions/ProjectDataPasteLinkAction.java
@@ -76,7 +76,7 @@ public class ProjectDataPasteLinkAction extends ProjectTreeAction {
 			}
 			catch (IOException e) {
 				Msg.showError(getClass(), context.getTree(), "Cannot Create Link",
-					"Error occured while creating link file", e);
+					"Error occurred while creating link file", e);
 			}
 		}
 		else {
@@ -86,7 +86,7 @@ public class ProjectDataPasteLinkAction extends ProjectTreeAction {
 			}
 			catch (IOException e) {
 				Msg.showError(getClass(), context.getTree(), "Cannot Create Link",
-					"Error occured while creating link file", e);
+					"Error occurred while creating link file", e);
 			}
 		}
 

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/model/DomainFile.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/model/DomainFile.java
@@ -254,7 +254,7 @@ public interface DomainFile extends Comparable<DomainFile> {
 	/**
 	 * Returns a new DomainObject that cannot be changed or saved to its original file.
 	 * NOTE: The use of this method should generally be avoided since it can't
-	 * handle version changes that may have occured and require a data upgrade
+	 * handle version changes that may have occurred and require a data upgrade
 	 * (e.g., DB schema change).
 	 * @param consumer consumer of the domain object which is responsible for
 	 * releasing it after use.

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/protocol/ghidra/ContentTypeQueryTask.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/protocol/ghidra/ContentTypeQueryTask.java
@@ -41,7 +41,7 @@ public class ContentTypeQueryTask extends GhidraURLQueryTask {
 
 	/**
 	 * Get the discovered content type (e.g., "Program")
-	 * @return content type or null if error occured or unsupported URL content
+	 * @return content type or null if error occurred or unsupported URL content
 	 * @throws IllegalStateException if task has not completed execution
 	 */
 	public String getContentType() {

--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/protocol/ghidra/GhidraURLQuery.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/protocol/ghidra/GhidraURLQuery.java
@@ -192,7 +192,7 @@ public class GhidraURLQuery {
 
 				case UNAVAILABLE:
 					generatedErr =
-						new IOException("Server connection error occured (see log files)");
+						new IOException("Server connection error occurred (see log files)");
 					break;
 
 				default:

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/ArrayDBAdapterV1.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/ArrayDBAdapterV1.java
@@ -52,7 +52,7 @@ class ArrayDBAdapterV1 extends ArrayDBAdapter {
 	 * @param create create table if true else acquire for read-only or update use
 	 * @throws VersionException if the table's version does not match the expected version
 	 * for this adapter.
-	 * @throws IOException an IO error occured during table creation
+	 * @throws IOException an IO error occurred during table creation
 	 */
 	public ArrayDBAdapterV1(DBHandle handle, String tablePrefix, boolean create)
 			throws VersionException, IOException {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/CompositeDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/CompositeDB.java
@@ -712,7 +712,7 @@ abstract class CompositeDB extends DataTypeDB implements CompositeInternal {
 	 * Set packing and alignment settings.  Record is modified but it is not written to the
 	 * database and no repacking or notification is performed.
 	 * @param composite instance whose packing and alignment are to be copied
-	 * @throws IOException if database IO error occured
+	 * @throws IOException if database IO error occurred
 	 */
 	protected void doSetPackingAndAlignment(CompositeInternal composite) throws IOException {
 		record.setIntValue(CompositeDBAdapter.COMPOSITE_MIN_ALIGN_COL,

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeArchiveTransformer.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeArchiveTransformer.java
@@ -71,7 +71,7 @@ public class DataTypeArchiveTransformer implements GhidraLaunchable {
 				throw new IOException("Archive requires language upgrade: " + oldFile);
 			}
 			if (warning != ArchiveWarning.NONE) {
-				throw new IOException("Archive language error occured: " + oldFile,
+				throw new IOException("Archive language error occurred: " + oldFile,
 					oldFileArchive.getWarningDetail());
 			}
 
@@ -81,7 +81,7 @@ public class DataTypeArchiveTransformer implements GhidraLaunchable {
 				throw new IOException("Archive requires language upgrade: " + newFile);
 			}
 			if (warning != ArchiveWarning.NONE) {
-				throw new IOException("Archive language error occured: " + newFile,
+				throw new IOException("Archive language error occurred: " + newFile,
 					newFileArchive.getWarningDetail());
 			}
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/DataTypeManagerDB.java
@@ -885,7 +885,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 	 * False will be returned when {@code ifPreviouslyStored} is true and data organization has never 
 	 * beeen saved.
 	 * @param ifPreviouslyStored if true and data organization has never been saved false will be returned
-	 * @return true if a data organization change has occured
+	 * @return true if a data organization change has occurred
 	 * @throws IOException if an IO error occurs
 	 */
 	protected final boolean hasDataOrganizationChange(boolean ifPreviouslyStored)
@@ -901,7 +901,7 @@ abstract public class DataTypeManagerDB implements DataTypeManager {
 	/**
 	 * Save the current data organization to facilitate future change detection and 
 	 * upgrades.
-	 * @throws IOException if failure occured while saving data organization.
+	 * @throws IOException if failure occurred while saving data organization.
 	 */
 	protected void saveDataOrganization() throws IOException {
 		DataOrganizationImpl.save(getDataOrganization(), getDataMap(true), "dataOrg.");

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumDBAdapterV1.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/EnumDBAdapterV1.java
@@ -56,7 +56,7 @@ class EnumDBAdapterV1 extends EnumDBAdapter {
 	 * @param create true if this constructor should create the table.
 	 * @throws VersionException if the table's version does not match the expected version
 	 * for this adapter.
-	 * @throws IOException an IO error occured during table creation
+	 * @throws IOException an IO error occurred during table creation
 	 */
 	public EnumDBAdapterV1(DBHandle handle, String tablePrefix, boolean create)
 			throws VersionException, IOException {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/ProgramDataTypeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/ProgramDataTypeManager.java
@@ -69,7 +69,7 @@ public class ProgramDataTypeManager extends ProgramBasedDataTypeManagerDB implem
 	 * Save the current data organization to facilitate future change detection and 
 	 * upgrades.  This method must be invoked by {@link ProgramDB} during the final
 	 * stage of program creation (i.e., openMode == CREATE).
-	 * @throws IOException if failure occured while saving data organization.
+	 * @throws IOException if failure occurred while saving data organization.
 	 */
 	@Override
 	public void saveDataOrganization() throws IOException {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StandAloneDataTypeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/data/StandAloneDataTypeManager.java
@@ -229,7 +229,7 @@ public class StandAloneDataTypeManager extends DataTypeManagerDB implements Clos
 	}
 
 	/**
-	 * Get the {@link ArchiveWarning} which may have occured immediately following 
+	 * Get the {@link ArchiveWarning} which may have occurred immediately following 
 	 * instatiation of this {@link StandAloneDataTypeManager}.  {@link ArchiveWarning#NONE}
 	 * will be returned if not warning condition.
 	 * @return warning type.
@@ -555,9 +555,9 @@ public class StandAloneDataTypeManager extends DataTypeManagerDB implements Clos
 	}
 
 	/**
-	 * Indicates that a failure occured establishing the program architecture 
+	 * Indicates that a failure occurred establishing the program architecture 
 	 * for the associated archive.
-	 * @return true if a failure occured establishing the program architecture 
+	 * @return true if a failure occurred establishing the program architecture 
 	 */
 	public boolean isProgramArchitectureMissing() {
 		return warning == ArchiveWarning.LANGUAGE_NOT_FOUND ||

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/ProgramUtilities.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/util/ProgramUtilities.java
@@ -226,7 +226,7 @@ public class ProgramUtilities {
 
 	/**
 	 * Determine if a program has a single unsaved change which corresponds to an
-	 * upgrade which occured during instantiation.
+	 * upgrade which occurred during instantiation.
 	 * @param program the program to be checked for an unsaved upgrade condition.
 	 * @return true if program upgraded and has not been saved, else false
 	 */

--- a/Ghidra/Processors/MIPS/src/main/java/ghidra/app/util/bin/format/elf/extend/MIPS_ElfExtension.java
+++ b/Ghidra/Processors/MIPS/src/main/java/ghidra/app/util/bin/format/elf/extend/MIPS_ElfExtension.java
@@ -368,7 +368,7 @@ public class MIPS_ElfExtension extends ElfExtension {
 		short sectionIndex = elfSymbol.getSectionHeaderIndex();
 		if (sectionIndex == SHN_MIPS_ACOMMON || sectionIndex == SHN_MIPS_TEXT ||
 			sectionIndex == SHN_MIPS_DATA) {
-			// NOTE: logic assumes no memory conflict occured during section loading
+			// NOTE: logic assumes no memory conflict occurred during section loading
 			AddressSpace defaultSpace =
 				elfLoadHelper.getProgram().getAddressFactory().getDefaultAddressSpace();
 			return defaultSpace.getAddress(


### PR DESCRIPTION
## Summary

Fixes a consistent misspelling of "occurred" throughout the codebase. 
The word "occured" (missing one 'r') appeared in 46 places across 35 
files including Java source files, Ghidra scripts, and documentation.

## Changes

- Replaced all instances of `occured` with `occurred`
- Replaced all instances of `Occured` with `Occurred`
- No functional changes — comments, Javadoc, and string literals only

## Notes

The third-party bundled `lzfse_encode.c` file was intentionally left 
unchanged as it is not part of the Ghidra codebase.