### PR TITLE
9301: Enhance manual viewer commands with page token

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/util/BrowserLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/BrowserLoader.java
@@ -17,6 +17,8 @@ package ghidra.util;
 
 import java.io.File;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -153,9 +155,29 @@ public class BrowserLoader {
 		List<String> argumentList = new ArrayList<String>();
 		argumentList.add(option.getCommandString());
 
+		// Substitute ${PAGE} (the manual page, carried as a "#page=N" fragment on the file URL)
+		// and ${FILENAME} (the local file path) tokens into the user-supplied arguments.  
+		// If the user places ${FILENAME} themselves, the file is not also appended at the end below.
+		String pageNumber = getManualPageNumber(fileURL);
+		String fileName = getManualFilePath(fileURL);
+		boolean fileNameInArgs = false;
 		String[] commandArguments = option.getCommandArguments();
 		for (String string : commandArguments) {
+			if (string.contains(ManualViewerCommandWrappedOption.FILENAME_REPLACEMENT_STRING)) {
+				fileNameInArgs = true;
+			}
+			string =
+				string.replace(ManualViewerCommandWrappedOption.PAGE_REPLACEMENT_STRING, pageNumber);
+			if (fileName != null) {
+				string = string.replace(
+					ManualViewerCommandWrappedOption.FILENAME_REPLACEMENT_STRING, fileName);
+			}
 			argumentList.add(string);
+		}
+
+		// The user already positioned the file via the ${FILENAME} token; don't append it again.
+		if (fileNameInArgs) {
+			return argumentList.toArray(new String[argumentList.size()]);
 		}
 
 		String urlString = option.getUrlReplacementString();
@@ -168,12 +190,12 @@ public class BrowserLoader {
 			urlArg = fileURL.toExternalForm();
 		}
 		else {
-			urlArg = new File(fileURL.getFile()).getAbsolutePath();
+			urlArg = fileName;
 		}
 
-		// If launching "cmd.exe /c start URL", surround the URL with double quotes to protect 
+		// If launching "cmd.exe /c start URL", surround the URL with double quotes to protect
 		// against special characters being misinterpreted by the shell.
-		// NOTE: If not already present, a double-quoted title must be inserted since the URL 
+		// NOTE: If not already present, a double-quoted title must be inserted since the URL
 		// argument that follows will start with a double quote.
 		if (commandArguments.length >= 2 && commandArguments[0].equalsIgnoreCase("/c") &&
 			commandArguments[1].equalsIgnoreCase("start")) {
@@ -185,6 +207,39 @@ public class BrowserLoader {
 		argumentList.add(urlArg);
 
 		return argumentList.toArray(new String[argumentList.size()]);
+	}
+
+	/**
+	 * Returns the decoded local file path for the given file URL (without the {@code #page=N}
+	 * fragment, which {@link URL#getPath()} already excludes), so viewers receive a real path
+	 * rather than a percent-encoded one.
+	 * @param fileURL the file URL (may be null)
+	 * @return the absolute local file path, or null if {@code fileURL} is null
+	 */
+	private static String getManualFilePath(URL fileURL) {
+		if (fileURL == null) {
+			return null;
+		}
+		String path = URLDecoder.decode(fileURL.getPath(), StandardCharsets.UTF_8);
+		return new File(path).getAbsolutePath();
+	}
+
+	/**
+	 * Extracts the manual page number from the {@code #page=N} fragment of the given file URL.
+	 * @param fileURL the file URL (may be null)
+	 * @return the page number, or {@code "1"} if none is present
+	 */
+	private static String getManualPageNumber(URL fileURL) {
+		if (fileURL != null) {
+			String ref = fileURL.getRef();
+			if (ref != null && ref.startsWith("page=")) {
+				String page = ref.substring("page=".length());
+				if (!page.isBlank()) {
+					return page;
+				}
+			}
+		}
+		return "1";
 	}
 
 //==================================================================================================

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/ManualViewerCommandEditor.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/ManualViewerCommandEditor.java
@@ -47,8 +47,11 @@ public class ManualViewerCommandEditor extends PropertyEditorSupport
 		"path to an executable that will be launched to open the processor manual.  " +
 		"Examples include 'firefox', 'netscape', 'open', etc.";
 	private static final String COMMAND_ARGUMENTS_DESCRIPTION =
-		"These are the arguments that will " +
-			"be passed to the command given in the 'Command String' field.";
+		"Arguments passed to the command.\n" +
+			ManualViewerCommandWrappedOption.PAGE_REPLACEMENT_STRING +
+			": replaced with the manual page number\n" +
+			ManualViewerCommandWrappedOption.FILENAME_REPLACEMENT_STRING +
+			": replaced with manual filename; automatically appended if not specified";
 
 	private static final String[] DESCRIPTIONS =
 		{ FILE_FORMAT_DESCRIPTION, COMMAND_STRING_DESCRIPTION, COMMAND_ARGUMENTS_DESCRIPTION };
@@ -69,6 +72,16 @@ public class ManualViewerCommandEditor extends PropertyEditorSupport
 
 	public ManualViewerCommandEditor() {
 		editorComponent = new LaunchDataInputPanel();
+	}
+
+	/**
+	 * Wraps description text in fixed-width HTML so the tooltip wraps across multiple lines rather
+	 * than rendering as a single long line.
+	 * @param text the plain description text
+	 * @return the text wrapped in width-constrained HTML
+	 */
+	private static String toHtmlTooltip(String text) {
+		return "<html><div style=\"width: 384px;\">" + text.replace("\n", "<br>") + "</div></html>";
 	}
 
 	@Override
@@ -205,16 +218,17 @@ public class ManualViewerCommandEditor extends PropertyEditorSupport
 			workPanel.setLayout(new PairLayout());
 
 			JLabel commandLabel = new GDLabel(COMMAND_STRING_LABEL);
-			commandLabel.setToolTipText(COMMAND_STRING_DESCRIPTION);
-			commandField = new JTextField(30);
+			commandField = new JTextField(50);
 
 			JLabel argumentsLabel = new GDLabel(COMMAND_ARGUMENTS_LABEL);
-			argumentsLabel.setToolTipText(COMMAND_ARGUMENTS_DESCRIPTION);
-			argumentsField = new JTextField(20);
+			argumentsLabel.setToolTipText(toHtmlTooltip(COMMAND_ARGUMENTS_DESCRIPTION));
+			argumentsField = new JTextField(50);
+			argumentsField.setToolTipText(toHtmlTooltip(COMMAND_ARGUMENTS_DESCRIPTION));
 
 			JLabel formatLabel = new GDLabel(FILE_FORMAT_LABEL);
-			formatLabel.setToolTipText(FILE_FORMAT_DESCRIPTION);
+			formatLabel.setToolTipText(toHtmlTooltip(FILE_FORMAT_DESCRIPTION));
 			fileFormatComboBox = new GComboBox<>();
+			fileFormatComboBox.setToolTipText(toHtmlTooltip(FILE_FORMAT_DESCRIPTION));
 			fileFormatComboBox.addItem(
 				ManualViewerCommandWrappedOption.HTTP_URL_REPLACEMENT_STRING);
 			fileFormatComboBox.addItem(

--- a/Ghidra/Features/Base/src/main/java/ghidra/util/ManualViewerCommandWrappedOption.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/util/ManualViewerCommandWrappedOption.java
@@ -28,6 +28,12 @@ public class ManualViewerCommandWrappedOption implements CustomOption {
 	static final String FILE_URL_REPLACEMENT_STRING = "${FILE_URL}";
 	static final String FILENAME_REPLACEMENT_STRING = "${FILENAME}";
 
+	/**
+	 * Token that may be used within the command arguments; it is replaced with the manual page
+	 * number when the command is launched (e.g. SumatraPDF's {@code -page ${PAGE}}).
+	 */
+	static final String PAGE_REPLACEMENT_STRING = "${PAGE}";
+
 	private static final String COMMAND_STRING = "commandString";
 	private static final String COMMAND_ARGUMENTS = "commandArguments";
 	private static final String URL_STRING = "urlReplacementString";


### PR DESCRIPTION
This introduces `${PAGE}` and `${FILENAME}` tokens, allowing users to specify exact page numbers (from `#page=N` URL fragments) and properly URL-decoded absolute file paths when launching external manual viewers. This enables more precise control, such as opening a PDF to a specific page using tools like SumatraPDF. The UI for command configuration now includes updated descriptions and multi-line tooltips to clarify these new options.

Explicit `${FILENAME}` is included in case the user doesn't want filename to be the last argument of the command, they are free to format the entire command to their liking.

This addresses #9301.