### PR TITLE
Fix WildcardAssembler LEA EAX, [ EDX + `Q1` ] 

### DIFF
--- a/Ghidra/Features/WildcardAssembler/src/main/java/ghidra/asm/wild/sem/WildAssemblyTreeResolver.java
+++ b/Ghidra/Features/WildcardAssembler/src/main/java/ghidra/asm/wild/sem/WildAssemblyTreeResolver.java
@@ -15,16 +15,24 @@
  */
 package ghidra.asm.wild.sem;
 
+import java.util.Arrays;
+
 import ghidra.app.plugin.assembler.sleigh.sem.*;
 import ghidra.app.plugin.assembler.sleigh.tree.AssemblyParseBranch;
 import ghidra.app.plugin.assembler.sleigh.tree.AssemblyParseTreeNode;
+import ghidra.app.plugin.processors.sleigh.SleighInstructionPrototype;
 import ghidra.app.plugin.processors.sleigh.SleighLanguage;
 import ghidra.app.plugin.processors.sleigh.symbol.*;
+import ghidra.asm.wild.WildOperandInfo;
 import ghidra.asm.wild.grammars.WildAssemblyProduction;
 import ghidra.asm.wild.symbol.*;
 import ghidra.asm.wild.tree.WildAssemblyParseHiddenNode;
 import ghidra.asm.wild.tree.WildAssemblyParseToken;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.lang.InsufficientBytesException;
+import ghidra.program.model.lang.UnknownInstructionException;
+import ghidra.program.model.mem.ByteMemBufferImpl;
+import ghidra.program.model.mem.MemBuffer;
 
 public class WildAssemblyTreeResolver
 		extends AbstractAssemblyTreeResolver<WildAssemblyResolvedPatterns> {
@@ -81,5 +89,85 @@ public class WildAssemblyTreeResolver
 				fromLeft);
 		}
 		return super.getStateGenerator(opSym, node, fromLeft);
+	}
+
+	/**
+	 * Validate wildcard assembly results by disassembling representative concrete bytes.
+	 *
+	 * <p>
+	 * The default resolver validates the pattern values directly, which means every unknown bit is
+	 * supplied as zero. For wildcard-owned bits, zero can select a more-specific constructor than the
+	 * one represented by the masked result, so this resolver uses wildcard-aware prototype check
+	 * bytes without changing the returned resolution.
+	 */
+	@Override
+	protected AssemblyResolutionResults filterByDisassembly(AssemblyResolutionResults temp) {
+		AssemblyDefaultContext asmCtx = new AssemblyDefaultContext(lang);
+		asmCtx.setContextRegister(context);
+		AssemblyResolutionResults results = factory.newAssemblyResolutionResults();
+		for (AssemblyResolution res : temp) {
+			if (res.isError()) {
+				results.add(res);
+				continue;
+			}
+			if (!(res instanceof AssemblyResolvedPatterns rp)) {
+				throw new AssertionError();
+			}
+			results.add(checkByDisassembly(rp, asmCtx));
+		}
+		return results;
+	}
+
+	/**
+	 * Run the final disassembly prototype check for a resolved pattern.
+	 *
+	 * <p>
+	 * The parsed prototype must still match the resolved constructor state. Only the temporary byte
+	 * sequence used for parsing differs from the stored instruction pattern.
+	 */
+	protected AssemblyResolution checkByDisassembly(AssemblyResolvedPatterns rp,
+			AssemblyDefaultContext asmCtx) {
+		MemBuffer buf =
+			new ByteMemBufferImpl(at, getPrototypeCheckBytes(rp), lang.isBigEndian());
+		try {
+			SleighInstructionPrototype ip =
+				(SleighInstructionPrototype) lang.parse(buf, asmCtx, false);
+			if (!rp.equivalentConstructState(ip.getRootState())) {
+				return factory.error("Disassembly prototype mismatch", rp);
+			}
+			return rp;
+		}
+		catch (InsufficientBytesException | UnknownInstructionException e) {
+			return factory.error("Disassembly failed: " + e.getMessage(), rp);
+		}
+	}
+
+	/**
+	 * Build the concrete byte sequence used only for prototype validation.
+	 *
+	 * <p>
+	 * Fixed instruction bits are kept as-is. Unknown bits are set only when they belong to a wildcard
+	 * operand location, which avoids validating wildcarded operands through zero-specialized
+	 * constructors while preserving the original pattern masks and wildcard metadata.
+	 */
+	protected byte[] getPrototypeCheckBytes(AssemblyResolvedPatterns rp) {
+		byte[] bytes = Arrays.copyOf(rp.getInstruction().getVals(),
+			rp.getInstruction().getVals().length);
+		byte[] instructionMask = rp.getInstruction().getMask();
+		int instructionOffset = rp.getInstruction().getOffset();
+		for (WildOperandInfo info : PatternUtils.castWild(rp).getOperandInfo()) {
+			AssemblyPatternBlock location = info.location();
+			byte[] locationMask = location.getMask();
+			for (int i = 0; i < locationMask.length; i++) {
+				int byteIndex = location.getOffset() + i - instructionOffset;
+				if (byteIndex < 0 || byteIndex >= bytes.length) {
+					continue;
+				}
+				int wildcardMask = locationMask[i] & 0xff;
+				int specifiedMask = instructionMask[byteIndex] & 0xff;
+				bytes[byteIndex] |= (byte) (wildcardMask & ~specifiedMask);
+			}
+		}
+		return bytes;
 	}
 }

--- a/Ghidra/Features/WildcardAssembler/src/test/java/ghidra/asm/wild/WildSleighAssemblerTest.java
+++ b/Ghidra/Features/WildcardAssembler/src/test/java/ghidra/asm/wild/WildSleighAssemblerTest.java
@@ -972,4 +972,32 @@ public class WildSleighAssemblerTest extends AbstractGhidraHeadlessIntegrationTe
 		assertEquals(AssemblyPatternBlock.fromString("SS:SS:X[x111]"), opInfoEDX.location());
 		assertEquals(Set.of("EDX"), Set.copyOf(allValidChoices));
 	}
+	
+	@Test
+	public void testLeaWild_x86() throws Exception {
+		x86();
+		Collection<AssemblyParseResult> parses = asmX86.parseLine("LEA EAX, [ EDX + `Q1` ]");
+		AssemblyParseResult[] allResults = parses.stream()
+				.filter(p -> !p.isError())
+				.toArray(AssemblyParseResult[]::new);
+
+		var allValidResults = new ArrayList<WildAssemblyResolvedPatterns>();
+		Address addr0 = x86.getAddressFactory().getDefaultAddressSpace().getAddress(0);
+		for (AssemblyParseResult r : allResults) {
+			AssemblyResolutionResults results = asmX86.resolveTree(r, addr0);
+			dumpResults(results);
+			allValidResults.addAll(getValidResults(results));
+		}
+
+		assertTrue(allValidResults.size() > 0);
+		// The direct disp8 form keeps only the displacement byte wildcarded.
+		WildAssemblyResolvedPatterns directDisp8 =
+			Unique.assertOne(allValidResults.stream()
+					.filter(r -> r.getInstruction()
+							.equals(AssemblyPatternBlock.fromString("8D:42:XX"))));
+		WildOperandInfo opInfoQ1 = Unique.assertOne(directDisp8.getOperandInfo());
+		assertEquals("Q1", opInfoQ1.wildcard());
+		assertEquals(AssemblyPatternBlock.fromString("SS:SS:FF"), opInfoQ1.location());
+		assertNull(opInfoQ1.choice());
+	}
 }


### PR DESCRIPTION
I am not sure if this is the best way to fix this, but it seems to fix the specific instruction described in #9332  and not break other WildcardAssembler test cases.