### PR TITLE
Include character 127 as invalid character

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/SymbolUtilities.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/SymbolUtilities.java
@@ -101,7 +101,7 @@ public class SymbolUtilities {
 	/**
 	 * Invalid characters for a symbol name.
 	 */
-	public final static char[] INVALIDCHARS = { ' ' };
+	public final static char[] INVALIDCHARS = { ' ', (char) 127 };
 
 	private static final Comparator<Symbol> CASE_INSENSITIVE_SYMBOL_NAME_COMPARATOR = (s1, s2) -> {
 		return s1.getName().compareToIgnoreCase(s2.getName());


### PR DESCRIPTION
This patch fixes #9165 by including character 127 in the list of invalid characters.