### PR TITLE
Fix merge crash on structure data types

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/merge/datatypes/DataTypeMergeManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/merge/datatypes/DataTypeMergeManager.java
@@ -2579,13 +2579,12 @@ public class DataTypeMergeManager implements MergeResolver {
 		int ordinal = info.resultOrdinal;
 
 		DataTypeComponent dtc;
-		if (ordinal >= 0 || ordinal < struct.getNumComponents()) {
-			dtc = struct.getComponent(ordinal);
-		}
-		else {
-			throw new AssertException(
-				"Expected fixup component at ordinal " + ordinal + " in " + struct.getPathName());
-		}
+		if (ordinal < 0 || ordinal >= struct.getNumComponents()) {
+            throw new AssertException(
+                "Expected fixup component at ordinal " + ordinal + " in " + struct.getPathName());
+        }
+
+		dtc = struct.getComponent(ordinal);
 
 		long lastChangeTime = struct.getLastChangeTime(); // Don't let the time change.
 		try {
@@ -2676,12 +2675,19 @@ public class DataTypeMergeManager implements MergeResolver {
 		int ordinal = info.resultOrdinal;
 
 		DataTypeComponent dtc;
-		if (ordinal >= 0 || ordinal < struct.getNumComponents()) {
-			dtc = struct.getComponent(ordinal);
-		}
-		else {
-			throw new AssertException(
-				"Expected fixup component at ordinal " + ordinal + " in " + struct.getPathName());
+		if (ordinal < 0 || ordinal >= struct.getNumComponents()) {
+            throw new AssertException(
+                "Expected fixup component at ordinal " + ordinal + " in " + struct.getPathName());
+        }
+
+		dtc = struct.getComponent(ordinal);
+
+		if (dtc.getDataType() != BadDataType.dataType && info.offset >= 0) {
+			DataTypeComponent atOffset = struct.getComponentAt(info.offset);
+			if (atOffset != null && atOffset.getDataType() == BadDataType.dataType) {
+				dtc = atOffset;
+				ordinal = dtc.getOrdinal();
+			}
 		}
 
 		long lastChangeTime = struct.getLastChangeTime(); // Don't let the time change.

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/merge/datatypes/DataTypeMergeManager.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/merge/datatypes/DataTypeMergeManager.java
@@ -2674,20 +2674,21 @@ public class DataTypeMergeManager implements MergeResolver {
 
 		int ordinal = info.resultOrdinal;
 
-		DataTypeComponent dtc;
-		if (ordinal < 0 || ordinal >= struct.getNumComponents()) {
-            throw new AssertException(
-                "Expected fixup component at ordinal " + ordinal + " in " + struct.getPathName());
-        }
-
-		dtc = struct.getComponent(ordinal);
-
-		if (dtc.getDataType() != BadDataType.dataType && info.offset >= 0) {
+		DataTypeComponent dtc = null;
+		if (info.offset >= 0) {
 			DataTypeComponent atOffset = struct.getComponentAt(info.offset);
 			if (atOffset != null && atOffset.getDataType() == BadDataType.dataType) {
 				dtc = atOffset;
 				ordinal = dtc.getOrdinal();
 			}
+		}
+
+		if (dtc == null) {
+			if (ordinal < 0 || ordinal >= struct.getNumComponents()) {
+				throw new AssertException(
+					"Expected fixup component at ordinal " + ordinal + " in " + struct.getPathName());
+			}
+			dtc = struct.getComponent(ordinal);
 		}
 
 		long lastChangeTime = struct.getLastChangeTime(); // Don't let the time change.


### PR DESCRIPTION
Randomly got `AssertException: Expected bad datatype placeholder.` while updating the program and found out it was caused by merge operation reusing ordinals to find structure components later, but ordinals are not stable because repack (e.g. when packing flag changes on a nested type) can shift them and old ordinal then points to wrong component.

Also fixed bounds check `ordinal >= 0 || ordinal < struct.getNumComponents()` that would always be true because `||` is used instead of `&&`