### PR TITLE
Remove explicit socket buffer locks in remote block stream handles

### DIFF
--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/stream/RemoteBlockStreamHandle.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/stream/RemoteBlockStreamHandle.java
@@ -134,14 +134,6 @@ public abstract class RemoteBlockStreamHandle<T extends BlockStream> implements 
 	}
 
 	/**
-	 * Get the preferred socket send/receive buffer size to be used
-	 * @return preferred socket send/receive buffer size
-	 */
-	protected int getPreferredBufferSize() {
-		return (getBlockSize() + 4) * 12;
-	}
-
-	/**
 	 * Generate a random number for use as a block stream authentication token.
 	 * @return random value
 	 */

--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/stream/RemoteInputBlockStreamHandle.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/stream/RemoteInputBlockStreamHandle.java
@@ -124,7 +124,6 @@ public class RemoteInputBlockStreamHandle extends RemoteBlockStreamHandle<InputB
 	public InputBlockStream openBlockStream() throws IOException {
 
 		Socket socket = connect();
-		socket.setReceiveBufferSize(getPreferredBufferSize());
 
 		return new ClientInputBlockStream(socket);
 	}
@@ -134,8 +133,6 @@ public class RemoteInputBlockStreamHandle extends RemoteBlockStreamHandle<InputB
 		if (!(blockStream instanceof InputBlockStream)) {
 			throw new IllegalArgumentException("expected InputBlockStream");
 		}
-
-		socket.setSendBufferSize(getPreferredBufferSize());
 
 		InputBlockStream inputBlockStream = (InputBlockStream) blockStream;
 		try (OutputStream out = getBlockInputStream(socket)) {

--- a/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/stream/RemoteOutputBlockStreamHandle.java
+++ b/Ghidra/Features/GhidraServer/src/main/java/ghidra/server/stream/RemoteOutputBlockStreamHandle.java
@@ -109,7 +109,6 @@ public class RemoteOutputBlockStreamHandle extends RemoteBlockStreamHandle<Outpu
 	public OutputBlockStream openBlockStream() throws IOException {
 
 		Socket socket = connect();
-		socket.setSendBufferSize(getPreferredBufferSize());
 
 		return new ClientOutputBlockStream(socket);
 	}
@@ -120,8 +119,6 @@ public class RemoteOutputBlockStreamHandle extends RemoteBlockStreamHandle<Outpu
 		if (!(blockStream instanceof OutputBlockStream)) {
 			throw new IllegalArgumentException("expected OutputBlockStream");
 		}
-
-		socket.setReceiveBufferSize(getPreferredBufferSize());
 
 		OutputBlockStream outputBlockStream = (OutputBlockStream) blockStream;
 		try (InputStream in = getBlockInputStream(socket)) {


### PR DESCRIPTION
`getPreferredBufferSize()` returns `(blockSize + 4) * 12` which is ~240 KB. Passing this to `set*BufferSize()` locks the kernel socket buffer at that value, disabling OS TCP autotuning and capping throughput to `~240 KB / RTT` regardless of available bandwidth.

Removing this lets the kernel autotune connection, eg with `net.ipv4.tcp_rmem` configured for high-BDP paths on the server, `rcv_ssthresh` can actually grow to match connection's bandwidth. Results for my 252 ms RTT WAN link:

Direction | Before | After
-- | -- | --
Check-in  | ~252 KB/s | ~12 MB/s
Check-out  | ~1 MB/s | ~56 MB/s

this can be confirmed visually by looking at amount of blocks transferred in status window over time and by using
`watch -n 0.5 'ss -tino sport = :13102'` on the server.

Fixes #2752 