### PR TITLE
Fix #8908 (Program export does not export globals' data)

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
@@ -16,6 +16,7 @@
 package ghidra.app.util.exporter;
 
 import java.io.*;
+import java.math.BigInteger;
 import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
@@ -34,6 +35,7 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.data.*;
 import ghidra.program.model.listing.*;
+import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.symbol.Equate;
 import ghidra.util.HelpLocation;
 import ghidra.util.Msg;
@@ -174,7 +176,7 @@ public class CppExporter extends ProgramExporter {
 		Listing listing = program.getListing();
 		FunctionIterator iterator = listing.getFunctions(addrSet, true);
 		List<Function> functions = new ArrayList<>();
-		Set<String> processedGlobals = new HashSet<>();
+		Set<Address> processedGlobals = new HashSet<>();
 		for (int i = 0; iterator.hasNext(); i++) {
 			//
 			// Write results every so many items so that we don't blow out memory
@@ -216,13 +218,15 @@ public class CppExporter extends ProgramExporter {
 		return excludeMatchingTags == hasTag;
 	}
 
-	private void writeResults(List<CPPResult> results, Set<String> processedGlobals,
+	private void writeResults(List<CPPResult> results, Set<Address> processedGlobals,
 			PrintWriter headerWriter, PrintWriter cFileWriter, TaskMonitor monitor)
 			throws CancelledException {
 		monitor.checkCancelled();
 
 		Collections.sort(results);
 
+		TreeMap<Address, String> newGlobalsByAddress = new TreeMap<>();
+		List<String> nonAddressedGlobalDecls = new ArrayList<>();
 		StringBuilder globalDecls = new StringBuilder();
 		StringBuilder headers = new StringBuilder();
 		StringBuilder bodies = new StringBuilder();
@@ -233,10 +237,14 @@ public class CppExporter extends ProgramExporter {
 				continue;
 			}
 			if (emitReferencedGlobals) {
-				for (String global : result.globals()) {
-					if (processedGlobals.add(global)) {
-						globalDecls.append(global);
-						globalDecls.append(EOL);
+				for (GlobalDecl gd : result.globals()) {
+					if (gd.address() != null) {
+						if (processedGlobals.add(gd.address())) {
+							newGlobalsByAddress.put(gd.address(), gd.declaration());
+						}
+					}
+					else {
+						nonAddressedGlobalDecls.add(gd.declaration());
 					}
 				}
 			}
@@ -254,6 +262,13 @@ public class CppExporter extends ProgramExporter {
 		}
 
 		monitor.checkCancelled();
+
+		for (String decl : nonAddressedGlobalDecls) {
+			globalDecls.append(decl).append(EOL);
+		}
+		for (String decl : newGlobalsByAddress.values()) {
+			globalDecls.append(decl).append(EOL);
+		}
 
 		if (headerWriter != null) {
 			headerWriter.println(headers.toString());
@@ -504,8 +519,7 @@ public class CppExporter extends ProgramExporter {
 	 * <p>
 	 * Returns a string suitable for use as a C initializer (e.g., {@code 0x42},
 	 * {@code "hello"}, {@code {1, 2, 3}}), or {@code null} if no valid initializer
-	 * can be produced (e.g., for pointer types whose address representation is not
-	 * portable C syntax).
+	 * can be produced (e.g., for pointer types, function types, or uninitialized memory).
 	 *
 	 * @param data the data item to render as a C initializer
 	 * @return C initializer string, or {@code null} if not representable
@@ -549,18 +563,71 @@ public class CppExporter extends ProgramExporter {
 			}
 		}
 
-		// For scalars, strings, enums, and undefined bytes use the default representation
-		String repr = data.getDefaultValueRepresentation();
-		if (repr != null && !repr.isEmpty()) {
-			return repr;
+		// For strings: use the default representation (already properly quoted)
+		if (data.hasStringValue()) {
+			String repr = data.getDefaultValueRepresentation();
+			return (repr != null && !repr.isEmpty() && !"??".equals(repr)) ? repr : null;
+		}
+
+		// For enums: use the default representation which returns the member name (valid C)
+		if (baseType instanceof ghidra.program.model.data.Enum) {
+			String repr = data.getDefaultValueRepresentation();
+			return (repr != null && !repr.isEmpty() && !"??".equals(repr)) ? repr : null;
+		}
+
+		// For floats: use the default representation (decimal notation, valid C)
+		if (baseType instanceof AbstractFloatDataType) {
+			String repr = data.getDefaultValueRepresentation();
+			return (repr != null && !repr.isEmpty() && !"??".equals(repr)) ? repr : null;
+		}
+
+		// For scalars (integers and undefined types): use getValue() to get the raw numeric
+		// value and format as 0x-prefixed hex, avoiding the display-oriented h-suffix format.
+		Object value = data.getValue();
+		if (value == null) {
+			return null; // uninitialized or inaccessible memory
+		}
+
+		if (value instanceof Scalar scalar) {
+			int byteSize = scalar.bitLength() / 8;
+			if (byteSize <= 0) {
+				byteSize = data.getLength();
+			}
+			if (byteSize <= 0) {
+				byteSize = 1;
+			}
+			String hex = Long.toHexString(scalar.getUnsignedValue()).toUpperCase();
+			// Pad to the natural byte width of the type
+			String padded = hex;
+			int hexLen = byteSize * 2;
+			while (padded.length() < hexLen) {
+				padded = "0" + padded;
+			}
+			return "0x" + padded;
+		}
+
+		if (value instanceof BigInteger bigInt) {
+			// Handle wide integer types (> 8 bytes): convert to unsigned representation
+			if (bigInt.signum() < 0) {
+				int bitLen = data.getLength() * 8;
+				bigInt = bigInt.add(BigInteger.ONE.shiftLeft(bitLen));
+			}
+			String hex = bigInt.toString(16).toUpperCase();
+			int hexLen = data.getLength() * 2;
+			while (hex.length() < hexLen) {
+				hex = "0" + hex;
+			}
+			return "0x" + hex;
 		}
 
 		return null;
 	}
 
 
+	private record GlobalDecl(Address address, String declaration) {}
+
 	private record CPPResult(Address address, String headerCode, String bodyCode,
-			List<String> globals) implements Comparable<CPPResult> {
+			List<GlobalDecl> globals) implements Comparable<CPPResult> {
 		@Override
 		public int compareTo(CPPResult other) {
 			return address.compareTo(other.address);
@@ -642,25 +709,30 @@ public class CppExporter extends ProgramExporter {
 
 			Program prog = function.getProgram();
 			DecompiledFunction decompiledFunction = dr.getDecompiledFunction();
-			List<String> globals =
+			List<GlobalDecl> globals =
 				CollectionUtils.asStream(dr.getHighFunction().getGlobalSymbolMap().getSymbols())
 						.map(hsym -> {
 							String dt = hsym.getDataType().getDisplayName();
 							String name = hsym.getName();
 							String space = dt.endsWith("*") ? "" : " ";
-							if (emitGlobalData) {
-								VariableStorage storage = hsym.getStorage();
-								if (storage != null && storage.isMemoryStorage()) {
-									Address addr = storage.getMinAddress();
-									Data data = prog.getListing().getDataAt(addr);
-									String initializer = buildDataInitializer(data);
-									if (initializer != null) {
-										return "%s%s%s = %s;".formatted(dt, space, name,
-											initializer);
-									}
-								}
+
+							VariableStorage storage = hsym.getStorage();
+							Address symAddr = (storage != null && storage.isMemoryStorage())
+									? storage.getMinAddress()
+									: null;
+
+							String declaration;
+							if (emitGlobalData && symAddr != null) {
+								Data data = prog.getListing().getDataAt(symAddr);
+								String initializer = buildDataInitializer(data);
+								declaration = initializer != null
+										? "%s%s%s = %s;".formatted(dt, space, name, initializer)
+										: "%s%s%s;".formatted(dt, space, name);
 							}
-							return "%s%s%s;".formatted(dt, space, name);
+							else {
+								declaration = "%s%s%s;".formatted(dt, space, name);
+							}
+							return new GlobalDecl(symAddr, declaration);
 						})
 						.toList();
 			return new CPPResult(entryPoint, decompiledFunction.getSignature(),

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
@@ -48,6 +48,7 @@ public class CppExporter extends ProgramExporter {
 	public static final String USE_CPP_STYLE_COMMENTS = "Use C++ Style Comments (//)";
 	public static final String EMIT_TYPE_DEFINITONS = "Emit Data-type Definitions";
 	public static final String EMIT_REFERENCED_GLOBALS = "Emit Referenced Globals";
+	public static final String EMIT_GLOBAL_DATA = "Emit Global Data Initializers";
 	public static final String FUNCTION_TAG_FILTERS = "Function Tags to Filter";
 	public static final String FUNCTION_TAG_EXCLUDE = "Function Tags Excluded";
 
@@ -58,6 +59,7 @@ public class CppExporter extends ProgramExporter {
 	private boolean isUseCppStyleComments = true;
 	private boolean emitDataTypeDefinitions = true;
 	private boolean emitReferencedGlobals = true;
+	private boolean emitGlobalData = true;
 	private String tagOptions = "";
 
 	private Set<FunctionTag> functionTagSet = new HashSet<>();
@@ -71,7 +73,8 @@ public class CppExporter extends ProgramExporter {
 	}
 
 	public CppExporter(DecompileOptions options, boolean createHeader, boolean createFile,
-			boolean emitTypes, boolean emitGlobals, boolean excludeTags, String tags) {
+			boolean emitTypes, boolean emitGlobals, boolean emitData, boolean excludeTags,
+			String tags) {
 		this();
 		this.options = options;
 		if (options != null) {
@@ -81,6 +84,7 @@ public class CppExporter extends ProgramExporter {
 		isCreateCFile = createFile;
 		emitDataTypeDefinitions = emitTypes;
 		emitReferencedGlobals = emitGlobals;
+		emitGlobalData = emitData;
 		excludeMatchingTags = excludeTags;
 		if (tags != null) {
 			tagOptions = tags;
@@ -373,6 +377,9 @@ public class CppExporter extends ProgramExporter {
 		list.add(Option.newBoolean(EMIT_REFERENCED_GLOBALS)
 				.value(emitReferencedGlobals)
 				.build());
+		list.add(Option.newBoolean(EMIT_GLOBAL_DATA)
+				.value(emitGlobalData)
+				.build());
 		list.add(Option.newString(FUNCTION_TAG_FILTERS)
 				.value(tagOptions)
 				.build());
@@ -401,6 +408,9 @@ public class CppExporter extends ProgramExporter {
 				}
 				else if (optName.equals(EMIT_REFERENCED_GLOBALS)) {
 					emitReferencedGlobals = ((Boolean) option.getValue()).booleanValue();
+				}
+				else if (optName.equals(EMIT_GLOBAL_DATA)) {
+					emitGlobalData = ((Boolean) option.getValue()).booleanValue();
 				}
 				else if (optName.equals(FUNCTION_TAG_FILTERS)) {
 					tagOptions = (String) option.getValue();
@@ -489,6 +499,66 @@ public class CppExporter extends ProgramExporter {
 // Inner Classes
 //==================================================================================================
 
+	/**
+	 * Builds a C initializer expression for the given data item.
+	 * <p>
+	 * Returns a string suitable for use as a C initializer (e.g., {@code 0x42},
+	 * {@code "hello"}, {@code {1, 2, 3}}), or {@code null} if no valid initializer
+	 * can be produced (e.g., for pointer types whose address representation is not
+	 * portable C syntax).
+	 *
+	 * @param data the data item to render as a C initializer
+	 * @return C initializer string, or {@code null} if not representable
+	 */
+	private static String buildDataInitializer(Data data) {
+		if (data == null) {
+			return null;
+		}
+
+		DataType dt = data.getDataType();
+
+		// Unwrap typedefs to check the base type
+		DataType baseType = dt;
+		while (baseType instanceof TypeDef td) {
+			baseType = td.getBaseDataType();
+		}
+
+		// Skip pointer types - their address representation is not valid C syntax
+		if (baseType instanceof Pointer || baseType instanceof FunctionDefinition) {
+			return null;
+		}
+
+		// For non-string composites (arrays, structs, unions), recurse into components
+		if (!data.hasStringValue()) {
+			int numComponents = data.getNumComponents();
+			if (numComponents > 0) {
+				StringBuilder sb = new StringBuilder("{");
+				for (int i = 0; i < numComponents; i++) {
+					if (i > 0) {
+						sb.append(", ");
+					}
+					Data component = data.getComponent(i);
+					String compInit = buildDataInitializer(component);
+					if (compInit == null) {
+						return null;
+					}
+					sb.append(compInit);
+				}
+				sb.append("}");
+				return sb.toString();
+			}
+		}
+
+		// For scalars, strings, enums, and undefined bytes use the default representation
+		String repr = data.getDefaultValueRepresentation();
+		if (repr != null && !repr.isEmpty()) {
+			return repr;
+		}
+
+		return null;
+	}
+
+
 	private record CPPResult(Address address, String headerCode, String bodyCode,
 			List<String> globals) implements Comparable<CPPResult> {
 		@Override
@@ -570,6 +640,7 @@ public class CppExporter extends ProgramExporter {
 				return null;
 			}
 
+			Program prog = function.getProgram();
 			DecompiledFunction decompiledFunction = dr.getDecompiledFunction();
 			List<String> globals =
 				CollectionUtils.asStream(dr.getHighFunction().getGlobalSymbolMap().getSymbols())
@@ -577,6 +648,18 @@ public class CppExporter extends ProgramExporter {
 							String dt = hsym.getDataType().getDisplayName();
 							String name = hsym.getName();
 							String space = dt.endsWith("*") ? "" : " ";
+							if (emitGlobalData) {
+								VariableStorage storage = hsym.getStorage();
+								if (storage != null && storage.isMemoryStorage()) {
+									Address addr = storage.getMinAddress();
+									Data data = prog.getListing().getDataAt(addr);
+									String initializer = buildDataInitializer(data);
+									if (initializer != null) {
+										return "%s%s%s = %s;".formatted(dt, space, name,
+											initializer);
+									}
+								}
+							}
 							return "%s%s%s;".formatted(dt, space, name);
 						})
 						.toList();

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
@@ -515,6 +515,40 @@ public class CppExporter extends ProgramExporter {
 //==================================================================================================
 
 	/**
+	 * Builds a C-style variable declaration string, correctly placing array dimensions
+	 * after the variable name rather than as part of the type prefix.
+	 * <p>
+	 * For example, a {@code byte[32]} type with name {@code "buf"} produces
+	 * {@code "byte buf[32]"} rather than {@code "byte[32] buf"}.
+	 *
+	 * @param dataType the variable's data type (may be an array type)
+	 * @param name the (already sanitized) variable name
+	 * @return declaration in C form, without a trailing semicolon
+	 */
+	private static String buildGlobalDeclaration(DataType dataType, String name) {
+		StringBuilder dims = new StringBuilder();
+		DataType base = dataType;
+		while (base instanceof Array arr) {
+			dims.append("[").append(arr.getNumElements()).append("]");
+			base = arr.getDataType();
+		}
+		String typeName = base.getDisplayName();
+		String space = typeName.endsWith("*") ? "" : " ";
+		return typeName + space + name + dims;
+	}
+
+	/**
+	 * Returns a valid C identifier by replacing any character that is not a letter,
+	 * digit, or underscore with an underscore.
+	 *
+	 * @param name the original symbol name
+	 * @return a valid C identifier
+	 */
+	private static String sanitizeCIdentifier(String name) {
+		return name.replaceAll("[^A-Za-z0-9_]", "_");
+	}
+
+	/**
 	 * Builds a C initializer expression for the given data item.
 	 * <p>
 	 * Returns a string suitable for use as a C initializer (e.g., {@code 0x42},
@@ -712,26 +746,36 @@ public class CppExporter extends ProgramExporter {
 			List<GlobalDecl> globals =
 				CollectionUtils.asStream(dr.getHighFunction().getGlobalSymbolMap().getSymbols())
 						.map(hsym -> {
-							String dt = hsym.getDataType().getDisplayName();
 							String name = hsym.getName();
-							String space = dt.endsWith("*") ? "" : " ";
+							String sanitizedName = sanitizeCIdentifier(name);
 
 							VariableStorage storage = hsym.getStorage();
 							Address symAddr = (storage != null && storage.isMemoryStorage())
 									? storage.getMinAddress()
 									: null;
 
+							String declBase =
+								buildGlobalDeclaration(hsym.getDataType(), sanitizedName);
+
 							String declaration;
 							if (emitGlobalData && symAddr != null) {
 								Data data = prog.getListing().getDataAt(symAddr);
 								String initializer = buildDataInitializer(data);
 								declaration = initializer != null
-										? "%s%s%s = %s;".formatted(dt, space, name, initializer)
-										: "%s%s%s;".formatted(dt, space, name);
+										? declBase + " = " + initializer + ";"
+										: declBase + ";";
 							}
 							else {
-								declaration = "%s%s%s;".formatted(dt, space, name);
+								declaration = declBase + ";";
 							}
+
+							if (!sanitizedName.equals(name)) {
+								String comment = isUseCppStyleComments
+										? " // " + name
+										: " /* " + name + " */";
+								declaration += comment;
+							}
+
 							return new GlobalDecl(symAddr, declaration);
 						})
 						.toList();

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/util/exporter/CppExporter.java
@@ -36,7 +36,7 @@ import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.data.*;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.scalar.Scalar;
-import ghidra.program.model.symbol.Equate;
+import ghidra.program.model.symbol.*;
 import ghidra.util.HelpLocation;
 import ghidra.util.Msg;
 import ghidra.util.exception.CancelledException;
@@ -553,12 +553,16 @@ public class CppExporter extends ProgramExporter {
 	 * <p>
 	 * Returns a string suitable for use as a C initializer (e.g., {@code 0x42},
 	 * {@code "hello"}, {@code {1, 2, 3}}), or {@code null} if no valid initializer
-	 * can be produced (e.g., for pointer types, function types, or uninitialized memory).
+	 * can be produced (e.g., for function types, or uninitialized memory).
+	 * <p>
+	 * Pointer types are resolved to symbol names when possible (e.g., {@code &a} or
+	 * {@code foo} for a function pointer), using {@code program} for symbol lookup.
 	 *
-	 * @param data the data item to render as a C initializer
+	 * @param data    the data item to render as a C initializer
+	 * @param program the program, used to resolve pointer targets to symbol names
 	 * @return C initializer string, or {@code null} if not representable
 	 */
-	private static String buildDataInitializer(Data data) {
+	private static String buildDataInitializer(Data data, Program program) {
 		if (data == null) {
 			return null;
 		}
@@ -571,8 +575,29 @@ public class CppExporter extends ProgramExporter {
 			baseType = td.getBaseDataType();
 		}
 
-		// Skip pointer types - their address representation is not valid C syntax
-		if (baseType instanceof Pointer || baseType instanceof FunctionDefinition) {
+		// For pointer types, resolve the referenced address to a symbol name
+		if (baseType instanceof Pointer) {
+			if (program == null) {
+				return null;
+			}
+			Object value = data.getValue();
+			if (!(value instanceof Address refAddr)) {
+				return null;
+			}
+			Symbol symbol = program.getSymbolTable().getPrimarySymbol(refAddr);
+			if (symbol == null) {
+				return null;
+			}
+			String symName = symbol.getName();
+			// Function pointers don't need the address-of operator
+			if (program.getFunctionManager().getFunctionAt(refAddr) != null) {
+				return symName;
+			}
+			return "&" + symName;
+		}
+
+		// Skip function definition types (bare function types, not pointer-to-function)
+		if (baseType instanceof FunctionDefinition) {
 			return null;
 		}
 
@@ -586,7 +611,7 @@ public class CppExporter extends ProgramExporter {
 						sb.append(", ");
 					}
 					Data component = data.getComponent(i);
-					String compInit = buildDataInitializer(component);
+					String compInit = buildDataInitializer(component, program);
 					if (compInit == null) {
 						return null;
 					}
@@ -760,7 +785,7 @@ public class CppExporter extends ProgramExporter {
 							String declaration;
 							if (emitGlobalData && symAddr != null) {
 								Data data = prog.getListing().getDataAt(symAddr);
-								String initializer = buildDataInitializer(data);
+								String initializer = buildDataInitializer(data, prog);
 								declaration = initializer != null
 										? declBase + " = " + initializer + ";"
 										: declBase + ";";


### PR DESCRIPTION
This MR addresses #8908 (Program export does not export globals' data).

A new "Emit Global Data Initializers" exporter option was added (enabled by default). When enabled, it exports initializers for global variables.

Also, it fixes number of issues discovered when the globals with initialization are exported in C source:

- scalars were formatted with Ghidra's h-suffix notation (FFFFFFFFh); `0x` prefix is used for C sources now.
- ASCII character was appended to the hex value (e.g. 78h    x) for `char`/`undefined`
- globals without initialization were exported as `type var = ??;` instead of plain `type var;`
- global arrays used "Java-style" type declarations (i.e. `byte[32] var;` instead of `byte var[32]`)
- some of the globals contained incorrect symbols in their names (e.g. `PTR_LAB_0001576c+1_000e0e3c`)

Also, globals were not sorted by address which made their analysis more cubersome

This MR contains four commits which can be squashed after the review (or some functionality can be split to separate MR if necessary).