### PR TITLE
Decompiler: Detect stack local variable addresses constructed with binary OR

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -335,11 +335,18 @@ bool ActionStackPtrFlow::isStackRelative(Varnode *spcbasein,Varnode *vn,uintb &c
     return true;
   }
   if (!vn->isWritten()) return false;
-  PcodeOp *addop = vn->getDef();
-  if (addop->code() != CPUI_INT_ADD) return false;
-  if (addop->getIn(0) != spcbasein) return false;
-  Varnode *constvn = addop->getIn(1);
+  PcodeOp *op = vn->getDef();
+  if (op->getIn(0) != spcbasein) return false;
+  Varnode *constvn = op->getIn(1);
   if (!constvn->isConstant()) return false;
+  if (op->code() == CPUI_INT_OR) {
+    if ((spcbasein->getNZMask() & constvn->getOffset()) == 0) {
+      constval = constvn->getOffset();
+      return true;
+    }
+    return false;
+  }
+  if (op->code() != CPUI_INT_ADD) return false;
   constval = constvn->getOffset();
   return true;
 }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/heritage.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/heritage.cc
@@ -1033,6 +1033,30 @@ bool Heritage::discoverIndexedStackPointers(AddrSpace *spc,vector<PcodeOp *> &fr
 	  }
 	  break;
 	}
+        case CPUI_INT_OR:
+        {
+          Varnode *otherVn = op->getIn(1-op->getSlot(curNode.vn));
+          uint4 traversals = curNode.traversals;
+          uintb newOffset = curNode.offset;
+          if (otherVn->isConstant()) {
+            if ((curNode.vn->getNZMask() & otherVn->getOffset()) == 0) {
+              newOffset = spc->wrapOffset(curNode.offset | otherVn->getOffset());
+            } else {
+              traversals |= StackNode::nonconstant_index;
+            }
+          } else {
+            traversals |= StackNode::nonconstant_index;
+          }
+          StackNode nextNode(outVn,newOffset,traversals);
+          if (nextNode.iter != nextNode.vn->endDescend()) {
+            outVn->setMark();
+            path.push_back(nextNode);
+            markedVn.push_back(outVn);
+          } else if (outVn->getSpace()->getType() == IPTR_SPACEBASE) {
+            unknownStackStorage = true;
+          }
+          break;
+        }
 	case CPUI_SEGMENTOP:
 	{
 	  if (op->getIn(2) != curNode.vn) break;	// Check that stackpointer comes in as inner pointer

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -4204,7 +4204,7 @@ AddrSpace *RuleLoadVarnode::correctSpacebase(Architecture *glb,Varnode *vn,AddrS
   return assoc;
 }
 
-/// \brief Check if given Varnode is spacebase + a constant
+/// \brief Check if given Varnode is spacebase + a constant, or spacebase | a constant
 ///
 /// If it is, pass back the constant and return the associated space
 /// \param glb is the address space manager
@@ -4226,23 +4226,49 @@ AddrSpace *RuleLoadVarnode::vnSpacebase(Architecture *glb,Varnode *vn,uintb &val
   }
   if (!vn->isWritten()) return (AddrSpace *)0;
   op = vn->getDef();
-  if (op->code() != CPUI_INT_ADD) return (AddrSpace *)0;
+  if (!(op->code() == CPUI_INT_ADD || op->code() == CPUI_INT_OR)) {
+    return (AddrSpace *)0;
+  }
+  if (op->code() == CPUI_INT_OR && vn->getSize() > sizeof(uintb)) {
+    return (AddrSpace *)0;
+  }
   vn1 = op->getIn(0);
   vn2 = op->getIn(1);
+  if (op->code() == CPUI_INT_OR) {
+    uintb baseval;
+    Varnode *basevn;
+    Varnode *constvn;
+    if (vn2->isConstant()) {
+      basevn = vn1;
+      constvn = vn2;
+    } else if (vn1->isConstant()) {
+      basevn = vn2;
+      constvn = vn1;
+    } else {
+      return (AddrSpace *)0;
+    }
+    retspace = vnSpacebase(glb,basevn,baseval,spc);
+    if (retspace != (AddrSpace *)0) {
+        if ((basevn->getNZMask() & constvn->getOffset()) != 0) {
+          return (AddrSpace *)0;
+        }
+        val = baseval + constvn->getOffset();
+    }
+    return retspace;
+  }
   retspace = correctSpacebase(glb,vn1,spc);
   if (retspace != (AddrSpace *)0) {
-    if (vn2->isConstant()) {
-      val = vn2->getOffset();
-      return retspace;
-    }
-    return (AddrSpace *)0;
+      if (vn2->isConstant()) {
+          val = vn2->getOffset();
+          return retspace;
+      }
   }
   retspace = correctSpacebase(glb,vn2,spc);
   if (retspace != (AddrSpace *)0) {
-    if (vn1->isConstant()) {
-      val = vn1->getOffset();
-      return retspace;
-    }
+      if (vn1->isConstant()) {
+          val = vn1->getOffset();
+          return retspace;
+      }
   }
   return (AddrSpace *)0;
 }


### PR DESCRIPTION
FIxes #9044 

Expands the decompiler's detection of stack-allocated variables to also identify cases where an address with a larger alignment is OR'd with a smaller offset to construct a less-aligned address for a local variable.

With this the example from #9044, now looks like this:
```c
void tmp(void) {
  int i;
  int asdf [2];
  
  memset(asdf,0,8);
  for (i = 0; i < 100; i = i + 1) {
    asdf[0] = i + asdf[0];
    asdf[1] = i * 2 + asdf[1];
    printf("%d\n",(ulong)(uint)asdf[0]);
    printf("%d\n",(ulong)(uint)asdf[1]);
  }
  return;
}
```