### PR TITLE
xtensa: decompile LITBASE-relative L32R instructions correctly

### DIFF
--- a/Ghidra/Processors/Xtensa/data/languages/xtensaInstructions.sinc
+++ b/Ghidra/Processors/Xtensa/data/languages/xtensaInstructions.sinc
@@ -637,8 +637,20 @@ macro extract_bit(bit, result) {
 }
 
 # L32R - Load 32-bit PC-relative (RI6), pg. 382.
-:l32r at, srel_oex_sh2 is srel_oex_sh2 & at & op0 = 0b0001 {
-    at = srel_oex_sh2;
+:l32r at, srel_oex_sh2_imm is srel_oex_sh2_imm & at & op0 = 0b0001 {
+	tmp_pc = (((inst_start + 3) & ~3) + srel_oex_sh2_imm);
+	tmp_lb = ((LITBASE & ~1) + srel_oex_sh2_imm);
+
+	if ((LITBASE & 1) == 1) goto <use_litbase>;
+
+	at = *:4 tmp_pc;
+	goto <end>;
+
+	<use_litbase>
+
+	at = *:4 tmp_lb;
+
+	<end>
 }
 
 # LDCT - Load Data Cache Tag (RRR), pg. 384.

--- a/Ghidra/Processors/Xtensa/data/languages/xtensaMain.sinc
+++ b/Ghidra/Processors/Xtensa/data/languages/xtensaMain.sinc
@@ -198,9 +198,9 @@ call_srel_sh2: rel is call_o18 [
     rel = (inst_start & ~3) + ( call_o18 << 2 ) + 4;
 ] { export *:4 rel; }
 
-srel_oex_sh2: rel is ri16_i16 [
-    rel = ((inst_start + 3) & ~3) + ((ri16_i16 | 0xffff0000) << 2);
-] { export *:4 rel; }
+srel_oex_sh2_imm: rel is ri16_i16 [
+    rel = ((ri16_i16 | 0xffff0000) << 2);
+] { export *[const]:4 rel; }
 
 # Immediates split across the instruction.
 u5_8_11_20: tmp is op2_0 & op_s  [ tmp = (op2_0 << 4) | op_s; ] { export *[const]:4 tmp; }


### PR DESCRIPTION
Certain Xtensa CPUs have a "LITBASE option", which changes the behavior of the `L32R` instruction depending on the value of the `LITBASE` special-purpose register.

If the LSB of `LITBASE` is 0, `L32R` performs a PC-relative read as usual. Otherwise, loads are performed relative to the new `LITBASE` MSR.

One piece of software using this `LITBASE` feature is firmware for the Atheros ath6k Wifi module used in e.g. [the Nintendo DSi](https://problemkaputt.de/gbatek-dsi-atheros-wifi-internal-hardware.htm) (see [ath6k-roms.zip](https://github.com/user-attachments/files/26845444/ath6k-roms.zip), base address `0x0e0000`, address space loops every `0x400000` bytes).

One slight issue is that now, by default, decompilation output looks like this:
```c
  uVar1 = in_LITBASE & 0xfffffffe;
  if ((in_LITBASE & 1) != 1) {
    uVar1 = 0xe1484;
  }
  puVar4 = *(undefined1 **)(uVar1 - 0x3f718);
  uVar1 = in_LITBASE & 0xfffffffe;
  if ((in_LITBASE & 1) != 1) {
    uVar1 = 0xe1488;
  }
  iVar5 = *(int *)(uVar1 - 0x3f7f4);
  uVar1 = in_LITBASE & 0xfffffffe;
  if ((in_LITBASE & 1) != 1) {
    uVar1 = 0xe148c;
  }
  // etc
```

Using the "Set Register Value..." feature to make the decompiler assume a certain value for `LITBASE` resolves this issue:
```c
  DAT_00004014 = &DAT_00015028;
  DAT_00500400 = 0;
  DAT_00501470 = 0;
```

However, I don't know if this degradation-by-default is considered too disruptive.