### PR TITLE
Decompiler: Fix call of function pointer in in-lined function

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/flow.cc
@@ -1087,6 +1087,8 @@ void FlowInfo::inlineClone(const FlowInfo &inlineflow,const Address &retaddr)
 /// Individual PcodeOps from the Funcdata being in-lined are cloned into
 /// the Funcdata for \b this flow but are reassigned a new fixed address,
 /// and the RETURN op is eliminated.
+/// A BRANCHIND op is replaced with a CALLIND op to handle function calls performed
+/// by the in-lined function.
 /// \param inlineflow is the given in-line flow to clone
 /// \param calladdr is the fixed address assigned to the cloned PcodeOps
 void FlowInfo::inlineEZClone(const FlowInfo &inlineflow,const Address &calladdr)
@@ -1097,7 +1099,12 @@ void FlowInfo::inlineEZClone(const FlowInfo &inlineflow,const Address &calladdr)
     PcodeOp *op = *iter;
     if (op->code() == CPUI_RETURN) break;
     SeqNum myseq(calladdr,op->getSeqNum().getTime());
-    data.cloneOp(op,myseq);
+    PcodeOp *cloneop = data.cloneOp(op,myseq);
+    if (op->code() == CPUI_BRANCHIND) {
+      data.opSetOpcode(cloneop,CPUI_CALLIND);
+    }
+    if (cloneop->isCallOrBranch())
+      xrefInlinedBranch(cloneop);
   }
   // Because we are processing only straightline code and it is all getting assigned to one
   // address, we don't touch unprocessed, addrlist, or visited
@@ -1137,6 +1144,7 @@ bool FlowInfo::testHardInlineRestrictions(Funcdata *inlinefd,PcodeOp *op,Address
 }
 
 /// A function is in the EZ model if it is a straight-line leaf function.
+/// For a leaf function the last op can also be a BRANCHIND.
 /// \return \b true if this flow contains no CALL or BRANCH ops
 bool FlowInfo::checkEZModel(void) const
 
@@ -1144,6 +1152,9 @@ bool FlowInfo::checkEZModel(void) const
   list<PcodeOp *>::const_iterator iter = obank.beginDead();
   while(iter != obank.endDead()) {
     PcodeOp *op = *iter;
+    if (std::next(iter) == obank.endDead()) {
+      if (op->code() == CPUI_BRANCHIND) return true;
+    }
     if (op->isCallOrBranch()) return false;
     ++iter;
   }


### PR DESCRIPTION
I'm reversing an AARCH64 binary where the compiler created a lot of out-lined functions. One of the out-lined function looks like
```
outlined_FUN
ldr        x8,[x8, #0x18]
br         x8
```
where x8 holds a pointer to a struct. The struct at offset 0x18 holds a function pointer and so `outlined_FUN` basically calls the function pointer. The calling function looks like
```
calling_FUN
[...]
bl         outlined_FUN
tbnz       w0,#0x0,LAB_
[...]
bl         outlined_FUN
tbnz       w0,#0x0,LAB_
[...]
```
where
1. the return value of the call to the function pointer is checked
2. the outlined_FUN is called multiple times

If I mark `outlined_FUN` as in line, then the decompiler
1. ends the control flow after the call of the function pointer and discards the test of the return value and the following code
2. only in-lines `outlined_FUN` once because the trailing br instruction is not allowed in the EZ Model

This PR addresses both issues by
1. allowing a BRANCHIND as last pcode op in the EZ Model
2. changing the BRANCHIND into CALLIND pcode op during the in-lining in the EZ Model

With this PR I'm able to in-line the above out-lined function multiple times in the same function and the decompiler doesn't omit the checks of the return value of the function pointer call, but instead the control flow continues as it should.