### PR TITLE
Skip callfixup targets with fall-through in non-returning function detection

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/FindNoReturnFunctionsAnalyzer.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/FindNoReturnFunctionsAnalyzer.java
@@ -373,6 +373,13 @@ public class FindNoReturnFunctionsAnalyzer extends AbstractAnalyzer {
 			}
 			for (Address target : flows) {
 
+				// Skip targets that have a callfixup with fall-through semantics.
+				// A fall-through callfixup explicitly models the function's return
+				// behavior, so heuristic evidence should not override it.
+				if (hasCallFixupWithFallThrough(cp, target)) {
+					continue;
+				}
+
 				int count = 1;
 				ReferenceIterator refsTo = cp.getReferenceManager().getReferencesTo(target);
 				for (Reference reference : refsTo) {
@@ -419,6 +426,30 @@ public class FindNoReturnFunctionsAnalyzer extends AbstractAnalyzer {
 			}
 		}
 		return hadSuspiciousFunctions;
+	}
+
+	/**
+	 * Check if the function at the given address has a callfixup that falls through.
+	 * A fall-through callfixup explicitly models the function's return behavior
+	 * (e.g., Watcom's __CHK/__STK stack-check functions), so heuristic noreturn
+	 * detection should not override it.
+	 *
+	 * @param cp current program
+	 * @param target address of the potential noreturn function
+	 * @return true if the function has a callfixup with fall-through semantics
+	 */
+	private boolean hasCallFixupWithFallThrough(Program cp, Address target) {
+		Function func = cp.getFunctionManager().getFunctionAt(target);
+		if (func == null) {
+			return false;
+		}
+		String callFixup = func.getCallFixup();
+		if (callFixup == null || callFixup.isEmpty()) {
+			return false;
+		}
+		PcodeInjectLibrary lib = cp.getCompilerSpec().getPcodeInjectLibrary();
+		InjectPayload payload = lib.getPayload(InjectPayload.CALLFIXUP_TYPE, callFixup);
+		return payload != null && payload.isFallThru();
 	}
 
 	private boolean targetOnlyCallsNoReturn(Program cp, Address target, AddressSet noReturnSet)


### PR DESCRIPTION
### Summary

`FindNoReturnFunctionsAnalyzer` ("Non-Returning Functions - Discovered") uses heuristic evidence (data immediately after a call, function boundary after a call, INT3 after a call, etc.) to identify functions that don't return. Currently it does not consult the target function's callfixup, so a callfixup that explicitly models fall-through behavior can be silently overridden by the heuristic when enough call sites accumulate suspicious evidence.

This PR makes `detectNoReturn()` skip any target whose callfixup payload reports `isFallThru() == true`, on the grounds that a fall-through callfixup is an explicit, authoritative statement about the function's return behavior and should win over heuristic evidence.

### Motivation

I hit this analyzing 32-bit Watcom DOS/4GW binaries (handled by the [ghidra-lx-loader](https://github.com/Luminger/ghidra-lx-loader) extension plus a callfixup for Watcom's `__CHK`/`__STK` stack-probe helpers). These are normal returning functions and the callfixup correctly models that, but with enough call sites the heuristic accumulates "function boundary after call" evidence, marks `__CHK` noreturn, and applies a `CALL_RETURN` flow override at every call site — truncating the disassembly of every caller right after the `CALL`.

### Related issues

- #889 – Linux kernel `printk` on ARM marked noreturn
- #1981 – Keil C51 runtime helpers (`LLDIDATA`, `FPMUL`, `CASTF`, …) marked noreturn
- #2103 – request for user-controllable handling of known noreturn functions

These have other root causes (bad references, malformed flow, namespace handling, etc.) and aren't fixed by this PR, but where the affected function has a fall-through callfixup attached this change will incidentally protect it.

### Testing

Manually verified on a 32-bit Watcom LE/LX binary (DOS/4GW): before the patch, `__CHK` is marked noreturn and every caller's body is truncated after the first instruction; after the patch, `__CHK` is left as a normal returning function and callers disassemble correctly.
