### PR TITLE
Decompiler: recognize alternative integer remainder optimization pattern

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -5611,6 +5611,7 @@ void ActionDatabase::universalAction(Architecture *conf)
 	actprop->addRule( new RuleDivChain("analysis") );
 	actprop->addRule( new RuleSignNearMult("analysis") );
 	actprop->addRule( new RuleModOpt("analysis") );
+	actprop->addRule( new RuleModOpt2("analysis") );
 	actprop->addRule( new RuleSignMod2nOpt("analysis") );
 	actprop->addRule( new RuleSignMod2nOpt2("analysis") );
 	actprop->addRule( new RuleSignMod2Opt("analysis") );

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -8612,7 +8612,7 @@ int4 RuleSignNearMult::applyOp(PcodeOp *op,Funcdata &data)
 }
 
 /// \class RuleModOpt
-/// \brief Simplify expressions that optimize INT_REM and INT_SREM
+/// \brief Simplify expressions that optimize INT_REM and INT_SREM: `(x + (x / div) * -div)  =>  x % div`
 void RuleModOpt::getOpList(vector<uint4> &oplist) const
 
 {
@@ -8667,6 +8667,65 @@ int4 RuleModOpt::applyOp(PcodeOp *op,Funcdata &data)
       else
 	data.opSetOpcode(addop,CPUI_INT_SREM);
       return 1;
+    }
+  }
+  return 0;
+}
+
+/// \class RuleModOpt2
+/// \brief Simplify expressions that optimize INT_REM and INT_SREM: `(x + ((x / div) * div) * -1)  =>  x % div`
+void RuleModOpt2::getOpList(vector<uint4> &oplist) const
+
+{
+  oplist.push_back(CPUI_INT_DIV);
+  oplist.push_back(CPUI_INT_SDIV);
+}
+
+int4 RuleModOpt2::applyOp(PcodeOp *op,Funcdata &data)
+
+{
+  PcodeOp *multop,*addop,*negop;
+  Varnode *div,*x,*outvn,*outvn2,*outvn3,*div2,*negvn2;
+  list<PcodeOp *>::const_iterator iter1,iter2,iter3;
+
+  x = op->getIn(0);
+  div = op->getIn(1);
+  outvn = op->getOut();
+  for(iter1=outvn->beginDescend();iter1!=outvn->endDescend();++iter1) {
+    multop = *iter1;
+    if (multop->code() != CPUI_INT_MULT) continue;
+    div2 = multop->getIn(1);
+    if (div2 == outvn)
+      div2 = multop->getIn(0);
+    if (div2 != div) continue;
+    outvn2 = multop->getOut();
+    for(iter2=outvn2->beginDescend();iter2!=outvn2->endDescend();++iter2) {
+      negop = *iter2;
+      negvn2 = negop->getIn(1);
+      if (negvn2 == outvn2)
+	negvn2 = negop->getIn(0);
+      if (negop->code() != CPUI_INT_MULT) continue;
+      if (!negvn2->isConstant() || negvn2->getOffset() != calc_mask(negvn2->getSize())) continue;
+      outvn3 = negop->getOut();
+      for(iter3=outvn3->beginDescend();iter3!=outvn3->endDescend();++iter3) {
+	addop = *iter3;
+	if (addop->code() != CPUI_INT_ADD) continue;
+	Varnode *lvn;
+	lvn = addop->getIn(0);
+	if (lvn == outvn2)
+	  lvn = addop->getIn(1);
+	if (lvn != x) continue;
+	data.opSetInput(addop,x,0);
+	if (div->isConstant())
+	  data.opSetInput(addop,data.newConstant(div->getSize(),div->getOffset()),1);
+	else
+	  data.opSetInput(addop,div,1);
+	if (op->code() == CPUI_INT_DIV) // Remainder of proper signedness
+	  data.opSetOpcode(addop,CPUI_INT_REM);
+	else
+	  data.opSetOpcode(addop,CPUI_INT_SREM);
+	return 1;
+      }
     }
   }
   return 0;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
@@ -1350,6 +1350,17 @@ public:
   virtual int4 applyOp(PcodeOp *op,Funcdata &data);
 };
 
+class RuleModOpt2: public Rule {
+public:
+  RuleModOpt2(const string &g) : Rule( g, 0, "modopt2") {}	///< Constructor
+  virtual Rule *clone(const ActionGroupList &grouplist) const {
+    if (!grouplist.contains(getGroup())) return (Rule *)0;
+    return new RuleModOpt2(getGroup());
+  }
+  virtual void getOpList(vector<uint4> &oplist) const;
+  virtual int4 applyOp(PcodeOp *op,Funcdata &data);
+};
+
 class RuleSignMod2nOpt : public Rule {
 public:
   RuleSignMod2nOpt(const string &g) : Rule( g, 0, "signmod2nopt") {}	///< Constructor


### PR DESCRIPTION
AArch64 doesn't have an instruction that gets the remainder of integer division, so x0 % x1 is typically implemented by compilers like this:
```asm
urem_test:
        udiv    x8, x0, x1
        msub    x0, x8, x1, x0
        ret

srem_test:
        sdiv    x8, x0, x1
        msub    x0, x8, x1, x0
        ret
```

In the current AArch64 SLEIGH division semantics, all operations are guarded for division by zero. I offer no opinion on whether or not that is the right thing to do (note: they don't account for integer overflow), but will say that if you remove the guard from the semantics like this:

```
:udiv Rd_GPR64, Rn_GPR64, Rm_GPR64
is sf=1 & b_3030=0 & S=0 & b_2428=0x1a & b_2123=6 & Rm_GPR64 & b_1015=0x2 & Rn_GPR64 & Rd_GPR64
{
	Rd_GPR64 = Rn_GPR64 / Rm_GPR64;
}
```

... then the decompiler can't match the div+msub pattern to RuleModOpt. RuleModOpt is looking for `x + (x / div) * -div`, but this div+msub sequence gets converted to `x + ((x / div) * div) * -1`, and ends up generating this decompilation: 

```c
long urem_test(ulong param_1,ulong param_2)

{
  return param_1 - (param_1 / param_2) * param_2;
}
```

The proposed RuleModOpt2 specifically targets this pattern and converts it to REM/SREM. In my opinion the operation is different enough to warrant having a separate rule as opposed to merging it into the existing rule.

```c
ulong urem_test(ulong param_1,ulong param_2)

{
  return param_1 % param_2;
}
```