### PR TITLE
Fix wrongly encoded ARM Thumb instructions

### DIFF
--- a/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
+++ b/Ghidra/Processors/ARM/data/languages/ARMTHUMBinstructions.sinc
@@ -1269,22 +1269,24 @@ with : ARMcondCk=1 {
 
 @if defined(VERSION_6T2) || defined(VERSION_7)
 
-:and^thSBIT_ZN^ItCond	Rd0811,Rn0003,ThumbExpandImm12 		is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=0 & thSBIT_ZN & Rn0003; thc1515=0 & Rd0811) & ThumbExpandImm12
+:and^thSBIT_CZN^ItCond	Rd0811,Rn0003,ThumbExpandImm12 		is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=0 & thSBIT_CZN & Rn0003; thc1515=0 & Rd0811) & ThumbExpandImm12
 {
   build ItCond;
   build ThumbExpandImm12;
   Rd0811 = Rn0003 & ThumbExpandImm12;
   resflags(Rd0811);
-  build thSBIT_ZN;
+  tmpCY = shift_carry;
+  build thSBIT_CZN;
 }
 
-:and^thSBIT_ZN^ItCond^".w"	Rd0811,Rn0003,thshift2 		is TMode=1 & ItCond & op11=0x1d & thc0910=1 & sop0508=0 & thSBIT_ZN & Rn0003; thc1515=0 & Rd0811 & thshift2
+:and^thSBIT_CZN^ItCond^".w"	Rd0811,Rn0003,thshift2 		is TMode=1 & ItCond & op11=0x1d & thc0910=1 & sop0508=0 & thSBIT_CZN & Rn0003; thc1515=0 & Rd0811 & thshift2
 {
   build ItCond;
   build thshift2;
   Rd0811 = Rn0003 & thshift2;
   resflags(Rd0811);
-  build thSBIT_ZN;
+  tmpCY = shift_carry;
+  build thSBIT_CZN;
 }
 @endif # VERSION_6T2 || VERSION_7
 
@@ -1412,13 +1414,14 @@ macro th_set_carry_for_asr(op1,shift_count) {
 
 @if defined(VERSION_6T2) || defined(VERSION_7)
 
-:bic^thSBIT_ZN^ItCond   Rd0811,Rn0003,ThumbExpandImm12 		is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=1 & thSBIT_ZN & Rn0003; thc1515=0 & Rd0811) & ThumbExpandImm12
+:bic^thSBIT_CZN^ItCond   Rd0811,Rn0003,ThumbExpandImm12 		is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=1 & thSBIT_CZN & Rn0003; thc1515=0 & Rd0811) & ThumbExpandImm12
 {
   build ItCond;
   build ThumbExpandImm12;
   Rd0811 = Rn0003&(~ThumbExpandImm12);
   resflags(Rd0811);
-  build thSBIT_ZN;
+  tmpCY = shift_carry;
+  build thSBIT_CZN;
 }
 
 :bic^thSBIT_CZNO^ItCond^".w"	Rd0811,Rn0003,thshift2 		is TMode=1 & ItCond & op11=0x1d & thc0910=1 & sop0508=1 & thSBIT_CZNO & Rn0003; thc1515=0 & Rd0811 & thshift2
@@ -2680,12 +2683,13 @@ macro th_set_carry_for_lsr(op1,shift_count) {
 
 @if defined(VERSION_6T2) || defined(VERSION_7)
 
-:mov^thSBIT_ZN^ItCond^".w"  Rd0811,ThumbExpandImm12  is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=2 & thSBIT_ZN & sop0003=15; thc1515=0 & Rd0811) & ThumbExpandImm12 {
+:mov^thSBIT_CZN^ItCond^".w"  Rd0811,ThumbExpandImm12  is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=2 & thSBIT_CZN & sop0003=15; thc1515=0 & Rd0811) & ThumbExpandImm12 {
   build ItCond;
   build ThumbExpandImm12;
   Rd0811 = ThumbExpandImm12;
   resflags(Rd0811);
-  build thSBIT_ZN;
+  tmpCY = shift_carry;
+  build thSBIT_CZN;
 }
 
 :movw^ItCond	Rd0811,Immed16 		is TMode=1 & ItCond & (op11=0x1e & thc0909=1 & sop0508=2 & thc0404=0; thc1515=0 & Rd0811) & Immed16
@@ -3065,21 +3069,23 @@ thspsrmask: spsr^thpsrmask	is thpsrmask & spsr { export thpsrmask; }
   spsr = (spsr& ~thspsrmask) | (Rn0003 & thspsrmask);
 }
 
-:mvn^thSBIT_ZN^ItCond  Rd0811,ThumbExpandImm12  is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=3 & thSBIT_ZN & thc0003=15; thc1515=0 & Rd0811) & ThumbExpandImm12 {
+:mvn^thSBIT_CZN^ItCond  Rd0811,ThumbExpandImm12  is TMode=1 & ItCond & (op11=0x1e & thc0909=0 & sop0508=3 & thSBIT_CZN & thc0003=15; thc1515=0 & Rd0811) & ThumbExpandImm12 {
 	build ItCond;
 	build ThumbExpandImm12;
 	Rd0811 = ~ThumbExpandImm12;
 	resflags(Rd0811);
-	build thSBIT_ZN;
+	tmpCY = shift_carry;
+	build thSBIT_CZN;
 }
 
-:mvn^thSBIT_ZN^ItCond^".w"  Rd0811,thshift2 		is TMode=1 & ItCond & op11=0x1d & thc0910=1 & sop0508=3 & thSBIT_ZN & thc0003=15; thc1515=0 & Rd0811 & thshift2
+:mvn^thSBIT_CZN^ItCond^".w"  Rd0811,thshift2 		is TMode=1 & ItCond & op11=0x1d & thc0910=1 & sop0508=3 & thSBIT_CZN & thc0003=15; thc1515=0 & Rd0811 & thshift2
 {
   build ItCond;
   build thshift2;
   Rd0811 = ~thshift2;
   resflags(Rd0811);
-  build thSBIT_ZN;
+  tmpCY = shift_carry;
+  build thSBIT_CZN;
 }
 
 @endif # VERSION_6T2 || VERSION_7


### PR DESCRIPTION
## Short Description
Some thumb instructions are incorrectly lifted, which leads to the carry flag never being written. It also leads to incorrect decompilation.

The instructions are (ARM Architecture Reference Manual for A-profile, ARM DDI 0487 M.b): 
- F5.1.12 AND, ANDS (register)
- F5.1.11 AND, ANDS (immediate)
- F5.1.21 BIC, BICS (immediate)
- F5.1.112 MOV, MOVS (immediate)
- F5.1.124 MVN, MVNS (immediate)
- F5.1.125 MVN, MVNS (register)

## GUI evidence
This is copied from the Ghidra GUI disassembler from the "Instruction Info" field. It shows that the instruction does not set the carry flag.

```
Instruction Summary
-------------------
Mnemonic          : ands.w
Number of Operands: 3
Address           : ram:0815c06c
Flow Type         : FALL_THROUGH
Fallthrough       : 0815c070
Delay slot depth  : 0
Hash              : c4dfd09e

Input Objects:
   r4, const:0x0, const:0x1f, const:0x20
Result Objects:
   NG, ZR, r4, shift_carry, tmpNG, tmpZR
Constructor Line #'s:
   instruction(ARMinstructions.sinc:1630), 
   and(ARMTHUMBinstructions.sinc:1281), ItCond(ARM.sinc:278), 
   thSBIT_ZN(ARMTHUMBinstructions.sinc:381), 
   thshift2(ARMTHUMBinstructions.sinc:557)

Byte Length : 4
Instr Bytes : 00010100 11101010 00100100 00000100
Mask        : 11110000 11111111 11110000 11110000
Masked Bytes: 00010000 11101010 00100000 00000000

Instr Context:
   LRset(01,01)        == 0x0
   TMode(00,00)        == 0x1
```


In comparison, the correctly implemented instruction bics.w looks like this:
```
Instruction Summary
-------------------
Mnemonic          : bics.w
Number of Operands: 3
Address           : ram:0815c0d0
Flow Type         : FALL_THROUGH
Fallthrough       : 0815c0d4
Delay slot depth  : 0
Hash              : 8ab84f79

Input Objects:
   OV, r0, r9, const:0x0, const:0x1f, const:0x20
Result Objects:
   CY, NG, OV, ZR, r9, shift_carry, tmpCY, 
   tmpNG, tmpOV, tmpZR
Constructor Line #'s:
   instruction(ARMinstructions.sinc:1630), 
   bic(ARMTHUMBinstructions.sinc:1424), ItCond(ARM.sinc:278), 
   thSBIT_CZNO(ARMTHUMBinstructions.sinc:377), 
   thshift2(ARMTHUMBinstructions.sinc:557)

Byte Length : 4
Instr Bytes : 00111001 11101010 00100000 00001001
Mask        : 11110000 11111111 11110000 11110000
Masked Bytes: 00110000 11101010 00100000 00000000

Instr Context:
   LRset(01,01)        == 0x0
   TMode(00,00)        == 0x1
```

## Impact
The reason I found this bug was because it caused a bug in my emulation:
```
        0815c06c 14 ea 24 04     ands.w     r4,r4,r4, asr #32
        0815c070 38 bf           it         cc
        0815c072 34 46           mov.cc     r4,r6
```


Because the `ands.w` instruction does not set the carry bit correctly the mov.cc instruction was never being executed, even though the condition was met. This was due to an earlier instruction always setting the carry bit.

Upon investigation, we saw that this issue exists for six instructions.

## Fix
The patch is pretty straight forward and just sets the according flags for the mentioned instructions.
This changes the example from above to:  
```
Instruction Summary
-------------------
Mnemonic          : ands.w
Number of Operands: 3
Address           : ram:0815c06c
Flow Type         : FALL_THROUGH
Fallthrough       : 0815c070
Delay slot depth  : 0
Hash              : c4dfd09e

Input Objects:
   r4, const:0x0, const:0x1f, const:0x20
Result Objects:
   CY, NG, ZR, r4, shift_carry, tmpCY, tmpNG, 
   tmpZR
Constructor Line #'s:
   instruction(ARMinstructions.sinc:1630), 
   and(ARMTHUMBinstructions.sinc:1286), ItCond(ARM.sinc:278), 
   thSBIT_CZN(ARMTHUMBinstructions.sinc:379), 
   thshift2(ARMTHUMBinstructions.sinc:557)

Byte Length : 4
Instr Bytes : 00010100 11101010 00100100 00000100
Mask        : 11110000 11111111 11110000 11110000
Masked Bytes: 00010000 11101010 00100000 00000000

Instr Context:
   LRset(01,01)        == 0x0
   TMode(00,00)        == 0x1
```


## Effect on decompilation
This patch also has effects on decompilation. For the example from above the disassembly was decompiled to:
```
    uVar1 = uVar1 & (int)uVar1 >> 0x20;
    if (!bVar8) {
      uVar1 = uVar6;
    }
```


Now, after the patch the decompiled code looks as follows:
```
  uVar1 = uVar2 & (int)uVar2 >> 0x20;
  if (-1 < (int)uVar2) {
    uVar1 = uVar6;
  }
```

