### PR TITLE
AArch64: convert mechanical implementations of SBFIZ to high-level equivalents

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64base.sinc
@@ -5117,12 +5117,11 @@ sbfiz_lsb64: "#"^imm is ImmR [ imm = 64 - ImmR; ] { export *[const]:4 imm; }
 :sbfiz Rd_GPR32, Rn_GPR32, sbfiz_lsb, sbfiz_width
 is sbfiz_lsb & sbfiz_width & ImmS_LT_ImmR=1 & ImmS_EQ_ImmR=0 & sf=0 & opc=0 & b_2428=0x13 & b_2323=0 & n=0 & b_21=0 & b_15=0 & ImmRConst32 & ImmSConst32 & DecodeWMask32 & DecodeTMask32 & Rn_GPR32 & Rd_GPR32 & Rd_GPR64
 {
-	local wmask:4 = DecodeWMask32;
-	local tmask:4 = DecodeTMask32;
+	local shift_up:4 = 31 - ImmSConst32;
+	local shift_left:4 = 32 - ImmRConst32;
 	local src:4 = Rn_GPR32;
-	local bot:4 = ((src>>ImmRConst32)|(src<<(32-ImmRConst32))) & wmask;
-	local top:4 = (((src>>ImmSConst32)&0x1)*(-1))&0xffffffff;
-	Rd_GPR64 = zext((top & ~(tmask)) | (bot & tmask));
+	local sign_extended:4 = (src << shift_up) s>> shift_up;
+	Rd_GPR64 = zext(sign_extended << shift_left);
 }
 
 # C6.2.267 SBFIZ page C6-1751 line 103178 MATCH x13000000/mask=x7f800000
@@ -5139,12 +5138,11 @@ is sbfiz_lsb & sbfiz_width & ImmS_LT_ImmR=1 & ImmS_EQ_ImmR=0 & sf=0 & opc=0 & b_
 :sbfiz Rd_GPR64, Rn_GPR64, sbfiz_lsb64, sbfiz_width
 is sbfiz_lsb64 & sbfiz_width & ImmS_LT_ImmR=1 & ImmS_EQ_ImmR=0 & sf=1 & opc=0 & b_2428=0x13 & b_2323=0 & n=1 & ImmRConst64 & ImmSConst64 & DecodeWMask64 & DecodeTMask64 & Rn_GPR64 & Rd_GPR64
 {
-	local wmask:8 = DecodeWMask64;
-	local tmask:8 = DecodeTMask64;
+	local shift_up:8 = 63 - ImmSConst64;
+	local shift_left:8 = 64 - ImmRConst64;
 	local src:8 = Rn_GPR64;
-	local bot:8 = ((src>>ImmRConst64)|(src<<(64-ImmRConst64))) & wmask;
-	local top:8 = ((src>>ImmSConst64)&0x1)*(-1);
-	Rd_GPR64 = (top & ~(tmask)) | (bot & tmask);
+	local sign_extended:8 = (src << shift_up) s>> shift_up;
+	Rd_GPR64 = sign_extended << shift_left;
 }
 
 # C6.2.268 SBFM page C6-1753 line 103272 MATCH x13000000/mask=x7f800000


### PR DESCRIPTION
For this function, which indexes into an array of 8-byte elements:
```asm
sbfiz_test:
	sbfiz	x8, x1, #0x3, #0x20
	add	x0, x8, x0
	ldr	x0, [x0]
	ret
```

The decompiler's optimization passes cannot "see" into it and recover the array indexing because the current semantic is a straightforward mechanical translation of the operation from the ARM ARM, which involves a lot of bitmasking.

```c
undefined8 sbfiz_test(long *param_1,ulong param_2)
{
  return *(undefined8 *)
          ((-(param_2 >> 0x1f & 1) & 0xfffffff800000000 | (param_2 & 0xffffffff) << 3) +
          (long)param_1);
}
```

This PR provides a significantly simplified implementation that is easier to follow and allows decompiler passes to actually map this sequence as an array indexing operation.

```c
long sbfiz_test(long *param_1,int param_2)
{
  return param_1[param_2];
}
```