### PR TITLE
Fix sev.w arm encoding.

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -4358,7 +4358,7 @@ thumbEndianNess: "BE" is op0=0xb658 { export 1:1; }
    build ItCond;
 }
 
-:sev^ItCond^".w"                      is TMode=1 & ItCond & op0=0xf3af; op0=8004
+:sev^ItCond^".w"                      is TMode=1 & ItCond & op0=0xf3af; op0=0x8004
 {
    build ItCond;
 }


### PR DESCRIPTION
Unlike the other hints, sev.w op0 missed the 0x in the beginning which led to incorrect parsing. The encoding should be 0xf3af8004 (https://developer.arm.com/documentation/ddi0403/latest/, sev encoding T2).