### PR TITLE
[Security] Reject null signatures in GhidraServer PKI Auth

### DIFF
--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/security/PKIAuthenticationModule.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/security/PKIAuthenticationModule.java
@@ -141,14 +141,14 @@ public class PKIAuthenticationModule implements AuthenticationModule {
 			DefaultTrustManagerFactory.validateClient(certChain, PKIUtils.RSA_TYPE);
 
 			byte[] sigBytes = sigCb.getSignature();
-			if (sigBytes != null) {
-
-				Signature sig = Signature.getInstance(certChain[0].getSigAlgName());
-				sig.initVerify(certChain[0]);
-				sig.update(token);
-				if (!sig.verify(sigBytes)) {
-					throw new FailedLoginException("Incorrect signature");
-				}
+			if (sigBytes == null) {
+				throw new FailedLoginException("Client signature required");
+			}
+			Signature sig = Signature.getInstance(certChain[0].getSigAlgName());
+			sig.initVerify(certChain[0]);
+			sig.update(token);
+			if (!sig.verify(sigBytes)) {
+				throw new FailedLoginException("Incorrect signature");
 			}
 
 			String dnUsername =


### PR DESCRIPTION
### Summary

A null-signature flaw in GhidraServer's PKI authentication module allows any user with a valid CA-signed certificate to impersonate any other user on the server. The attacker only needs the target's **public** certificate — their private key is not required. This enables a low-privileged analyst to escalate to administrator, exfiltrate or destroy shared reverse engineering databases, and permanently rewrite repository access controls.

The vulnerability exists in `PKIAuthenticationModule.authenticate()`, which skips client signature verification when the signature bytes are null instead of rejecting the authentication attempt. It has been present since Ghidra's initial open-source release in March 2019 and affects all versions through at least 12.0.4.

### Details

GhidraServer's PKI mode (`-a2`) authenticates users via a challenge-response protocol: the server sends a random 64-byte token, the client signs it with their private key, and the server verifies the signature against the client's certificate. This proves the client possesses the private key corresponding to the certificate they present.

The flaw is in the server-side verification at [`PKIAuthenticationModule.java:143-152`](https://github.com/NationalSecurityAgency/ghidra/blob/78729379e471bbb3d969409be6a8c3d24af84220/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/security/PKIAuthenticationModule.java#L143-L152):

```java
byte[] sigBytes = sigCb.getSignature();
if (sigBytes != null) {                              // ← null → entire block skipped

    Signature sig = Signature.getInstance(certChain[0].getSigAlgName());
    sig.initVerify(certChain[0]);
    sig.update(token);
    if (!sig.verify(sigBytes)) {
        throw new FailedLoginException("Incorrect signature");
    }
}
// Falls through to DN lookup without any exception

String dnUsername =
    userMgr.getUserByDistinguishedName(certChain[0].getSubjectX500Principal());
if (dnUsername != null) {
    return dnUsername;                                // ← Authenticated!
}
```

When `sigBytes` is null, the verification block is skipped entirely — no exception is thrown. Execution falls through to the Distinguished Name lookup, which resolves the certificate's subject DN to a registered username and returns it as the authenticated identity. No proof of private key possession was required.

### Fix

This patch fixes the vulnerability by rejecting authentication requests that do not include a token signature.