### PR TITLE
#9434 Fix LoongArch halfword reversal semantics

### DIFF
--- a/Ghidra/Processors/Loongarch/data/languages/loongarch64_instructions.sinc
+++ b/Ghidra/Processors/Loongarch/data/languages/loongarch64_instructions.sinc
@@ -598,22 +598,18 @@
 #la-bitops-64.txt revh.2w mask=0x00004000	
 #0x00004000	0xfffffc00	r0:5,r5:5	['reg0_5_s0', 'reg5_5_s0']
 :revh.2w RD, RJsrc                    is op10_31=0x10 & RD & RJsrc {
-	tmp0:8 = (zext(RJsrc[0,16]) << 16) + zext(RJsrc[16,16]);
-	tmp1:8 = (zext(RJsrc[32,16]) << 8) + zext(RJsrc[48,16]);
-
-	RD = (tmp1 << 32) + tmp0;
+	RD = ((RJsrc & 0x0000ffff0000ffff) << 16) |
+	     ((RJsrc & 0xffff0000ffff0000) >> 16);
 }
 
 
 #la-bitops-64.txt revh.d mask=0x00004400	
 #0x00004400	0xfffffc00	r0:5,r5:5	['reg0_5_s0', 'reg5_5_s0']
 :revh.d RD, RJsrc                     is op10_31=0x11 & RD & RJsrc {
-	tmp0:8 = zext(RJsrc[0,16]);
-	tmp1:8 = zext(RJsrc[16,16]);
-	tmp2:8 = zext(RJsrc[32,16]);
-	tmp3:8 = zext(RJsrc[48,16]);
-
-	RD = (tmp3 << 48) + (tmp2 << 32) + (tmp1 << 16) + tmp0;
+	RD = ((RJsrc & 0x000000000000ffff) << 48) |
+	     ((RJsrc & 0x00000000ffff0000) << 16) |
+	     ((RJsrc & 0x0000ffff00000000) >> 16) |
+	     ((RJsrc & 0xffff000000000000) >> 48);
 }
 
 


### PR DESCRIPTION
Fixes #9434.

The LoongArch SLEIGH expressions for `revh.2w` and `revh.d` do not implement the architectural halfword permutations.

In `revh.2w`, the lower halfword of the upper 32-bit word is shifted by 8 rather than 16. For `RJsrc = 0x0123456789abcdef`, the original expression produces `0x00456823cdef89ab`; the ISA result is `0x45670123cdef89ab`.

In `revh.d`, the extracted halfwords are written back in their original order, so the operation returns `0x0123456789abcdef` unchanged. Reversing all four halfwords should produce `0xcdef89ab45670123`.

This replaces only those two expressions with explicit masks and shifts. The original `revb.2h`, `revb.4h`, `revb.2w`, and `revb.d` constructors remain unchanged.

The modified language compiles with SLEIGH, and both concrete cases produce the expected values.