### PR TITLE
MC6800/6809: fix BGT/LBGT branch condition (uses Carry instead of Zero)

### DIFF
--- a/Ghidra/Processors/MC6800/data/languages/6x09.sinc
+++ b/Ghidra/Processors/MC6800/data/languages/6x09.sinc
@@ -1007,7 +1007,7 @@ macro PushEntireState()
 
 :BGT REL    is op=0x2E; REL
 {
-        if (($(N) == $(V)) & $(C)) goto REL;
+        if (($(N) == $(V)) & ($(Z) == 0)) goto REL;
 }
 
 :BLE REL     is op=0x2F; REL
@@ -1346,7 +1346,7 @@ macro PushEntireState()
 
 :LBGT REL2    is PAGE2; op=0x2E; REL2
 {
-        if (($(N) == $(V)) & $(C)) goto REL2;
+        if (($(N) == $(V)) & ($(Z) == 0)) goto REL2;
 }
 
 :LBLE REL2     is PAGE2; op=0x2F; REL2


### PR DESCRIPTION
`BGT` (opcode `0x2E`) and `LBGT` (PAGE2, `op=0x2E`) in `Ghidra/Processors/MC6800/data/languages/6x09.sinc` test the Carry flag:

```
if (($(N) == $(V)) & $(C)) goto REL;
```

Per the MC6809 programming manual, signed `BGT` branches on `Z==0 AND (N == V)`; carry is not involved. This is corroborated internally by `BLE` (`0x2F`), the logical complement of `BGT`, which is correctly implemented as `(N^V) | Z` — so as written, `BGT` and `BLE` are not complements.

Example: `LDX #$0060; CMPX #$005F; BGT t` (96 > 95; N=V=Z=0, C=0) fails to branch.

Fix: in `BGT` and `LBGT`, replace `& $(C)` with `& ($(Z) == 0)`. `BGE`/`BLT`/`BLE` and the long-branch forms are already correct.

Verified with `gradle :MC6800:sleighCompile` — all three MC6800 languages compile with no errors.