### PR TITLE
Fix VarargsFilter doing nothing: set firstVarArgSlot from Function Editor

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/editor/FunctionData.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/editor/FunctionData.java
@@ -218,7 +218,7 @@ class FunctionData extends FunctionDataView {
 		}
 
 		VariableStorage[] paramStorage =
-			effectiveCallingConvention.getStorageLocations(getProgram(), dataTypes, true);
+			effectiveCallingConvention.getStorageLocations(getProgram(), dataTypes, true, hasVarArgs);
 
 		returnInfo.setStorage(paramStorage[0]);
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/PrototypeModel.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/lang/PrototypeModel.java
@@ -398,6 +398,30 @@ public class PrototypeModel {
 	 */
 	public VariableStorage[] getStorageLocations(Program program, DataType[] dataTypes,
 			boolean addAutoParams) {
+		return getStorageLocations(program, dataTypes, addAutoParams, false);
+	}
+
+	/**
+	 * Calculate input and output storage locations given a function prototype,
+	 * with optional variable-argument support.
+	 * <p>
+	 * This overload additionally sets {@link PrototypePieces#firstVarArgSlot} when
+	 * {@code isVarArgs} is true, enabling {@code VarargsFilter}-based calling-convention
+	 * rules (e.g. {@code <varargs/>} in a .cspec) to be applied correctly.
+	 *
+	 * @param program is the Program
+	 * @param dataTypes return/parameter datatypes (first element is always the return datatype,
+	 * i.e., minimum array length is 1)
+	 * @param addAutoParams true if auto-parameter storage locations can be generated
+	 * @param isVarArgs true if the function takes variable arguments; when true, all
+	 * data-types supplied in {@code dataTypes} are treated as non-optional and the first
+	 * vararg slot is set to immediately follow the last supplied parameter
+	 * @return dynamic storage locations ordered by ordinal where first element corresponds to
+	 * return storage. The returned array may also include additional auto-parameter storage
+	 * locations.
+	 */
+	public VariableStorage[] getStorageLocations(Program program, DataType[] dataTypes,
+			boolean addAutoParams, boolean isVarArgs) {
 
 		DataType injectedThis = null;
 		if (addAutoParams && hasThis) {
@@ -406,6 +430,10 @@ public class PrototypeModel {
 			injectedThis = new PointerDataType(program.getDataTypeManager());
 		}
 		PrototypePieces proto = new PrototypePieces(this, dataTypes, injectedThis);
+		if (isVarArgs) {
+			// All supplied parameters are non-optional; varargs begin immediately after them.
+			proto.firstVarArgSlot = proto.intypes.size();
+		}
 
 		ArrayList<ParameterPieces> res = new ArrayList<>();
 		assignParameterStorage(proto, program.getDataTypeManager(), res, addAutoParams);


### PR DESCRIPTION
## Summary

Fixes #9091 — `VarargsFilter` does nothing when storage is assigned via the Function Editor UI.

### Root cause

`PrototypePieces.firstVarArgSlot` was always left at `-1` when `FunctionData.updateParameterAndReturnStorage()` called `PrototypeModel.getStorageLocations()`. Because `VarargsFilter.filter()` returns `false` immediately when `firstVarArgSlot < 0`, any `.cspec` rule using `<varargs/>` (e.g. MSP430's `<goto_stack/>` for the last fixed argument) had no effect when storage was (re-)assigned through the UI.

### Fix

- **`PrototypeModel`**: Added a new `getStorageLocations(..., boolean isVarArgs)` overload. When `isVarArgs=true`, it sets `proto.firstVarArgSlot = proto.intypes.size()` — meaning all supplied parameters are non-optional and the first vararg slot follows immediately after the last one. The existing 3-argument overload delegates to this new one with `isVarArgs=false`, preserving all existing behaviour.

- **`FunctionData`**: `updateParameterAndReturnStorage()` now calls the new overload passing `hasVarArgs`, so the vararg flag flows through to `VarargsFilter`.

### Test plan

- [ ] Open a varargs function in the Function Editor for an architecture whose .cspec uses a `<varargs/>`-gated rule (e.g. MSP430 `<goto_stack/>` with `first="-1"`).
- [ ] Verify that the last fixed parameter is assigned stack storage instead of a register, matching the intended calling-convention rule.
- [ ] Verify that non-varargs functions are unaffected (storage unchanged).
