### PR TITLE
Fix 2 typos in DomainObjectDBTransaction

### DIFF
--- a/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/DomainObjectDBTransaction.java
+++ b/Ghidra/Framework/Project/src/main/java/ghidra/framework/data/DomainObjectDBTransaction.java
@@ -107,7 +107,7 @@ class DomainObjectDBTransaction implements TransactionInfo {
 	 */
 	void setHasCommittedDBTransaction() {
 		if (getStatus() != Status.COMMITTED) {
-			throw new IllegalStateException("transaction was not committed");
+			throw new IllegalStateException("Transaction was not committed");
 		}
 		hasDBTransaction = true;
 	}
@@ -146,7 +146,7 @@ class DomainObjectDBTransaction implements TransactionInfo {
 		}
 		if (entry.status != Status.NOT_DONE) {
 			throw new IllegalStateException(
-				"Attempted to end Transaction " + "more that once: " + entry.description);
+				"Attempted to end Transaction " + "more than once: " + entry.description);
 		}
 		entry.status = commit ? Status.COMMITTED : Status.ABORTED;
 		if (!commit) {


### PR DESCRIPTION
noticed it because I made a little oopsy while writing a python script and thought, might as well make a pull request

Also fixes a small typo/capitalization error