### PR TITLE
Add Apple AARCH64 proprietary instructions

### DIFF
--- a/Ghidra/Processors/AARCH64/certification.manifest
+++ b/Ghidra/Processors/AARCH64/certification.manifest
@@ -18,6 +18,7 @@ data/languages/AARCH64.pspec||GHIDRA||||END|
 data/languages/AARCH64.slaspec||GHIDRA||||END|
 data/languages/AARCH64BE.slaspec||GHIDRA||||END|
 data/languages/AARCH64_AMXext.sinc||GHIDRA||||END|
+data/languages/AARCH64_AppleExt.sinc||GHIDRA||||END|
 data/languages/AARCH64_AppleSilicon.slaspec||GHIDRA||||END|
 data/languages/AARCH64_apple.cspec||GHIDRA||||END|
 data/languages/AARCH64_base_PACoptions.sinc||GHIDRA||||END|

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64_AppleExt.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64_AppleExt.sinc
@@ -1,0 +1,145 @@
+#
+# Apple AARCH64 proprietary instructions (non-AMX)
+# Based on Asahi Linux reverse-engineering documentation:
+#   https://asahilinux.org/docs/hw/cpu/apple-instructions/
+#
+# Covers: MUL53, WKDMC/WKDMD, GENTER/GEXIT, AT_AS1ELX, SDSB
+#
+
+# --- MUL53: 53-bit vector multiply ---
+# mul53lo.2d Vd, Vm - low 53 bits of product
+# mul53hi.2d Vd, Vm - product >> 53
+define pcodeop __apple_mul53lo;
+define pcodeop __apple_mul53hi;
+
+# --- WKdm memory page compression/decompression ---
+# wkdmc rS, rD - compress page at [rS] to [rD], status in rS
+# wkdmd rS, rD - decompress from [rS] to [rD], status in rS
+define pcodeop __apple_wkdmc;
+define pcodeop __apple_wkdmd;
+
+# --- Guarded Execution Mode ---
+# genter imm5  - enter guarded mode (used by macOS kernel)
+# gexit        - exit guarded mode
+define pcodeop __apple_genter;
+define pcodeop __apple_gexit;
+
+# --- Address Translation ---
+# at_as1elx rA - translate address; result in rA
+#   [63:56] = MAIR attributes, [??:12] = physical address, [11:0] = flags
+define pcodeop __apple_at_as1elx;
+
+# --- Synchronize Data Stream Buffer ---
+# sdsb {osh|nsh|ish|sy}
+define pcodeop __apple_sdsb;
+
+
+with : ImmS_ImmR_TestSet=1 {
+
+# =========================================================================
+# MUL53 - 53-bit vector multiply (Apple A11+)
+# Encoding space: 0x00200000–0x002003ff (lo), 0x00200400–0x002007ff (hi)
+# =========================================================================
+
+# mul53lo.2d Vd, Vm
+# Encoding: 0x00200000 | Vm<<5 | Vd
+# b_2431=0x00 b_1623=0x20 b_1215=0 b_1011=0 b_0509=Vm b_0004=Vd
+:mul53lo.2d Rd_VPR128, Rn_VPR128 is b_2431=0x00 & b_1623=0x20 & b_1215=0 & b_1011=0 & Rn_VPR128 & Rd_VPR128
+{
+    Rd_VPR128 = __apple_mul53lo(Rd_VPR128, Rn_VPR128);
+}
+
+# mul53hi.2d Vd, Vm
+# Encoding: 0x00200400 | Vm<<5 | Vd
+# b_2431=0x00 b_1623=0x20 b_1215=0 b_1011=1 b_0509=Vm b_0004=Vd
+:mul53hi.2d Rd_VPR128, Rn_VPR128 is b_2431=0x00 & b_1623=0x20 & b_1215=0 & b_1011=1 & Rn_VPR128 & Rd_VPR128
+{
+    Rd_VPR128 = __apple_mul53hi(Rd_VPR128, Rn_VPR128);
+}
+
+# =========================================================================
+# WKDMC / WKDMD - WKdm memory page compression/decompression
+# =========================================================================
+
+# wkdmc Xd, Xs — compress page at [Xs] to [Xd], status returned in Xs
+# Encoding: 0x00200800 | rD<<5 | rS
+# b_2431=0x00 b_1623=0x20 b_1215=0 b_1011=2 b_0509=rD b_0004=rS
+# Display order: rD(bits[9:5]) first, rS(bits[4:0]) second (matches Capstone)
+:wkdmc Rn_GPR64, Rd_GPR64 is b_2431=0x00 & b_1623=0x20 & b_1215=0 & b_1011=2 & Rn_GPR64 & Rd_GPR64
+{
+    Rd_GPR64 = __apple_wkdmc(Rd_GPR64, Rn_GPR64);
+}
+
+# wkdmd Xd, Xs — decompress from [Xs] to [Xd], status returned in Xs
+# Encoding: 0x00200c00 | rD<<5 | rS
+# b_2431=0x00 b_1623=0x20 b_1215=0 b_1011=3 b_0509=rD b_0004=rS
+# Display order: rD(bits[9:5]) first, rS(bits[4:0]) second (matches Capstone)
+:wkdmd Rn_GPR64, Rd_GPR64 is b_2431=0x00 & b_1623=0x20 & b_1215=0 & b_1011=3 & Rn_GPR64 & Rd_GPR64
+{
+    Rd_GPR64 = __apple_wkdmd(Rd_GPR64, Rn_GPR64);
+}
+
+# =========================================================================
+# GEXIT / GENTER - Guarded Execution Mode
+# =========================================================================
+
+# gexit
+# Encoding: 0x00201400 (fixed, no operands)
+# b_2431=0x00 b_1623=0x20 b_1215=1 b_1011=1 b_0509=0 b_0004=0
+:gexit is b_2431=0x00 & b_1623=0x20 & b_1215=1 & b_1011=1 & b_0509=0 & b_0004=0
+{
+    __apple_gexit();
+}
+
+# genter imm5
+# Encoding: 0x00201420 | imm5
+# b_2431=0x00 b_1623=0x20 b_1215=1 b_1011=1 b_0509=1 b_0004=imm5
+AppleImm5: "#"^b_0004 is b_0004 { export *[const]:1 b_0004; }
+
+:genter AppleImm5 is b_2431=0x00 & b_1623=0x20 & b_1215=1 & b_1011=1 & b_0509=1 & AppleImm5
+{
+    __apple_genter(AppleImm5);
+}
+
+# =========================================================================
+# AT_AS1ELX - Apple proprietary address translation
+# Result: [63:56]=MAIR, [??:12]=PA, [11:0]=flags
+# =========================================================================
+
+# at_as1elx Xa
+# Encoding: 0x00201440 | rA
+# b_2431=0x00 b_1623=0x20 b_1215=1 b_1011=1 b_0509=2 b_0004=rA
+:at_as1elx Rd_GPR64 is b_2431=0x00 & b_1623=0x20 & b_1215=1 & b_1011=1 & b_0509=2 & Rd_GPR64
+{
+    Rd_GPR64 = __apple_at_as1elx(Rd_GPR64);
+}
+
+# =========================================================================
+# SDSB - Synchronize Data Stream Buffer
+# Four shareability domain variants
+# =========================================================================
+
+# Encoding: 0x00201460–0x00201463
+# b_2431=0x00 b_1623=0x20 b_1215=1 b_1011=1 b_0509=3 b_0004=variant
+
+:sdsb "osh" is b_2431=0x00 & b_1623=0x20 & b_1215=1 & b_1011=1 & b_0509=3 & b_0004=0
+{
+    __apple_sdsb(0:1);
+}
+
+:sdsb "nsh" is b_2431=0x00 & b_1623=0x20 & b_1215=1 & b_1011=1 & b_0509=3 & b_0004=1
+{
+    __apple_sdsb(1:1);
+}
+
+:sdsb "ish" is b_2431=0x00 & b_1623=0x20 & b_1215=1 & b_1011=1 & b_0509=3 & b_0004=2
+{
+    __apple_sdsb(2:1);
+}
+
+:sdsb "sy" is b_2431=0x00 & b_1623=0x20 & b_1215=1 & b_1011=1 & b_0509=3 & b_0004=3
+{
+    __apple_sdsb(3:1);
+}
+
+}

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64_AppleSilicon.slaspec
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64_AppleSilicon.slaspec
@@ -3,4 +3,5 @@
 
 @include "AARCH64instructions.sinc"
 @include "AARCH64_AMXext.sinc"
+@include "AARCH64_AppleExt.sinc"
 

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64instructions.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64instructions.sinc
@@ -3988,13 +3988,5 @@ with : ImmS_ImmR_TestSet=1 {
 is b_0031=0xe7ffdeff
 unimpl
 
-:NotYetImplemented_UNK2
-is b_0031=0x00200820
-unimpl
-
-:NotYetImplemented_UNK3
-is b_0031=0x00200c20
-unimpl
-
 } # end with ImmS_ImmR_TestSet=1
 

--- a/Ghidra/Processors/AARCH64/data/languages/AppleSilicon.ldefs
+++ b/Ghidra/Processors/AARCH64/data/languages/AppleSilicon.ldefs
@@ -9,7 +9,7 @@
             processorspec="AARCH64.pspec"
             manualindexfile="../manuals/AARCH64.idx"
             id="AARCH64:LE:64:AppleSilicon">
-    <description>AppleSilicon ARM v8.5-A LE instructions, LE data, AMX extensions</description>
+    <description>AppleSilicon ARM v8.5-A LE instructions, LE data, AMX and proprietary extensions</description>
     <compiler name="default" spec="AARCH64_apple.cspec" id="default"/>
     <compiler name="Swift" spec="AARCH64_swift.cspec" id="swift"/>
     <compiler name="golang" spec="AARCH64_golang.cspec" id="golang"/>


### PR DESCRIPTION
This change adds Apple proprietary instructions found in iPhone and ARM64 based Mac.

They are described in https://asahilinux.org/docs/hw/cpu/apple-instructions/

I checked the existing issues but I did no found anything related to Apple's instructions.
Thoses instructions are implemented in capstone-next: [capstone/aarch64_const.py](https://github.com/capstone-engine/capstone/blob/905d2d29514a97e18516871ec36bc4143549905d/bindings/python/capstone/aarch64_const.py)

To test it I applied the patch to Ghidra 12.0.4 and tested it on archlinux.

genter and gexit can be found in XNU, SPTM binary, at_as1elx can be found in TXM binary

```
ipsw download ipsw --device "iPhone16,2" --build "23D127"
ipsw extract --sptm iPhone16,2_26.3_23D127_Restore.ipsw
```
 - `23D127__iPhone16,2/Firmware/sptm.t8122.release`
 - `23D127__iPhone16,2/Firmware/txm.iphoneos.release`

<img width="1370" height="587" alt="screen_2026-03-23_17-22-51" src="https://github.com/user-attachments/assets/5ec90588-84d5-4fc7-babe-2a59f2082e56" />
<img width="1327" height="475" alt="screen_2026-03-23_17-21-23" src="https://github.com/user-attachments/assets/f95b8cdb-f1d6-46f4-8c4a-a2522d47ddc9" />
<img width="1304" height="327" alt="screen_2026-03-23_17-26-32" src="https://github.com/user-attachments/assets/75616ef1-2eea-4802-b6e5-ddc3119fb9d1" />

While searching for other examples I checked the decompilation with a man made binary


**Full disclosure: I used LLM (Claude+Opus) for this.**