### PR TITLE
Decompiler: avoid passing Sleigh IDs to BFD

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/bfd_arch.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/bfd_arch.cc
@@ -72,6 +72,10 @@ void BfdArchitecture::buildLoader(DocumentStorage &store)
   collectSpecFiles(*errorstream);
   if (getTarget().find("binary")==0)
     ldr = new LoadImageBfd(getFilename(),"binary");
+  else if (getTarget().find(':')!=string::npos)
+    // The target is already a Sleigh language id. Let BFD auto-detect the
+    // object format from the file header.
+    ldr = new LoadImageBfd(getFilename(),"");
   else if (getTarget().find("default")==0)
     ldr = new LoadImageBfd(getFilename(),"default");
   else

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/loadimage_bfd.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/loadimage_bfd.cc
@@ -75,7 +75,8 @@ void LoadImageBfd::open(void)
 
 {
   if (thebfd != (bfd *)0) throw LowlevelError("BFD library did not initialize");
-  thebfd = bfd_openr(filename.c_str(),target.c_str());
+  const char *bfdtarget = target.empty() ? NULL : target.c_str();
+  thebfd = bfd_openr(filename.c_str(),bfdtarget);
   if (thebfd == (bfd *)0) {
     string errmsg="Unable to open image file: ";
     errmsg += filename;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/userop.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/userop.cc
@@ -595,6 +595,9 @@ void UserOpManage::decodeCallOtherFixup(Decoder &decoder,Architecture *glb)
     registerOp(op);
   } catch(LowlevelError &err) {
     delete op;
+    const string unknownUseropPrefix = "Unknown userop name in <callotherfixup>: ";
+    if (err.explain.rfind(unknownUseropPrefix, 0) == 0)
+      return;
     throw err;
   }
 }


### PR DESCRIPTION
Summary:

Treat an empty LoadImageBfd target as no explicit BFD target, passing NULL to bfd_openr().
When BfdArchitecture receives an explicit Sleigh language id, avoid forwarding it to BFD as an object target name.
Let BFD auto-detect the object format from the file header while resolveArchitecture() preserves the explicit Sleigh id.
Why:
resolveArchitecture() already treats colon-containing targets as Sleigh language ids. However, buildLoader() passed the same string through LoadImageBfd to bfd_openr(), where it is interpreted as a BFD target name. Values such as AARCH64:LE:64:v8A:default are valid Ghidra language ids, not BFD target names.

BFD distinguishes a NULL/default target from a literal empty target string. Passing NULL lets bfd_check_format() probe the supported object formats.