### PR TITLE
Round down PointerToRawData to the nearest multiple 0x200

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/SectionHeader.java
@@ -415,19 +415,27 @@ public class SectionHeader implements StructConverter, ByteArrayConverter {
 	/**
 	 * Returns the file offset where the data 
 	 * for the section begins. For executables, 
-	 * this value must be a multiple of the file 
+	 * this value *should* be a multiple of the file
 	 * alignment given in the PE header.
-	 * <p>
-	 * If a section is uninitialized, this value will be 0.
+	 * Note: While this value *should* be a
+	 * multiple of the file alignment, Windows will
+	 * round down to the nearest multiple of 0x200
+	 * regardless of the file alignment.
+	 * Also note that for values below 0x200 but above 0x0
+	 * Windows will round down to 0 but still load the section
+	 * into memory instead of not loading anything as it would
+	 * if it were 0 from the start.
 	 * 
 	 * @return the file offset where the data for the section begins
 	 */
 	public int getPointerToRawData() {
-		if (pointerToRawData < 0x200) {
-			return 0;
-		}
+		return (pointerToRawData / 0x200) * 0x200;
+	}
+
+	public int getRawPointerToRawData() {
 		return pointerToRawData;
 	}
+
 
 	/**
 	 * Returns the file offset of relocations for this section. 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/PeLoader.java
@@ -679,8 +679,9 @@ public class PeLoader extends AbstractPeDebugLoader {
 				int rawDataSize = sections[i].getSizeOfRawData();
 				int rawDataPtr = sections[i].getPointerToRawData();
 				virtualSize = sections[i].getVirtualSize();
+				int unChangedRawDataPtr = sections[i].getRawPointerToRawData();
 				MemoryBlock block = null;
-				if (rawDataSize != 0 && rawDataPtr != 0) {
+				if (rawDataSize != 0 && unChangedRawDataPtr != 0) { // Check PointerToRawData before it was rounded down
 					int dataSize =
 						((rawDataSize > virtualSize && virtualSize > 0) || rawDataSize < 0)
 								? virtualSize


### PR DESCRIPTION
This patch rounds down PointerToRawData to the nearest multiple 0x200. And it correctly loads sections where PointerToRawData is between 0x001 and 0x1ff. This fixes #9170