### PR TITLE
AArch64: add constant reference analyzer to track fixup_aarch64_add_imm12

### DIFF
--- a/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/plugin/core/analysis/AARCH64RelocationAnalyzer.java
+++ b/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/plugin/core/analysis/AARCH64RelocationAnalyzer.java
@@ -56,10 +56,10 @@ public class AARCH64RelocationAnalyzer extends ConstantPropagationAnalyzer {
 			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
 			throws CancelledException {
 
-		HashSet<Address> adrpInstructions = new HashSet<>();
-
 		final ConstantPropagationContextEvaluator eval;
 		if (createDataRefsFromAddressRelocationsOption) {
+			HashSet<Address> adrpInstructions = new HashSet<>();
+
 			eval = new ConstantPropagationContextEvaluator(monitor, trustWriteMemOption) {
 
 				@Override
@@ -78,14 +78,18 @@ public class AARCH64RelocationAnalyzer extends ConstantPropagationAnalyzer {
 							Address addendProvenanceAddr = context.getLastSetLocation(addend, null);
 
 							if (addendVal != null && adrpInstructions.contains(addendProvenanceAddr)) {
-								long offsetAddr = addendVal.longValue() + constantOffset.getUnsignedValue();
-								AddressSpace space = instr.getMinAddress().getAddressSpace();
-								Address addr = space.getTruncatedAddress(offsetAddr, true);
-								instr.addOperandReference(0, addr, RefType.DATA, SourceType.ANALYSIS);
+								createDataReference(instr, 0, addendVal.longValue() + constantOffset.getUnsignedValue());
 							}
 						}
-					}
+					} else if (mnemonic.equals("adr")) {
+						// fixup_aarch64_pcrel_adr_imm21
+						Register dest = instr.getRegister(0);
+						Scalar constantOffset = getScalar(instr, 1);
 
+						if (dest != null && constantOffset != null) {
+							createDataReference(instr, 0, constantOffset.getUnsignedValue());
+						}
+					}
 					return false;
 				}
 
@@ -100,6 +104,12 @@ public class AARCH64RelocationAnalyzer extends ConstantPropagationAnalyzer {
 					}
 
 					return null;
+				}
+
+				private void createDataReference(Instruction instr, int opIndex, long offset) {
+					AddressSpace space = instr.getMinAddress().getAddressSpace();
+					Address addr = space.getTruncatedAddress(offset, true);
+					instr.addOperandReference(opIndex, addr, RefType.DATA, SourceType.ANALYSIS);
 				}
 
 			};

--- a/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/plugin/core/analysis/AARCH64RelocationAnalyzer.java
+++ b/Ghidra/Processors/AARCH64/src/main/java/ghidra/app/plugin/core/analysis/AARCH64RelocationAnalyzer.java
@@ -1,0 +1,132 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.plugin.core.analysis;
+
+import java.util.HashSet;
+import java.math.BigInteger;
+
+import ghidra.framework.options.Options;
+import ghidra.program.model.address.*;
+import ghidra.program.model.lang.*;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.scalar.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.util.*;
+import ghidra.util.exception.*;
+import ghidra.util.task.TaskMonitor;
+
+public class AARCH64RelocationAnalyzer extends ConstantPropagationAnalyzer {
+
+	private static final String PROCESSOR_NAME = "AARCH64";
+
+	protected static final String CREATE_DATA_REFERENCE_FROM_ADDRESS_RELOCATIONS_OPTION_NAME  =
+		"Create data references from address relocations";
+	protected static final String CREATE_DATA_REFERENCE_FROM_ADDRESS_RELOCATIONS_OPTION_DESCRIPTION =
+		"Create data references from address relocations computed by adrp and add instruction pairs";
+	protected static final boolean CREATE_DATA_REFERENCE_FROM_ADDRESS_RELOCATIONS_OPTION_DEFAULT_VALUE = true;
+
+	protected boolean createDataRefsFromAddressRelocationsOption =
+		CREATE_DATA_REFERENCE_FROM_ADDRESS_RELOCATIONS_OPTION_DEFAULT_VALUE;
+	
+	public AARCH64RelocationAnalyzer() {
+		super(PROCESSOR_NAME);
+	}
+
+	@Override
+	public boolean canAnalyze(Program program) {
+		return program.getLanguage().getProcessor().equals(
+			Processor.findOrPossiblyCreateProcessor(PROCESSOR_NAME));
+	}
+
+	@Override
+	public AddressSet flowConstants(final Program program, Address flowStart,
+			AddressSetView flowSet, final SymbolicPropogator symEval, final TaskMonitor monitor)
+			throws CancelledException {
+
+		HashSet<Address> adrpInstructions = new HashSet<>();
+
+		final ConstantPropagationContextEvaluator eval;
+		if (createDataRefsFromAddressRelocationsOption) {
+			eval = new ConstantPropagationContextEvaluator(monitor, trustWriteMemOption) {
+
+				@Override
+				public boolean evaluateContextBefore(VarnodeContext context, Instruction instr) {
+					String mnemonic = instr.getMnemonicString();
+
+					if (mnemonic.equals("adrp")) {
+						adrpInstructions.add(instr.getAddress());
+					} else if (mnemonic.equals("add")) {
+						// fixup_aarch64_pcrel_adrp_imm21 -> fixup_aarch64_add_imm12
+						Register addend = instr.getRegister(1);
+						Scalar constantOffset = getScalar(instr, 2);
+
+						if (addend != null && constantOffset != null) {
+							BigInteger addendVal = context.getValue(addend, false);
+							Address addendProvenanceAddr = context.getLastSetLocation(addend, null);
+
+							if (addendVal != null && adrpInstructions.contains(addendProvenanceAddr)) {
+								long offsetAddr = addendVal.longValue() + constantOffset.getUnsignedValue();
+								AddressSpace space = instr.getMinAddress().getAddressSpace();
+								Address addr = space.getTruncatedAddress(offsetAddr, true);
+								instr.addOperandReference(0, addr, RefType.DATA, SourceType.ANALYSIS);
+							}
+						}
+					}
+
+					return false;
+				}
+
+				private Scalar getScalar(Instruction instr, int operandIndex) {
+					Object[] scalarObjects = instr.getOpObjects(operandIndex);
+
+					if (scalarObjects != null && scalarObjects.length > 0) {
+						Object scalarObject = scalarObjects[0];
+						if (scalarObject instanceof Scalar scalar) {
+							return scalar;
+						}
+					}
+
+					return null;
+				}
+
+			};
+		} else {
+			eval = new ConstantPropagationContextEvaluator(monitor, trustWriteMemOption);
+		}
+
+		eval.setTrustWritableMemory(trustWriteMemOption)
+		    .setMinSpeculativeOffset(minSpeculativeRefAddress)
+		    .setMaxSpeculativeOffset(maxSpeculativeRefAddress)
+		    .setMinStoreLoadOffset(minStoreLoadRefAddress)
+		    .setCreateComplexDataFromPointers(createComplexDataFromPointers);
+
+		return symEval.flowConstants(flowStart, flowSet, eval, true, monitor);
+	}
+
+	@Override
+	public void registerOptions(Options options, Program program) {
+		super.registerOptions(options, program);
+		options.registerOption(CREATE_DATA_REFERENCE_FROM_ADDRESS_RELOCATIONS_OPTION_NAME, createDataRefsFromAddressRelocationsOption,
+			null, CREATE_DATA_REFERENCE_FROM_ADDRESS_RELOCATIONS_OPTION_DESCRIPTION);
+	}
+	
+	@Override
+	public void optionsChanged(Options options, Program program) {
+		super.optionsChanged(options, program);
+		createDataRefsFromAddressRelocationsOption =
+			options.getBoolean(CREATE_DATA_REFERENCE_FROM_ADDRESS_RELOCATIONS_OPTION_NAME, createDataRefsFromAddressRelocationsOption);
+	}
+}


### PR DESCRIPTION
The basic constant reference analyzer does a good job with fixup_aarch64_ldst_imm12_scaleX because the reference is immediately consumed at the site of the memory operand, but it reliably fails for fixup_aarch64_add_imm12 if the operation that consumes the reference isn't visible. Example code:
```cpp
// clang++ -Os --target=aarch64-unknown-linux test.cpp -c -o test.o
class ReferencesData {
public:
	virtual void usesData(char** data) = 0;
	void referencesData(int i);
	void referencesDataDirectly();

private:
	static char* s_Data[0x100];
};

char* ReferencesData::s_Data[0x100];
void ReferencesData::referencesData(int i)
{
	char** x = &s_Data[i];

	if (i >= 0x100) {
		usesData(nullptr);
	} else {
		usesData(x);
	}
}
void ReferencesData::referencesDataDirectly()
{
	usesData(s_Data);
}
```
Ghidra currently analyzes it like this, which is unhelpful because the xref to s_Data is completely lost:
```
_ZN14ReferencesData14referencesDataEi:
    adrp       x8,0x100000
    add        x8,x8,#0x38                  ; data reference occurs here
    ldr        x9,[this]
    add        x8,x8,param_1, SXTW  #0x3
    cmp        param_1,#0xff
    ldr        x2,[x9]
    csel       param_1,xzr,x8,gt
    br         x2

_ZN14ReferencesData22referencesDataDirectlyEv:
    ldr        x8,[this]
    adrp       x1,0x100000
    add        x1,x1,#0x38                  ; data reference occurs here
    ldr        x2,[x8]
    br         x2

_ZN14ReferencesData6s_DataE: XREF[2]:     Entry Point(*),
                                          _elfSectionHeaders::00000110(*)  
    ...
```
With the proposed AArch64-specific constant reference analyzer, if an adrp (fixup_aarch64_pcrel_adrp_imm21) flows into an add, that is now tracked as a data reference:
```
_ZN14ReferencesData14referencesDataEi:   
    adrp       x8,0x100000
    add        x8=>ReferencesData::s_Data,x8,#0x38              = ??
    ldr        x9,[this]
    add        x8,x8,param_1, SXTW  #0x3
    cmp        param_1,#0xff
    ldr        x2,[x9]
    csel       param_1,xzr,x8,gt
    br         x2

_ZN14ReferencesData22referencesDataDirectlyEv:  
    ldr        x8,[this]
    adrp       x1,0x100000
    add        x1=>ReferencesData::s_Data,x1,#0x38              = ??
    ldr        x2,[x8]
    br         x2

_ZN14ReferencesData6s_DataE: XREF[4]:     Entry Point(*), 
                                          referencesData:00100004(*),
                                          referencesDataDirectly:00100028(*),
                                          _elfSectionHeaders::00000110(*)  
    ...
```