### PR TITLE
#9434 Fix LoongArch bit-field insertion semantics

### DIFF
--- a/Ghidra/Processors/Loongarch/data/languages/loongarch32_instructions.sinc
+++ b/Ghidra/Processors/Loongarch/data/languages/loongarch32_instructions.sinc
@@ -968,9 +968,10 @@ define pcodeop bstrins.w;
 	local msb:1 = imm16_5;
 	local lsb:1 = imm10_5;
 	local len:1 = msb + 1 - lsb;
-	local mask:4 = (1 << len) - 1;
-	local repl:4 = (RJ32src & (mask << lsb)) >> lsb;
-	RD = sext((RD32 & (~mask)) | repl);
+	local lowmask:4 = (1 << len) - 1;
+	local fieldmask:4 = lowmask << lsb;
+	local repl:4 = (RJ32src & lowmask) << lsb;
+	RD = sext((RD32 & (~fieldmask)) | repl);
 }
 
 

--- a/Ghidra/Processors/Loongarch/data/languages/loongarch64_instructions.sinc
+++ b/Ghidra/Processors/Loongarch/data/languages/loongarch64_instructions.sinc
@@ -669,10 +669,11 @@ define pcodeop crcc.w.d.w;
 	local msb:1 = imm16_6;
 	local lsb:1 = imm10_6;
 	local len:1 = msb + 1 - lsb;
-	local mask:8 = (1 << len) - 1;
-	local repl:8 = (RJsrc & (mask << lsb)) >> lsb;
+	local lowmask:8 = (1 << len) - 1;
+	local fieldmask:8 = lowmask << lsb;
+	local repl:8 = (RJsrc & lowmask) << lsb;
 
-	RD = (RD & (~mask)) | repl;
+	RD = (RD & (~fieldmask)) | repl;
 }
 
 


### PR DESCRIPTION
Fixes #9434.

The bstrins.w and bstrins.d SLEIGH constructors extract source bits from [msb:lsb], place them at bit zero, and clear destination bits starting at bit zero. The instructions instead replace destination bits [msb:lsb] with source bits [msb-lsb:0].

This separates the unshifted source mask from the positioned destination mask, then shifts the replacement field to lsb before combining it with the preserved destination bits.

The modified language compiles with SLEIGH. Both word and doubleword forms have been checked against direct mask-and-shift reference implementations.