### PR TITLE
Decompiler: Increase maximum type recovery steps

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -5586,6 +5586,8 @@ void ActionInferTypes::propagateAcrossReturns(Funcdata &data)
   }
 }
 
+#define MAX_ITERS_TYPE_RECOVERY 16       // This constant arrived at empirically
+
 int4 ActionInferTypes::apply(Funcdata &data)
 
 {
@@ -5602,8 +5604,8 @@ int4 ActionInferTypes::apply(Funcdata &data)
     data.getArch()->printDebug(s.str());
   }
 #endif
-  if (localcount >= 7) {       // This constant arrived at empirically
-    if (localcount == 7) {
+  if (localcount >= MAX_ITERS_TYPE_RECOVERY) {
+    if (localcount == MAX_ITERS_TYPE_RECOVERY) {
       data.warningHeader("Type propagation algorithm not settling");
       data.setTypeRecoveryExceeded();
       localcount += 1;


### PR DESCRIPTION
Related: #3422

This allows properly finding the right structure field in deeply nested structures. Previously, the cutoff was 7, and now it is 16. A better fix to the linked issue would be to make this configurable from the java-side. Another alternative fix would be to not increase `localcount` when resolving a structure offset.