### PR TITLE
Emulate function frames in eBPF specifications

### DIFF
--- a/Ghidra/Processors/eBPF/data/languages/eBPF.cspec
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.cspec
@@ -51,13 +51,13 @@
         </pentry>
        </output>
       <unaffected>
-        <varnode space="ram" offset="8" size="8"/>
-        <register name="R6"/>       
-	    <register name="R7"/>
+        <varnode space="ram" offset="0" size="8"/>
+        <register name="R6"/>
+        <register name="R7"/>
         <register name="R8"/>
-        <register name="R9"/>       
-		<register name="R10"/> 	
-      </unaffected> 
+        <register name="R9"/>
+        <register name="R10"/>
+      </unaffected>
     </prototype>
   </default_proto>
  </compiler_spec>

--- a/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
@@ -14,6 +14,39 @@ define space syscall type=ram_space size=4;
 
 define register offset=0 size=8 [ R0  R1  R2  R3  R4  R5  R6  R7  R8  R9  R10  PC ];
 
+# In Linux kernel, when a function calls another function, a new stack frame is allocated (to R10) and all registers
+# are reset (except R1, R2..., R5 holding parameters). All registers are restored when the function returns but R0.
+# To emulate this behavior in Ghidra, R10 is decreased by the maximum stack frame size and enough space to save the
+# registers. Linux kernel uses frames of at most 512 bytes and Solana eBPF VM uses 4096 bytes, so use the largest.
+# The frame layout is:
+#   R10             return address (saved PC)
+#   R10-8...-4096   local variables
+#   R10-4104        saved R1
+#   R10-4112        saved R2
+#   R10-4120        saved R3
+#   R10-4128        saved R4
+#   R10-4136        saved R5
+#   R10-4144        saved R6
+#   R10-4152        saved R7
+#   R10-4160        saved R8
+#   R10-4168        saved R9
+# When a function is called, R10 is decreased by $(BPF_FRAME_SIZE)
+@define BPF_FRAME_SIZE 4176
+
+macro save_regs_with_new_frame() {
+    R10 = R10 - $(BPF_FRAME_SIZE);
+    *:8 R10 = inst_next;
+    *:8 (R10 - 4104) = R1;
+    *:8 (R10 - 4112) = R2;
+    *:8 (R10 - 4120) = R3;
+    *:8 (R10 - 4128) = R4;
+    *:8 (R10 - 4136) = R5;
+    *:8 (R10 - 4144) = R6;
+    *:8 (R10 - 4152) = R7;
+    *:8 (R10 - 4160) = R8;
+    *:8 (R10 - 4168) = R9;
+}
+
 # Instruction encoding: Insop:8, dst_reg:4, src_reg:4, off:16, imm:32 - from lsb to msb
 @if ENDIAN == "little"
 define token instr(64)
@@ -437,11 +470,13 @@ SysCall:  imm is imm { export *[syscall]:1 imm; }
 disp32: reloc is imm [ reloc = inst_next + imm * 8; ] { export *:4 reloc; }
 
 :CALL disp32 is imm & src=1 & op_alu_jmp_opcode=0x8 & op_alu_jmp_source=0 & op_insn_class=0x5 & disp32 {
+    save_regs_with_new_frame();
     call disp32;
 }
 
 # GCC encoding and LLVM 19.1+ encoding
 :CALLX dst is op_alu_jmp_opcode=0x8 & op_alu_jmp_source=1 & op_insn_class=0x5 & src=0 & imm=0 & dst {
+    save_regs_with_new_frame();
     call [dst];
 }
 
@@ -449,11 +484,27 @@ disp32: reloc is imm [ reloc = inst_next + imm * 8; ] { export *:4 reloc; }
 # Introduced in https://github.com/llvm/llvm-project/commit/9a67245d881f4cf89fd8f897ae2cd0bccec49496
 # Modified in https://github.com/llvm/llvm-project/commit/c43ad6c0fddac0bbed5e881801dd2bc2f9eeba2d
 :CALLX llvm_reg_callx is op_alu_jmp_opcode=0x8 & op_alu_jmp_source=1 & op_insn_class=0x5 & dst=0 & src=0 & llvm_imm_callx_zero=0 & llvm_reg_callx {
+    save_regs_with_new_frame();
     call [llvm_reg_callx];
 }
 # Both CALLX encodings are matched when both dst and imm are zero
 :CALLX R0 is op_alu_jmp_opcode=0x8 & op_alu_jmp_source=1 & op_insn_class=0x5 & dst=0 & src=0 & imm=0 & R0 {
+    save_regs_with_new_frame();
     call [R0];
 }
 
-:EXIT is op_alu_jmp_opcode=0x9 & op_alu_jmp_source=0 & op_insn_class=0x5 { return [*:8 R10]; }
+:EXIT is op_alu_jmp_opcode=0x9 & op_alu_jmp_source=0 & op_insn_class=0x5 {
+    # Restore all registers except R0
+    R1 = *:8 (R10 - 4104);
+    R2 = *:8 (R10 - 4112);
+    R3 = *:8 (R10 - 4120);
+    R4 = *:8 (R10 - 4128);
+    R5 = *:8 (R10 - 4136);
+    R6 = *:8 (R10 - 4144);
+    R7 = *:8 (R10 - 4152);
+    R8 = *:8 (R10 - 4160);
+    R9 = *:8 (R10 - 4168);
+    PC = *:8 R10;
+    R10 = R10 + $(BPF_FRAME_SIZE);
+    return [PC];
+}


### PR DESCRIPTION
Hello,

When the Linux kernel runs an eBPF programs, it provides a function frame of at most 512 bytes through register `FP` = `R10`: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/bpf/core.c?h=v7.1#n2333

```c
#define DEFINE_BPF_PROG_RUN(stack_size) \
static unsigned int PROG_NAME(stack_size)(const void *ctx, const struct bpf_insn *insn) \
{ \
    u64 stack[stack_size / sizeof(u64)]; \
    u64 regs[MAX_BPF_EXT_REG]; \
    /* ... */
    FP = (u64) (unsigned long) &stack[ARRAY_SIZE(stack)]; \

/* ... */
EVAL6(DEFINE_BPF_PROG_RUN, 32, 64, 96, 128, 160, 192);
EVAL6(DEFINE_BPF_PROG_RUN, 224, 256, 288, 320, 352, 384);
EVAL4(DEFINE_BPF_PROG_RUN, 416, 448, 480, 512);
```

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/filter.h?h=v7.1#n97

```c
/* BPF program can access up to 512 bytes of stack space. */
#define MAX_BPF_STACK   512
```

When calling a subprogram through instruction `CALL`, it simply calls the same function to run the subprogram:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/bpf/core.c?h=v7.1#n2082

```c
    JMP_CALL_ARGS:
        BPF_R0 = interpreters_args[insn->off](BPF_R1, BPF_R2, BPF_R3,
                                              BPF_R4, BPF_R5,
                                              insn + insn->imm + 1);
```

This means the subprogram runs with a dedicated stack and dedicated registers, and that no registers except `R0` (holding the return value) are modified by eBPF function calls.

This mechanism also relies on the `CALL` instructions being patched to provide the stack depth in `insn->off`:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/bpf/core.c?h=v7.1#n2399

```c
int bpf_patch_call_args(struct bpf_insn *insn, u32 stack_depth)
{
        stack_depth = max_t(u32, stack_depth, 1);
        /* Prevent out-of-bounds read to interpreters_args */
        if (stack_depth > MAX_BPF_STACK)
                return -EINVAL;
        insn->off = (round_up(stack_depth, 32) / 32) - 1;
        insn->code = BPF_JMP | BPF_CALL_ARGS;
        return 0;
}
```

eBPF code does not adjust the frame pointer (`R10`) in prologs and epilogs of functions. Moreover, the program counter (`PC`) is never saved to the stack or restored when functions return.

In Ghidra, it is not possible to compute how much stack space is used by a function. To have a proper emulation of function calls, the frame pointer has to be adjusted in Sleigh and the program counter saved and restored like other ISAs.

Moreover, regarding the registers the kernel documentation states in https://kernel.org/doc/html/latest/bpf/standardization/abi.html

> The BPF calling convention is defined as:
>
> - R0: return value from function calls, and exit value for BPF programs
> - R1 - R5: arguments for function calls
> - R6 - R9: callee saved registers that function calls will preserve
> - R10: read-only frame pointer to access stack
>
> R0 - R5 are scratch registers and BPF programs needs to spill/fill
> them if necessary across calls.
>
> The BPF program needs to store the return value into register R0
> before doing an EXIT.

For Ghidra Emulator to be correct, `CALL` and `EXIT` instructions need to save/restore registers `R6` to `R9`. As in practice the implementation of the eBPF interpreter keeps registers `R1` to `R5`, save them as well. The ABI specification in `eBPF.cspec` may however be kept as it currently is. A varnode was nonetheless incorrectly stating that the 8 bytes at offset 8 from the stack were unaffected by function call, whereas it makes more sence to use offset 0 to target the saved program counter:

```diff
  <unaffected>
-   <varnode space="ram" offset="8" size="8"/>
+   <varnode space="ram" offset="0" size="8"/>
```

Moreover, other eBPF implementations may use larger frame sizes. For example Solana uses 4KB frames:
https://github.com/anza-xyz/agave/blob/v3.1.8/program-runtime/src/execution_budget.rs#L37

```rust
/// The size of one SBF stack frame.
pub const STACK_FRAME_SIZE: usize = 4096;
```

Define a new constant, `BPF_FRAME_SIZE`, and use it in the specification of `CALL` and `EXIT` to ajust the frame pointer accordingly.

## Testing

The motivation of this Pull Request was to get pcodetests work on eBPF. While this would require much more work (for example because eBPF compilers do not support calling functions with more than 5 arguments), it failed because function calls were not properly handled.

To reproduce on a minimal program, I wrote [`call_saving_regs.c`](https://github.com/Ledger-Donjon/ghidra-ebpf-tests/blob/ccb4ee3865c91ff9753643689a7f7586cbbed4ab/simple_programs/call_saving_regs.c) with some C/assembly tricks to get some reasonable eBPF assembly code ([`objdump/call_saving_regs.deb13-clangO2-le.ebpf.txt`](https://github.com/Ledger-Donjon/ghidra-ebpf-tests/blob/main/simple_programs/objdump/call_saving_regs.deb13-clangO2-le.ebpf.txt)):

```text
Disassembly of section .text:

0000000000000000 <modify_all_registers>:
       0:	b7 00 00 00 10 00 00 00	r0 = 0x10
       1:	b7 07 00 00 17 00 00 00	r7 = 0x17
       2:	b7 02 00 00 12 00 00 00	r2 = 0x12
       3:	b7 04 00 00 14 00 00 00	r4 = 0x14
       4:	b7 06 00 00 16 00 00 00	r6 = 0x16
       5:	b7 01 00 00 11 00 00 00	r1 = 0x11
       6:	b7 08 00 00 18 00 00 00	r8 = 0x18
       7:	b7 03 00 00 13 00 00 00	r3 = 0x13
       8:	b7 05 00 00 15 00 00 00	r5 = 0x15
       9:	95 00 00 00 00 00 00 00	exit

0000000000000050 <use_registers>:
      10:	b7 01 00 00 01 00 00 00	r1 = 0x1
      11:	b7 08 00 00 08 00 00 00	r8 = 0x8
      12:	b7 03 00 00 03 00 00 00	r3 = 0x3
      13:	b7 05 00 00 05 00 00 00	r5 = 0x5
      14:	b7 07 00 00 07 00 00 00	r7 = 0x7
      15:	b7 02 00 00 02 00 00 00	r2 = 0x2
      16:	b7 09 00 00 09 00 00 00	r9 = 0x9
      17:	b7 04 00 00 04 00 00 00	r4 = 0x4
      18:	b7 06 00 00 06 00 00 00	r6 = 0x6
      19:	85 10 00 00 ff ff ff ff	call -0x1
		0000000000000098:  R_BPF_64_32	modify_all_registers
      20:	67 07 00 00 08 00 00 00	r7 <<= 0x8
      21:	67 08 00 00 0c 00 00 00	r8 <<= 0xc
      22:	0f 78 00 00 00 00 00 00	r8 += r7
      23:	67 00 00 00 04 00 00 00	r0 <<= 0x4
      24:	a7 00 00 00 00 01 00 00	r0 ^= 0x100
      25:	0f 90 00 00 00 00 00 00	r0 += r9
      26:	67 00 00 00 10 00 00 00	r0 <<= 0x10
      27:	0f 80 00 00 00 00 00 00	r0 += r8
      28:	67 06 00 00 04 00 00 00	r6 <<= 0x4
      29:	0f 56 00 00 00 00 00 00	r6 += r5
      30:	0f 06 00 00 00 00 00 00	r6 += r0
      31:	67 03 00 00 08 00 00 00	r3 <<= 0x8
      32:	67 04 00 00 0c 00 00 00	r4 <<= 0xc
      33:	0f 34 00 00 00 00 00 00	r4 += r3
      34:	67 06 00 00 10 00 00 00	r6 <<= 0x10
      35:	0f 46 00 00 00 00 00 00	r6 += r4
      36:	67 02 00 00 04 00 00 00	r2 <<= 0x4
      37:	0f 12 00 00 00 00 00 00	r2 += r1
      38:	0f 62 00 00 00 00 00 00	r2 += r6
      39:	bf 20 00 00 00 00 00 00	r0 = r2
      40:	95 00 00 00 00 00 00 00	exit
```

A PyGhidra script using Ghidra Emulator, [`ghidra_emulate_call_saving_regs.py`](https://github.com/Ledger-Donjon/ghidra-ebpf-tests/blob/ccb4ee3865c91ff9753643689a7f7586cbbed4ab/simple_programs/ghidra_emulate_call_saving_regs.py), displays an execution trace and checks this programs computes the expected value.

Moreover I did not find any regression in the decompiler output of other test programs.