### PR TITLE
Add support for the debugger on OpenBSD

### DIFF
--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/arch.py
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/arch.py
@@ -103,6 +103,7 @@ data64_compiler_map: Dict[Optional[str], str] = {
 
 x86_compiler_map: Dict[Optional[str], str] = {
     'GNU/Linux': 'gcc',
+    'OpenBSD': 'gcc',
     'Windows': 'windows',
     # This may seem wrong, but Ghidra cspecs really describe the ABI
     'Cygwin': 'windows',
@@ -110,6 +111,7 @@ x86_compiler_map: Dict[Optional[str], str] = {
 
 riscv_compiler_map: Dict[Optional[str], str] = {
     'GNU/Linux': 'gcc',
+    'OpenBSD': 'gcc',
     'Cygwin': 'gcc',
 }
 

--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/util.py
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/util.py
@@ -19,7 +19,6 @@ import bisect
 from dataclasses import dataclass
 import re
 from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
-import platform
 
 import gdb
 
@@ -468,7 +467,7 @@ class RegisterDesc:
 
 def get_register_descs(arch: gdb.Architecture, group: str = 'all') -> List[
         Union[RegisterDesc, gdb.RegisterDescriptor]]:
-    if hasattr(arch, "registers") and platform.system() != "OpenBSD":
+    if hasattr(arch, "registers"):
         try:
             return list(arch.registers(group))
         except ValueError:  # No such group, or version too old
@@ -482,7 +481,7 @@ def get_register_descs(arch: gdb.Architecture, group: str = 'all') -> List[
             regset = gdb.execute(
                 f"info registers", to_string=True).strip().split('\n')
         for line in regset:
-            if not line.startswith(" ") and "<unavailable>" not in line:
+            if not line.startswith(" "):
                 tokens = line.strip().split()
                 descs.append(RegisterDesc(tokens[0]))
         return descs

--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/util.py
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/util.py
@@ -19,6 +19,7 @@ import bisect
 from dataclasses import dataclass
 import re
 from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
+import platform
 
 import gdb
 
@@ -467,7 +468,7 @@ class RegisterDesc:
 
 def get_register_descs(arch: gdb.Architecture, group: str = 'all') -> List[
         Union[RegisterDesc, gdb.RegisterDescriptor]]:
-    if hasattr(arch, "registers"):
+    if hasattr(arch, "registers") and platform.system() != "OpenBSD":
         try:
             return list(arch.registers(group))
         except ValueError:  # No such group, or version too old
@@ -481,7 +482,7 @@ def get_register_descs(arch: gdb.Architecture, group: str = 'all') -> List[
             regset = gdb.execute(
                 f"info registers", to_string=True).strip().split('\n')
         for line in regset:
-            if not line.startswith(" "):
+            if not line.startswith(" ") and "<unavailable>" not in line:
                 tokens = line.strip().split()
                 descs.append(RegisterDesc(tokens[0]))
         return descs

--- a/Ghidra/Debug/Debugger-agent-lldb/src/main/py/src/ghidralldb/arch.py
+++ b/Ghidra/Debug/Debugger-agent-lldb/src/main/py/src/ghidralldb/arch.py
@@ -135,6 +135,7 @@ default_compiler_map: Dict[Optional[str], str] = {
     'freebsd': 'gcc',
     'linux': 'gcc',
     'netbsd': 'gcc',
+    'openbsd': 'gcc',
     'ps4': 'gcc',
     'ios': 'gcc',
     'macosx': 'gcc',

--- a/Ghidra/Features/FunctionID/build.gradle
+++ b/Ghidra/Features/FunctionID/build.gradle
@@ -113,9 +113,10 @@ task buildFidHelpPdf(type: Exec) {
 	// Check the OS before executing command.
 	doFirst {
 		if ( !(org.gradle.internal.os.OperatingSystem.current().isLinux() 
-			|| org.gradle.internal.os.OperatingSystem.current().isMacOsX())) {
+			|| org.gradle.internal.os.OperatingSystem.current().isMacOsX()
+			|| org.gradle.internal.os.OperatingSystem.current().isOpenBSD())) {
 			throw new TaskExecutionException( it,
-				new Exception( "The '$it.name' task only works on Linux or Mac Os X" ))
+				new Exception( "The '$it.name' task only works on Linux, Mac Os X or OpenBSD" ))
 		}
 	}
 
@@ -177,8 +178,9 @@ task buildFidHelpHtml(type: Exec) {
 
 	// Check the OS before executing command.
 	doFirst {
-		if (!getCurrentPlatformName().startsWith("linux")) {
-			throw new TaskExecutionException( it, new Exception("The '$it.name' task only works on Linux."))
+		if (!(getCurrentPlatformName().startsWith("linux")
+		    || getCurrentPlatformName().startsWith("openbsd"))) {
+			throw new TaskExecutionException( it, new Exception("The '$it.name' task only works on Linux or OpenBSD."))
 		}
 	}
 

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/PtyFactory.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/PtyFactory.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import ghidra.framework.OperatingSystem;
 import ghidra.pty.linux.LinuxPtyFactory;
+import ghidra.pty.openbsd.OpenBSDPtyFactory;
 import ghidra.pty.macos.MacosPtyFactory;
 import ghidra.pty.windows.ConPtyFactory;
 
@@ -40,6 +41,8 @@ public interface PtyFactory {
 				return MacosPtyFactory.INSTANCE;
 			case LINUX:
 				return LinuxPtyFactory.INSTANCE;
+			case OPEN_BSD:
+				return OpenBSDPtyFactory.INSTANCE;
 			case WINDOWS:
 				return ConPtyFactory.INSTANCE;
 			default:

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDIoctls.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDIoctls.java
@@ -1,0 +1,38 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pty.openbsd;
+
+import ghidra.pty.unix.PosixC.Ioctls;
+import ghidra.pty.unix.UnixPtySessionLeader;
+
+public enum OpenBSDIoctls implements Ioctls {
+	INSTANCE;
+
+	@Override
+	public Class<? extends UnixPtySessionLeader> leaderClass() {
+		return OpenBSDPtySessionLeader.class;
+	}
+
+	@Override
+	public long TIOCSCTTY() {
+		return 0x20007461L;
+	}
+
+	@Override
+	public long TIOCSWINSZ() {
+		return 0x80087467L;
+	}
+}

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtyFactory.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtyFactory.java
@@ -1,0 +1,40 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pty.openbsd;
+
+import java.io.IOException;
+
+import ghidra.pty.Pty;
+import ghidra.pty.PtyFactory;
+import ghidra.pty.unix.UnixPty;
+
+public enum OpenBSDPtyFactory implements PtyFactory {
+	INSTANCE;
+
+	@Override
+	public Pty openpty(short cols, short rows) throws IOException {
+		UnixPty pty = UnixPty.openpty(OpenBSDIoctls.INSTANCE);
+		if (cols != 0 && rows != 0) {
+			pty.getChild().setWindowSize(cols, rows);
+		}
+		return pty;
+	}
+
+	@Override
+	public String getDescription() {
+		return "local (OpenBSD)";
+	}
+}

--- a/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtySessionLeader.java
+++ b/Ghidra/Framework/Pty/src/main/java/ghidra/pty/openbsd/OpenBSDPtySessionLeader.java
@@ -1,0 +1,33 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pty.openbsd;
+
+import ghidra.pty.unix.PosixC.Ioctls;
+import ghidra.pty.unix.UnixPtySessionLeader;
+
+public class OpenBSDPtySessionLeader extends UnixPtySessionLeader {
+
+	public static void main(String[] args) throws Exception {
+		OpenBSDPtySessionLeader leader = new OpenBSDPtySessionLeader();
+		leader.parseArgs(args);
+		leader.run();
+	}
+
+	@Override
+	protected Ioctls ioctls() {
+		return OpenBSDIoctls.INSTANCE;
+	}
+}

--- a/GhidraDocs/GettingStarted.md
+++ b/GhidraDocs/GettingStarted.md
@@ -203,8 +203,8 @@ Ghidra supports running on the following additional platforms with user-built na
 * Linux ARM 64-bit
 * FreeBSD x86 64-bit (no debugger support)
 * FreeBSD ARM 64-bit (no debugger support)
-* OpenBSD x86 64-bit (no debugger support)
-* OpenBSD ARM 64-bit (no debugger support)
+* OpenBSD x86 64-bit
+* OpenBSD ARM 64-bit
 
 For supported systems where native binaries have not been supplied, or those that are supplied fail
 to run properly, it may be necessary to build the native Ghidra binaries. In order to build native

--- a/gradle/hasProtobuf.gradle
+++ b/gradle/hasProtobuf.gradle
@@ -53,6 +53,9 @@ dependencies {
 			protocArtifact "com.google.protobuf:protoc:${version}:osx-aarch_64@exe"
 		}
 	}
+	if (isCurrentOpenBSD()) {
+		protocArtifact files('/usr/local/bin/protoc')
+	}
 }
 
 /*protobuf {


### PR DESCRIPTION
This PR adds pty and gdb debugger support for OpenBSD 7.9 and higher. It relies on using OpenBSD's installed jna and protobuf packages which are at different versions then what are available from upstream gradle/maven repos. Also of note is the base system gdb on OpenBSD/amd64 is the pre-GPL v3 version 6.3 which is built without python support. The package version is installed with a binary name of 'egdb' and is at version 17 with python support and is what works with ghidra.

OpenBSD 7.9 has a ghidra 12.0.4 package for amd64 and aarch64 with working debugger support, or to build from git on you will need the following packages installed:

`doas pkg_add jdk%25 jna protobuf protobuf-java python%3 py3-protobuf py3-pip py3-psutil bash gradle unzip-- gdb git`

and to work-around the version differences for jna and protobuf I use the following scripts which assume ghidra source located at $HOME/git/ghidra:

**ghidra.prepDev.sh**
```
#!/bin/ksh
set -ex
# doas pkg_add jdk%25 jna protobuf protobuf-java python%3 py3-protobuf py3-pip py3-psutil bash gradle unzip-- gdb git
JAVA_HOME=/usr/local/jdk-25
cd ~/git/ghidra
rm -rf dependencies
mkdir dependencies
env HOME='/ghidra-writes_to_HOME' JAVA_HOME=${JAVA_HOME} \
    gradle --no-daemon --info --stacktrace \
    -g ~/git/ghidra/dependencies/gradle \
    -I ~/git/ghidra/gradle/support/fetchDependencies.gradle
env HOME='/ghidra-writes_to_HOME' JAVA_HOME=${JAVA_HOME} \
    gradle --no-daemon --info --stacktrace \
    -g ~/git/ghidra/dependencies/gradle \
    prepDev

# delete protobuf-java and jna. gradle/maven upstream does
# not have OpenBSD support and we need to use locally built
# versions

find dependencies -path *protobuf-*/4.31.0 -o \
    -name net.java.dev.jna | xargs rm -rf
```

**ghidra.build.sh**
```
#!/bin/ksh
set -ex
export JAVA_HOME=/usr/local/jdk-25
export JDK_JAVA_OPTIONS="-Duser.home='/home/truk/git/home'"
export LC_CTYPE="en_US.UTF-8"

# note the OpenBSD versions of jna and protobuf are newer
# than what Ghidra uses. Copying the newer versions to the
# expected ghidra versions is the easist way to build from
# git. In the ports tree I have additional patches to ghidra
# to update the version as an alternate approach.

rm -f ~/git/ghidra/build/dist/ghidra_12*.zip
cd ~/git/ghidra
cp /usr/local/share/java/classes/jna.jar \
   dependencies/flatRepo/jna-5.14.0.jar
cp /usr/local/share/java/classes/jna-platform.jar \
   dependencies/flatRepo/jna-platform-5.14.0.jar
cp /usr/local/share/java/classes/protobuf-java.jar \
   dependencies/flatRepo/protobuf-java-4.31.0.jar

# --offline is needed to force ghidra to use the flatRepo with
# jna and protobuf-java.
env HOME='/ghidra-writes_to_HOME' JAVA_HOME=${JAVA_HOME} \
    gradle --no-daemon --info --stacktrace \
    -g ~/git/ghidra/dependencies/gradle \
    --offline buildGhidra
```

**ghidra.install.sh** 
```
#!/bin/ksh
set -ex

[ ! -d ~/bin ] && mkdir ~/bin
cd ~/bin
rm -rf ghidra_12* ghidraRun
unzip ~/git/ghidra/build/dist/ghidra_12*.zip
cp ~/git/ghidra/Ghidra/RuntimeScripts/ghidraRun ~/bin/ghidra_12*/
cp ~/git/ghidra/Ghidra/RuntimeScripts/support/launch.sh ~/bin/ghidra_12*/support
ed -s ghidra_12*/ghidraRun << EOF                                                                                                                                                                  
1a
export JAVA_HOME=/usr/local/jdk-25
.
w
EOF
ln -s ghidra_12*/ghidraRun ghidraRun
```