### PR TITLE
Add SECURITY.md with vulnerability reporting guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 12.1    | :white_check_mark: |
+| < 12.1  | :x:                |
+
+## Reporting a Vulnerability
+
+To report a security vulnerability in Ghidra, please use GitHub's
+private vulnerability reporting:
+
+**[Report a vulnerability](https://github.com/NationalSecurityAgency/ghidra/security/advisories/new)**
+
+This ensures the report is only visible to repository maintainers
+and allows coordinated disclosure. Please do not open public issues
+for security vulnerabilities.
+
+### What to include
+
+- Affected file(s) and line numbers
+- Description of the vulnerability and its impact
+- Steps to reproduce or proof of concept
+- Suggested fix if available
+
+### What to expect
+
+The Ghidra team will review your report and respond through the
+advisory thread. Confirmed vulnerabilities are typically patched
+in the next release and credited in the published advisory.


### PR DESCRIPTION
GitHub flags this repository as having no security policy ("No security policy detected" on the Security tab). 

This adds a `SECURITY.md` that documents:
- Currently supported versions
- How to report vulnerabilities via GitHub's existing private advisory flow
- What to include in a report
- What to expect from the maintainers

The repository already has private vulnerability reporting enabled and 18 published advisories, but no documentation directing reporters to that process. This brings the repo in line with GitHub's recommended security practices.