### PR TITLE
Fix partial register return recovery

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -10431,6 +10431,30 @@ Varnode *RulePopcountBoolXor::getBooleanResult(Varnode *vn,int4 bitPos,int4 &con
   }
 }
 
+/// \brief Return \b true if the PIECE looks like a partial register write
+///
+/// A partial write to the least significant bytes of a register can be modeled
+/// by assigning the most significant bytes of the register, then concatenating
+/// them with the new least significant bytes.  Treat this as pathological if
+/// the most significant input is stored in the corresponding high bytes of the
+/// PIECE output.
+/// \param op is the CPUI_PIECE op
+/// \return \b true if the PIECE writes only the least significant output bytes
+bool RulePiecePathology::isPartialWrite(PcodeOp *op)
+
+{
+  Varnode *outVn = op->getOut();
+  if (outVn == (Varnode *)0) return false;
+  if (outVn->getSpace()->getType() == IPTR_INTERNAL) return false;
+  Varnode *hiVn = op->getIn(0);
+  int4 loSize = op->getIn(1)->getSize();
+  if (hiVn->getSize() + loSize != outVn->getSize()) return false;
+  Address addr = outVn->getAddr();
+  if (!addr.getSpace()->isBigEndian())
+    addr = addr + loSize;
+  return (addr == hiVn->getAddr());
+}
+
 /// \brief Return \b true if concatenating with a SUBPIECE of the given Varnode is unusual
 ///
 /// \param vn is the given Varnode
@@ -10593,6 +10617,8 @@ int4 RulePiecePathology::applyOp(PcodeOp *op,Funcdata &data)
   Varnode *vn = op->getIn(0);
   if (!vn->isWritten()) return 0;
   PcodeOp *subOp = vn->getDef();
+  if (isPartialWrite(op))
+    return tracePathologyForward(op, data);
 
   // Make sure we are concatenating the most significant bytes of a truncation
   OpCode opc = subOp->code();

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.hh
@@ -1525,6 +1525,7 @@ public:
 };
 
 class RulePiecePathology : public Rule {
+  static bool isPartialWrite(PcodeOp *op);
   static bool isPathology(Varnode *vn,Funcdata &data);
   static int4 tracePathologyForward(PcodeOp *op,Funcdata &data);
 public:

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/partialreturn.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/partialreturn.xml
@@ -1,0 +1,24 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:windows">
+<!--
+  A small return value is written through AL.  The old high bytes of RAX
+  should not force recovery of an 8-byte return value with a CONCAT expression.
+-->
+<bytechunk space="ram" offset="0x100000" readonly="true">
+31d248c7c0ffffffff48ffc066833c4100
+75f64839c273110fb704516683f87f7603
+b001c3ffc2ebd930c0c390909090
+</bytechunk>
+<symbol space="ram" offset="0x100000" name="partial_register_return"/>
+</binaryimage>
+<script>
+  <com>lo fu partial_register_return</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Partial register return #1" min="0" max="0">CONCAT</stringmatch>
+<stringmatch name="Partial register return #2" min="0" max="0">uint8 partial_register_return</stringmatch>
+<stringmatch name="Partial register return #3" min="1" max="1">return 1;</stringmatch>
+<stringmatch name="Partial register return #4" min="1" max="1">return 0;</stringmatch>
+</decompilertest>


### PR DESCRIPTION
This fixes a decompiler case where a function writes only the low byte of the return register, but the recovered return value keeps unrelated high bytes via a `CONCAT` expression.

For x86-64, code like writing `AL` before return can produce raw p-code shaped like:

```text
RAX+1:7 = ...
RAX = CONCAT71(RAX+1:7, 1)
return RAX
```
Before this change, the decompiler could infer an 8-byte return value and emit CONCAT71(...). This patch teaches RulePiecePathology to recognize this partial-register write pattern and mark only the low return byte as consumed.