### PR TITLE
testfunction: add -dumpdir flag to capture actual decompiler output

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/test.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/test.cc
@@ -148,8 +148,17 @@ int main(int argc, char **argv) {
       dataTestNames.insert(argv + 1,argv + argc);
       break;
     }
+    else if (command == "-dumpdir") {
+      // Sprint 9 audit support (issue #215): when set, the test harness
+      // writes <dumpdir>/<testfile-basename>.actual containing the raw
+      // decompiler output for each datatest file. Lets audit-datatests.yml
+      // categorize cosmetic-regex-drift vs. real-regression failures.
+      FunctionTestCollection::dumpDir = argv[1];
+      argv += 2;
+      argc -= 2;
+    }
     else {
-      cout << "USAGE: ghidra_test [-usesleighenv] [-sleighpath <sleighdir>] [-path <datatestdir>] [[unittests|datatests] [testname1 testname2 ...]]" << endl;
+      cout << "USAGE: ghidra_test [-usesleighenv] [-sleighpath <sleighdir>] [-path <datatestdir>] [-dumpdir <actualdir>] [[unittests|datatests] [testname1 testname2 ...]]" << endl;
       return -1;
     }
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/testfunction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/testfunction.cc
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 #include "ifacedecomp.hh"
+#include <fstream>
 
 namespace ghidra {
+
+string FunctionTestCollection::dumpDir;
 
 void FunctionTestProperty::startTest(void) const
 
@@ -328,6 +331,21 @@ void FunctionTestCollection::runTests(list<string> &lateStream)
     return;
   }
   string result = bulkout.str();
+  if (!dumpDir.empty()) {
+    // Sprint 9 audit (issue #215): dump the raw decompiler output for this
+    // file so the workflow can compare expected stringmatch regexes against
+    // what the decompiler actually emitted. Strip the path; keep only the
+    // basename so a single dumpDir holds all .actual files flat.
+    string base = fileName;
+    string::size_type slash = base.find_last_of("/\\");
+    if (slash != string::npos)
+      base = base.substr(slash + 1);
+    string::size_type dot = base.rfind('.');
+    if (dot != string::npos)
+      base = base.substr(0, dot);
+    std::ofstream actual((dumpDir + "/" + base + ".actual").c_str());
+    actual << result;
+  }
   if (result.size() == 0) {
     ostringstream fs;
     fs << "No output for " << fileName;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/testfunction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/testfunction.hh
@@ -96,6 +96,17 @@ public:
   void restoreXmlOldForm(DocumentStorage &store,const Element *el);	///< Load tests from \<binaryimage> tag.
   void runTests(list<string> &lateStream);	///< Run the script and perform the tests
   static int runTestFiles(const vector<string> &testFiles,ostream &s);	///< Run tests for each listed file
+
+  /// \brief Optional dump directory for the raw decompiler output of each test file.
+  ///
+  /// Sprint 9 audit support (issue #215). When non-empty, runTests() writes the
+  /// full `bulkout` stream (the actual decompiled C text produced by the script
+  /// commands) to `<dumpDir>/<basename(fileName)>.actual`. This lets the
+  /// `audit-datatests.yml` workflow capture actual-vs-expected and feed the
+  /// cosmetic-regex-drift vs. real-regression categorization. Empty (default)
+  /// preserves the original behavior of discarding bulkout after pattern
+  /// matching.
+  static string dumpDir;
 };
 
 } // End namespace ghidra


### PR DESCRIPTION
## Summary

Adds a `-dumpdir <path>` flag to `decomp_test_dbg`. When set, the test harness writes `<path>/<testfile-basename>.actual` containing the raw decompiled-C bulkout (the same text the `<stringmatch>` regexes are evaluated against) for every datatest XML file processed.

Default behavior — empty `dumpDir` — is unchanged.

## Why

Categorizing datatest failures (cosmetic stringmatch-regex drift vs. real decompiler behavior change) currently requires rebuilding the decompiler, re-running each failing test locally, and copy-pasting the output. With `-dumpdir`, the actual output for every file is captured as part of a single CI run and downloadable as a workflow artifact alongside the standard pass/fail output. The whole categorization can happen offline against the artifact.

Companion PR with the resulting regex updates (189 cosmetic-drift failures across 27 XML files): #9207.

## Implementation

- New static member `FunctionTestCollection::dumpDir` (default empty string).
- Set from `main()` when the new `-dumpdir <path>` CLI flag is parsed.
- Read inside `runTests()` once per loaded test XML — if non-empty, write `bulkout.str()` to `<dumpDir>/<testfile-basename>.actual` after the per-line pattern matching runs.

Three files, +39/-1 lines. No behavior change unless the flag is passed.

## Verification

Used end-to-end in CryptoJones/GayHydra's `audit-datatests.yml` workflow — see the audit history for that repo for runtime characteristics. Build clean on Ubuntu, macOS, Windows.