### PR TITLE
Annotation: Adjust Variable Handler

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/VariableAnnotatedStringHandler.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/VariableAnnotatedStringHandler.java
@@ -251,9 +251,14 @@ public class VariableAnnotatedStringHandler implements AnnotatedStringHandler {
 		return null;
 	}
 
+	/* Only local addresses, such as Stack, register, and HASH need to be supported. */
 	private static Address toAddress(Program p, String s) {
 		AddressFactory af = p.getAddressFactory();
-		return af.getAddress(s);
+		Address addr = af.getAddress(s);
+		if (addr == null) {
+			return null;
+		}
+		return addr.isMemoryAddress() ? null : addr;
 	}
 
 	private static interface VariableMatcher {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/viewer/field/AnnotationTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/viewer/field/AnnotationTest.java
@@ -48,8 +48,7 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressFactory;
 import ghidra.program.model.data.UnsignedIntegerDataType;
 import ghidra.program.model.data.VoidDataType;
-import ghidra.program.model.listing.Function;
-import ghidra.program.model.listing.Program;
+import ghidra.program.model.listing.*;
 import ghidra.program.model.mem.Memory;
 import ghidra.program.model.symbol.*;
 import ghidra.program.util.LabelFieldLocation;
@@ -87,9 +86,11 @@ public class AnnotationTest extends AbstractGhidraHeadedIntegrationTest {
 		builder.createLabel("1001018", "mySym{0}"); // symbol with braces
 		builder.createLabel("1001022", "mySym\\{0\\}"); // symbol with braces escaped
 
+		Parameter p = new ParameterImpl("deadbeef", UnsignedIntegerDataType.dataType, builder.getProgram());
 		Function myFunction =
-			builder.createEmptyFunction("MyFunction", "1002000", 0x10, VoidDataType.dataType);
+			builder.createEmptyFunction("MyFunction", "1002000", 0x10, VoidDataType.dataType, p);
 		builder.createLocalVariable(myFunction, "myVariable", UnsignedIntegerDataType.dataType, 10);
+		builder.createLocalVariable(myFunction, "ram:deadbeef", UnsignedIntegerDataType.dataType, 14);
 
 		return builder.getProgram();
 	}
@@ -758,6 +759,20 @@ public class AnnotationTest extends AbstractGhidraHeadedIntegrationTest {
 	}
 
 	@Test
+	public void testVariableAnnotation_BasicModify_ImplicitAddressName() {
+		String rawComment = "{@variable deadbeef MyFunction}";
+		String display = CommentUtils.fixupAnnotations(rawComment, program, Address.NO_ADDRESS);
+		assertEquals("{@variable register:1030 01002000}", display);
+	}
+
+	@Test
+	public void testVariableAnnotation_BasicModify_ExplicitAddressName() {
+		String rawComment = "{@variable ram:deadbeef MyFunction}";
+		String display = CommentUtils.fixupAnnotations(rawComment, program, Address.NO_ADDRESS);
+		assertEquals("{@variable Stack[0xe] 01002000}", display);
+	}
+
+	@Test
 	public void testLocalAnnotation_VariableAddress() {
 		String rawComment = "{@variable Stack[0xa] MyFunction}";
 		String display = CommentUtils.fixupAnnotations(rawComment, program, Address.NO_ADDRESS);
@@ -771,6 +786,13 @@ public class AnnotationTest extends AbstractGhidraHeadedIntegrationTest {
 		Address entryPoint = addr(functionAddress);
 		String display = CommentUtils.fixupAnnotations(rawComment, program, entryPoint);
 		assertEquals("{@variable Stack[0xa] 01002000}", display);
+	}
+
+	@Test
+	public void testLocalAnnotation_RegisterAddress() {
+		String rawComment = "{@variable register:1030 MyFunction}";
+		String display = CommentUtils.fixupAnnotations(rawComment, program, Address.NO_ADDRESS);
+		assertEquals("{@variable register:1030 01002000}", display);
 	}
 
 	@Test


### PR DESCRIPTION
Reduce the supported address set to exclude non-local addresses.
Currently, Variable Annotations support `abcde` and other hex values as valid addresses, but will show an error when rendering:
```
Annotation Exception: Could not find variable at address main in function abcde
```
These addresses are already handled by Symbol Annotations.