### PR TITLE
[fix] Preserve typed external data references in decompiler

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.cc
@@ -769,12 +769,16 @@ void LabSymbol::decode(Decoder &decoder)
 }
 
 /// Build name, type, and flags based on the placeholder address
-void ExternRefSymbol::buildNameType(void)
+void ExternRefSymbol::buildNameType(Datatype *ct)
 
 {
   TypeFactory *typegrp = scope->getArch()->types;
-  type = typegrp->getTypeCode();
-  type = typegrp->getTypePointer(refaddr.getAddrSize(),type,refaddr.getSpace()->getWordSize());
+  if (ct != (Datatype *)0)
+    type = ct;
+  else {
+    type = typegrp->getTypeCode();
+    type = typegrp->getTypePointer(refaddr.getAddrSize(),type,refaddr.getSpace()->getWordSize());
+  }
   if (name.size() == 0) {	// If a name was not already provided
     ostringstream s;		// Give the reference a unique name
     s << refaddr.getShortcut();
@@ -821,8 +825,12 @@ void ExternRefSymbol::decode(Decoder &decoder)
       displayName = decoder.readString();
   }
   refaddr = Address::decode(decoder);
+  Datatype *ct = (Datatype *)0;
+  // External data references may include a type supplied by the Ghidra callback.
+  if (decoder.peekElement() != 0)
+    ct = scope->getArch()->types->decodeType(decoder);
   decoder.closeElement(elemId);
-  buildNameType();
+  buildNameType(ct);
 }
 
 /// The iterator is advanced by one

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/database.hh
@@ -346,7 +346,7 @@ public:
 /// meta-data on.
 class ExternRefSymbol : public Symbol {
   Address refaddr;			///< The \e placeholder address for meta-data
-  void buildNameType(void);		///< Create a name and data-type for the Symbol
+  void buildNameType(Datatype *ct=(Datatype *)0);	///< Create a name and data-type for the Symbol
   virtual ~ExternRefSymbol(void) {}
 public:
   ExternRefSymbol(Scope *sc,const Address &ref,const string &nm);	///< Construct given a \e placeholder address

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileCallback.java
@@ -67,6 +67,20 @@ public class DecompileCallback {
 		}
 	}
 
+	/**
+	 * Keeps the local import pointer data with its external reference, since the listing data may
+	 * carry type information that is not stored on the ExternalLocation.
+	 */
+	private static class ExternalReferenceData {
+		private final ExternalReference reference;
+		private final Data pointerData;
+
+		ExternalReferenceData(ExternalReference reference, Data pointerData) {
+			this.reference = reference;
+			this.pointerData = pointerData;
+		}
+	}
+
 	private DecompileDebug debug;
 	private Program program;
 	private Listing listing;
@@ -664,8 +678,8 @@ public class DecompileCallback {
 				encodeHole(resultEncoder, addr);
 			}
 		}
-		else if (obj instanceof ExternalReference) {
-			encodeExternalRef(resultEncoder, addr, (ExternalReference) obj);
+		else if (obj instanceof ExternalReferenceData) {
+			encodeExternalRef(resultEncoder, addr, (ExternalReferenceData) obj);
 		}
 		else if (obj instanceof Symbol) {
 			encodeLabel(resultEncoder, (Symbol) obj, addr);
@@ -687,8 +701,9 @@ public class DecompileCallback {
 			func = cachedFunction;
 		}
 		else {
-			ExternalReference extRef = getExternalReference(addr);
-			if (extRef != null) {
+			ExternalReferenceData extRefData = getExternalReferenceData(addr);
+			if (extRefData != null) {
+				ExternalReference extRef = extRefData.reference;
 				func = listing.getFunctionAt(extRef.getToAddress());
 				if (func == null) {
 					Symbol symbol = extRef.getExternalLocation().getSymbol();
@@ -999,7 +1014,7 @@ public class DecompileCallback {
 			addr.getUnsignedOffset(), mutability);
 	}
 
-	private void encodeExternalRef(Encoder encoder, Address addr, ExternalReference ref)
+	private void encodeExternalRef(Encoder encoder, Address addr, ExternalReferenceData refData)
 			throws IOException {
 		// The decompiler model was to assume that the ExternalReference
 		// object could resolve the physical address where the dll
@@ -1014,8 +1029,45 @@ public class DecompileCallback {
 		// the address of the reference to hang the function on, and make
 		// no attempt to get a realistic linked address.  This works because
 		// we never read bytes or look up code units at the address.
-		HighSymbol externSymbol = new HighExternalSymbol(ref.getLabel(), addr, addr, dtmanage);
+		ExternalReference ref = refData.reference;
+		DataType dataType = getExternalReferenceDataType(refData);
+		HighSymbol externSymbol =
+			new HighExternalSymbol(ref.getLabel(), addr, addr, dataType, dtmanage);
 		encodeResult(encoder, externSymbol, null);
+	}
+
+	/**
+	 * Get the datatype to attach to the decompiler's external reference symbol. For imported
+	 * external data, the useful user-defined type is often on the local pointer data item, not on
+	 * the ExternalLocation itself.
+	 */
+	private DataType getExternalReferenceDataType(ExternalReferenceData refData) {
+		ExternalLocation location = refData.reference.getExternalLocation();
+		DataType externalType = location.getDataType();
+		if (isDefinedExternalDataType(externalType)) {
+			return externalType;
+		}
+		if (location.isFunction()) {
+			return externalType;
+		}
+		DataType importPointerType = refData.pointerData.getDataType();
+		DataType basePointerType = importPointerType;
+		while (basePointerType instanceof TypeDef) {
+			basePointerType = ((TypeDef) basePointerType).getBaseDataType();
+		}
+		if (basePointerType instanceof Pointer pointer) {
+			DataType referencedType = pointer.getDataType();
+			if (isDefinedExternalDataType(referencedType)) {
+				// Keep the import pointer type intact. The native decompiler wraps external
+				// symbol types in a pointer when materializing the reference address.
+				return importPointerType;
+			}
+		}
+		return externalType;
+	}
+
+	private boolean isDefinedExternalDataType(DataType dataType) {
+		return dataType != null && dataType != DataType.DEFAULT && !Undefined.isUndefined(dataType);
 	}
 
 	private void encodeTrackSet(Encoder encoder, Register reg, long val) throws IOException {
@@ -1047,11 +1099,16 @@ public class DecompileCallback {
 	}
 
 	private ExternalReference getExternalReference(Address addr) {
+		ExternalReferenceData refData = getExternalReferenceData(addr);
+		return refData != null ? refData.reference : null;
+	}
+
+	private ExternalReferenceData getExternalReferenceData(Address addr) {
 		Data data = listing.getDefinedDataAt(addr);
 		if (data != null && data.isPointer()) {
 			Reference ref = data.getPrimaryReference(0);
 			if (ref instanceof ExternalReference) {
-				return (ExternalReference) ref;
+				return new ExternalReferenceData((ExternalReference) ref, data);
 			}
 		}
 		return null;
@@ -1064,9 +1121,9 @@ public class DecompileCallback {
 	 * @return the global object
 	 */
 	private Object lookupSymbol(Address addr) {
-		ExternalReference ref = getExternalReference(addr);
-		if (ref != null) {
-			return ref;
+		ExternalReferenceData refData = getExternalReferenceData(addr);
+		if (refData != null) {
+			return refData;
 		}
 		Function func = getFunctionContaining(addr);
 		if (func != null) {

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighExternalSymbol.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/pcode/HighExternalSymbol.java
@@ -41,15 +41,20 @@ public class HighExternalSymbol extends HighSymbol {
 	 * @param nm is the given name
 	 * @param addr is the symbol Address
 	 * @param resolveAddr is the resolve Address
+	 * @param dataType is an optional type associated with the external reference
 	 * @param dtmanage is a PcodeDataTypeManager for facilitating XML marshaling
 	 */
-	public HighExternalSymbol(String nm, Address addr, Address resolveAddr,
+	public HighExternalSymbol(String nm, Address addr, Address resolveAddr, DataType dataType,
 			PcodeDataTypeManager dtmanage) {
-		super(0, nm, DataType.DEFAULT, true, true, dtmanage);
+		super(0, nm, dataType != null ? dataType : DataType.DEFAULT, true, true, dtmanage);
 		resolveAddress = resolveAddr;
 		VariableStorage store;
 		try {
-			store = new VariableStorage(getProgram(), addr, 1);
+			int size = addr.getPointerSize();
+			if (size <= 0) {
+				size = 1;
+			}
+			store = new VariableStorage(getProgram(), addr, size);
 		}
 		catch (InvalidInputException e) {
 			store = VariableStorage.UNASSIGNED_STORAGE;
@@ -65,6 +70,9 @@ public class HighExternalSymbol extends HighSymbol {
 			encoder.writeString(ATTRIB_NAME, name + "_exref");
 		}
 		AddressXML.encode(encoder, resolveAddress);
+		if (type != DataType.DEFAULT) {
+			dtmanage.encodeTypeRef(encoder, type, type.getLength());
+		}
 		encoder.closeElement(ELEM_EXTERNREFSYMBOL);
 	}
 }


### PR DESCRIPTION
Hi. 

While I was reversing an old game engine consisting of several dlls I've encountered an annoying quirk. 
Ghidra does a decent job of creating thunks, crossreferencing them etc. But dlls (and not only them) can actually export and import variables, and unfortunately Ghidra did pretty bad there. 

Essentially what I've encountered was a giant vtable of math functions focusing on SSE and processor support, and that vtable is heavily used outside of the declaring dll. I had to manually comment and override signature for all callsights. Pretty annoying huh.

The 12.1 version produces this:
<img width="1919" height="1038" alt="image" src="https://github.com/user-attachments/assets/4a69c878-1cd0-42eb-95af-00f367e26e6b" />

Setting a type for this global did absolutely nothing. 

So I spun up codex with the research task.
Turns out, while Ghidra did allow setting a datatype to the global, it never passed the datatype to the decompiler engine. 

After a few iterations I got this:
<img width="1915" height="1039" alt="image" src="https://github.com/user-attachments/assets/dfe32811-dd1c-4cbb-ab10-6c0fc099f2f0" />

Now I just have to create like a hundred funcdefs, but that's another story.

I made sure to follow the contribution guide, checked the code (it seems reasonable enough to me), compiled locally on windows, and stripped the pr of everything unrelated. 

Open to comments and suggestions)

---

relates to #2206, #5711

---
### below is ai description
---

## Summary
- Preserve the local import pointer data item when resolving external references for decompilation.
- Use that local pointer datatype as a fallback when the ExternalLocation has no explicit datatype.
- Encode optional datatypes on HighExternalSymbol and decode them in native ExternRefSymbol.

## Motivation
Imported external data references can carry useful user-applied types on the local pointer data item, while the ExternalLocation remains untyped. Without passing that type through, the decompiler falls back to generic code-pointer casts for imported function tables.

## Validation
- Verified with: `.\gradlew.bat assembleAll -x ip`