### PR TITLE
fix: persist StoredAnalyzerTimes in PyGhidra analysis

### DIFF
--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/core.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/core.py
@@ -162,8 +162,12 @@ def _analyze_program(flat_api, program):
     if GhidraProgramUtilities.shouldAskToAnalyze(program):
         GhidraScriptUtil.acquireBundleHostReference()
         try:
-            flat_api.analyzeAll(program)
-            GhidraProgramUtilities.markProgramAnalyzed(program)
+            tx_id = program.startTransaction("Analyze")
+            try:
+                flat_api.analyzeAll(program)
+                GhidraProgramUtilities.markProgramAnalyzed(program)
+            finally:
+                program.endTransaction(tx_id, True)
         finally:
             GhidraScriptUtil.releaseBundleHostReference()
 


### PR DESCRIPTION
## Summary

Wrap flat_api.analyzeAll() in a transaction so that AutoAnalysisManager.saveTaskTimes() properly persists analysis timing data to program options.

## Root Cause
saveTaskTimes() modifies program options via StoredAnalyzerTimes.setStoredAnalyzerTimes(), but this was running outside any transaction in PyGhidra. Ghidra options changes require an active transaction to persist.

analyzeHeadless already wraps this in a transaction, which is why it works correctly.

Fixes #9346