### PR TITLE
Fix conditional constant MULTIEQUAL placement

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -4323,7 +4323,7 @@ Varnode *ActionConditionalConst::placeCopy(PcodeOp *op,BlockBasic *bl,Varnode *c
 /// \param marks are the marks applied to the MULTIEQUALs (2 == flowtogether)
 /// \param constVn is the constant being assigned by the COPY
 /// \param data is the function
-void ActionConditionalConst::placeMultipleConstants(vector<PcodeOpNode> &phiNodeEdges,vector<int4> &marks,
+void ActionConditionalConst::placeMultipleConstants(vector<PcodeOpNode> &phiNodeEdges,vector<int4> &marks,FlowBlock *constBlock,
 						    Varnode *constVn,Funcdata &data)
 {
   vector<FlowBlock *> blocks;
@@ -4336,6 +4336,8 @@ void ActionConditionalConst::placeMultipleConstants(vector<PcodeOpNode> &phiNode
     blocks.push_back(bl);
   }
   BlockBasic *rootBlock = (BlockBasic *)FlowBlock::findCommonBlock(blocks);
+  if (constBlock->dominates(rootBlock))
+    rootBlock = (BlockBasic *)constBlock;
   Varnode *outVn = placeCopy(op, rootBlock, constVn, data);
   for(int4 i=0;i<phiNodeEdges.size();++i) {
     if (marks[i] != 2) continue;
@@ -4383,10 +4385,12 @@ void ActionConditionalConst::pushConstant(list<ConstPoint> &points,PcodeOp *op)
 /// data-flow, and the output of a MULTIEQUAL does not rejoin with the Varnode along an alternate path, then that
 /// edge is replaced with a constant.
 /// \param varVn is the given Varnode
+/// \param constBlock is the block from which the constant path starts
 /// \param constVn is the constant to replace it with
 /// \param phiNodeEdges is the set of edges the Varnode is known to be constant on
 /// \param data is the function containing this data-flow
-void ActionConditionalConst::handlePhiNodes(Varnode *varVn,Varnode *constVn,vector<PcodeOpNode> &phiNodeEdges,Funcdata &data)
+void ActionConditionalConst::handlePhiNodes(Varnode *varVn,FlowBlock *constBlock,Varnode *constVn,
+					    vector<PcodeOpNode> &phiNodeEdges,Funcdata &data)
 
 {
   vector<PcodeOp *> alternateFlow;
@@ -4416,12 +4420,14 @@ void ActionConditionalConst::handlePhiNodes(Varnode *varVn,Varnode *constVn,vect
     PcodeOp *op = phiNodeEdges[i].op;
     int4 slot = phiNodeEdges[i].slot;
     BlockBasic *bl = (BlockBasic *)op->getParent()->getIn(slot);
+    if (constBlock->dominates(bl))
+      bl = (BlockBasic *)constBlock;
     Varnode *outVn = placeCopy(op, bl, constVn, data);
     data.opSetInput(op,outVn,slot);
     count += 1;
   }
   if (hasFlowTogether) {
-    placeMultipleConstants(phiNodeEdges, results, constVn, data);	// Add COPY assignment for edges that flow together
+    placeMultipleConstants(phiNodeEdges, results, constBlock, constVn, data);	// Add COPY assignment for edges that flow together
     count += 1;
   }
 }
@@ -4549,7 +4555,7 @@ void ActionConditionalConst::propagateConstant(list<ConstPoint> &points,bool use
     if (!phiNodeEdges.empty()) {
       if (constVn == (Varnode *)0)
 	constVn = data.newConstant(varVn->getSize(), point.value);
-      handlePhiNodes(varVn, constVn, phiNodeEdges, data);
+      handlePhiNodes(varVn, constBlock, constVn, phiNodeEdges, data);
       phiNodeEdges.clear();
     }
     points.pop_front();

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.hh
@@ -588,8 +588,9 @@ class ActionConditionalConst : public Action {
   static Varnode *placeCopy(PcodeOp *op,BlockBasic *bl,Varnode *constVn,Funcdata &data);
   static void findConstCompare(list<ConstPoint> &points,Varnode *boolVn,FlowBlock *bl,bool *blockDom,bool flipEdge);
   static void pushConstant(list<ConstPoint> &points,PcodeOp *op);
-  static void placeMultipleConstants(vector<PcodeOpNode> &phiNodeEdges,vector<int4> &marks,Varnode *constVn,Funcdata &data);
-  void handlePhiNodes(Varnode *varVn,Varnode *constVn,vector<PcodeOpNode> &phiNodeEdges,Funcdata &data);
+  static void placeMultipleConstants(vector<PcodeOpNode> &phiNodeEdges,vector<int4> &marks,FlowBlock *constBlock,
+				     Varnode *constVn,Funcdata &data);
+  void handlePhiNodes(Varnode *varVn,FlowBlock *constBlock,Varnode *constVn,vector<PcodeOpNode> &phiNodeEdges,Funcdata &data);
   bool testAlternatePath(Varnode *vn,PcodeOp *op,int4 slot,int4 depth);
   void propagateConstant(list<ConstPoint> &points,bool useMultiequal,Funcdata &data);
 public:

--- a/Ghidra/Processors/68000/data/languages/68000.sinc
+++ b/Ghidra/Processors/68000/data/languages/68000.sinc
@@ -557,6 +557,11 @@ e2b: (d16)".w" is savmod2=7 & regsan=0; d16	{ export *:1 d16; }
 e2b: (d32)".l" is savmod2=7 & regsan=1; d32	{ export *:1 d32; }
 e2b: "#"^d8 is savmod2=7 & regsan=4; d8		{ export *[const]:1 d8; }
 
+e2bPostSP: (regsan)+ is savmod2=3 & regsan & regsan=7	{ export regsan; }
+e2bPost: (regsan)+ is savmod2=3 & regtsan!=7 & regsan	{ export regsan; }
+e2wPost: (regsan)+ is savmod2=3 & regsan			{ export regsan; }
+e2lPost: (regsan)+ is savmod2=3 & regsan			{ export regsan; }
+
 # For instructions like lea and pea that manipulative the effective address
 # itself rather than the data the address is pointing at
 eaptr: (regan)			is mode=2 & regan					{ export regan; }
@@ -1614,9 +1619,18 @@ macro shiftCXFlags(cntreg) {
 	XF = CF;
 }
 
-:move.b eab,e2b			is (op=1 & $(DAT_ALTER_ADDR_MODES2))... & eab ; e2b	{ build eab; local tmp = eab; build e2b; e2b = tmp; resflags(tmp); logflags(); }
-:move.w eaw,e2w			is (op=3 & $(DAT_ALTER_ADDR_MODES2))... & eaw ; e2w	{ build eaw; local tmp = eaw; build e2w; e2w = tmp; resflags(tmp); logflags(); }
-:move.l eal,e2l			is (op=2 & $(DAT_ALTER_ADDR_MODES2))... & eal ; e2l	{ build eal; local tmp = eal; build e2l; e2l = tmp; resflags(tmp); logflags(); }
+:move.b eab,e2bPostSP		is (op=1 & mode2=3 & reg9an=7 & reg9an)... & eab ; e2bPostSP
+			{ build eab; local tmp = eab; build e2bPostSP; *:1 e2bPostSP = tmp; e2bPostSP = e2bPostSP + 2; resflags(tmp); logflags(); }
+:move.b eab,e2bPost		is (op=1 & mode2=3 & reg9an!=7 & reg9an)... & eab ; e2bPost
+			{ build eab; local tmp = eab; build e2bPost; *:1 e2bPost = tmp; e2bPost = e2bPost + 1; resflags(tmp); logflags(); }
+:move.w eaw,e2wPost		is (op=3 & mode2=3 & reg9an)... & eaw ; e2wPost
+			{ build eaw; local tmp = eaw; build e2wPost; *:2 e2wPost = tmp; e2wPost = e2wPost + 2; resflags(tmp); logflags(); }
+:move.l eal,e2lPost		is (op=2 & mode2=3 & reg9an)... & eal ; e2lPost
+			{ build eal; local tmp = eal; build e2lPost; *:4 e2lPost = tmp; e2lPost = e2lPost + 4; resflags(tmp); logflags(); }
+
+:move.b eab,e2b			is (op=1 & (mode2=0 | mode2=2 | mode2=4 | mode2=5 | mode2=6 | mode2=7))... & eab ; e2b	{ build eab; local tmp = eab; build e2b; e2b = tmp; resflags(tmp); logflags(); }
+:move.w eaw,e2w			is (op=3 & (mode2=0 | mode2=2 | mode2=4 | mode2=5 | mode2=6 | mode2=7))... & eaw ; e2w	{ build eaw; local tmp = eaw; build e2w; e2w = tmp; resflags(tmp); logflags(); }
+:move.l eal,e2l			is (op=2 & (mode2=0 | mode2=2 | mode2=4 | mode2=5 | mode2=6 | mode2=7))... & eal ; e2l	{ build eal; local tmp = eal; build e2l; e2l = tmp; resflags(tmp); logflags(); }
 
 :move "CCR",eaw			is (opbig=0x42 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ packflags(SR); eaw = SR; }
 :move eaw,"CCR"			is (opbig=0x44 & op67=3 & $(DAT_ALTER_ADDR_MODES))... & eaw				{ unpackflags(eaw); }


### PR DESCRIPTION
When conditional constant propagation infers a constant that flows into a MULTIEQUAL, the decompiler might generate a synthetic COPY on the incoming edge. In some cases - this COPY was being placed in the predecessor block even when that block is part of a loop (e.g a loop latch/body), causing the decompiled output to incorrectly show a constant assignment occurring inside the loop. This change corrects the placement by hoisting the generated COPY into the constant-defining path block when that block dominates the corresponding phi predecessor. This ensures the constant assignment is shown outside the loop in cases where it is guaranteed to execute before the loop is entered; while preserving the existing placement behaviour in all other cases.

Related discussions/issues:
- #9203