### PR TITLE
9394: Export CS directly for 16-bit CS segment overrides

### DIFF
--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -1117,7 +1117,7 @@ segWide: FS: is segover=5 & FS	{ export FS_OFFSET; }
 segWide: GS: is segover=6 & GS	{ export GS_OFFSET; }
 
 seg16: 	   is segover=0			{ export DS; }
-seg16: currentCS: is segover=1 & currentCS	{ export currentCS; }
+seg16: CS: is segover=1 & CS	{ export CS; }
 seg16: SS: is segover=2 & SS	{ export SS; }
 seg16: DS: is segover=3 & DS	{ export DS; }
 seg16: ES: is segover=4 & ES	{ export ES; }


### PR DESCRIPTION
Fixes #9394.

The `seg16` selector table routes a CS segment override (`segover=1`) through the `currentCS` subconstructor, which recomputes CS from the instruction address (`(inst_next >> 4) & 0xf000` in real mode) and writes the result back into the CS register as a side effect. Every other segment override (SS/DS/ES/FS/GS) exports its register directly — so a CS-prefixed data operand both discards the loader-/analysis-assigned CS value and mutates CS in the p-code on every access (repro in the issue: `2E A0 34 12`, `MOV AL, CS:[0x1234]`).

This one-line change makes the CS: override export the CS register directly, symmetric with the other five segments. `currentCS` is retained where its address-derived recomputation is legitimate: the near-indirect `CALL/JMP rm16` constructors, which derive the target segment from the instruction's own address.

Verified with `./gradlew :x86:sleighCompile` on current master (13a308a8f9), and exercised on real-mode MZ executables using CS:-relative data access: the loads now go through the analysis-assigned CS value, and the spurious CS writes disappear from the p-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
