### PR TITLE
Add IDA-PRO external names for AARCH64, RISCV, others

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64.ldefs
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64.ldefs
@@ -14,6 +14,7 @@
     <compiler name="Visual Studio" spec="AARCH64_win.cspec" id="windows"/>
     <compiler name="golang" spec="AARCH64_golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64"/>
+    <external_name tool="IDA-PRO" name="arm"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
     <external_name tool="Golang.register.info.file" name="AARCH64_golang.register.info"/>
     <external_name tool="qemu" name="qemu-aarch64"/>
@@ -33,6 +34,7 @@
     <compiler name="default" spec="AARCH64.cspec" id="default"/>
     <compiler name="golang" spec="AARCH64_golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64"/>
+    <external_name tool="IDA-PRO" name="armb"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
     <external_name tool="Golang.register.info.file" name="AARCH64_golang.register.info"/>
     <external_name tool="qemu" name="qemu-aarch64_be"/>
@@ -52,6 +54,7 @@
     <compiler name="default" spec="AARCH64_ilp32.cspec" id="default"/>
     <compiler name="golang" spec="AARCH64_golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64:ilp32"/>
+    <external_name tool="IDA-PRO" name="arm"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
     <external_name tool="qemu" name="qemu-aarch64"/>
     <external_name tool="qemu_system" name="qemu-system-aarch64"/>
@@ -71,6 +74,7 @@
     <compiler name="default" spec="AARCH64_ilp32.cspec" id="default"/>
     <compiler name="golang" spec="AARCH64_golang.cspec" id="golang"/>
     <external_name tool="gnu" name="aarch64:ilp32"/>
+    <external_name tool="IDA-PRO" name="armb"/>
     <external_name tool="DWARF.register.mapping.file" name="AARCH64.dwarf"/>
     <external_name tool="qemu" name="qemu-aarch64_be"/>
     <external_name tool="qemu_system" name="qemu-system-aarch64"/>

--- a/Ghidra/Processors/Dalvik/data/languages/Dalvik.ldefs
+++ b/Ghidra/Processors/Dalvik/data/languages/Dalvik.ldefs
@@ -14,6 +14,7 @@
             id="Dalvik:LE:32:default">
     <description>Dalvik Base</description>
     <compiler name="default" spec="Dalvik_Base.cspec" id="default"/>
+    <external_name tool="IDA-PRO" name="dalvik"/>
   </language>
 
   <language processor="Dalvik"

--- a/Ghidra/Processors/HCS12/data/languages/HCS12.ldefs
+++ b/Ghidra/Processors/HCS12/data/languages/HCS12.ldefs
@@ -13,6 +13,7 @@
     <description>HC12 Microcontroller Family</description>
     <compiler name="default" spec="HC12.cspec" id="default"/>
     <external_name tool="gnu" name="m68hc12"/>
+    <external_name tool="IDA-PRO" name="6812"/>
   </language>
   <language processor="HCS-12"
             endian="big"
@@ -26,6 +27,7 @@
     <description>HCS12 Microcontroller Family</description>
     <compiler name="default" spec="HCS12.cspec" id="default"/>
     <external_name tool="gnu" name="m9s12x"/>
+    <external_name tool="IDA-PRO" name="hcs12"/>
   </language>
   <language processor="HCS-12X"
             endian="big"
@@ -39,6 +41,7 @@
     <description>HCS12X Microcontroller Family</description>
     <compiler name="default" spec="HCS12X.cspec" id="default"/>
     <external_name tool="gnu" name="m9s12x"/>
+    <external_name tool="IDA-PRO" name="hcs12x"/>
   </language>
   
   <!-- deprecated HCS12, which was equivalent to HCS12X, allows opening of existing Programs which use the old ID -->
@@ -55,5 +58,6 @@
     <description>HCS12X Microcontroller Family</description>
     <compiler name="default" spec="HCS12X.cspec" id="default"/>
     <external_name tool="gnu" name="m9s12x"/>
+    <external_name tool="IDA-PRO" name="hcs12x"/>
   </language>
 </language_definitions>

--- a/Ghidra/Processors/M16C/data/languages/M16C_60.ldefs
+++ b/Ghidra/Processors/M16C/data/languages/M16C_60.ldefs
@@ -16,5 +16,6 @@
     <description>Renesas M16C/60 16-Bit MicroComputer</description>
     <compiler name="default" spec="M16C_60.cspec" id="default"/>
     <external_name tool="gnu" name="m16c"/>
+    <external_name tool="IDA-PRO" name="m16c60"/>
   </language>
 </language_definitions>

--- a/Ghidra/Processors/M16C/data/languages/M16C_80.ldefs
+++ b/Ghidra/Processors/M16C/data/languages/M16C_80.ldefs
@@ -16,5 +16,6 @@
     <description>Renesas M16C/80 16-Bit MicroComputer</description>
     <compiler name="default" spec="M16C_80.cspec" id="default"/>
     <external_name tool="gnu" name="m16c"/>
+    <external_name tool="IDA-PRO" name="m16c80"/>
   </language>
 </language_definitions>

--- a/Ghidra/Processors/MCS96/data/languages/MCS96.ldefs
+++ b/Ghidra/Processors/MCS96/data/languages/MCS96.ldefs
@@ -12,5 +12,10 @@
             id="MCS96:LE:16:default">
     <description>Intel MCS-96 Microcontroller Family</description>
     <compiler name="default" spec="MCS96.cspec" id="default"/>
+    <external_name tool="IDA-PRO" name="80196"/>
+    <external_name tool="IDA-PRO" name="80196np"/>
+    <external_name tool="IDA-PRO" name="8096"/>
+    <external_name tool="IDA-PRO" name="8061"/>
+    <external_name tool="IDA-PRO" name="8065"/>
   </language>
 </language_definitions>

--- a/Ghidra/Processors/NDS32/data/languages/nds32.ldefs
+++ b/Ghidra/Processors/NDS32/data/languages/nds32.ldefs
@@ -13,6 +13,7 @@
     <description>NDS32 default processor 32-bit big-endian</description>
     <compiler name="default" spec="nds32.cspec" id="default"/>
     <external_name tool="gnu" name="n1h_v3m"/>
+    <external_name tool="IDA-PRO" name="nds32"/>
     <external_name tool="DWARF.register.mapping.file" name="nds32.dwarf"/>
   </language>
   <language processor="NDS32"
@@ -27,6 +28,7 @@
     <description>NDS32 default processor 32-bit little-endian</description>
     <compiler name="default" spec="nds32.cspec" id="default"/>
     <external_name tool="gnu" name="n1h_v3m"/>
+    <external_name tool="IDA-PRO" name="nds32"/>
     <external_name tool="DWARF.register.mapping.file" name="nds32.dwarf"/>
   </language>
 </language_definitions>

--- a/Ghidra/Processors/RISCV/data/languages/riscv.ldefs
+++ b/Ghidra/Processors/RISCV/data/languages/riscv.ldefs
@@ -12,6 +12,7 @@
             id="RISCV:LE:64:default">
     <description>RISC-V 64 little default</description>
     <compiler name="gcc" spec="riscv64-fp.cspec" id="gcc"/>
+    <external_name tool="IDA-PRO" name="riscv"/>
     <external_name tool="DWARF.register.mapping.file" name="riscv64.dwarf"/>
     <external_name tool="gnu" name="riscv:rv64"/>
     <external_name tool="qemu" name="qemu-riscv64"/>
@@ -28,6 +29,7 @@
             id="RISCV:LE:32:default">
     <description>RISC-V 32 little default</description>
     <compiler name="gcc" spec="riscv32-fp.cspec" id="gcc"/>
+    <external_name tool="IDA-PRO" name="riscv"/>
     <external_name tool="gnu" name="riscv:rv32"/>
     <external_name tool="DWARF.register.mapping.file" name="riscv32.dwarf"/>
     <external_name tool="qemu" name="qemu-riscv32"/>

--- a/Ghidra/Processors/SuperH/data/languages/superh.ldefs
+++ b/Ghidra/Processors/SuperH/data/languages/superh.ldefs
@@ -12,6 +12,7 @@
             id="SuperH:BE:32:SH-2A">
     <description>SuperH SH-2A processor 32-bit big-endian</description>
     <compiler name="default" spec="superh2a.cspec" id="default"/>
+    <external_name tool="IDA-PRO" name="sh2a"/>
   </language>
   <language processor="SuperH"
             endian="big"

--- a/Ghidra/Processors/V850/data/languages/V850.ldefs
+++ b/Ghidra/Processors/V850/data/languages/V850.ldefs
@@ -12,6 +12,7 @@
             id="V850:LE:32:default">
     <description>Renesas V850 family</description>
     <compiler name="default" spec="V850.cspec" id="default"/>
+    <external_name tool="IDA-PRO" name="v850"/>
     <external_name tool="DWARF.register.mapping.file" name="V850.dwarf"/>
     <external_name tool="gnu" name="v850e2v4"/>
     

--- a/Ghidra/Processors/Xtensa/data/languages/xtensa.ldefs
+++ b/Ghidra/Processors/Xtensa/data/languages/xtensa.ldefs
@@ -13,6 +13,7 @@
     <description>Tensilica Xtensa 32-bit little-endian</description>
     <compiler name="default" spec="xtensa.cspec" id="default"/>
     <external_name tool="gnu" name="xtensa"/>
+    <external_name tool="IDA-PRO" name="xtensa"/>
     <external_name tool="DWARF.register.mapping.file" name="xtensa.dwarf"/>
     <external_name tool="qemu" name="qemu-xtensa"/>
     <external_name tool="qemu_system" name="qemu-system-xtensa"/>
@@ -29,6 +30,7 @@
     <description>Tensilica Xtensa 32-bit big-endian</description>
     <compiler name="default" spec="xtensa.cspec" id="default"/>
     <external_name tool="gnu" name="xtensa"/>
+    <external_name tool="IDA-PRO" name="xtensab"/>
     <external_name tool="DWARF.register.mapping.file" name="xtensa.dwarf"/>
     <external_name tool="qemu" name="qemu-xtensaeb"/>
     <external_name tool="qemu_system" name="qemu-system-xtensaeb"/>

--- a/Ghidra/Processors/tricore/data/languages/tricore.ldefs
+++ b/Ghidra/Processors/tricore/data/languages/tricore.ldefs
@@ -26,6 +26,7 @@
             id="tricore:LE:32:tc29x">
     <description>Infineon Tricore Embedded Processor TC29x</description>
     <compiler name="default" spec="tricore.cspec" id="default"/>
+    <external_name tool="IDA-PRO" name="tricore"/>
     <external_name tool="DWARF.register.mapping.file" name="tricore.dwarf"/>
   </language>
   <language processor="tricore"
@@ -39,6 +40,7 @@
             id="tricore:LE:32:tc172x">
     <description>Infineon Tricore Embedded Processor TC1724/TC1728</description>
     <compiler name="default" spec="tricore.cspec" id="default"/>
+    <external_name tool="IDA-PRO" name="tricore"/>
     <external_name tool="DWARF.register.mapping.file" name="tricore.dwarf"/>
   </language>
     <language processor="tricore"
@@ -52,6 +54,7 @@
             id="tricore:LE:32:tc176x">
     <description>Infineon Tricore Embedded Processor TC1762/TC1766</description>
     <compiler name="default" spec="tricore.cspec" id="default"/>
+    <external_name tool="IDA-PRO" name="tricore"/>
     <external_name tool="DWARF.register.mapping.file" name="tricore.dwarf"/>
   </language>
 </language_definitions>


### PR DESCRIPTION
Currently IDA Pro bindings are missing for AARCH64 and should match the ARM ones as IDA uses `arm` for little-endian and `armb` for big-endian.  The others are: RISCV, ND532, TriCore, Xtensa, M16C, HCS12, MCS96, SuperH, V850 and Dalvik.