### PR TITLE
Fix typos

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/plugins/importer/batch/BatchImportDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/plugins/importer/batch/BatchImportDialog.java
@@ -336,7 +336,7 @@ public class BatchImportDialog extends DialogComponentProvider {
 		mirrorFsCb = new GCheckBox("Mirror Filesystem", mirrorFs);
 		mirrorFsCb.addChangeListener(e -> setMirrorFs(mirrorFsCb.isSelected()));
 		mirrorFsCb.setToolTipText(
-			"The imported files' project paths will mirror the filesystem rooted at the desination folder");
+			"The imported files' project paths will mirror the filesystem rooted at the destination folder");
 		mirrorFsCb.getAccessibleContext().setAccessibleName("Mirror Filesystem");
 		setMirrorFs(mirrorFs); // needed to possibly disable other checkboxes
 

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/VTMarkupType.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/VTMarkupType.java
@@ -103,7 +103,7 @@ public abstract class VTMarkupType {
 	/**
 	 * Returns true if both the source and destination have the same value such that there is
 	 * nothing to apply.
-	 * @param markupItem the markup item to check for having the save source and desination values.
+	 * @param markupItem the markup item to check for having the save source and destination values.
 	 * @return true if both the source and destination have the same value such that there is
 	 * nothing to apply.
 	 */


### PR DESCRIPTION
This pull request fixes two typos wherein the word `destination` is missing the first `t`.