### PR TITLE
Do not normalize `build_exe` in pcodetests definitions

### DIFF
--- a/Ghidra/Extensions/SleighDevTools/pcodetest/pcodetest.py
+++ b/Ghidra/Extensions/SleighDevTools/pcodetest/pcodetest.py
@@ -91,7 +91,6 @@ class PCodeTestBuild(BuildUtil):
 
         # make sure compiler exists and runnable
         self.config.compile_exe = self.config.exec_dir + self.config.exec_prefix + self.config.compile_exe
-        self.config.build_exe = self.config.exec_dir + str(self.config.exec_prefix) + str(self.config.build_exe)
         self.config.strip_exe = self.config.exec_dir + str(self.config.exec_prefix) + str(self.config.strip_exe)
         self.config.objdump_exe = self.config.exec_dir + str(self.config.exec_prefix) + str(self.config.objdump_exe)
         self.config.readelf_exe = self.config.exec_dir + str(self.config.exec_prefix) + str(self.config.readelf_exe)


### PR DESCRIPTION
In pcodetests definition, `build_exe` is an integer set to `1` when an executable may be built. Contrary to other `*_exe` fields, it is not the name of a command and therefore should not be normalized with `exec_dir`.

Fixes: 71cd33572c87 ("GP-6007: Updated NDS32 analyzer and elf relocation handler and test fixups")

For context, I was trying to configure pcodetests for eBPF and tried to define `build_exe: 0` in `ghidra/Ghidra/Extensions/SleighDevTools/pcodetest/pcode_defs.py`. This setting was ignored as `pcodetest.py` was transforming `self.config.build_exe` to `"bin/0"`.