### PR TITLE
Fix NPE in DecompilerSearcher when Find dialog invoked with no prior results

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/DecompilerSearchResults.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/DecompilerSearchResults.java
@@ -109,7 +109,9 @@ public class DecompilerSearchResults extends SearchResults {
 
 	public DecompilerSearchLocation getContainingLocation(FieldLocation fieldLocation,
 			boolean searchForward) {
-
+		if (fieldLocation == null) {
+			return null;
+		}
 		// getNextLocation() will find the next matching location, starting at the given field
 		// location.  The next location may or may not actually contain the given field location.
 		DecompilerSearchLocation nextLocation = getNextLocation(fieldLocation, searchForward);

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/DecompilerSearcher.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/DecompilerSearcher.java
@@ -155,6 +155,10 @@ public class DecompilerSearcher implements FindDialogSearcher {
 
 	private FieldLocation getNextSearchStartLocation(
 			DecompilerCursorPosition decompilerCursorPosition, boolean searchForward) {
+		
+		if (searchResults == null) {
+			return decompilerCursorPosition.getFieldLocation();
+		}
 
 		FieldLocation cursor = decompilerCursorPosition.getFieldLocation();
 		DecompilerSearchLocation containingLocation =


### PR DESCRIPTION
Guard against null searchResults/fieldLocation in getNextSearchStartLocation  and getContainingLocation when the Find dialog is used before any search results are initialized.

Crash log:
```
Cannot invoke "ghidra.app.plugin.core.decompile.actions.DecompilerSearchLocation.contains(docking.widgets.fieldpanel.support.FieldLocation)" because "nextLocation" is null
java.lang.NullPointerException: Cannot invoke "ghidra.app.plugin.core.decompile.actions.DecompilerSearchLocation.contains(docking.widgets.fieldpanel.support.FieldLocation)" because "nextLocation" is null
	at ghidra.app.plugin.core.decompile.actions.DecompilerSearchResults.getContainingLocation(DecompilerSearchResults.java:116)
	at ghidra.app.plugin.core.decompile.actions.DecompilerSearcher.getNextSearchStartLocation(DecompilerSearcher.java:161)
	at ghidra.app.plugin.core.decompile.actions.DecompilerSearcher.search(DecompilerSearcher.java:145)
	at docking.widgets.FindDialog.doSearch(FindDialog.java:200)
	at docking.widgets.FindDialog.lambda$buildFindButtons$0(FindDialog.java:84)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2314)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:407)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6570)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3390)
	at java.desktop/java.awt.Component.processEvent(Component.java:6335)
	at java.desktop/java.awt.Container.processEvent(Container.java:2260)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4952)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2318)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4784)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4917)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4560)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4501)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2304)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2667)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4784)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:716)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:693)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)

---------------------------------------------------
Build Date: 2025-Dec-16 1203 GMT
Ghidra Version: 12.1
Java Home: /usr/lib/jvm/java-26-openjdk
JVM Version: Arch Linux 26.0.2
OS: Linux 6.19.10-lqx2-1-lqx amd64
```