### PR TITLE
Ensure reasonable PNG chunk size

### DIFF
--- a/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/PNGChunk.java
+++ b/Ghidra/Features/FileFormats/src/main/java/ghidra/file/formats/ios/png/PNGChunk.java
@@ -40,6 +40,9 @@ public class PNGChunk implements StructConverter {
 	 */
 	public PNGChunk(BinaryReader reader) throws IOException {
 		length = reader.readNextInt();
+		if (length < 0 || length > 8 * 1024 * 1024) {
+			throw new IllegalArgumentException("Unreasonable PNG chunk length: " + length);
+		}
 		chunkID = reader.readNextInt();
 		data = reader.readNextByteArray(length);
 		crc32 = reader.readNextInt();


### PR DESCRIPTION
Prevent out of memory error due to invalid input data. 8 MB ought to be enough for an iOS icon.