### PR TITLE
Limit the maximum loadable characters for symbol names

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/BinaryReader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/BinaryReader.java
@@ -791,9 +791,17 @@ public class BinaryReader {
 	// String stuff
 	//--------------------------------------------------------------------------------------------
 	private byte[] readUntilNullTerm(long index, int charLen) throws IOException {
+		return this.readUntilNullTerm(index, charLen, -1);
+	}
+
+
+	private byte[] readUntilNullTerm(long index, int charLen, int maxLen) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		long curPos = index;
 		for (; Long.compareUnsigned(curPos, index) >= 0; curPos += charLen) {
+			if(maxLen > 0 && curPos - index >= maxLen) {
+				throw new EOFException("Max Length was reached");
+			}
 			// loop while we haven't wrapped the index value around to 0
 			if ((long) baos.size() + charLen >= MAX_SANE_BUFFER) {
 				// gracefully handle hitting the limit of the ByteArrayOutputStream before it fails
@@ -854,6 +862,19 @@ public class BinaryReader {
 	 */
 	public String readAsciiString(long index) throws IOException {
 		return readString(index, StandardCharsets.US_ASCII, 1);
+	}
+
+        /**
+         * Reads a null terminated US-ASCII string, starting at specified index, stopping at
+         * the first null character or if maxLen is reached.
+         *
+         * @param index starting position of the string
+         * @param maxLen number of bytes to read at most
+         * @return US-ASCII string, excluding the trailing null terminator character
+         * @throws IOException if error reading bytes or if after maxLen bytes a null character was not reached
+         */
+	public String readAsciiStringWithMaxLen(long index, int maxLen) throws IOException {
+		return readString(index, StandardCharsets.US_ASCII, 1, maxLen);
 	}
 
 	/**
@@ -968,7 +989,22 @@ public class BinaryReader {
 	 * @exception IOException if an I/O error occurs
 	 */
 	public String readString(long index, Charset charset, int charLen) throws IOException {
-		byte[] bytes = readUntilNullTerm(index, charLen);
+		return this.readString(index, charset, charLen, -1);
+	}
+
+        /**
+         * Reads a null-terminated string starting at <code>index</code>, using a specific
+         * {@link Charset}.
+         *
+         * @param index where the string begins
+         * @param charset {@link Charset}, see {@link StandardCharsets}
+         * @param charLen number of bytes in each character
+         * @param maxLen number of bytes to read at most
+         * @return the string
+         * @exception IOException if an I/O error occurs or if after maxLen bytes a null character was not reached
+         */
+	public String readString(long index, Charset charset, int charLen, int maxLen) throws IOException {
+		byte[] bytes = readUntilNullTerm(index, charLen, maxLen);
 
 		String result = new String(bytes, charset);
 		return result;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/NTHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/NTHeader.java
@@ -46,6 +46,7 @@ public class NTHeader implements StructConverter, OffsetValidator {
 	 */
 	public final static int SIZEOF_SIGNATURE = BinaryReader.SIZEOF_INT;
 	public final static int MAX_SANE_COUNT = 0x10000;
+	public final static int MAX_SANE_SYMBOL_NAME_LENGTH = 0x2000;
 
 	private int signature;
 	private FileHeader fileHeader;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
@@ -18,6 +18,7 @@ package ghidra.app.util.bin.format.pe;
 import java.io.*;
 
 import ghidra.app.util.bin.*;
+import ghidra.app.util.bin.format.pe.NTHeader;
 import ghidra.program.model.data.*;
 import ghidra.program.model.mem.*;
 import ghidra.util.DataConverter;
@@ -257,11 +258,11 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 		if (result.name.startsWith("/") && stringTableOffset != -1) {
 			try {
 				int nameOffset = Integer.parseInt(result.name.substring(1));
-				result.name = reader.readAsciiString(stringTableOffset + nameOffset);
+				result.name = reader.readAsciiStringWithMaxLen(stringTableOffset + nameOffset, NTHeader.MAX_SANE_SYMBOL_NAME_LENGTH);
 			}
-			catch (NumberFormatException nfe) {
-				// ignore error, section name will remain as it was
-			}
+			// ignore errors, section name will remain as it was
+			catch (NumberFormatException nfe) { }
+			catch (IOException ioe) { }
 		}
 
 		// we need to skip IMAGE_SIZEOF_SHORT_NAME chars no matter what,

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/debug/DebugCOFFSymbol.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/debug/DebugCOFFSymbol.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import ghidra.app.util.bin.*;
 import ghidra.program.model.data.*;
 import ghidra.util.exception.DuplicateNameException;
+import ghidra.app.util.bin.format.pe.NTHeader;
+
 
 /**
  * A class to represent the COFF symbol data structure.
@@ -146,7 +148,7 @@ public class DebugCOFFSymbol implements StructConverter {
             int longVal = reader.readInt(index);
             index += BinaryReader.SIZEOF_INT;
             if (longVal > 0) {
-            	name = reader.readAsciiString(stringTableIndex + longVal);
+                name = reader.readAsciiStringWithMaxLen(stringTableIndex + longVal, NTHeader.MAX_SANE_SYMBOL_NAME_LENGTH);
             } 
         }
 


### PR DESCRIPTION
To fix #9169 I propose to limit the maximum loadable characters per string to 0x2000, which is 0.5 GiB for 2 ^ 16 symbols.

This patch implements this limit for both PE debug symbols as well as section names.

SectionHeader.java now also needs to catch the newly thrown IOException. This incidentally fixes #9167.