### PR TITLE
fix: bump binutils from 2.41 to 2.44 to fix gcc C11 compilation

### DIFF
--- a/GPL/GnuDisassembler/build.gradle
+++ b/GPL/GnuDisassembler/build.gradle
@@ -28,10 +28,10 @@
 //     directory once the extension has been installed/unpacked by Ghidra.  The binutils referenced 
 //     by the script below may be downloaded from the following URL:
 //
-//         https://ftp.gnu.org/pub/gnu/binutils/binutils-2.41.tar.bz2
+//         https://ftp.gnu.org/pub/gnu/binutils/binutils-2.44.tar.bz2
 //
 
-ext.binutils = "binutils-2.41"
+ext.binutils = "binutils-2.44"
 ext.binutilsDistro = "${binutils}.tar.bz2"
 
 // Find the GPL dir


### PR DESCRIPTION
## Summary

Bumps binutils from 2.41 to 2.44 to fix compilation errors with newer gcc versions that treat `static_assert` as a C11 keyword.

## Problem

Binutils 2.41 has conflicts with newer gcc (C11) where `static_assert` is now a reserved keyword. This causes compilation failures when building GnuDisassembler with modern gcc versions.

## Solution

Upgrade to binutils 2.44, which includes the fix for this issue as documented in the binutils changelog.

## Changes

- Updated `ext.binutils` from `binutils-2.41` to `binutils-2.44` in `GPL/GnuDisassembler/build.gradle`
- Updated download URL comment to reflect new version

## Testing

- Verified binutils 2.44 exists at https://ftp.gnu.org/pub/gnu/binutils/binutils-2.44.tar.bz2
- Confirmed the version bump resolves the static_assert keyword conflict

Fixes #9067