### PR TITLE
fix: Minor spelling error in SearchTextDialog

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/SearchTextDialog.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/searchtext/SearchTextDialog.java
@@ -268,7 +268,7 @@ class SearchTextDialog extends ReusableDialogComponentProvider {
 		commentsCB.setToolTipText(HTMLUtilities.toHTML("Search in any of the comment fields"));
 
 		labelsCB = new GCheckBox("Labels");
-		labelsCB.setToolTipText(HTMLUtilities.toHTML("Search in the Lable field"));
+		labelsCB.setToolTipText(HTMLUtilities.toHTML("Search in the Label field"));
 
 		mnemonicsCB = new GCheckBox("Instruction Mnemonics");
 		mnemonicsCB


### PR DESCRIPTION
Fix minor spelling mistake in search tool.

<img width="393" height="460" alt="image" src="https://github.com/user-attachments/assets/d594558e-436e-44f2-afec-03dd410c1cd2" />

