### PR TITLE
Add PowerPC 64 (32bit addr) EABI compiler spec

### DIFF
--- a/Ghidra/Processors/PowerPC/certification.manifest
+++ b/Ghidra/Processors/PowerPC/certification.manifest
@@ -40,6 +40,7 @@ data/languages/ppc_32_quicciii_be.slaspec||GHIDRA||||END|
 data/languages/ppc_32_quicciii_le.slaspec||GHIDRA||||END|
 data/languages/ppc_64.pspec||GHIDRA||||END|
 data/languages/ppc_64_32.cspec||GHIDRA||||END|
+data/languages/ppc_64_32_eabi.cspec||GHIDRA||||END|
 data/languages/ppc_64_be.cspec||GHIDRA||||END|
 data/languages/ppc_64_be.slaspec||GHIDRA||||END|
 data/languages/ppc_64_be_Mac.cspec||GHIDRA||||END|

--- a/Ghidra/Processors/PowerPC/data/languages/ppc.ldefs
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc.ldefs
@@ -370,6 +370,7 @@
     <description>Power ISA 3.0 Big Endian w/VLE, EVX and 32-bit Addressing </description>
     <truncate_space space="ram" size="4"/>
     <compiler name="default" spec="ppc_64_32.cspec" id="default"/>
+    <compiler name="EABI" spec="ppc_64_32_eabi.cspec" id="eabi"/>
     <external_name tool="IDA-PRO" name="ppc"/>
     <external_name tool="DWARF.register.mapping.file" name="ppc.dwarf"/>
   </language>

--- a/Ghidra/Processors/PowerPC/data/languages/ppc_64_32_eabi.cspec
+++ b/Ghidra/Processors/PowerPC/data/languages/ppc_64_32_eabi.cspec
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- PowerPC EABI variant of the 32-bit ABI implemented for 64-bit code.
+     Matches the Freescale/NXP Embedded ABI convention used by MPC5500/MPC55xx/MPC56xx
+     and other embedded PowerPC parts: r2 holds _SDA2_BASE_ (read-only small data anchor)
+     and r13 holds _SDA_BASE_ (read-write small data anchor). Both are preserved across
+     calls so the decompiler must treat them as unaffected.
+-->
+<compiler_spec>
+  <global>
+    <range space="ram"/>
+  </global>
+  <data_organization>
+	<pointer_size value="4"/>
+  </data_organization>
+  <aggressivetrim signext="true"/>  <!-- Pointers are 4-bytes but are held in 8-byte registers -->
+  <stackpointer register="r1" space="ram"/>
+  <default_proto>
+    <prototype name="__stdcall" extrapop="0" stackshift="0">
+      <input>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f1"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f2"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f3"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f4"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f5"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f6"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f7"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f8"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f9"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f10"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f11"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f12"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f13"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r3"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r4"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r5"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r6"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r7"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r8"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r9"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r10"/>
+        </pentry>
+        <pentry minsize="1" maxsize="500" align="4">
+          <addr offset="8" space="stack"/>
+        </pentry>
+      </input>
+      <output>
+        <pentry minsize="1" maxsize="8" metatype="float" extension="float">
+          <register name="f1"/>
+        </pentry>
+        <pentry minsize="1" maxsize="8" extension="sign">
+          <register name="r3"/>
+        </pentry>
+      </output>
+      <unaffected>
+        <register name="r2"/>  <!-- _SDA2_BASE_ -->
+        <register name="r13"/> <!-- _SDA_BASE_  -->
+        <register name="r14"/>
+        <register name="r15"/>
+        <register name="r16"/>
+        <register name="r17"/>
+        <register name="r18"/>
+        <register name="r19"/>
+        <register name="r20"/>
+        <register name="r21"/>
+        <register name="r22"/>
+        <register name="r23"/>
+        <register name="r24"/>
+        <register name="r25"/>
+        <register name="r26"/>
+        <register name="r27"/>
+        <register name="r28"/>
+        <register name="r29"/>
+        <register name="r30"/>
+        <register name="r31"/>
+        <register name="r1"/>
+        <register name="cr4"/>
+      </unaffected>
+    </prototype>
+  </default_proto>
+
+  <callfixup name="get_pc_thunk_lr">
+    <pcode>
+      <body><![CDATA[
+      LR = inst_dest + 4;
+      ]]></body>
+    </pcode>
+  </callfixup>
+
+</compiler_spec>


### PR DESCRIPTION
This change adds a new compiler spec and processor option for the PPC 64-32 SoC used in many embedded applications. The relevant change from other PPC64 specs is the use of r2 and r13 for local data and branch control. More details are available in  the freescale docs.

https://www.nxp.com/docs/en/application-note/PPCEABI.pdf

With this config, BookE and other cores are easily decoded. It has been tested on MPC5534 firmwares.

