### PR TITLE
7494: Sanitize generated label name in AutoRenameSimpleLabels script

### DIFF
--- a/Ghidra/Features/Base/ghidra_scripts/AutoRenameSimpleLabels.java
+++ b/Ghidra/Features/Base/ghidra_scripts/AutoRenameSimpleLabels.java
@@ -114,6 +114,10 @@ public class AutoRenameSimpleLabels extends GhidraScript {
 			else if (flow.isJump()) {
 				//println("unconditional jump instruction at " + startAddr.toString(false).toUpperCase() );
 				newName = "branch_" + startAddr.toString(false).toUpperCase() + "_" + operand;
+				// The operand representation can contain characters that are not valid in a
+				// symbol name (e.g. "dword ptr [EBP*0x4 + 0x10029dec]"), which would cause
+				// setName() to throw an InvalidInputException. Sanitize before use.
+				newName = SymbolUtilities.replaceInvalidChars(newName, true);
 				// NOTE: can't end on a hex number for operands that start with 'LAB_CODE' ??
 				// so append '_' 
 				// ???


### PR DESCRIPTION
Fixes #7494

The bundled `AutoRenameSimpleLabels` script crashes when renaming an unconditional-jump label whose operand representation contains characters that are not valid in a symbol name:

```
AutoRenameSimpleLabels.java> Renaming BR @ 10029BE5: switchD to branch_10029BE5_dword ptr [EBP*0x4 + 0x10029dec]
ghidra.util.exception.InvalidInputException: Symbol name contains invalid characters: branch_10029BE5_dword ptr [EBP*0x4 + 0x10029dec]
	at ghidra.program.model.symbol.SymbolUtilities.validateName(SymbolUtilities.java:238)
	...
	at AutoRenameSimpleLabels.run(AutoRenameSimpleLabels.java:143)
```

The branch-rename path builds the new label as `branch_<addr>_<operand>`, where `operand` comes from `getDefaultOperandRepresentation(0)`. For memory operands that string contains spaces/brackets (e.g. `dword ptr [EBP*0x4 + 0x10029dec]`), so `setName()` rejects it.

Fix: run the generated name through `SymbolUtilities.replaceInvalidChars(name, true)` before calling `setName()` — the same helper Ghidra already uses elsewhere when deriving symbol names from arbitrary text. The `ret_` path is unaffected, since it is built only from the address.