### PR TITLE
Decompiler: Add builtin_memset optimizations

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.cc
@@ -429,26 +429,21 @@ PcodeOp *StringSequence::buildFill(void)
     return (PcodeOp *)0;
   PcodeOp *insertPoint = moveOps[0].op;
   Architecture *glb = data.getArch();
-  uint4 builtInId = (fillVal == 0) ? UserPcodeOp::BUILTIN_BZERO : UserPcodeOp::BUILTIN_MEMSET;
+  uint4 builtInId = UserPcodeOp::BUILTIN_MEMSET;
   glb->userops.registerBuiltin(builtInId);
-  int4 numInputs = (fillVal == 0) ? 3 : 4;
-  PcodeOp *fillOp = data.newOp(numInputs, insertPoint->getAddr());
+  PcodeOp *fillOp = data.newOp(4, insertPoint->getAddr());
   data.opSetOpcode(fillOp, CPUI_CALLOTHER);
   data.opSetInput(fillOp, data.newConstant(4, builtInId), 0);
   Varnode *destPtr = constructTypedPointer(insertPoint);
   data.opSetInput(fillOp, destPtr, 1);
   if (destPtr->getType()->needsResolution())
     data.inheritUnionFieldPtr(destPtr->getType(), fillOp, 1, insertPoint, -1);
-  int4 lenSlot = 2;
-  if (fillVal != 0) {
-    Varnode *valVn = data.newConstant(4, fillVal);
-    valVn->updateType(fillOp->inputTypeLocal(2));
-    data.opSetInput(fillOp, valVn, 2);
-    lenSlot = 3;
-  }
+  Varnode *valVn = data.newConstant(4, fillVal);
+  valVn->updateType(fillOp->inputTypeLocal(2));
+  data.opSetInput(fillOp, valVn, 2);
   Varnode *lenVn = data.newConstant(4, moveOps.size() * charType->getSize());
-  lenVn->updateType(fillOp->inputTypeLocal(lenSlot));
-  data.opSetInput(fillOp, lenVn, lenSlot);
+  lenVn->updateType(fillOp->inputTypeLocal(3));
+  data.opSetInput(fillOp, lenVn, 3);
   data.opInsertBefore(fillOp, insertPoint);
   return fillOp;
 }
@@ -906,23 +901,18 @@ PcodeOp *HeapSequence::buildFill(void)
     if (basePointer->getType()->needsResolution())
       data.inheritUnionField(basePointer->getType(), ptrAdd, 0, immedRead, immedRead->getSlot(basePointer));
   }
-  uint4 builtInId = (fillVal == 0) ? UserPcodeOp::BUILTIN_BZERO : UserPcodeOp::BUILTIN_MEMSET;
+  uint4 builtInId = UserPcodeOp::BUILTIN_MEMSET;
   glb->userops.registerBuiltin(builtInId);
-  int4 numInputs = (fillVal == 0) ? 3 : 4;
-  PcodeOp *fillOp = data.newOp(numInputs, insertPoint->getAddr());
+  PcodeOp *fillOp = data.newOp(4, insertPoint->getAddr());
   data.opSetOpcode(fillOp, CPUI_CALLOTHER);
   data.opSetInput(fillOp, data.newConstant(4, builtInId), 0);
   data.opSetInput(fillOp, destPtr, 1);
-  int4 lenSlot = 2;
-  if (fillVal != 0) {
-    Varnode *valVn = data.newConstant(4, fillVal);
-    valVn->updateType(fillOp->inputTypeLocal(2));
-    data.opSetInput(fillOp, valVn, 2);
-    lenSlot = 3;
-  }
+  Varnode *valVn = data.newConstant(4, fillVal);
+  valVn->updateType(fillOp->inputTypeLocal(2));
+  data.opSetInput(fillOp, valVn, 2);
   Varnode *lenVn = data.newConstant(4, moveOps.size() * charType->getSize());
-  lenVn->updateType(fillOp->inputTypeLocal(lenSlot));
-  data.opSetInput(fillOp, lenVn, lenSlot);
+  lenVn->updateType(fillOp->inputTypeLocal(3));
+  data.opSetInput(fillOp, lenVn, 3);
   data.opInsertBefore(fillOp, insertPoint);
   if (destPtr->getType()->needsResolution())
     data.inheritUnionField(destPtr->getType(), fillOp, 1, immedRead, immedRead->getSlot(destPtr));

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.cc
@@ -154,6 +154,29 @@ int4 ArraySequence::formByteArray(int4 sz,int4 slot,uint8 rootOff,bool bigEndian
   return count;
 }
 
+/// Check if all collected writes set every byte of the element to the same byte value.
+/// \param slot is the input slot holding the constant value
+/// \param val will hold the repeated byte value
+/// \return \b true if the sequence is a byte fill
+bool ArraySequence::isFill(int4 slot,uint1 &val) const
+
+{
+  if (moveOps.empty()) return false;
+  int4 elSize = charType->getSize();
+  uint8 mask = calc_mask(elSize);
+  uint8 firstVal = moveOps[0].op->getIn(slot)->getOffset() & mask;
+  val = (uint1)(firstVal & 0xff);
+  uint8 fillVal = 0;
+  for(int4 i=0;i<elSize;++i)
+    fillVal = (fillVal << 8) | val;
+  for(int4 i=0;i<moveOps.size();++i) {
+    uint8 curVal = moveOps[i].op->getIn(slot)->getOffset() & mask;
+    if (curVal != fillVal)
+      return false;
+  }
+  return true;
+}
+
 /// Use the \b charType to select the appropriate string copying function.  If a match to the \b charType
 /// doesn't exist, use a built-in \b memcpy function.  The id of the selected built-in function is returned.
 /// The value indicating either the number of characters or number of bytes being copied is also passed back.
@@ -194,8 +217,6 @@ StringSequence::StringSequence(Funcdata &fdata,Datatype *ct,SymbolEntry *ent,Pco
     return;
   int8 off = rootAddr.getOffset() - entry->getFirst();
   if (off >= entry->getSize())
-    return;
-  if (rootOp->getIn(0)->getOffset() == 0)
     return;
   Datatype *parentType = entry->getSymbol()->getType();
   Datatype *arrayType = (Datatype *)0;
@@ -367,6 +388,9 @@ Varnode *StringSequence::constructTypedPointer(PcodeOp *insertPoint)
 PcodeOp *StringSequence::buildStringCopy(void)
 
 {
+  PcodeOp *fillOp = buildFill();
+  if (fillOp != (PcodeOp *)0)
+    return fillOp;
   PcodeOp *insertPoint = moveOps[0].op;		// Earliest COPY in the block
   int4 numBytes = moveOps.size() * charType->getSize();
   Architecture *glb = data.getArch();
@@ -391,6 +415,42 @@ PcodeOp *StringSequence::buildStringCopy(void)
   data.opSetInput(copyOp, lenVn, 3);
   data.opInsertBefore(copyOp, insertPoint);
   return copyOp;
+}
+
+/// A built-in user-op that fills the destination with a repeated byte value is created.
+/// \return the constructed PcodeOp representing the fill, or null if this is not a fill
+PcodeOp *StringSequence::buildFill(void)
+
+{
+  uint1 fillVal;
+  if (!isFill(0, fillVal))
+    return (PcodeOp *)0;
+  if (fillVal >= 0x20 && fillVal < 0x7f)
+    return (PcodeOp *)0;
+  PcodeOp *insertPoint = moveOps[0].op;
+  Architecture *glb = data.getArch();
+  uint4 builtInId = (fillVal == 0) ? UserPcodeOp::BUILTIN_BZERO : UserPcodeOp::BUILTIN_MEMSET;
+  glb->userops.registerBuiltin(builtInId);
+  int4 numInputs = (fillVal == 0) ? 3 : 4;
+  PcodeOp *fillOp = data.newOp(numInputs, insertPoint->getAddr());
+  data.opSetOpcode(fillOp, CPUI_CALLOTHER);
+  data.opSetInput(fillOp, data.newConstant(4, builtInId), 0);
+  Varnode *destPtr = constructTypedPointer(insertPoint);
+  data.opSetInput(fillOp, destPtr, 1);
+  if (destPtr->getType()->needsResolution())
+    data.inheritUnionFieldPtr(destPtr->getType(), fillOp, 1, insertPoint, -1);
+  int4 lenSlot = 2;
+  if (fillVal != 0) {
+    Varnode *valVn = data.newConstant(4, fillVal);
+    valVn->updateType(fillOp->inputTypeLocal(2));
+    data.opSetInput(fillOp, valVn, 2);
+    lenSlot = 3;
+  }
+  Varnode *lenVn = data.newConstant(4, moveOps.size() * charType->getSize());
+  lenVn->updateType(fillOp->inputTypeLocal(lenSlot));
+  data.opSetInput(fillOp, lenVn, lenSlot);
+  data.opInsertBefore(fillOp, insertPoint);
+  return fillOp;
 }
 
 /// \brief Analyze output descendants of the given PcodeOp being removed
@@ -721,6 +781,9 @@ bool HeapSequence::collectStoreOps(void)
 PcodeOp *HeapSequence::buildStringCopy(void)
 
 {
+  PcodeOp *fillOp = buildFill();
+  if (fillOp != (PcodeOp *)0)
+    return fillOp;
   PcodeOp *insertPoint = moveOps[0].op;		// Earliest STORE in the block
   Datatype *charPtrType = rootOp->getIn(1)->getTypeReadFacing(rootOp);
   int4 numBytes = numElements * charType->getSize();
@@ -786,6 +849,84 @@ PcodeOp *HeapSequence::buildStringCopy(void)
   if (destPtr->getType()->needsResolution())
     data.inheritUnionField(destPtr->getType(), copyOp, 1, immedRead, immedRead->getSlot(destPtr));
   return copyOp;
+}
+
+/// A built-in user-op that fills the destination with a repeated byte value is created.
+/// \return the constructed PcodeOp representing the fill, or null if this is not a fill
+PcodeOp *HeapSequence::buildFill(void)
+
+{
+  uint1 fillVal;
+  if (!isFill(2, fillVal))
+    return (PcodeOp *)0;
+  if (fillVal >= 0x20 && fillVal < 0x7f)
+    return (PcodeOp *)0;
+  PcodeOp *insertPoint = moveOps[0].op;
+  Architecture *glb = data.getArch();
+  Varnode *destPtr = basePointer;
+  if (baseOffset != 0 || !nonConstAdds.empty()) {
+    Varnode *indexVn = (Varnode *)0;
+    Datatype *intType = glb->types->getBase(basePointer->getSize(), TYPE_INT);
+    if (nonConstAdds.size() > 0) {
+      indexVn = nonConstAdds[0];
+      for(int4 i=1;i<nonConstAdds.size();++i) {
+	PcodeOp *addOp = data.newOp(2,insertPoint->getAddr());
+	data.opSetOpcode(addOp, CPUI_INT_ADD);
+	data.opSetInput(addOp, indexVn, 0);
+	data.opSetInput(addOp, nonConstAdds[i],1);
+	indexVn = data.newUniqueOut(indexVn->getSize(), addOp);
+	indexVn->updateType(intType);
+	data.opInsertBefore(addOp, insertPoint);
+      }
+    }
+    if (baseOffset != 0) {
+      uint8 numEl = baseOffset / charType->getAlignSize();
+      Varnode *cvn = data.newConstant(basePointer->getSize(), numEl);
+      cvn->updateType(intType);
+      if (indexVn == (Varnode *)0)
+	indexVn = cvn;
+      else {
+	PcodeOp *addOp = data.newOp(2,insertPoint->getAddr());
+	data.opSetOpcode(addOp, CPUI_INT_ADD);
+	data.opSetInput(addOp, indexVn, 0);
+	data.opSetInput(addOp, cvn,1);
+	indexVn = data.newUniqueOut(indexVn->getSize(), addOp);
+	indexVn->updateType(intType);
+	data.opInsertBefore(addOp, insertPoint);
+      }
+    }
+    PcodeOp *ptrAdd = data.newOp(3,insertPoint->getAddr());
+    data.opSetOpcode(ptrAdd, CPUI_PTRADD);
+    destPtr = data.newUniqueOut(basePointer->getSize(), ptrAdd);
+    data.opSetInput(ptrAdd,basePointer,0);
+    data.opSetInput(ptrAdd,indexVn,1);
+    data.opSetInput(ptrAdd,data.newConstant(basePointer->getSize(), charType->getAlignSize()),2);
+    destPtr->updateType(rootOp->getIn(1)->getTypeReadFacing(rootOp));
+    data.opInsertBefore(ptrAdd, insertPoint);
+    if (basePointer->getType()->needsResolution())
+      data.inheritUnionField(basePointer->getType(), ptrAdd, 0, immedRead, immedRead->getSlot(basePointer));
+  }
+  uint4 builtInId = (fillVal == 0) ? UserPcodeOp::BUILTIN_BZERO : UserPcodeOp::BUILTIN_MEMSET;
+  glb->userops.registerBuiltin(builtInId);
+  int4 numInputs = (fillVal == 0) ? 3 : 4;
+  PcodeOp *fillOp = data.newOp(numInputs, insertPoint->getAddr());
+  data.opSetOpcode(fillOp, CPUI_CALLOTHER);
+  data.opSetInput(fillOp, data.newConstant(4, builtInId), 0);
+  data.opSetInput(fillOp, destPtr, 1);
+  int4 lenSlot = 2;
+  if (fillVal != 0) {
+    Varnode *valVn = data.newConstant(4, fillVal);
+    valVn->updateType(fillOp->inputTypeLocal(2));
+    data.opSetInput(fillOp, valVn, 2);
+    lenSlot = 3;
+  }
+  Varnode *lenVn = data.newConstant(4, moveOps.size() * charType->getSize());
+  lenVn->updateType(fillOp->inputTypeLocal(lenSlot));
+  data.opSetInput(fillOp, lenVn, lenSlot);
+  data.opInsertBefore(fillOp, insertPoint);
+  if (destPtr->getType()->needsResolution())
+    data.inheritUnionField(destPtr->getType(), fillOp, 1, immedRead, immedRead->getSlot(destPtr));
+  return fillOp;
 }
 
 /// \brief Gather INDIRECT ops attached to the final sequence STOREs and their input/output Varnode pairs

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.hh
@@ -51,6 +51,7 @@ protected:
   static bool interfereBetween(PcodeOp *startOp,PcodeOp *endOp);	///< Check for interfering ops between the two given ops
   bool checkInterference(void);	///< Find maximal set of ops containing the root with no interfering ops in between
   int4 formByteArray(int4 sz,int4 slot,uint8 rootOff,bool bigEndian);	///< Put constant values from COPYs into a single byte array
+  bool isFill(int4 slot,uint1 &val) const;	///< Return true if all constants write the same byte value
   uint4 selectStringCopyFunction(int4 &index);	///< Pick either strncpy, wcsncpy, or memcpy function used to copy string
 public:
   ArraySequence(Funcdata &fdata,Datatype *ct,PcodeOp *root);	///< Constructor
@@ -68,6 +69,7 @@ class StringSequence : public ArraySequence {
   Address startAddr;		///< Starting address of the memory region
   SymbolEntry *entry;		///< Symbol at the root Address
   bool collectCopyOps(int size);	///< Collect ops COPYing constants into the memory region
+  PcodeOp *buildFill(void);		///< Build the bzero or memset function for repeated byte values
   PcodeOp *buildStringCopy(void);	///< Build the strncpy,wcsncpy, or memcpy function with string as input
   static void removeForward(const WriteNode &curNode,map<PcodeOp *,list<WriteNode>::iterator> &xref,
 			    list<WriteNode> &points,vector<WriteNode> &deadOps);
@@ -108,6 +110,7 @@ class HeapSequence : public ArraySequence {
   static bool setsEqual(const vector<Varnode *> &op1,const vector<Varnode *> &op2);
   bool testValue(PcodeOp *op);		///< Test if a STORE value has the matching form for the sequence
   bool collectStoreOps(void);		///< Collect ops STOREing into a memory region from the same root pointer
+  PcodeOp *buildFill(void);		///< Build the bzero or memset function for repeated byte values
   PcodeOp *buildStringCopy(void);	///< Build the strncpy,wcsncpy, or memcpy function with string as input
   void gatherIndirectPairs(vector<PcodeOp *> &indirects,vector<IndirectPair> &pairs);
   bool deduplicatePairs(vector<IndirectPair> &pairs);	///< Find and eliminate duplicate INDIRECT pairs

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/constseq.hh
@@ -69,7 +69,7 @@ class StringSequence : public ArraySequence {
   Address startAddr;		///< Starting address of the memory region
   SymbolEntry *entry;		///< Symbol at the root Address
   bool collectCopyOps(int size);	///< Collect ops COPYing constants into the memory region
-  PcodeOp *buildFill(void);		///< Build the bzero or memset function for repeated byte values
+  PcodeOp *buildFill(void);		///< Build the memset function for repeated byte values
   PcodeOp *buildStringCopy(void);	///< Build the strncpy,wcsncpy, or memcpy function with string as input
   static void removeForward(const WriteNode &curNode,map<PcodeOp *,list<WriteNode>::iterator> &xref,
 			    list<WriteNode> &points,vector<WriteNode> &deadOps);
@@ -110,7 +110,7 @@ class HeapSequence : public ArraySequence {
   static bool setsEqual(const vector<Varnode *> &op1,const vector<Varnode *> &op2);
   bool testValue(PcodeOp *op);		///< Test if a STORE value has the matching form for the sequence
   bool collectStoreOps(void);		///< Collect ops STOREing into a memory region from the same root pointer
-  PcodeOp *buildFill(void);		///< Build the bzero or memset function for repeated byte values
+  PcodeOp *buildFill(void);		///< Build the memset function for repeated byte values
   PcodeOp *buildStringCopy(void);	///< Build the strncpy,wcsncpy, or memcpy function with string as input
   void gatherIndirectPairs(vector<PcodeOp *> &indirects,vector<IndirectPair> &pairs);
   bool deduplicatePairs(vector<IndirectPair> &pairs);	///< Find and eliminate duplicate INDIRECT pairs

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/userop.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/userop.cc
@@ -33,6 +33,8 @@ const uint4 UserPcodeOp::BUILTIN_VOLATILE_WRITE = 0x10000002;
 const uint4 UserPcodeOp::BUILTIN_MEMCPY = 0x10000003;
 const uint4 UserPcodeOp::BUILTIN_STRNCPY = 0x10000004;
 const uint4 UserPcodeOp::BUILTIN_WCSNCPY = 0x10000005;
+const uint4 UserPcodeOp::BUILTIN_BZERO = 0x10000006;
+const uint4 UserPcodeOp::BUILTIN_MEMSET = 0x10000007;
 
 int4 UserPcodeOp::extractAnnotationSize(const Varnode *vn,const PcodeOp *op)
 
@@ -474,6 +476,26 @@ UserPcodeOp *UserOpManage::registerBuiltin(uint4 i)
       Datatype *ptrType = glb->types->getTypePointer(ptrSize,cType,wordSize);
       Datatype *intType = glb->types->getBase(4,TYPE_INT);
       res = new DatatypeUserOp("builtin_wcsncpy",glb,UserPcodeOp::BUILTIN_WCSNCPY,ptrType,ptrType,ptrType,intType);
+      break;
+    }
+    case UserPcodeOp::BUILTIN_BZERO:
+    {
+      int4 ptrSize = glb->types->getSizeOfPointer();
+      int4 wordSize = glb->getDefaultDataSpace()->getWordSize();
+      Datatype *vType = glb->types->getTypeVoid();
+      Datatype *ptrType = glb->types->getTypePointer(ptrSize,vType,wordSize);
+      Datatype *intType = glb->types->getBase(4,TYPE_INT);
+      res = new DatatypeUserOp("builtin_bzero",glb,UserPcodeOp::BUILTIN_BZERO,vType,ptrType,intType);
+      break;
+    }
+    case UserPcodeOp::BUILTIN_MEMSET:
+    {
+      int4 ptrSize = glb->types->getSizeOfPointer();
+      int4 wordSize = glb->getDefaultDataSpace()->getWordSize();
+      Datatype *vType = glb->types->getTypeVoid();
+      Datatype *ptrType = glb->types->getTypePointer(ptrSize,vType,wordSize);
+      Datatype *intType = glb->types->getBase(4,TYPE_INT);
+      res = new DatatypeUserOp("builtin_memset",glb,UserPcodeOp::BUILTIN_MEMSET,ptrType,ptrType,intType,intType);
       break;
     }
     default:

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/userop.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/userop.cc
@@ -33,8 +33,7 @@ const uint4 UserPcodeOp::BUILTIN_VOLATILE_WRITE = 0x10000002;
 const uint4 UserPcodeOp::BUILTIN_MEMCPY = 0x10000003;
 const uint4 UserPcodeOp::BUILTIN_STRNCPY = 0x10000004;
 const uint4 UserPcodeOp::BUILTIN_WCSNCPY = 0x10000005;
-const uint4 UserPcodeOp::BUILTIN_BZERO = 0x10000006;
-const uint4 UserPcodeOp::BUILTIN_MEMSET = 0x10000007;
+const uint4 UserPcodeOp::BUILTIN_MEMSET = 0x10000006;
 
 int4 UserPcodeOp::extractAnnotationSize(const Varnode *vn,const PcodeOp *op)
 
@@ -476,16 +475,6 @@ UserPcodeOp *UserOpManage::registerBuiltin(uint4 i)
       Datatype *ptrType = glb->types->getTypePointer(ptrSize,cType,wordSize);
       Datatype *intType = glb->types->getBase(4,TYPE_INT);
       res = new DatatypeUserOp("builtin_wcsncpy",glb,UserPcodeOp::BUILTIN_WCSNCPY,ptrType,ptrType,ptrType,intType);
-      break;
-    }
-    case UserPcodeOp::BUILTIN_BZERO:
-    {
-      int4 ptrSize = glb->types->getSizeOfPointer();
-      int4 wordSize = glb->getDefaultDataSpace()->getWordSize();
-      Datatype *vType = glb->types->getTypeVoid();
-      Datatype *ptrType = glb->types->getTypePointer(ptrSize,vType,wordSize);
-      Datatype *intType = glb->types->getBase(4,TYPE_INT);
-      res = new DatatypeUserOp("builtin_bzero",glb,UserPcodeOp::BUILTIN_BZERO,vType,ptrType,intType);
       break;
     }
     case UserPcodeOp::BUILTIN_MEMSET:

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/userop.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/userop.hh
@@ -69,6 +69,8 @@ public:
   static const uint4 BUILTIN_MEMCPY;		///< Built-in id for memcpy
   static const uint4 BUILTIN_STRNCPY;		///< Built-in id for strcpy
   static const uint4 BUILTIN_WCSNCPY;		///< Built-in id for wcsncpy
+  static const uint4 BUILTIN_BZERO;		///< Built-in id for bzero
+  static const uint4 BUILTIN_MEMSET;		///< Built-in id for memset
 protected:
   string name;			///< Low-level name of p-code operator
   Architecture *glb;		///< Architecture owning the user defined op

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/userop.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/userop.hh
@@ -69,7 +69,6 @@ public:
   static const uint4 BUILTIN_MEMCPY;		///< Built-in id for memcpy
   static const uint4 BUILTIN_STRNCPY;		///< Built-in id for strcpy
   static const uint4 BUILTIN_WCSNCPY;		///< Built-in id for wcsncpy
-  static const uint4 BUILTIN_BZERO;		///< Built-in id for bzero
   static const uint4 BUILTIN_MEMSET;		///< Built-in id for memset
 protected:
   string name;			///< Low-level name of p-code operator


### PR DESCRIPTION
Add decompiler built-ins for builtin_bzero and builtin_memset, which extends the constant sequence/string copy optimization pass, detecting repeated byte writes and collapse zero-filled or constant-filled memory regions (including patterns like zeroed buffers and non-printable fill bytes such as 0xAA) into the appropriate calls for improved output.

Closes #9230.