### PR TITLE
Fix documentation errors: wrong API type, broken link, and typos

### DIFF
--- a/GhidraDocs/GhidraClass/Debugger/B3-Scripting.md
+++ b/GhidraDocs/GhidraClass/Debugger/B3-Scripting.md
@@ -293,7 +293,7 @@ We do not need to be precise in this check; it suffices to check the program cou
 while (true) {
 	monitor.checkCancelled();
 
-	TargetExecutionState execState = getExecutionState(trace);
+	TraceExecutionState execState = getExecutionState(trace);
 	switch (execState) {
 		case STOPPED:
 			resume();
@@ -338,7 +338,7 @@ Using a timeout of 1 second ensures we can terminate promptly should the user ca
 
 Before waiting, we need to make sure the target is running.
 Because we could repeat the loop while the target is already running, we should only call `resume()` if the target is stopped.
-There are utility methods on `TargetExecutionState` like `isRunning()`, which you might prefer to use.
+You might also simplify this with a comparison like `execState == TraceExecutionState.RUNNING`.
 Here, we exhaustively handle every kind of state using a switch statement, which does make the code a bit verbose.
 
 When the target does break, we first allow the UI to finish interrogating the target.

--- a/GhidraDocs/GhidraClass/Debugger/B4-Modeling.md
+++ b/GhidraDocs/GhidraClass/Debugger/B4-Modeling.md
@@ -387,7 +387,7 @@ public class ModelingScript extends GhidraScript {
 
 It should be fairly apparent how you could add more expression types to complete the model.
 There is some odd nuance in the naming of p-code operations, so do read the documentation carefully.
-If you are not entirely certain what an operation does, take a look at [OpBehaviorFactory](../../../Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/opbehavior/OpBehaviorFactory.java).
+If you are not entirely certain what an operation does, take a look at [OpBehaviorFactory](../../../Ghidra/Framework/Emulation/src/main/java/ghidra/pcode/opbehavior/OpBehaviorFactory.java).
 You can also examine the concrete implementation on byte arrays [BytesPcodeArithmetic](../../../Ghidra/Framework/Emulation/src/main/java/ghidra/pcode/exec/BytesPcodeArithmetic.java).
 
 ### Mapping the Model

--- a/GhidraDocs/languages/html/pseudo-ops.html
+++ b/GhidraDocs/languages/html/pseudo-ops.html
@@ -149,7 +149,7 @@ still have normal data-flow and can be manipulated symbolically.
 </tr>
 <tr>
   <td></td>
-  <td colspan="2"><code class="code">output = cpool(input0,intput1);</code></td>
+  <td colspan="2"><code class="code">output = cpool(input0,input1);</code></td>
 </tr>
 </tfoot>
 </table>

--- a/GhidraDocs/languages/html/sleigh_constructors.html
+++ b/GhidraDocs/languages/html/sleigh_constructors.html
@@ -2138,7 +2138,7 @@ scope. The macro can refer to these and any global specific symbol.
 <div class="informalexample"><pre class="programlisting">
 macro resultflags(op) {
   zeroflag = (op == 0);
-  signflag = (op1 s&lt; 0);
+  signflag = (op s&lt; 0);
 }
 
 :add r1,r2 is opcode=0xba &amp; r1 &amp; r2 { r1 = r1 + r2; resultflags(r1); }


### PR DESCRIPTION
Fixes #9366

- B3-Scripting.md: Replace non-existent TargetExecutionState with correct TraceExecutionState enum; fix misleading isRunning() method reference with accurate enum comparison
- B4-Modeling.md: Fix broken link pointing to SoftwareModeling module (does not exist) to correct Emulation module path for OpBehaviorFactory
- sleigh_constructors.html: Fix op1 to op in macro resultflags() example where the parameter is defined as (op) but incorrectly referenced as op1
- pseudo-ops.html: Fix intput1 to input1 typo in CPOOLREF semantic statement