### PR TITLE
Optimize AssemblyPatternBlock fromString method

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyPatternBlock.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/app/plugin/assembler/sleigh/sem/AssemblyPatternBlock.java
@@ -139,17 +139,32 @@ public class AssemblyPatternBlock implements Comparable<AssemblyPatternBlock> {
 		}
 
 		// Convert the bytes
-		// TODO: Optimize this some
 		byte[] mask = new byte[length];
 		byte[] vals = new byte[length];
-		AtomicLong msk = new AtomicLong();
-		AtomicLong val = new AtomicLong();
 		int i = 0;
-		for (String hex : str.substring(pos).split(":")) {
-			NumericUtilities.convertHexStringToMaskedValue(msk, val, hex, 2, 0, null);
-			mask[i] = (byte) msk.get();
-			vals[i] = (byte) val.get();
+		int p = pos;
+		while (p < str.length()) {
+			int newpos = str.indexOf(':', p);
+			if (newpos == -1) {
+				newpos = str.length();
+			}
+			byte m = 0;
+			byte v = 0;
+			for (int j = p; j < newpos; j++) {
+				char c = str.charAt(j);
+				m <<= 4;
+				v <<= 4;
+				if (c == 'X' || c == 'x') {
+					continue;
+				}
+				int nibble = Character.digit(c, 16);
+				m |= 0x0f;
+				v |= nibble;
+			}
+			mask[i] = m;
+			vals[i] = v;
 			i++;
+			p = newpos + 1;
 		}
 
 		return new AssemblyPatternBlock(offset, mask, vals);


### PR DESCRIPTION
The method was splitting a string into an array of strings to parse hex bytes, calling NumericUtilities.convertHexStringToMaskedValue with AtomicLong parameters, which created multiple intermediate strings and objects for each byte array element.

I optimized this method by replacing the object allocations, strings splitting, and AtomicLong usage with an in-place single-pass loop over the string, computing the byte mask and value directly.

This optimization speeds up assembly pattern block parsing from string representations and reduces unnecessary memory allocations.

I successfully ran AssemblyPatternBlockTest tests locally in the SoftwareModeling module.