### PR TITLE
Fix typo in WildRange constructor error message

### DIFF
--- a/Ghidra/Features/WildcardAssembler/src/main/java/ghidra/asm/wild/tree/WildAssemblyParseToken.java
+++ b/Ghidra/Features/WildcardAssembler/src/main/java/ghidra/asm/wild/tree/WildAssemblyParseToken.java
@@ -98,7 +98,7 @@ public class WildAssemblyParseToken extends AssemblyParseToken {
 	public record WildRange(long min, long max) implements Comparable<WildRange> {
 		public WildRange(long min, long max) {
 			if (min > max) {
-				throw new AssertionError("max > max");
+				throw new AssertionError("min > max");
 			}
 			this.min = min;
 			this.max = max;


### PR DESCRIPTION
## Description
Fix a typo in the error message of `WildRange` constructor.

## Change
- Changed `"max > max"` to `"min > max"` in the `AssertionError` message
- The original message was inaccurate - the validation checks `min > max`

## Verification
The error message now correctly describes the validation condition:
- Before: `throw new AssertionError("max > max");` (incorrect)
- After: `throw new AssertionError("min > max");` (correct)

