### PR TITLE
ghidragdb: map n32/n64 MIPS GPR names to Ghidra's O32 register names (#9412)

### DIFF
--- a/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/arch.py
+++ b/Ghidra/Debug/Debugger-agent-gdb/src/main/py/src/ghidragdb/arch.py
@@ -322,11 +322,58 @@ class Intel_x86_64_RegisterMapper(DefaultRegisterMapper):
         return name
 
 
+class MIPS_RegisterMapper(DefaultRegisterMapper):
+    """Reconcile GDB's ABI-dependent MIPS GPR names with Ghidra's SLEIGH names.
+
+    Ghidra's MIPS language always names general registers $8-$15 using the O32
+    convention (t0-t7). GDB, however, renames that band per the selected ABI:
+    under n32/n64 the same registers become a4-a7 ($8-$11) and t0-t3 ($12-$15).
+    So under an n-ABI, GDB's "t3" is $15 while Ghidra's "t3" is $11, and without
+    translation every value in $8-$15 lands in the wrong Ghidra register (e.g. a
+    loop counter in $11 shows up under Ghidra's t7). Detect the n-ABI and remap.
+
+    Under o32/o64 GDB already uses t0-t7, matching Ghidra, so the map is a no-op.
+    """
+
+    # GDB n32/n64 GPR name ($8-$15) -> Ghidra O32 GPR name
+    _gdb_to_ghidra = {
+        'a4': 't0', 'a5': 't1', 'a6': 't2', 'a7': 't3',
+        't0': 't4', 't1': 't5', 't2': 't6', 't3': 't7',
+    }
+    _ghidra_to_gdb = {v: k for k, v in _gdb_to_ghidra.items()}
+
+    def _uses_n_abi_names(self, inf: gdb.Inferior) -> bool:
+        # o32/o64 name $8-$15 as t0-t7 (matching Ghidra) and expose no 'a4';
+        # n32/n64 expose a4-a7. Presence of 'a4' means the band needs remapping.
+        try:
+            return any(r.name == 'a4' for r in inf.architecture().registers())
+        except Exception:
+            # Older GDBs lacking Inferior.architecture(): assume O32 naming,
+            # i.e. no remap. No worse than the un-patched behavior.
+            return False
+
+    def map_name(self, inf: gdb.Inferior, name: str) -> str:
+        if self._uses_n_abi_names(inf):
+            name = self._gdb_to_ghidra.get(name, name)
+        return super().map_name(inf, name)
+
+    def map_name_back(self, inf: gdb.Inferior, name: str) -> str:
+        if self._uses_n_abi_names(inf):
+            name = self._ghidra_to_gdb.get(name, name)
+        return super().map_name_back(inf, name)
+
+
 DEFAULT_BE_REGISTER_MAPPER = DefaultRegisterMapper('big')
 DEFAULT_LE_REGISTER_MAPPER = DefaultRegisterMapper('little')
 
 register_mappers: Dict[str, DefaultRegisterMapper] = {
-    'x86:LE:64:default': Intel_x86_64_RegisterMapper()
+    'x86:LE:64:default': Intel_x86_64_RegisterMapper(),
+    # Only the 64-bit MIPS languages can be driven by an n32/n64 GDB; the
+    # mapper self-detects the ABI and is a no-op under o32/o64.
+    'MIPS:BE:64:default': MIPS_RegisterMapper('big'),
+    'MIPS:LE:64:default': MIPS_RegisterMapper('little'),
+    'MIPS:BE:64:64-32addr': MIPS_RegisterMapper('big'),
+    'MIPS:LE:64:64-32addr': MIPS_RegisterMapper('little'),
 }
 
 


### PR DESCRIPTION
Fixes #9412

### Problem

`ghidragdb` maps target registers to Ghidra registers by **name**. Ghidra's MIPS SLEIGH always names general registers `$8`–`$15` with the **O32** convention (`t0`–`t7`), but gdb renames that band per the selected ABI: under **n32/n64** they are `a4`–`a7` (`$8`–`$11`) and `t0`–`t3` (`$12`–`$15`). So gdb's `t3` is `$15` while Ghidra's `t3` is `$11`, and every value in `$8`–`$15` was recorded under the wrong Ghidra register — e.g. a loop counter in `$11` (gdb `a7`) read back the unrelated `$15`, which often looks like a pointer. Register hovers, Decompiler variable values, and register writes were all affected for that band.

Forcing gdb to the o32/o64 ABI to realign the names is not a viable workaround — it changes gdb's address handling and breaks breakpoints on 64-bit targets — so the reconciliation is done in `ghidragdb`.

### Fix

Add `MIPS_RegisterMapper` (paralleling the existing `Intel_x86_64_RegisterMapper`) in `ghidragdb/arch.py`. It detects the n-ABI at runtime (gdb exposes an `a4` register only under n32/n64) and translates the `$8`–`$15` band in both directions:

- gdb `a4`–`a7` → Ghidra `t0`–`t3`
- gdb `t0`–`t3` → Ghidra `t4`–`t7`

It is a **no-op under o32/o64** (gdb already uses `t0`–`t7`, matching Ghidra) and is registered only for the 64-bit MIPS languages. Independent of, and complementary to, the ISA-arch mapping already on `master` (#9367).

### Testing

Verified against live big-endian MIPS targets (Qiling gdb stub + `gdb-multiarch 17.1`):

- **n64** (MIPS64 target): stopped at a loop `addiu a7,a7,1`, gdb `$a7` (`$11`, the counter) is recorded under Ghidra `t3` and gdb `$t3` (`$15`, a pointer) under Ghidra `t7`; after a `stepi` the counter under Ghidra `t3` advances `0 → 1`, as expected.
- **o32** (MIPS32 target): resolves to `MIPS:BE:32:default` with the default register mapper (the new mapper is not bound to 32-bit languages); all registers map identically.
- **Exhaustive name sweep** over the full 72-register file for `o32`/`n32`/`n64`/`o64`: o32 and o64 are pure identity; n32/n64 remap only `$8`–`$15`; no name collisions, no changes to `pc`/`sp`/`ra`/`gp`/args/saved registers, and `map_name_back ∘ map_name` is lossless.

### Note

AI-assisted (see `Co-Authored-By` trailer); the change was reviewed and tested end-to-end as above.
