### PR TITLE
#9445 Preserve inferred mixed-width load sizes

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -10992,7 +10992,8 @@ int4 RuleExpandLoad::applyOp(PcodeOp *op,Funcdata &data)
       lsbCut = offset;
   }
   else {
-    // Check for natural integer truncation
+    // Check for natural integer truncation from an explicitly typed pointer
+    if (!rootPtr->isTypeLock()) return 0;
     if (meta != TYPE_INT && meta != TYPE_UINT) return 0;
     type_metatype outMeta = outVn->getTypeDefFacing()->getMetatype();
     if (outMeta != TYPE_INT && outMeta != TYPE_UINT && outMeta != TYPE_UNKNOWN && outMeta != TYPE_BOOL)

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/loadwidth.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/loadwidth.xml
@@ -1,0 +1,21 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+  <!--
+      A pointer is used by LOADs of two different widths.  The inferred uint8
+      pointer must be cast before the one-byte LOAD; casting its result would
+      retain an incorrect eight-byte dereference in the emitted C.
+  -->
+<bytechunk space="ram" offset="0x100000" readonly="true">
+85f67404488b07c30fb607c3
+</bytechunk>
+</binaryimage>
+<script>
+  <com>map fun r0x100000 mixed_width_load</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Mixed-width load #1" min="1" max="1">return \(uint8\)\*\(uint1 \*\)param_1;</stringmatch>
+<stringmatch name="Mixed-width load #2" min="1" max="1">return \*param_1;</stringmatch>
+<stringmatch name="Mixed-width load #3" min="0" max="0">return \(uint8\)\(uint1\)\*param_1;</stringmatch>
+</decompilertest>


### PR DESCRIPTION

Fixes #9445.

## Summary

Preserve a narrow LOAD when its wider pointer type is inferred rather than
explicitly locked.

`RuleExpandLoad` currently treats an inferred pointer element type as evidence
that a smaller integer LOAD is a natural truncation of a wider source-level
load. It widens the LOAD and inserts a `SUBPIECE`. For mixed-width accesses,
this can turn a one-byte machine read into C such as:

```c
(uint8)(uint1)*param_1
```

The cast applies after dereferencing the inferred `uint8 *`, so recompiling
the output reads eight bytes.

## Change

Require the root pointer type to be locked before applying the
natural-integer-truncation form of `RuleExpandLoad`. If the pointer type was
only inferred, the original LOAD width remains intact and the C printer emits
a pointer cast instead:

```c
(uint8)*(uint1 *)param_1
```

Explicitly typed pointers retain the existing natural-truncation behavior.
The separate AND/comparison form of `RuleExpandLoad` is unchanged.

Add a twelve-byte x86-64 decompiler data test that exercises one-byte and
eight-byte loads through the same pointer. The test requires the pointer-cast
form and explicitly rejects the previous result-cast form. No generated
binary files are added.

## Validation

- New regression test on the unmodified behavior: 1/3 checks pass, with the
  expected pointer-cast and forbidden-result-cast checks failing.
- New regression test with this patch: 3/3 checks pass.
- Native decompiler unit-test suite with this patch: 204/204 tests pass.
- Complete native decompiler data-test suite with this patch: 721/721 checks
  pass.
- Built the patched native decompiler and exercised it through headless
  Ghidra. It preserves the one-byte load in the minimal reproducer and in the
  two original real-world cases, FFmpeg's `av_adler32_update` and
  `av_base64_encode`.