### PR TITLE
Fix nds32 fmul* and fdiv* instructions having incorrect fop4

### DIFF
--- a/Ghidra/Processors/NDS32/data/languages/nds32.sinc
+++ b/Ghidra/Processors/NDS32/data/languages/nds32.sinc
@@ -1317,12 +1317,12 @@ define pcodeop fnmsubs;
 }
 
 define pcodeop fmuls;
-:fmuls Fst, Fsa, Fsb is $(I32) & $(COP) & fop4=0xa & Fst & Fsa & Fsb  & cop4=0x0 {
+:fmuls Fst, Fsa, Fsb is $(I32) & $(COP) & fop4=0xc & Fst & Fsa & Fsb  & cop4=0x0 {
 	Fst = fmuls(Fsa, Fsb);
 }
 
 define pcodeop fdivs;
-:fdivs Fst, Fsa, Fsb is $(I32) & $(COP) & fop4=0xb & Fst & Fsa & Fsb  & cop4=0x0 {
+:fdivs Fst, Fsa, Fsb is $(I32) & $(COP) & fop4=0xd & Fst & Fsa & Fsb  & cop4=0x0 {
 	Fst = fdivs(Fsa, Fsb);
 }
 
@@ -1439,12 +1439,12 @@ define pcodeop fnmsubd;
 }
 
 define pcodeop fmuld;
-:fmuld Fdt, Fda, Fdb is $(I32) & $(COP) & fop4=0xa & Fdt & Fda & Fdb  & cop4=0x8 {
+:fmuld Fdt, Fda, Fdb is $(I32) & $(COP) & fop4=0xc & Fdt & Fda & Fdb  & cop4=0x8 {
 	Fdt = fmuld(Fda, Fdb);
 }
 
 define pcodeop fdivd;
-:fdivd Fdt, Fda, Fdb is $(I32) & $(COP) & fop4=0xb & Fdt & Fda & Fdb  & cop4=0x8 {
+:fdivd Fdt, Fda, Fdb is $(I32) & $(COP) & fop4=0xd & Fdt & Fda & Fdb  & cop4=0x8 {
 	Fdt = fdivd(Fda, Fdb);
 }
 


### PR DESCRIPTION
It seems the definition for fmuld, fmuls, fdivd, and fdivs is slightly incorrect, leading to the instructions not being parsed.
In particular, for the mul instructions, fop4 should be 0b1100 (0xC) and for the div instructions, 0b1101 (0xD).
Here's the relevant docs:
<img width="1436" height="460" alt="Screenshot 2026-07-04 122343" src="https://github.com/user-attachments/assets/7cfc477e-d552-47f6-9dee-1745aa5c9042" />
<img width="1412" height="456" alt="Screenshot 2026-07-04 122354" src="https://github.com/user-attachments/assets/68f2427a-5559-468e-97b4-80169da044ad" />
(The double precision variant is the same)

I did a brief check through the other fpu instructions, and they all seemed correct, so it's just these that need updating.

As for reproducing the issue, I was running [this](https://github.com/andestech/Andes-Development-Kit/releases/tag/ast-v3_2_5-release-linux) toolchain with the following:
```c
float fdivs(float a, float b) { return a / b; }

float fmuls(float a, float b) { return a * b; }

double fdivd(double a, double b) { return a / b; }

double fmuld(double a, double b) { return a * b; }

int main() { return 0; }
```

```sh
nds32le-elf-gcc -mext-fpu-sp -mext-fpu-dp -O main.c
```

Relevant objdump:
```
00500084 <fdivs>:
  500084:       6a 00 00 09     fmtsr $r0,$fs0
  500088:       6a 10 80 09     fmtsr $r1,$fs1
  50008c:       6a 00 07 40     fdivs $fs0,$fs0,$fs1
  500090:       6a 00 00 01     fmfsr $r0,$fs0
  500094:       4a 00 78 20     ret $lp

00500098 <fmuls>:
  500098:       6a 00 00 09     fmtsr $r0,$fs0
  50009c:       6a 10 80 09     fmtsr $r1,$fs1
  5000a0:       6a 00 07 00     fmuls $fs0,$fs0,$fs1
  5000a4:       6a 00 00 01     fmfsr $r0,$fs0
  5000a8:       4a 00 78 20     ret $lp

005000ac <fdivd>:
  5000ac:       6a 00 00 49     fmtdr $r0,$fd0
  5000b0:       6a 20 80 49     fmtdr $r2,$fd1
  5000b4:       6a 00 07 48     fdivd $fd0,$fd0,$fd1
  5000b8:       6a 00 00 41     fmfdr $r0,$fd0
  5000bc:       4a 00 78 20     ret $lp

005000c0 <fmuld>:
  5000c0:       6a 00 00 49     fmtdr $r0,$fd0
  5000c4:       6a 20 80 49     fmtdr $r2,$fd1
  5000c8:       6a 00 07 08     fmuld $fd0,$fd0,$fd1
  5000cc:       6a 00 00 41     fmfdr $r0,$fd0
  5000d0:       4a 00 78 20     ret $lp
```

Using fdivs as an example, `6a 00 07 40` is `01101010000000000000011101000000` which leaves `1101` for fop4.

I'm pretty sure these only need to be updated in nds32.sinc, but let me know if I missed another spot.