### PR TITLE
fix: stabilize recursive typedef resolution in composite viewer

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompositeViewerDataTypeManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/compositeeditor/CompositeViewerDataTypeManager.java
@@ -17,12 +17,14 @@ package ghidra.app.plugin.core.compositeeditor;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.TreeSet;
 
 import javax.help.UnsupportedOperationException;
 
 import db.util.ErrorHandler;
 import ghidra.program.database.DbObject;
+import ghidra.program.database.data.DataTypeUtilities;
 import ghidra.program.model.data.*;
 import ghidra.program.model.lang.ProgramArchitecture;
 import ghidra.util.Swing;
@@ -66,6 +68,7 @@ public class CompositeViewerDataTypeManager<T extends Composite> extends StandAl
 	// datatype IDs to be checked as orphaned.
 	// NOTE: Orphan removal can only be done when this DTM actively manages the viewComposite
 	private TreeSet<Long> orphanIds = new TreeSet<>();
+	private final Set<Long> resolvingOriginalIds = new TreeSet<>();
 
 	/**
 	 * Creates a data type manager that the composite editor will use internally for managing 
@@ -230,13 +233,90 @@ public class CompositeViewerDataTypeManager<T extends Composite> extends StandAl
 			// DataTypeManager instance.
 			return viewComposite;
 		}
-		DataType resolvedDt = super.resolve(dataType, handler);
-		if ((dataType instanceof DbObject) && originalDTM.contains(dataType)) {
-			long originalId = originalDTM.getID(dataType);
-			long myId = getID(resolvedDt);
-			dataTypeIDMap.put(myId, originalId);
+
+		if (contains(dataType)) {
+			return dataType;
 		}
-		return resolvedDt;
+
+		DataType typedefMatch = findOriginalTypedefMatch(dataType);
+		if (typedefMatch != null) {
+			return resolve(typedefMatch, handler);
+		}
+
+		Long originalId = getOriginalId(dataType);
+		DataType existingViewDt =
+			originalId != null ? findMyDataTypeFromOriginalID(originalId) : null;
+		if (originalId != null) {
+			if (existingViewDt != null) {
+				return existingViewDt;
+			}
+			if (resolvingOriginalIds.contains(originalId)) {
+				DataType inProgressViewDt = findInProgressViewDataType(dataType);
+				if (inProgressViewDt != null) {
+					return inProgressViewDt;
+				}
+			}
+		}
+
+		boolean isTrackingOriginal = originalId != null && resolvingOriginalIds.add(originalId);
+		try {
+			DataType resolvedDt = super.resolve(dataType, handler);
+			if (originalId != null) {
+				DataType mappedResolvedDt = findMyDataTypeFromOriginalID(originalId);
+				if (shouldPreferMappedResolvedDataType(resolvedDt, mappedResolvedDt)) {
+					resolvedDt = mappedResolvedDt;
+				}
+				long myId = getID(resolvedDt);
+				dataTypeIDMap.put(myId, originalId);
+			}
+			return resolvedDt;
+		}
+		finally {
+			if (isTrackingOriginal) {
+				resolvingOriginalIds.remove(originalId);
+			}
+		}
+	}
+
+	private Long getOriginalId(DataType dataType) {
+		if (!(dataType instanceof DbObject) || !originalDTM.contains(dataType)) {
+			return null;
+		}
+		return originalDTM.getID(dataType);
+	}
+
+	private DataType findOriginalTypedefMatch(DataType dataType) {
+		if (dataType == null || !(dataType instanceof TypeDef)) {
+			return null;
+		}
+		if ((dataType instanceof DbObject && dataType.getDataTypeManager() == this) ||
+			originalDTM.contains(dataType)) {
+			return null;
+		}
+		DataType originalDataType =
+			originalDTM.getDataType(dataType.getCategoryPath(), dataType.getName());
+		if (originalDataType != null &&
+			DataTypeUtilities.isSameKindDataType(dataType, originalDataType)) {
+			return originalDataType;
+		}
+		return null;
+	}
+
+	private boolean shouldPreferMappedResolvedDataType(DataType resolvedDt, DataType mappedResolvedDt) {
+		if (resolvedDt == null || mappedResolvedDt == null || resolvedDt == mappedResolvedDt) {
+			return false;
+		}
+		return DataTypeUtilities.isSameKindDataType(resolvedDt, mappedResolvedDt) &&
+			DataTypeUtilities.equalsIgnoreConflict(resolvedDt.getPathName(),
+				mappedResolvedDt.getPathName());
+	}
+
+	private DataType findInProgressViewDataType(DataType dataType) {
+		DataType candidate = getDataType(dataType.getCategoryPath(), dataType.getName());
+		if (candidate != null && DataTypeUtilities.isSameKindDataType(dataType, candidate)) {
+			return candidate;
+		}
+		return null;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/TypedefDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/data/TypedefDB.java
@@ -240,6 +240,12 @@ class TypedefDB extends DataTypeDB implements TypeDef {
 		}
 		TypeDef td = (TypeDef) dt;
 		validate(lock);
+		if (resolving) { // actively resolving children
+			if (dt.getUniversalID().equals(getUniversalID())) {
+				return true;
+			}
+			return DataTypeUtilities.equalsIgnoreConflict(getPathName(), dt.getPathName());
+		}
 
 		boolean autoNamed = isAutoNamed();
 		if (autoNamed != td.isAutoNamed()) {
@@ -258,8 +264,6 @@ class TypedefDB extends DataTypeDB implements TypeDef {
 			// treat this type as equivalent if existing type will be used
 			return true;
 		}
-
-		// TODO: add pointer-post-resolve logic with resolving bypass (similar to StructureDB components)
 
 		DataType dataType = getDataType();
 		DataType otherDataType = td.getDataType();


### PR DESCRIPTION
To add this at the start: I did use AI to help develop this, but I did my best to carefully review the actual changes.

In short, I was experiencing behavior in the Structure Editor where I would select a data type for a member and it would appear with the `.conflict` suffix upon selection (or, sometimes, upon saving the structure). There was no `.conflict` type in the actual Data Type Manager, so I was confused until I found out that the Structure Editor uses its on working Data Type Manager. The structures I was working with were oddly recursive and would trigger some edge cases in the resolution logic. Unfortunately, I cannot provide a minimum repro at this time, but I can work to provide one later. The changes here, when built, _do_ fix my issue.