### PR TITLE
AArch64: respect S bit impact on display when decoding load/store addressing

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64instructions.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64instructions.sinc
@@ -2195,7 +2195,8 @@ ExtendReg64: Rm_GPR32, "UXTH " is Rm_GPR32 & b_2121=1 & aa_extreg_option=1 { tmp
 ExtendReg64: Rm_GPR32, "UXTW " is Rm_GPR32 & b_2121=1 & aa_extreg_option=2 { tmp:8 = zext(Rm_GPR32); export tmp; }
 ExtendReg64: LSL_Sp_Special64 is Rm_GPR64 & b_2121=1 & aa_extreg_option=3 & b_29=1 & b_25=1 & (Rn=0x1f) & LSL_Sp_Special64 { tmp:8 = Rm_GPR64; export tmp; }
 ExtendReg64: LSL_Sp_Special64 is Rm_GPR64 & b_2121=1 & aa_extreg_option=3 & b_29=0 & b_25=1 & (Rd=0x1f | Rn=0x1f) & LSL_Sp_Special64 { tmp:8 = Rm_GPR64; export tmp; }
-ExtendReg64: Rm_GPR64, "LSL " is Rm_GPR64 & b_2121=1 & aa_extreg_option=3 & b_29 & b_25=0 { tmp:8 = Rm_GPR64; export tmp; }
+ExtendReg64: Rm_GPR64, "LSL " is Rm_GPR64 & b_1212=1 & b_2121=1 & aa_extreg_option=3 & b_29 & b_25=0 { tmp:8 = Rm_GPR64; export tmp; }
+ExtendReg64: Rm_GPR64 is Rm_GPR64 & b_1212=0 & b_2121=1 & aa_extreg_option=3 & b_29 & b_25=0 { tmp:8 = Rm_GPR64; export tmp; }
 ExtendReg64: Rm_GPR64, "UXTX " is Rm_GPR64 & b_2121=1 & aa_extreg_option=3 { tmp:8 = Rm_GPR64; export tmp; }
 ExtendReg64: Rm_GPR32, "SXTB " is Rm_GPR32 & b_2121=1 & aa_extreg_option=4 { tmp0:4 = Rm_GPR32; tmp:8 = sext(tmp0:1); export tmp; }
 ExtendReg64: Rm_GPR32, "SXTH " is Rm_GPR32 & b_2121=1 & aa_extreg_option=5 { tmp0:4 = Rm_GPR32; tmp:8 = sext(tmp0:2); export tmp; }


### PR DESCRIPTION
The S bit controls whether or not the `LSL` operand is 0 or some other value in disassembly if \<option\>=3 (LSL). The preferred form for disassembly is then to omit `LSL` if the shift operand is zero.

The current disassembly is matched well to [Load/store addressing modes](https://developer.arm.com/documentation/ddi0487/maa/-Part-C-The-AArch64-Instruction-Set/-Chapter-C1-The-A64-Instruction-Set/-C1-3-Address-generation/-C1-3-3-Load-store-addressing-modes), but omits a minor detail for load/store addressing addressed in such operations like [A64 STRB (register)](https://developer.arm.com/documentation/ddi0596/2021-09/Base-Instructions/STRB--register---Store-Register-Byte--register--)

This only affects display and not semantics.

Fixes #9042