### PR TITLE
5984: Honor the segment override on 16-bit XLAT

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -5171,7 +5171,7 @@ define pcodeop xend;
 :XCHG Rmr64,Reg64   is $(LONGMODE_ON) & vexMode=0 & opsize=2 & byte=0x87; mod=3 & Rmr64 & Reg64        { local tmp = Rmr64; Rmr64 = Reg64; Reg64 = tmp; }
 @endif
 
-:XLAT seg16^BX      is vexMode=0 & addrsize=0 & seg16 & byte=0xd7; BX           { tmp:$(SIZE)= 0; ptr2(tmp,BX+zext(AL)); AL = *tmp; }
+:XLAT seg16^BX      is vexMode=0 & addrsize=0 & seg16 & byte=0xd7; BX           { tmp:$(SIZE) = segment(seg16,BX+zext(AL)); AL = *tmp; }
 :XLAT segWide^EBX     is vexMode=0 & addrsize=1 & segWide & byte=0xd7; EBX          { tmp:$(SIZE)= 0; ptr4(tmp,EBX+zext(AL)); AL = *tmp; }
 @ifdef IA64
 :XLAT segWide^RBX     is $(LONGMODE_ON) & vexMode=0 & addrsize=2 & segWide & byte=0xd7; RBX          { tmp:$(SIZE)= 0; ptr8(tmp,RBX+zext(AL)); AL = *tmp; }


### PR DESCRIPTION
Fixes #5984.

The `addrsize=0` XLAT constructor parses and prints its `seg16` selector but then discards it, computing the table address through `ptr2`'s flat zext of `BX+AL`. It is the only memory access in the spec modeled this way — every other 16-bit memory operand builds its address with `segment(seg16,...)`. The result is that XLAT reads linear `0000:(BX+AL)` (in real mode, the interrupt vector table) regardless of DS, and a CS: or SS: override prefix is decoded but silently ignored. Per the SDM, XLAT reads `DS:(BX+AL)` by default and honors a segment-override prefix.

This is the source of the "horrible C" in #5984, and on real-mode programs it also surfaces as `Unable to read bytes at ram:0000:*` decompiler warnings whenever the decompiler tries to read an XLAT lookup table, plus wrong constant propagation when the memory at linear `BX+AL` happens to be readable.

The fix builds the address with `segment(seg16,BX+zext(AL))`, exactly like `Mem16`. It differs slightly from the sketch in the issue thread (which applied `segment()` on top of the flat `ptr2` result): constructing the address directly with `segment()` keeps the operand symmetric with every other 16-bit memory access. The 32/64-bit forms are untouched — their `segWide`/`ptr4`/`ptr8` flat addressing matches the other wide memory operands, and their missing FS/GS base handling is a separate, milder issue.

Verified with `./gradlew :x86:sleighCompile` on current master (13a308a8f9), and exercised against real-mode MZ executables making CS:-overridden XLAT table lookups: the `ram:0000:*` warnings disappear and the tables are read from the correct segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
