### PR TITLE
9392: Compute 16-bit rel16 branch targets without 64KB-page wrap

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -1148,6 +1148,11 @@ Mem: segWide^addr32 is $(LONGMODE_OFF) & addrsize=1 & segWide; addr32       		{ 
 Mem: segWide^addr32 is $(LONGMODE_OFF) & addrsize=1 & segWide & highseg=1; addr32 	{ tmp:$(SIZE) = segWide + zext(addr32); export tmp; }
 
 rel8: reloc is simm8        [ reloc=inst_next+simm8; ] { export *[ram]:$(SIZE) reloc; }
+# In 16-bit mode IP stays within the code segment, whose base is an arbitrary
+# paragraph — anchoring the wrap to the linear 64KB page (below) sends any branch
+# crossing a page boundary into the wrong segment. Plain addition is exact for
+# every in-segment branch (offset result in [0,0xFFFF]), matching rel8 above.
+rel16: reloc is addrsize=0 & simm16 [ reloc=inst_next+simm16; ] { export *[ram]:$(SIZE) reloc; }
 rel16: reloc is simm16      [ reloc=((inst_next >> 16) << 16) | ((inst_next + simm16) & 0xFFFF); ] { export *[ram]:$(SIZE) reloc; }
 rel32: reloc is simm32      [ reloc=inst_next+simm32; ] { export *[ram]:$(SIZE) reloc; }
 


### PR DESCRIPTION
Fixes #9392.

The `rel16` operand anchors 16-bit IP wraparound to the linear 64KB page of `inst_next`, which is only correct when the code segment starts on a 64KB linear boundary. Real-mode MZ segments are arbitrary paragraphs, so any `JMP`/`CALL`/`Jcc rel16` whose instruction and target lie on opposite sides of a linear `0x?0000` boundary resolves 0x10000 away, into a different segment — severing real control flow and disassembling garbage at the phantom target (details and a three-byte synthetic repro in the issue).

This change adds an `addrsize=0` variant of `rel16` computing plain `inst_next + simm16`. For a 16-bit branch whose target offset lies in [0,0xFFFF] — every branch that stays in its segment — this is exact, and it is the same model `rel8` has always used. The 32/64-bit `rel16` variants (66-prefix EIP truncation) keep the existing page-anchored formula, where linear-page wrap is the architecturally correct behavior.

Verified with `./gradlew :x86:sleighCompile` on current master (13a308a8f9), and exercised on real-mode MZ executables whose code segments cross a 64KB linear boundary: cross-boundary branches now resolve within their segment, and the phantom labels/functions in neighboring segments no longer appear on import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
