### PR TITLE
Golang: recover symbols from stripped Go 1.24/1.25 (swiss-map) binaries

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/GoRttiMapper.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/GoRttiMapper.java
@@ -1065,6 +1065,23 @@ public class GoRttiMapper extends DataTypeMapper implements DataTypeMapperContex
 				"Unable to find containing module for structure at 0x%x".formatted(ptrInModule));
 		}
 		long nameStart = module.getTypesOffset() + off;
+		if (nameStart < module.getTypesOffset() || nameStart >= module.getTypesEndOffset()) {
+			// A name offset is relative to the module's types base and must
+			// resolve to an address within the module's type/name area
+			// [types, etypes).  A value outside that range means the referring
+			// structure's name offset is corrupt, or the structure was
+			// misidentified as a Go type (observed on stripped Go >= 1.25
+			// binaries, where one rtti type's pkgPath name offset reads as a
+			// large garbage value).  Return null (no name) rather than reading
+			// an out-of-bounds address, which throws an EOFException that
+			// aborts the entire Go analysis pass and leaves the program with
+			// no recovered Go symbols.
+			Msg.warn(this,
+				"Ignoring out-of-bounds Go name offset 0x%x for structure at 0x%x (module types [0x%x, 0x%x))"
+						.formatted(off, ptrInModule, module.getTypesOffset(),
+							module.getTypesEndOffset()));
+			return null;
+		}
 		return getGoName(nameStart);
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/GoTypeManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/GoTypeManager.java
@@ -165,7 +165,17 @@ public class GoTypeManager {
 		// were referenced from the firstModule struct
 		for (GoType goType : allTypes()) {
 			monitor.checkCancelled();
-			markupSession.markup(goType, false);
+			try {
+				markupSession.markup(goType, false);
+			}
+			catch (IOException e) {
+				// Don't let one bad type (e.g. a mis-recovered type in a
+				// stripped binary whose name-offset resolves out of bounds)
+				// abort markup of every remaining type and the later function
+				// markup pass.  Log and continue.
+				Msg.warn(this, "Failed to markup Go type at %s"
+						.formatted(goType.getStructureContext().getStructureAddress()), e);
+			}
 		}
 	}
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoMapType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/golang/rtti/types/GoMapType.java
@@ -30,7 +30,8 @@ import ghidra.util.Msg;
  * Maps are passed by address, and in Go sizeof(mapvar) will always be ptrSize
  */
 @StructureMapping(
-	structureName = { "runtime.maptype", "internal/abi.MapType", "internal/abi.OldMapType" }
+	structureName = { "runtime.maptype", "internal/abi.MapType", "internal/abi.SwissMapType",
+		"internal/abi.OldMapType" }
 )
 public class GoMapType extends GoType {
 
@@ -42,24 +43,24 @@ public class GoMapType extends GoType {
 	@MarkupReference("getElement")
 	private long elem;	// ptr to type
 
-	@FieldMapping(presentWhen = "-1.25")
+	@FieldMapping(presentWhen = "-1.23")
 	@MarkupReference("getBucket")
 	private long bucket;	// ptr to type
 
-	@FieldMapping(presentWhen = "1.26-")
+	@FieldMapping(presentWhen = "1.24-")
 	@MarkupReference("getGroup")
 	private long group;	// ptr to group type
 
 	@FieldMapping
 	private long hasher;	// pointer to "func(Pointer, pointer) pointer"
 
-	@FieldMapping(presentWhen = "-1.25")
+	@FieldMapping(presentWhen = "-1.23")
 	private int keysize;
 
-	@FieldMapping(fieldName = { "elemsize", "ValueSize" }, presentWhen = "-1.25")
+	@FieldMapping(fieldName = { "elemsize", "ValueSize" }, presentWhen = "-1.23")
 	private int elemsize;
 
-	@FieldMapping(presentWhen = "-1.25")
+	@FieldMapping(presentWhen = "-1.23")
 	private int bucketsize;
 
 	@FieldMapping


### PR DESCRIPTION
On stripped Go 1.24/1.25 binaries, `GolangSymbolAnalyzer` can recover **no** Go symbols — only `FUN_*` names, with `main.main` unresolved.

## Root cause

Swiss-table maps are the default map implementation since Go 1.24. The runtime map rtti struct is named `internal/abi.SwissMapType` in 1.24 and 1.25; it was renamed to the canonical `internal/abi.MapType` in 1.26, and in ≤ 1.23 the (old) map is `internal/abi.MapType`.

`GoMapType`'s `@StructureMapping` candidate list was:

```
{ "runtime.maptype", "internal/abi.MapType", "internal/abi.OldMapType" }
```

For 1.24/1.25, `runtime.maptype` resolves to a typedef (skipped by the `Structure`-typed lookup) and `internal/abi.MapType` isn't in those snapshots, so resolution falls through to the 88-byte `internal/abi.OldMapType`. But a default-built 1.24/1.25 binary emits the 112-byte `SwissMapType` layout, so the struct is under-read by 24 bytes. `getEndOfTypeInfo()` then reports each map type ending 24 bytes early, `findUnindexedClosureStructTypes()` scans that phantom gap, mis-reads bytes in the middle of the real struct as a new type, and indexes it. When one of those phantom types has a `pkgPath` name offset that resolves out of bounds, `GoName.readStructure()` throws `EOFException`; because `markupGoTypes()` runs before function naming under one try/catch, that one exception rolls back the whole analyzer → zero symbols.

Whether the mis-read escalates to the crash is **layout-sensitive** — every 1.24/1.25 default build mis-reads the map, but only some land the gap scan on out-of-bounds bytes. (The 16-line reproducer below crashes at both 1.24 and 1.25, while the larger sample from the original report crashes at 1.25 but happens to survive at 1.24.)

1.26 is unaffected: its swiss struct uses the canonical `internal/abi.MapType`, which is already in the candidate list.

## Fix

Three commits:

- **`GoMapType`** (the fix) — add `internal/abi.SwissMapType` to the candidate list, ahead of `OldMapType`, and gate the map fields by layout: the old `bucket`/`keysize`/`elemsize`/`bucketsize` fields present for `-1.23`, `group` present for `1.24-`. **No apisnapshot regeneration is needed** — the 1.24/1.25 snapshots already contain `internal/abi.SwissMapType`.
- **`GoTypeManager.markupGoTypes`** (defense in depth) — guard each type's markup (log + continue), matching the existing guard in the type-discovery loop, so one bad type can't sink the whole pass.
- **`GoRttiMapper.resolveNameOff`** (defense in depth) — a name offset must resolve within the module's `[types, etypes)` region; return `null` instead of reading out of bounds.

The `GoMapType` change alone restores recovery; the two guards are independent robustness (graceful degradation), complementary to the `isValid()` size checks added in GP-6871.

## Validation

Built from this branch, `analyzeHeadless` on stripped `linux-amd64` binaries against master `e6ee047`:

| binary | Go | stock master | with fix |
|---|---|---|---|
| 16-line reproducer | 1.23 | 5402 named | 5402 (unchanged) |
| 16-line reproducer | 1.24 | 3 named (`EOFException`) | 5776 named |
| 16-line reproducer | 1.25 | 3 named (`EOFException`) | 5878 named, `main.main` resolved |
| 16-line reproducer | 1.26 | 6155 named | 6155 (unchanged) |
| larger sample | 1.24 | 6100 named (no crash) | 6100 (unchanged) |
| larger sample | 1.25 | 3 named (`EOFException`) | 6198 named, `main.main` resolved |
| larger sample | 1.26 | 6483 named | 6483 (unchanged) |

Unstripped binaries are unaffected.

The same commits on a `Ghidra_12.1.2_build` base are on [`fix/golang-stripped-type-markup`](https://github.com/kubrickfr/ghidra/tree/fix/golang-stripped-type-markup) for a release backport.
