### PR TITLE
Fix RISC-V division and remainder by zero emulation behavior

### DIFF
--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv32m.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv32m.sinc
@@ -3,6 +3,10 @@
 # div d,s,t 02004033 fe00707f SIMPLE (0, 0) 
 :div rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x4 & funct7=0x1
 {
+	if (rs2 != 0) goto <do_div>;
+	rd = -1;
+	goto inst_next;
+<do_div>
 	rd = rs1 s/ rs2;
 }
 
@@ -10,6 +14,10 @@
 # divu d,s,t 02005033 fe00707f SIMPLE (0, 0) 
 :divu rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x5 & funct7=0x1
 {
+	if (rs2 != 0) goto <do_divu>;
+	rd = -1;
+	goto inst_next;
+<do_divu>
 	rd = rs1 / rs2;
 }
 
@@ -54,6 +62,10 @@
 # rem d,s,t 02006033 fe00707f SIMPLE (0, 0) 
 :rem rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x6 & funct7=0x1
 {
+	if (rs2 != 0) goto <do_rem>;
+	rd = rs1;
+	goto inst_next;
+<do_rem>
 	rd = rs1 s% rs2;
 }
 
@@ -61,5 +73,9 @@
 # remu d,s,t 02007033 fe00707f SIMPLE (0, 0) 
 :remu rd,rs1,rs2 is rs1 & rs2 & rd & op0001=0x3 & op0204=0x4 & op0506=0x1 & funct3=0x7 & funct7=0x1
 {
+	if (rs2 != 0) goto <do_remu>;
+	rd = rs1;
+	goto inst_next;
+<do_remu>
 	rd = rs1 % rs2;
 }

--- a/Ghidra/Processors/RISCV/data/languages/riscv.rv64m.sinc
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.rv64m.sinc
@@ -5,6 +5,10 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	if (tmpr2 != 0) goto <do_divuw>;
+	rd = -1;
+	goto inst_next;
+<do_divuw>
 	rd = sext(tmpr1 / tmpr2);
 }
 
@@ -14,6 +18,10 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	if (tmpr2 != 0) goto <do_divw>;
+	rd = -1;
+	goto inst_next;
+<do_divw>
 	rd = sext(tmpr1 s/ tmpr2);
 }
 
@@ -31,6 +39,10 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	if (tmpr2 != 0) goto <do_remuw>;
+	rd = sext(tmpr1);
+	goto inst_next;
+<do_remuw>
 	rd = sext(tmpr1 % tmpr2);
 }
 
@@ -40,5 +52,9 @@
 {
 	local tmpr1:4 = rs1:4;
 	local tmpr2:4 = rs2:4;
+	if (tmpr2 != 0) goto <do_remw>;
+	rd = sext(tmpr1);
+	goto inst_next;
+<do_remw>
 	rd = sext(tmpr1 s% tmpr2);
 }


### PR DESCRIPTION
Update the RISC-V M-extension Sleigh semantics for integer division and remainder instructions so that they correctly implement the ISA-specified behaviour for divide-by-zero cases. Currently, instructions such as div, divu, rem, remu, along with their RV64 word variants, may fall back to raw pcode division/remainder operations. This causes unintended emulator exceptions instead of producing the defined architectural results. This change ensures that divide-by-zero conditions are handled explicitly in accordance with the RISC-V specification.

Closes #9225 