### PR TITLE
Round SizeOfRawData up to the nearest multiple of the FileAlignment

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/FileHeader.java
@@ -374,7 +374,7 @@ public class FileHeader implements StructConverter {
 			sectionHeaders = new SectionHeader[numberOfSections];
 			for (int i = 0; i < numberOfSections; ++i) {
 				SectionHeader section =
-					SectionHeader.readSectionHeader(reader, tmpIndex, stringTableOffset);
+					SectionHeader.readSectionHeader(reader, tmpIndex, stringTableOffset, optHeader.getFileAlignment());
 				sectionHeaders[i] = section;
 
 				int pointerToRawData = section.getPointerToRawData();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
@@ -236,6 +236,8 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 	private short numberOfLinenumbers;
 	private int characteristics;
 
+	private int fileAlignment;
+
 	private BinaryReader reader;
 
 	/**
@@ -248,7 +250,7 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 	 * @throws IOException if error reading data
 	 */
 	public static SectionHeader readSectionHeader(BinaryReader reader, long index,
-			long stringTableOffset) throws IOException {
+			long stringTableOffset, int fileAlignment) throws IOException {
 		SectionHeader result = new SectionHeader();
 
 		result.reader = reader;
@@ -277,6 +279,7 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 		result.numberOfRelocations = reader.readNextShort();
 		result.numberOfLinenumbers = reader.readNextShort();
 		result.characteristics = reader.readNextInt();
+		result.fileAlignment = fileAlignment;
 
 		return result;
 	}
@@ -319,6 +322,7 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 				characteristics |= SectionFlags.IMAGE_SCN_CNT_UNINITIALIZED_DATA.getMask();
 			}
 		}
+		fileAlignment = optHeader.getFileAlignment();
 	}
 
 	/**
@@ -409,7 +413,10 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 	 * @return the size (in bytes) of data stored for the section
 	 */
 	public int getSizeOfRawData() {
-		return sizeOfRawData;
+		if(this.fileAlignment <= 0) { // In case of unknown fileAlignment return without adjustment
+			return this.sizeOfRawData;
+		}
+		return Math.ceilDiv(sizeOfRawData, this.fileAlignment) * this.fileAlignment;
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SeparateDebugHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SeparateDebugHeader.java
@@ -110,7 +110,7 @@ public class SeparateDebugHeader implements OffsetValidator {
 
 		sections = new SectionHeader[numberOfSections];
 		for (int i = 0; i < numberOfSections; ++i) {
-			sections[i] = SectionHeader.readSectionHeader(reader, ptr, -1);
+			sections[i] = SectionHeader.readSectionHeader(reader, ptr, -1, -1);
 			ptr += SectionHeader.IMAGE_SIZEOF_SECTION_HEADER;
 		}
 


### PR DESCRIPTION
This fixes #9171.

I sadly was not able to get the FileAlignment for all contexts, so I default to the old behavior in cases where it was not available.
