### PR TITLE
Decompiler: Add parentheses around double unary token

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
@@ -288,6 +288,8 @@ bool PrintLanguage::parentheses(const OpToken *op2)
   case OpToken::unary_prefix:
     if (topToken->precedence > op2->precedence) return true;
     if (topToken->precedence < op2->precedence) return false;
+    // Double unary prefix - add parentheses so we print -(-x) instead of --x
+    if (topToken == op2) return true;
     //    if (associative && (this == &op2)) return false;
     if ((op2->type==OpToken::unary_prefix)||(op2->type==OpToken::presurround)) return false;
     return true;
@@ -343,7 +345,7 @@ void PrintLanguage::emitOp(const ReversePolish &entry)
     break;
   case OpToken::postsurround:
     if (entry.visited==0) return;
-    if (entry.visited==1) {	// Front surround token 
+    if (entry.visited==1) {	// Front surround token
       emit->spaces(entry.tok->spacing,entry.tok->bump);
       entry.id2 = emit->openParen(entry.tok->print1);
       emit->spaces(0,entry.tok->bump);
@@ -354,7 +356,7 @@ void PrintLanguage::emitOp(const ReversePolish &entry)
     break;
   case OpToken::presurround:
     if (entry.visited==2) return;
-    if (entry.visited==0) {	// Front surround token 
+    if (entry.visited==0) {	// Front surround token
       entry.id2 = emit->openParen(entry.tok->print1);
     }
     else {			// Back surround token
@@ -787,7 +789,7 @@ int4 PrintLanguage::mostNaturalBase(uintb val)
       tmp >>= 4;
     }
   }
-  
+
   return (countdec > counthex) ? 10 : 16;
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printlanguage.cc
@@ -345,7 +345,7 @@ void PrintLanguage::emitOp(const ReversePolish &entry)
     break;
   case OpToken::postsurround:
     if (entry.visited==0) return;
-    if (entry.visited==1) {	// Front surround token
+    if (entry.visited==1) {	// Front surround token 
       emit->spaces(entry.tok->spacing,entry.tok->bump);
       entry.id2 = emit->openParen(entry.tok->print1);
       emit->spaces(0,entry.tok->bump);
@@ -356,7 +356,7 @@ void PrintLanguage::emitOp(const ReversePolish &entry)
     break;
   case OpToken::presurround:
     if (entry.visited==2) return;
-    if (entry.visited==0) {	// Front surround token
+    if (entry.visited==0) {	// Front surround token 
       entry.id2 = emit->openParen(entry.tok->print1);
     }
     else {			// Back surround token
@@ -789,7 +789,7 @@ int4 PrintLanguage::mostNaturalBase(uintb val)
       tmp >>= 4;
     }
   }
-
+  
   return (countdec > counthex) ? 10 : 16;
 }
 


### PR DESCRIPTION
Fixes #2786

When the same unary prefix token is printed twice (for example a double float negation, as in the linked issue), make sure to surround the expression with parentheses after the first token. This way, the decompiler prints `-(-x)` instead of `--x`. The downside to this patch is that the decompiler will now also emit `!(!x)`, where the parentheses are not strictly necessary. However, such an expression should be optimised to just `x` in the first place. And even if it isn't, the output might be a bit more verbose than strictly necessary, but at least it isn't misleading, like the output for this example is.

Example decompiler debug xml (adapted from linked issue): 
[issue-2786-double-float-negation-emits-predecrement.xml](https://github.com/user-attachments/files/27140114/issue-2786-double-float-negation-emits-predecrement.xml)


**Before**
```c
float FUN_000000f4(float param_1)

{
  return --param_1;
}
```

**After**
```c
float FUN_000000f4(float param_1)

{
  return -(-param_1);
}
```