### PR TITLE
docs(tests): add docstrings and unit tests for pyghidra.converters

### DIFF
--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/converters.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/converters.py
@@ -13,16 +13,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
+"""JPype type conversions for transparent Python-to-Java interop.
+
+This module registers JPype conversion handlers so that Python
+:class:`pathlib.Path` instances can be passed directly to Java APIs
+that expect ``java.lang.String`` or ``java.io.File`` parameters. The
+:func:`jpype.JConversion` decorator installs each handler the first
+time this module is imported, so importing :mod:`pyghidra` is
+sufficient to enable the conversions globally.
+"""
 from pathlib import Path
 
 from jpype import JConversion, JClass
 
+__all__ = ["pathToString", "pathToFile"]
+
 
 @JConversion("java.lang.String", instanceof=Path)
 def pathToString(cls: JClass, path: Path):
+    """Convert a :class:`Path` to a ``java.lang.String`` via JPype.
+
+    The path is first resolved to an absolute, canonical form via
+    :meth:`Path.resolve` before being passed to ``cls`` (the target
+    Java class constructor).
+
+    :param cls: The target ``java.lang.String`` class supplied by JPype.
+    :param path: The Python :class:`Path` to convert.
+    :return: A ``java.lang.String`` representing the absolute path.
+    """
     return cls(path.resolve().__str__())
 
 
 @JConversion("java.io.File", instanceof=Path)
 def pathToFile(cls: JClass, path: Path):
+    """Convert a :class:`Path` to a ``java.io.File`` via JPype.
+
+    Unlike :func:`pathToString`, the path is passed through unchanged
+    (no ``resolve()`` call) so that Java receives the path exactly as
+    the Python caller provided it.
+
+    :param cls: The target ``java.io.File`` class supplied by JPype.
+    :param path: The Python :class:`Path` to convert.
+    :return: A ``java.io.File`` pointing at the same location.
+    """
     return cls(path)

--- a/Ghidra/Features/PyGhidra/src/main/py/tests/test_converters.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/tests/test_converters.py
@@ -1,0 +1,85 @@
+## ###
+# IP: GHIDRA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+"""Unit tests for :mod:`pyghidra.converters`.
+
+The JPype :func:`JConversion` decorator stores the user-supplied
+function unchanged (see ``jpype._jcustomizer.JConversion``) and only
+attaches the conversion metadata to JPype's internal registry. As a
+result, the conversion bodies can be exercised directly with a mock
+target class, no live JVM is required.
+"""
+from pathlib import Path
+
+from pyghidra.converters import pathToFile, pathToString
+
+
+class _MockJClass:
+    """Stand-in for a Java class. Records the constructor argument."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        return isinstance(other, _MockJClass) and self.value == other.value
+
+    def __hash__(self):
+        return hash(self.value)
+
+
+def test_module_exposes_public_helpers():
+    """Both conversion helpers are part of the public API."""
+    import pyghidra.converters as converters
+
+    assert converters.__all__ == ["pathToString", "pathToFile"]
+    assert converters.pathToString is pathToString
+    assert converters.pathToFile is pathToFile
+
+
+def test_pathToString_invokes_resolve(tmp_path: Path):
+    """``pathToString`` should call ``Path.resolve()`` before constructing the target."""
+    nested = tmp_path / "missing" / "child.txt"
+
+    result = pathToString(_MockJClass, nested)
+
+    assert isinstance(result, _MockJClass)
+    assert result.value == str(nested.resolve())
+
+
+def test_pathToFile_preserves_input_path(tmp_path: Path):
+    """``pathToFile`` should pass the path through unchanged (no ``resolve()``)."""
+    nested = tmp_path / "missing" / "child.txt"
+
+    result = pathToFile(_MockJClass, nested)
+
+    assert isinstance(result, _MockJClass)
+    assert result.value == str(nested)
+
+
+def test_helpers_diverge_on_path_with_dotdot(tmp_path: Path):
+    """The two helpers must produce different output for an un-resolved path.
+
+    ``tmp_path`` is absolute, so a plain ``tmp_path / "x"`` is already
+    canonical. To exercise the ``Path.resolve()`` branch in
+    :func:`pathToString`, the input has to contain ``..`` segments.
+    """
+    nested = tmp_path / "missing" / ".." / "child.txt"
+
+    as_string = pathToString(_MockJClass, nested)
+    as_file = pathToFile(_MockJClass, nested)
+
+    assert as_string.value != as_file.value
+    assert as_file.value == str(nested)
+    assert as_string.value == str(nested.resolve())


### PR DESCRIPTION
## What

This PR adds module-level and per-function docstrings to
`Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/converters.py`,
declares `__all__` for the public API, and introduces a new
`tests/test_converters.py` covering the existing
`pathToString` / `pathToFile` conversion helpers.

## Why

`pyghidra.converters` is the small but non-obvious bridge that lets
PyGhidra users pass a `pathlib.Path` straight into a Java method that
expects `java.lang.String` or `java.io.File`. Today the module has no
docstring, neither function has a docstring, and there is no dedicated
test file (`tests/` only ships `test_argparser.py`, `test_core.py`,
`test_plugin.py`). The first thing a contributor hits when they try to
extend the conversions is a wall of silence.

This PR fills those gaps without changing behaviour. The change set
stays well under 100 lines of functional impact and is split into:

* `converters.py`: +31 lines (docs only, no logic change).
* `tests/test_converters.py`: +85 lines (4 unit tests).

## How the tests work

`jpype._jcustomizer.JConversion` is implemented as:

```python
def customizer(func=None):
    if exact is not None:
        hints._addTypeConversion(exact, func, True)
    if instanceof is not None:
        hints._addTypeConversion(instanceof, func, False)
    ...
    return func
```

It returns the wrapped function unchanged, so the conversion bodies can
be exercised directly with a mock JClass. The new tests do exactly that,
which means no live JVM is required and no JPype import side effects
need to be accounted for.

Tests added:

* `test_module_exposes_public_helpers` — verifies `__all__` and the
  `is`-identity of the public names.
* `test_pathToString_invokes_resolve` — `pathToString` resolves the
  path before constructing the target.
* `test_pathToFile_preserves_input_path` — `pathToFile` forwards the
  path as-is, no `resolve()`.
* `test_helpers_diverge_on_path_with_dotdot` — given a path containing
  `..` segments, the two helpers produce different output, which is
  the actual behavioural asymmetry that callers need to be aware of.

## Source code locations touched

* `Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/converters.py`
  * Module docstring added at top of file (after the IP header).
  * `__all__ = ["pathToString", "pathToFile"]` added.
  * Docstring added to `pathToString` (lines 33-43 in the new file).
  * Docstring added to `pathToFile` (lines 48-58 in the new file).
* `Ghidra/Features/PyGhidra/src/main/py/tests/test_converters.py`
  * New file, 85 lines, 4 test cases.

## Issue

Refs #9352 (MCP feature request — this PR is a small, supporting
documentation+test improvement to PyGhidra, **not** an MCP server
implementation. The original PR #9353 was closed per the maintainer's
request to consolidate. The MCP direction is being moved to a separate
extension repository and will not be pursued on `master`.)

## Local verification

* `python -c "import ast; ast.parse(open('.../converters.py').read())"`
  → OK
* `python -c "import ast; ast.parse(open('.../test_converters.py').read())"`
  → OK
* `git diff --stat` → 2 files changed, 116 insertions(+), 0 deletions(-)
* Test design is grounded in the JPype source: the `JConversion`
  customizer returns the wrapped function unchanged, so direct calls
  with a mock class are an accurate test of the conversion bodies.

A full PyGhidra test run requires the Ghidra Gradle/JVM environment,
which the GitHub Actions CI provides. No CI was run locally.

## AI disclosure

此PR由AI辅助生成，已通过静态检查（Python AST 解析 + JPype 源码验证），
但核心逻辑变更请重点复核：建议关注 `pathToString` 文档中对 `resolve()`
行为的描述是否与项目使用场景一致，以及 `__all__` 声明是否符合项目惯例
（项目其他模块 `__init__.py` 没有 `__all__`，但子模块没有先例可循，
本 PR 选择显式声明以减少阅读歧义）。

PR submitted in Draft mode. Will keep this branch up to date with
review feedback via force-push rather than opening a follow-up PR.
