### PR TITLE
Fix author typo in ImportSymbolsScript header

### DIFF
--- a/Ghidra/Extensions/Jython/ghidra_scripts/ImportSymbolsScript.py
+++ b/Ghidra/Extensions/Jython/ghidra_scripts/ImportSymbolsScript.py
@@ -22,7 +22,7 @@
 # - MEMORY_REGION:1234abcd
 # - MEMORY_REGION:0x1234abcd
 # Omitting the address space or memory region specifier from the address will result in the function or label being created in the default address space.
-# @author unkown; edited by matedealer <git@matedealer.de>
+# @author unknown; edited by matedealer <git@matedealer.de>
 # @category Import
 # @runtime Jython
 #


### PR DESCRIPTION
Fixes a typo in the @author line of ImportSymbolsScript.py.