### PR TITLE
decompiler: fix broken stack variable tracking

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -2985,7 +2985,7 @@ void ActionNameVars::lookForFuncParamNames(Funcdata &data,const vector<Varnode *
 /// \param vn is the given \e spacebase Varnode
 /// \param data is the function containing the Varnode
 /// \param namerec is used to store any recovered Symbol without a name
-void ActionNameVars::linkSpacebaseSymbol(Varnode *vn,Funcdata &data,vector<Varnode *> &namerec)
+void ActionNameVars::linkSpacebaseSymbol(Varnode *vn,Funcdata &data,vector<Varnode *> &namerec,vector<Varnode *> *failedLinks)
 
 {
   if (!vn->isConstant() && !vn->isInput()) return;
@@ -2995,6 +2995,7 @@ void ActionNameVars::linkSpacebaseSymbol(Varnode *vn,Funcdata &data,vector<Varno
     if (op->code() != CPUI_PTRSUB) continue;
     Varnode *offVn = op->getIn(1);
     Symbol *sym = data.linkSymbolReference(offVn);
+    if (!sym && failedLinks) failedLinks->push_back(offVn);
     if ((sym != (Symbol *)0) && sym->isNameUndefined())
       namerec.push_back(offVn);
   }
@@ -3024,6 +3025,7 @@ void ActionNameVars::linkSymbols(Funcdata &data,vector<Varnode *> &namerec)
       linkSpacebaseSymbol(curvn, data, namerec);
   }
 
+  std::vector<Varnode *> failedSpacebases;
   TypeFactory *typeFactory = data.getArch()->types;
   for(int4 i=0;i<manage->numSpaces();++i) { // Build a list of nameable highs
     spc = manage->getSpace(i);
@@ -3036,7 +3038,7 @@ void ActionNameVars::linkSymbols(Funcdata &data,vector<Varnode *> &namerec)
 	continue;
       }
       if (curvn->isSpacebase())
-	linkSpacebaseSymbol(curvn, data, namerec);
+	linkSpacebaseSymbol(curvn, data, namerec, &failedSpacebases);
       Varnode *vn = curvn->getHigh()->getNameRepresentative();
       if (vn != curvn) continue; // Hit each high only once
       HighVariable *high = vn->getHigh();
@@ -3053,6 +3055,11 @@ void ActionNameVars::linkSymbols(Funcdata &data,vector<Varnode *> &namerec)
 	  high->finalizeDatatype(typeFactory);
       }
     }
+  }
+  
+  for (Varnode *constVn : failedSpacebases) {
+    if (constVn->getSymbolEntry()) continue;
+    linkSpacebaseSymbol(constVn, data, namerec);
   }
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.hh
@@ -477,7 +477,7 @@ class ActionNameVars : public Action {
   static void makeRec(ProtoParameter *param,Varnode *vn,map<HighVariable *,OpRecommend> &recmap);
   static void lookForBadJumpTables(Funcdata &data);	///< Mark the switch variable for bad jump-tables
   static void lookForFuncParamNames(Funcdata &data,const vector<Varnode *> &varlist);
-  static void linkSpacebaseSymbol(Varnode *vn,Funcdata &data,vector<Varnode *> &namerec);
+  static void linkSpacebaseSymbol(Varnode *vn,Funcdata &data,vector<Varnode *> &namerec,vector<Varnode *> *failedLinks = nullptr);
   static void linkSymbols(Funcdata &data,vector<Varnode *> &namerec);
 public:
   ActionNameVars(const string &g) : Action(rule_onceperfunc,"namevars",g) {}	///< Constructor

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
@@ -1227,7 +1227,55 @@ Symbol *Funcdata::linkSymbolReference(Varnode *vn)
     throw LowlevelError("Unable to generate proper address from spacebase");
   SymbolEntry *entry = scope->queryContainer(addr,1,Address());
   if (entry == (SymbolEntry *)0)
+  {
+    if (vn->getHigh())
+    {
+      VarnodeLocSet::const_iterator begiter,enditer;
+      
+      for (int desperation = 0; desperation < 2; ++desperation)
+      {
+        for (int spacebaseIndex = 0; spacebaseIndex < addr.getSpace()->numSpacebase(); ++spacebaseIndex)
+        {
+          const VarnodeData &spacebasedata(addr.getSpace()->getSpacebase(spacebaseIndex));
+          begiter = beginLoc(spacebasedata.size, addr);
+          enditer = endLoc(spacebasedata.size, addr);
+          bool assigned = false;
+          while(begiter != enditer)
+          {
+            Varnode *otherVn = *begiter;
+            HighVariable *otherHigh = otherVn->getHigh();
+            if (otherHigh && otherHigh->getSymbol())
+            {
+              switch (desperation)
+              {
+                case 0:
+                  entry = otherVn->getSymbolEntry();
+                  if (entry)
+                  {
+                    vn->setSymbolReference(entry, 0);
+                    return entry->getSymbol();
+                  }
+                  break;
+                case 1:
+                  if (!otherVn->getSymbolEntry())
+                  {
+                    entry = otherVn->getHigh()->getSymbolEntry();
+                    if (entry)
+                    {
+                      vn->setSymbolReference(entry, 0);
+                      return entry->getSymbol();
+                    }
+                  }
+                  break;
+              }
+            }
+            ++begiter;
+          }
+        }
+      }
+    }
     return (Symbol *)0;
+  }
   int4 off = (int4)(addr.getOffset() - entry->getAddr().getOffset()) + entry->getOffset();
   vn->setSymbolReference(entry, off);
   return entry->getSymbol();

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/variable.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/variable.cc
@@ -241,6 +241,25 @@ HighVariable::~HighVariable(void)
     delete piece;
 }
 
+static bool vnPointsToSymbol(Varnode *vn, Symbol *symbol, SymbolEntry *entry) {
+  if (symbol->getType()->getSize() == vn->getSize()
+      && entry->getAddr().getSpace() && entry->getAddr().getSpace()->getType() == IPTR_SPACEBASE
+      && vn->getAddr().getSpace() && vn->getAddr().getSpace()->getType() == IPTR_CONSTANT
+      && entry->getAddr().getOffset() == vn->getOffset()
+  ) {
+    PcodeOp *op = vn->loneDescend();
+    if (!op || op->code() != CPUI_PTRSUB || op->getIn(1) != vn) return false;
+    Varnode *in0 = op->getIn(0);
+    if (!in0->isSpacebase()) return false;
+    TypePointer *ptype = (TypePointer *)in0->getHigh()->getType();
+    if (ptype->getMetatype() != TYPE_PTR) return false;
+    TypeSpacebase *sb = (TypeSpacebase *)ptype->getPtrTo();
+    if (sb->getMetatype() != TYPE_SPACEBASE) return false;
+    return sb->getAddress(vn->getOffset(), in0->getSize(), op->getAddr()) == entry->getAddr();
+  }
+  return false;
+}
+
 /// The given Varnode \b must be a member and \b must have a non-null SymbolEntry
 void HighVariable::setSymbol(Varnode *vn) const
 
@@ -262,6 +281,8 @@ void HighVariable::setSymbol(Varnode *vn) const
     symboloffset = -1;
   else if (symbol->getCategory() == Symbol::equate)
     symboloffset = -1;			// For equates, we don't care about size
+  else if (vnPointsToSymbol(vn, symbol, entry))
+    symboloffset = 0;
   else if (symbol->getType()->getSize() == vn->getSize() &&
       entry->getAddr() == vn->getAddr() && !entry->isPiece())
     symboloffset = -1;			// A matching entry


### PR DESCRIPTION
This PR (Pull Request) is aimed to fix situations where Ghidra Decompiler produces output like this:

```cpp
    FName::Constructor((FName *)&stack0xfffffeb4,"XboxTypeS_LeftX",FNAME_Add);
    REDGfxMoviePlayer_ChatWindow::addFocusIgnoreKey(gameData->ChatWindow,(int)Text);
```

But `Text` is actually a pointer that points to the `stack0xfffffeb4` stack variable. But Ghidra never shows the assignment of `&stack0xfffffeb4` to `Text` anywhere, so this connection isn't clear, and we're misled to believe the variables are unrelated to each other.

I will now explain why they're actually the same stack variable.

The function does eight PUSHes (each PUSH 4 bytes) and a SUB ESP,0x124. So normally ESP is always at Stack[-0x144] (Stack[0] is the return address and is where ESP points to at the very start of the function).

Then it calls FName::Constructor like this:
```
        00e6ce3c 83 ec 08        SUB        ESP,0x8
        00e6ce3f 8b cc           MOV        ECX,ESP  // the function is a __thiscall, so accepts the first argument in ECX. The size of the object that is supposed to be pointed to by ECX is exactly 8 bytes.
        ... one instruction skipped, as it is irrelevant
        00e6ce45 6a 01           PUSH       0x1  // this is the second non-this arg
        00e6ce47 68 a0 c0        PUSH       s_XboxTypeS_LeftX_0172c0a0  // first non-this arg
                 72 01
        00e6ce4c e8 0f 3f        CALL       FName::Constructor  // cleans up stack after itself, so ESP becomes += 8
                 62 ff
        00e6ce51 8b 8e 5c        MOV        ECX,dword ptr [ESI + 0x15c]  // ESI is gameData, and 0x15c is ChatWindow (a pointer)
                 01 00 00
        00e6ce57 e8 a4 13        CALL       REDGfxMoviePlayer_ChatWindow::addFocusIgnoreKey  // a __thiscall, so first arg is ECX, second is 8 bytes on stack - an FName (8 bytes) passed whole on stack
                 e4 ff
```

The passed ECX would point at a stack location equal to Stack[-0x14c] (i.e. 0xfffffeb4). So, ECX is our `stack0xfffffeb4` variable.

The `Text` variable is extra mysterious. It is not a stack variable. Last assignment to it was `Text = &TextLocal;` where TextLocal is a stack variable at Stack[-0x124], and since then it was only assigned to in an if branch:
```cpp
  if (TextLocal.Text != (wchar_t *)0x0) {
    Text = (FString *)0xe6ce2b;
    appFree(TextLocal.Text);
  }
```

0xe6ce2b is an address of an instruction in this same if branch which cleans up stack immediately after the __cdecl appFree(...) function call:

```
        00e6ce2b 83 c4 04        ADD        ESP,0x4
```

The reason we see such a weird assignment there is because the return address of the appFree call is that instruction, and appFree has one stack argument, so if ESP started at Stack[-0x144], subtract 4 for one stack argument, and 4 more to point at the return address, and we get Stack[-0x14c], meaning Text is actually some kind of variable that points to the stack location at Stack[-0x14c].

This means `Text` points to the same place on the stack where `stack0xfffffeb4` just happens to be located.

I will now explain why Ghidra thought these are two different variables.

There are multiple address spaces in Ghidra Decompiler: one refers to constants, another to stack variables. There're more address spaces, but that's irrelevant. Each varnode holds a number, called an "offset", and that number is an address into an address space, which is stored also in the varnode. So a combination of space pointer plus offset precisely defines what the variable refers to.

Internally, the `stack0xfffffeb4` variable is a constant with value 0xfffffeb4, and what makes it special is that it is the right operand to a PTRSUB operator whose left operand is register ESP who has a very special type that points to the "stack" address space, meaning that the constant is pointing at offset 0xfffffeb4 into the "stack" space. And Ghidra tries to a find a symbol for that variable, and fails, because the function's stack variables don't even go that far, since this stack variable is located after all the other, "officially declared" stack variables, i.e. this is some temporary scratchpad variable. When a variable does not find a symbol, it gets a new abstract symbol (a HighVariable) generated for it, and then all similar HighVariables that are located in the same location get fused together using the Merge::mergeAddrTied(...) function. Problem is that the merging mechanism relies on data.beginLoc(spc) and data.endLoc(spc) to locate variables that share the same location as another variable, and the way the variables are ordered in, is they're sorted in VarnodeBank::loc_tree first by address space, then by offset, then by size, then by 'input' and 'written' flags, and then some more. And the `stack0xfffffeb4` variable is in the "constant" address space holding value 0xfffffeb4, while the `Text` variable is a bunch of variables fused together, most of which (there're more ways to fuse variables, not just by location, and it sucked some in that are located in other places) are located in the "stack" address space and hold the value 0xfffffeb4 as well. And the "stack" address space is different from the "constant" address space, and you're not allowed to just assume that a "stack" 0xfffffeb4 refers to the same thing as "constant" 0xfffffeb4. A constant could be anything. Except that our `stack0xfffffeb4` constant is special beacause it is used in a PTRSUB with a ESP. That ESP holds a pointer back to the "stack" address space, and the "stack" address space holds a pointer (in a member called `baseloc`) back to the ESP. They're clearly linked to each other, yet in Ghidra there is no mechanism currently that fuses HighVariables based on this link.

My PR makes it so that Funcdata::linkSymbolReference(...), called from ActionNameVars::linkSymbols(...), for all constant varnodes that failed to link to a symbol, tries to copy a symbol from another varnode, and the way those other varnodes are found, is they're being searched for at the location of that constant's involved PTRSUB's left operand's type's pointed-to space's `baseloc` plus the constant's value. If one of those other varnodes happens to have a HighVariable or a symbol, it will get copied to the constant. Since this was causing the constant to point at offset -1 to the resulting symbol, I had to also patch the HighVariable::setSymbol(...) function so that it recognizes a constant involved in a PTRSUB with a (for example) ESP as pointing to a (for example) "stack" address space at the offset equal to the constant's value, so that it is tricked into thinking the constant points at offset 0 of the symbol.

As a result, my PR fixes this decompiler output:
```cpp
    FName::Constructor((FName *)&stack0xfffffeb4,"XboxTypeS_LeftX",FNAME_Add);
    REDGfxMoviePlayer_ChatWindow::addFocusIgnoreKey(gameData->ChatWindow,(int)Text);
```

to produce the correct output:
```cpp
    FName::Constructor((FName *)&Text,"XboxTypeS_LeftX",FNAME_Add);
    REDGfxMoviePlayer_ChatWindow::addFocusIgnoreKey(gameData->ChatWindow,(int)Text);
```