### PR TITLE
fix: Decompiler: Enum values will use their complement representation if simpler expression

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/type.cc
@@ -1539,6 +1539,18 @@ void TypeEnum::getMatches(uintb val,Representation &rep) const
 {
   map<uintb,string>::const_iterator iter;
   int4 count;
+  bool isComplement = false;
+
+  // First match complement if representation would be cleaner (combination of fewer enums)
+  // We'll do this by counting the number of set bits using Brian Kernighan's Algorithm
+  uintb bitsleft = val;
+  for (count=0;bitsleft!=0;++count){
+    bitsleft &= (bitsleft - 1);
+  }
+  if (count > size * 4) {
+    val = val ^ calc_mask(size);	// Switch value we are trying to represent (to complement)
+    isComplement = true;
+  }
 
   for(count=0;count<2;++count) {
     bool allmatch = true;
@@ -1576,10 +1588,11 @@ void TypeEnum::getMatches(uintb val,Representation &rep) const
       allmatch = (bitsleft == 0);
     }
     if (allmatch) {			// If we have a complete representation
-      rep.complement = (count==1);	// Set whether we represented original value or complement
+      rep.complement = isComplement;
       return;
     }
     val = val ^ calc_mask(size);	// Switch value we are trying to represent (to complement)
+    isComplement = !isComplement;
     rep.matchname.clear();		// Clear out old attempt
   }
   // If we reach here, no representation was possible, -matchname- is empty


### PR DESCRIPTION
Fixes #7234 and #5021.


## Current behavior

Given a bitfield-like enum E:
```c++
enum E {
    A = 0x01,
    B = 0x02,
    C = 0x04,
    D = 0x08,
    E = 0x10,
    F = 0x20,
    G = 0x40,
    H = 0x80,
};
```

The value `0xfd` decompiles to `A|C|D|E|F|G|H`. `TypeEnum::getMatches` will only look for a complement representation if no standard representation can be found.


## Behavior after fix

`0xfd` decompiles to `~B`. `TypeEnum::getMatches` preprocesses the enum value to determine which representation to attempt first, preferring the representation with fewer terms (inferred by whether more or less bits are set).
