### PR TITLE
Fix NullPointerException in BundleStatusTableModel.bundleBuilt

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/BundleStatusTableModel.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/osgi/BundleStatusTableModel.java
@@ -300,9 +300,11 @@ public class BundleStatusTableModel
 			if (summary != null) {
 				Swing.runLater(() -> {
 					BundleStatus status = getStatus(bundle);
-					status.setSummary(summary);
-					int rowIndex = getRowIndex(status);
-					fireTableRowsUpdated(rowIndex, rowIndex);
+					if (status != null) {
+						status.setSummary(summary);
+						int rowIndex = getRowIndex(status);
+						fireTableRowsUpdated(rowIndex, rowIndex);
+					}
 				});
 			}
 		}


### PR DESCRIPTION
Hi!

I ran into an uncaught `NullPointerException` when a bundle gets built that isn't tracked in the Bundle Manager table (in my case a bundle that was built programmatically rather than added through the UI).

`MyBundleHostListener.bundleBuilt` does:

```java
BundleStatus status = getStatus(bundle);
status.setSummary(summary);
```

but `getStatus()` returns `null` when the bundle isn't in `bundleLocToStatusMap`, so it blows up on the Swing thread:

```
java.lang.NullPointerException: Cannot invoke
  "ghidra.app.plugin.core.osgi.BundleStatus.setSummary(String)" because "status" is null
    at ...BundleStatusTableModel$MyBundleHostListener.lambda$bundleBuilt$0(BundleStatusTableModel.java:303)
```

The fix just guards the status before using it, the same way `bundleException()` in this class already does. Reproduced and tested against current `master` (also on 12.1.2).

Cheers!