### PR TITLE
#9375 Warn on delay-load INT/IAT import count mismatch

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/DelayImportDescriptor.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/pe/DelayImportDescriptor.java
@@ -84,6 +84,20 @@ public class DelayImportDescriptor implements StructConverter {
 		if (thunksINT == null) {
 			return;
 		}
+		
+		// Warn if the INT and IAT declare different numbers of entries.
+        // These are parallel arrays so a length mismatch is malformed.
+        // The thunk lists include the trailing null terminator, so the
+        // import count is size() - 1. This only surfaces the discrepancy;
+		// it does not change import enumeration.
+        if (pIAT != 0 && pINT != 0 && thunksIAT.size() != thunksINT.size()) {
+        	int intCount = Math.max(0, thunksINT.size() - 1);
+        	int iatCount = Math.max(0, thunksIAT.size() - 1);
+            Msg.warn(this, "Delay-load INT/IAT import count mismatch for " +
+                (dllName != null ? dllName : "unknown DLL") +
+                ": INT=" + intCount + " IAT=" + iatCount);
+        }
+		
 		thunksBoundIAT = readThunks(ntHeader, reader, pBoundIAT, false);
 		if (thunksBoundIAT == null) {
 			return;


### PR DESCRIPTION
Addresses #9375. 

Adds a warning when a delay-load descriptor's Import Name Table (INT) and Import Address Table (IAT) contain a different numbers of entries. These are parallel arrays, so a length mismatch is malformed. The discrepancy is surfaced via the existing warning mechanism and import enumeration is unchanged. 

As discussed in #9375, the change was confirmed to be safe and isolated. 

Verified against two minimal PE32+ fixtures: 
- INT=3 / IAT=2 mismatch -> warning fires: "Delay-load INT/IAT import count mismatch for test.dll: INT=3 IAT=2" 
- Well-formed control with matching INT/IAT -> no warning 
 
Both files import normally in either case.