### PR TITLE
#9434 Fix LoongArch immediate doubleword shift masks

### DIFF
--- a/Ghidra/Processors/Loongarch/data/languages/loongarch64_instructions.sinc
+++ b/Ghidra/Processors/Loongarch/data/languages/loongarch64_instructions.sinc
@@ -151,7 +151,7 @@
 #la-base-64.txt slli.d mask=0x00410000	[@qemu]
 #0x00410000	0xffff0000	r0:5,r5:5,u10:6	['reg0_5_s0', 'reg5_5_s0', 'imm10_6_s0']
 :slli.d RD, RJsrc, imm10_6            is op16_31=0x41 & RD & RJsrc & imm10_6 {
-	local shift:1 = imm10_6 & 0x1f;
+	local shift:1 = imm10_6 & 0x3f;
 	RD = RJsrc << shift;
 }
 
@@ -166,7 +166,7 @@
 #la-base-64.txt srai.d mask=0x00490000	[@qemu]
 #0x00490000	0xffff0000	r0:5,r5:5,u10:6	['reg0_5_s0', 'reg5_5_s0', 'imm10_6_s0']
 :srai.d RD, RJsrc, imm10_6            is op16_31=0x49 & RD & RJsrc & imm10_6 {
-	local shift:1 = imm10_6 & 0x1f;
+	local shift:1 = imm10_6 & 0x3f;
 	RD = RJsrc s>> shift;
 }
 
@@ -181,7 +181,7 @@
 #la-base-64.txt srli.d mask=0x00450000	[@qemu]
 #0x00450000	0xffff0000	r0:5,r5:5,u10:6	['reg0_5_s0', 'reg5_5_s0', 'imm10_6_s0']
 :srli.d RD, RJsrc, imm10_6            is op16_31=0x45 & RD & RJsrc & imm10_6 {
-	local shift:1 = imm10_6 & 0x1f;
+	local shift:1 = imm10_6 & 0x3f;
 	RD = RJsrc >> shift;
 }
 


### PR DESCRIPTION
Fixes #9434.

The LoongArch SLEIGH constructors for slli.d, srli.d, and srai.d mask their six-bit ui6 operands with 0x1f. Shift amounts 32 through 63 are consequently executed as amounts 0 through 31.

This changes the mask to 0x3f for all three doubleword immediate shifts. Word forms retain their correct five-bit mask.

For example, slli.d a0,a1,32 currently generates a shift by zero (0x20 & 0x1f). After this change it generates a shift by 32.

The modified language compiles with SLEIGH, and all three instructions have been checked for immediate amounts 1 through 63.