### PR TITLE
#9470 Recover pass-through return values when the callee prototype is known

### DIFF
--- a/Ghidra/Features/Decompiler/certification.manifest
+++ b/Ghidra/Features/Decompiler/certification.manifest
@@ -78,6 +78,7 @@ src/decompile/datatests/pointersub.xml||GHIDRA||||END|
 src/decompile/datatests/promotecompare.xml||GHIDRA||||END|
 src/decompile/datatests/ptrtoarray.xml||GHIDRA||||END|
 src/decompile/datatests/readvolatile.xml||GHIDRA||||END|
+src/decompile/datatests/retpassthrough.xml||GHIDRA||||END|
 src/decompile/datatests/retspecial.xml||GHIDRA||||END|
 src/decompile/datatests/retstruct.xml||GHIDRA||||END|
 src/decompile/datatests/revisit.xml||GHIDRA||||END|

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -2000,6 +2000,50 @@ void ActionReturnRecovery::buildReturnOutput(ParamActive *active,PcodeOp *retop,
   }
 }
 
+/// \brief Check if a return trial Varnode holds a called function's return value
+///
+/// A function that ends in \b return \b callee(...) leaves the value produced by the
+/// CALL in the return storage without ever writing it itself. Funcdata::ancestorOpUse()
+/// deliberately refuses to accept a CALL as evidence of a single use, because every call
+/// leaves its return storage defined whether or not the caller passes that value on. When
+/// the callee's prototype is known and declares a return value occupying exactly the
+/// trial's storage, that ambiguity is resolved: the value reaching the RETURN is the
+/// callee's return value, not an incidental leftover.  If the trial Varnode merges
+/// several control-flow paths (MULTIEQUAL), every path must be such a declared return
+/// value for the trial to qualify.
+/// \param data is the function being analyzed
+/// \param vn is the trial Varnode reaching the RETURN
+/// \param trial is the associated parameter trial object
+/// \param depth is the remaining depth for following MULTIEQUAL merges
+/// \return \b true if the Varnode is a called function's declared return value
+static bool trialIsCalleeReturnValue(const Funcdata &data,const Varnode *vn,const ParamTrial &trial,int4 depth)
+
+{
+  if (!vn->isWritten()) return false;
+  const PcodeOp *def = vn->getDef();
+  OpCode opc = def->code();
+  if (opc == CPUI_MULTIEQUAL) {
+    if (depth <= 0) return false;	// Also acts as a loop guard
+    for(int4 i=0;i<def->numInput();++i) {
+      if (!trialIsCalleeReturnValue(data,def->getIn(i),trial,depth-1))
+	return false;
+    }
+    return true;
+  }
+  if ((opc != CPUI_CALL)&&(opc != CPUI_CALLIND)) return false;
+  FuncCallSpecs *fc = data.getCallSpecs(def);
+  if (fc == (FuncCallSpecs *)0) return false;
+  if (!fc->isOutputLocked()) return false;	// Only a known prototype resolves the ambiguity
+  ProtoParameter *outparam = fc->getOutput();
+  if (outparam == (ProtoParameter *)0) return false;
+  Datatype *ct = outparam->getType();
+  if (ct == (Datatype *)0) return false;
+  if (ct->getMetatype() == TYPE_VOID) return false;
+  if (outparam->getSize() != trial.getSize()) return false;
+  if (outparam->getAddress() != trial.getAddress()) return false;
+  return true;
+}
+
 int4 ActionReturnRecovery::apply(Funcdata &data)
 
 {
@@ -2022,9 +2066,12 @@ int4 ActionReturnRecovery::apply(Funcdata &data)
 	if (trial.isChecked()) continue; // Already checked
 	int4 slot = trial.getSlot();
 	vn = op->getIn(slot);
-	if (ancestorReal.execute(op,slot,&trial,false))
+	if (ancestorReal.execute(op,slot,&trial,false)) {
 	  if (data.ancestorOpUse(maxancestor,vn,op,trial,0,0))
 	    trial.markActive(); // This varnode sees active use as a parameter
+	  else if (trialIsCalleeReturnValue(data,vn,trial,4))
+	    trial.markActive(); // Passed through from a callee with a known return value
+	}
 	count += 1;
       }
     }

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/retpassthrough.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/retpassthrough.xml
@@ -1,0 +1,40 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+  <!--
+      callee_ret  (0x100000):  mov rax,rdi ; sub rax,rsi ; ret
+      wrapper     (0x100007):  call callee_ret ; ret
+      callee_ret2 (0x100010):  mov rax,rdi ; add rax,rsi ; ret
+      wrapper2    (0x100020):  test rdx,rdx ; je L2 ; call callee_ret ; jmp L3
+                               L2: call callee_ret2 ; L3: ret
+
+      Neither wrapper ever writes RAX itself: the value each returns is
+      produced by a CALL.  With the callees' prototypes known to return an
+      8-byte value in RAX, the wrappers must be recovered as returning that
+      value, not as void.  wrapper2 exercises the case where return paths
+      from two different calls merge (MULTIEQUAL) before the RETURN.
+  -->
+<bytechunk space="ram" offset="0x100000" readonly="true">
+4889f84829f0c3e8f4ffffffc39090904889f84801f0c39090909090909090904885d27407e8d6ffffffeb05e8dfffffffc3
+</bytechunk>
+</binaryimage>
+<script>
+  <com>map fun r0x100000 callee_ret</com>
+  <com>map fun r0x100007 wrapper</com>
+  <com>map fun r0x100010 callee_ret2</com>
+  <com>map fun r0x100020 wrapper2</com>
+  <com>parse line extern int8 callee_ret(int8 a,int8 b);</com>
+  <com>parse line extern int8 callee_ret2(int8 a,int8 b);</com>
+  <com>lo fu wrapper</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>lo fu wrapper2</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Return passthrough #1" min="1" max="1">int8 wrapper\(</stringmatch>
+<stringmatch name="Return passthrough #2" min="1" max="2">= callee_ret\(param_1,param_2\);</stringmatch>
+<stringmatch name="Return passthrough #3" min="0" max="0">void wrapper</stringmatch>
+<stringmatch name="Return passthrough #4" min="1" max="1">int8 wrapper2\(</stringmatch>
+<stringmatch name="Return passthrough #5" min="1" max="1">= callee_ret2\(param_1,param_2\);</stringmatch>
+</decompilertest>


### PR DESCRIPTION
Addresses #9470 (the known-prototype case; the no-information case is
documented there as out of scope).

## Summary

A function whose return value is produced entirely by a call, such as the C
shape `return callee(a, b);`, is recovered as `void` and the value is dropped,
while the same decompilation emits its caller assigning from it:

```c
void wrapper_passthrough(undefined8 param_1,undefined8 param_2)
{ callee_returns_i64(param_1,param_2); return; }

uint main(int param_1)
{ lVar1 = wrapper_passthrough((long)param_1,3); ... }   /* assigns from void */
```

Crucially, this persists **even when the callee's prototype is known**:
committing `long callee_returns_i64(long,long)` by hand, or letting the
Decompiler Parameter ID analyzer commit it (it is enabled by default for
Windows PE programs smaller than 2 MB), still leaves the wrapper `void`. The locked prototype
puts a real output Varnode on the CALL feeding the RETURN, but
`Funcdata::ancestorOpUse()` unconditionally refuses CALL-defined Varnodes as
evidence of use (`case CPUI_CALL: return false; // A call is never a good
indication of a single op use`), so `ActionReturnRecovery` never marks the
return trial active. That conservatism is correct when nothing is known because
every call leaves its return storage defined whether or not the value is
passed on. With an output-locked callee, however, the ambiguity it guards
against is already resolved, and the information is discarded.

## Change

Add one narrowly scoped exception in `coreaction.cc`
(`trialIsCalleeReturnValue`, called only after `ancestorOpUse()` declines).
A return trial is marked active if the Varnode reaching the RETURN is:

- written by a CALL or CALLIND whose call spec is **output-locked**, with a
  declared non-void output occupying **exactly** the trial's storage (same
  address, same size); or
- a MULTIEQUAL merge of several return paths where **every** merged path is
  such a value (recursion over MULTIEQUAL is depth-limited to 4, which also
  serves as the loop guard). This covers
  `if (c) return f(a); return g(a);` with both prototypes known. Mixed
  merges (one path a computed value) were already accepted by
  `ancestorOpUse()`'s any-path rule and are unchanged.

Nothing changes when the callee prototype is unknown, so no existing
inference is weakened. The helper is static and documented in place.

Two trade-offs are worth naming:

- A known callee prototype resolves *what* the value in the return storage
  is, not *whether* the source wrapper passed it on. A source-level
  `void f(void) { g(); }` with non-void `g` in tail position compiles to the
  same bytes and is now recovered as returning `g`'s value. The two sources
  are indistinguishable in the machine code; recovering the value is the
  self-consistent choice, and callers that ignore it are unaffected.
- The change trusts locked prototypes: if a committed callee signature is
  itself wrong (non-void for a genuinely void function), the wrapper now
  inherits that error. This is consistent with how locks are treated
  elsewhere in the decompiler.

Both trade-offs were measured at whole-binary scale (same-base A/B, unpatched
vs patched build of this branch's base). On a real Decompiler-Parameter-ID-
analyzed binary (openssl's `bio_enc_test`, all 395 functions): 6 wrappers
gained their genuine source return type, while 18 source-void functions
gained a behaviorally-faithful but source-spurious return value. In every
case the propagating prototype was DPID's own prior non-void commit, i.e.
exactly the trust-the-lock semantics described above; no changed function
introduces any new self-contradiction (nothing void is assigned from). On a
fully DWARF-locked binary (openssl, first 800 functions checked) the patch
changes **nothing** because, with the caller's own return type locked, there is no
trial to rescue.

Add a decompiler data test (fifty reviewable x86-64 bytes, four tiny
functions: two callees, a single-call wrapper, and a two-path wrapper whose
return values merge in a MULTIEQUAL) with declared callee prototypes,
requiring both wrappers to be recovered with their return values, plus its
`certification.manifest` entry. No generated binary files are added.

## Scope

This fixes the *known-prototype* case. It deliberately does **not** change
output for a stripped binary under default analysis with no prototype
information anywhere (measured end-to-end with a patched build, not assumed):
in that situation `void w(){ g(); }` and `T w(){ return g(); }` are
byte-identical (`call ; ret` with the return register untouched), so the
wrapper's body alone cannot distinguish them, and guessing non-void would
merely fabricate return values for genuinely void callees. Interprocedural
information is exactly what committed prototypes provide; this patch makes
the decompiler honor them at the wrapper's RETURN, which previously it did
not. As a result, the user-commit workflow and the Decompiler Parameter ID pipeline
now resolve the reproducer end-to-end.

## Validation

- New regression test on the unmodified decompiler: 0/5 correctness checks
  pass (the `void` recovery is matched).
- New regression test with this patch: 5/5 checks pass; the single-call
  wrapper is recovered as `int8 wrapper(...)` with
  `iVar1 = callee_ret(param_1,param_2); return iVar1;`, and the two-path
  wrapper as `int8 wrapper2(...)` returning either callee's value.
- Complete native decompiler data-test suite with this patch: **723/723**
  checks pass. Baseline on the same tree and harness: **718/723**, the five
  failures being exactly the five new checks, providing sensitivity and
  no-regression in one measurement.
- Native decompiler unit-test suite: **204/204** with the patch (and at
  baseline).
- End-to-end A/B on the stripped 30-line reproducer through
  `analyzeHeadless` (Ghidra 12.1.2 install with only the `decompile` binary
  swapped):
  - stock, default analysis: contradiction (void wrapper, caller assigns);
  - stock, + Decompiler Parameter ID: callee committed
    `long(long,long)`; wrapper **still void** (the bug this PR fixes);
  - patched, default analysis: unchanged, as intended;
  - patched, + Decompiler Parameter ID: wrapper recovered and committed as
    `long wrapper_passthrough(long,long) { return callee_returns_i64(...); }`,
    caller binds it, producing consistent output that matches the original source.
- Field evidence: found by differential equivalence checking against FFmpeg
  binaries with DWARF stripped, where `av_size_mult` reproduced the shape in
  thirteen distinct executables and `av_rescale` in two more. In the same
  binaries the callees were recovered *with* their return values.