### PR TITLE
#9472 Keep a call-aliased stack object open across interior field acc…

### DIFF
--- a/Ghidra/Features/Decompiler/certification.manifest
+++ b/Ghidra/Features/Decompiler/certification.manifest
@@ -83,6 +83,7 @@ src/decompile/datatests/retstruct.xml||GHIDRA||||END|
 src/decompile/datatests/revisit.xml||GHIDRA||||END|
 src/decompile/datatests/sbyte.xml||GHIDRA||||END|
 src/decompile/datatests/skipnext2.xml||GHIDRA||||END|
+src/decompile/datatests/stackobjectalias.xml||GHIDRA||||END|
 src/decompile/datatests/stackreturn.xml||GHIDRA||||END|
 src/decompile/datatests/stackspill.xml||GHIDRA||||END|
 src/decompile/datatests/stackstring.xml||GHIDRA||||END|

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.cc
@@ -165,6 +165,10 @@ bool RangeHint::preferred(const RangeHint *b,bool reconcile) const
 ///   - must not be a locked data-type
 ///   - must not extend the size of the first array beyond what is known of its limits
 ///
+/// Alternately, if \b this is an \e open range whose base address is passed to a sub-function
+/// and there is no data-type evidence bounding the underlying object, the following RangeHint
+/// is absorbed unless there is evidence that a distinct object starts at it (see the comment
+/// in the method body).
 /// \param b is the other RangeHint to absorb
 /// \return \b true if the other RangeHint was successfully absorbed
 bool RangeHint::attemptJoin(RangeHint *b)
@@ -173,6 +177,29 @@ bool RangeHint::attemptJoin(RangeHint *b)
   if (rangeType != open) return false;
   if (b->rangeType == endpoint) return false;			// Don't merge with bounding range
   if (isConstAbsorbable(b)) {
+    absorb(b);
+    return true;
+  }
+  if (callAlias && highind < 0 && type->getSize() == 1 && !isTypeLock() &&
+      b->rangeType == fixed && !b->isTypeLock()) {
+    // The base address of this open range is passed to a sub-function, which may read or write
+    // any part of the underlying object.  The alias analysis commits to exactly this
+    // (see AliasChecker::gatherInternal and ScopeLocal::markUnaliased): every offset from the base
+    // up is treated as potentially accessed through the pointer, and Varnodes there keep their
+    // INDIRECT effects across the calls.  If the variable model nevertheless cut the object at the
+    // next directly referenced offset, accesses the sub-function makes beyond the cut could not be
+    // expressed in terms of any variable, contradicting the alias analysis and producing an object
+    // too small for the sub-function's accesses.  So a following direct reference is treated as
+    // evidence of an access to the interior of the object, not of a distinct variable, and is
+    // absorbed.  The rule only applies while there is no better evidence of the object's extent:
+    //   - highind >= 0 means an access pattern (indexing or constant fill) has been observed;
+    //     that extent evidence takes precedence, and the data-type driven join below governs;
+    //   - a recovered element data-type (more than a 1-byte placeholder, or a type-lock on
+    //     \b this) likewise carries extent/alignment information and takes precedence.
+    // Positive evidence that a distinct object starts at -b- also blocks absorption:
+    //   - -b- is type-locked: a user assertion outranks this inference;
+    //   - -b- is itself an open range: its base address was independently derived or escaped,
+    //     marking the start of a separate object (the artificial endpoint is excluded above).
     absorb(b);
     return true;
   }
@@ -217,6 +244,8 @@ bool RangeHint::attemptJoin(RangeHint *b)
 void RangeHint::absorb(RangeHint *b)
 
 {
+  if (b->callAlias)
+    callAlias = true;		// The base address of the combined range still escapes to a sub-function
   if (b->rangeType == open) {
     if (type->getAlignSize() == b->type->getAlignSize()) {	// Compatible element data-type
       rangeType = open;
@@ -293,6 +322,7 @@ bool RangeHint::merge(RangeHint *b,AddrSpace *space,TypeFactory *typeFactory)
     rangeType = b->rangeType;
     highind = b->highind;
     size = b->size;
+    callAlias = b->callAlias;	// absorb() recovers the property from the original range
     absorb(&copyRange);
   }
   else if (resType == 2) {
@@ -314,8 +344,8 @@ bool RangeHint::merge(RangeHint *b,AddrSpace *space,TypeFactory *typeFactory)
   return false;
 }
 
-/// Compare (signed) offset, size, RangeType, flags, and high index, in that order.
-/// Datatype is \e not compared.
+/// Compare (signed) offset, size, RangeType, flags, high index, and the \b callAlias
+/// property, in that order.  Datatype is \e not compared.
 /// \param op2 is the other RangeHint to compare with \b this
 /// \return -1, 0, or 1 depending on if \b this comes before, is equal to, or comes after
 int4 RangeHint::compare(const RangeHint &op2) const
@@ -331,6 +361,8 @@ int4 RangeHint::compare(const RangeHint &op2) const
     return (flags < op2.flags) ? -1 : 1;
   if (highind != op2.highind)
     return (highind < op2.highind) ? -1 : 1;
+  if (callAlias != op2.callAlias)
+    return op2.callAlias ? -1 : 1;		// Ranges without the callAlias property come first
   return 0;
 }
 
@@ -747,6 +779,7 @@ void AliasChecker::gatherAdditiveBase(Varnode *startvn,vector<AddBase> &addbase)
   list<PcodeOp *>::const_iterator iter;
   PcodeOp *op;
   bool nonadduse;
+  bool calluse;
   int4 i=0;
 
   vn = startvn;
@@ -756,6 +789,7 @@ void AliasChecker::gatherAdditiveBase(Varnode *startvn,vector<AddBase> &addbase)
     vn = vnqueue[i].base;
     indexvn = vnqueue[i++].index;
     nonadduse = false;
+    calluse = false;
     for(iter=vn->beginDescend();iter!=vn->endDescend();++iter) {
       op = *iter;
       switch(op->code()) {
@@ -797,12 +831,17 @@ void AliasChecker::gatherAdditiveBase(Varnode *startvn,vector<AddBase> &addbase)
 	  vnqueue.push_back(AddBase(subvn,indexvn));
 	}
 	break;
+      case CPUI_CALL:
+      case CPUI_CALLIND:
+	calluse = true;		// The pointer escapes to a sub-function
+	nonadduse = true;
+	break;
       default:
 	nonadduse = true;	// Used in non-additive expression
       }
     }
     if (nonadduse)
-      addbase.push_back(AddBase(vn,indexvn));
+      addbase.push_back(AddBase(vn,indexvn,calluse));
   }
   for(i=0;i<vnqueue.size();++i)
     vnqueue[i].base->clearMark();
@@ -894,7 +933,8 @@ MapState::~MapState(void)
 /// \param fl is additional boolean properties
 /// \param rt is the type of the hint
 /// \param hi is the biggest guaranteed index for \e open range hints
-void MapState::addRange(uintb st,Datatype *ct,uint4 fl,RangeHint::RangeType rt,int4 hi)
+/// \param ca is \b true if the base address of an \e open range is passed to a sub-function
+void MapState::addRange(uintb st,Datatype *ct,uint4 fl,RangeHint::RangeType rt,int4 hi,bool ca)
 
 {
   if ((ct == (Datatype *)0)||(ct->getSize()==0)) // Must have a real type
@@ -906,6 +946,7 @@ void MapState::addRange(uintb st,Datatype *ct,uint4 fl,RangeHint::RangeType rt,i
   sst = sign_extend(sst,spaceid->getAddrSize()*8-1);
   sst = (intb)AddrSpace::addressToByte(sst,spaceid->getWordSize());
   RangeHint *newRange = new RangeHint(st,sz,sst,ct,fl,rt,hi);
+  newRange->callAlias = ca;
   maplist.push_back(newRange);
 #ifdef OPACTION_DEBUG
   if (debugon) {
@@ -1237,7 +1278,7 @@ void MapState::gatherOpen(const Funcdata &fd)
     else {
       minItems = -1;
     }
-    addRange(offset,ct,0,RangeHint::open,minItems);
+    addRange(offset,ct,0,RangeHint::open,minItems,addbase[i].callUse);
   }
 
   TypeFactory *typeFactory = fd.getArch()->types;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/varmap.hh
@@ -110,10 +110,11 @@ private:
   uint4 flags;		///< Additional boolean properties of this range
   RangeType rangeType;	///< The type of range
   int4 highind;		///< Minimum upper bound on the array index (if \b this is \e open)
+  bool callAlias;	///< True if \b this is an \e open range whose base address is passed to a sub-function
 public:
   RangeHint(void) {}	///< Uninitialized constructor
   RangeHint(uintb st,int4 sz,intb sst,Datatype *ct,uint4 fl,RangeType rt,int4 hi) {
-    start=st; size=sz; sstart=sst; type=ct; flags=fl; rangeType = rt; highind=hi; }	///< Initialized constructor
+    start=st; size=sz; sstart=sst; type=ct; flags=fl; rangeType = rt; highind=hi; callAlias=false; }	///< Initialized constructor
   bool isTypeLock(void) const { return ((flags & typelock)!=0); }	///< Is the data-type for \b this range locked
   bool isConstAbsorbable(const RangeHint *b) const;	///< Can another range by absorbed into \b this as a constant
   bool reconcile(const RangeHint *b) const;
@@ -140,7 +141,8 @@ public:
   struct AddBase {
     Varnode *base;		///< The Varnode holding the base pointer
     Varnode *index;		///< The index value or NULL
-    AddBase(Varnode *b,Varnode *i) { base=b; index=i; }	///< Constructor
+    bool callUse;		///< True if the pointer is passed to a sub-function (CALL or CALLIND)
+    AddBase(Varnode *b,Varnode *i,bool c=false) { base=b; index=i; callUse=c; }	///< Constructor
   };
 private:
   const Funcdata *fd;		///< Function being searched for aliases
@@ -179,7 +181,7 @@ class MapState {
   Datatype *defaultType;		///< The default data-type to use for RangeHints
   AliasChecker checker;			///< A collection of pointer Varnodes into our address space
   void addGuard(const LoadGuard &guard,OpCode opc,TypeFactory *typeFactory);	///< Add LoadGuard record as a hint to the collection
-  void addRange(uintb st,Datatype *ct,uint4 fl,RangeHint::RangeType rt,int4 hi);	///< Add a hint to the collection
+  void addRange(uintb st,Datatype *ct,uint4 fl,RangeHint::RangeType rt,int4 hi,bool ca=false);	///< Add a hint to the collection
   void addFixedType(uintb start,Datatype *ct,uint4 flags,TypeFactory *types);	///< Add a fixed reference to a specific data-type
   void reconcileDatatypes(void);	///< Decide on data-type for RangeHints at the same address
   static bool isReadActive(Varnode *vn);	///< Is the given Varnode read by an active operation

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/stackobjectalias.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/stackobjectalias.xml
@@ -1,0 +1,37 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+   A stack object is passed by address to external calls and later read through an
+   interior field.  The open stack range for the address-taken object should not
+   be cut off at the first following field access.
+-->
+<bytechunk space="ram" offset="0x100000" readonly="true">
+4881ec2804000048897c2408488d442410
+baffffff7fbe010000004889c7e8dd0000
+00488d4424104889c7e8e000000085c0
+7519488d442410be000000004889c7e8
+da000000b8f4ffffffeb33488b542408
+488d4424104889d64889c7e8be000000
+8984241c04000083bc241c0400000079
+098b84241c040000eb048b4424184881
+c428040000c3
+</bytechunk>
+<symbol space="ram" offset="0x100000" name="stack_object_call_alias"/>
+<symbol space="ram" offset="0x100100" name="init_bigprint"/>
+<symbol space="ram" offset="0x100110" name="is_complete"/>
+<symbol space="ram" offset="0x100120" name="finalize_bigprint"/>
+</binaryimage>
+<script>
+  <com>parse line extern void init_bigprint(char *bp, int4 size, int4 max);</com>
+  <com>parse line extern int4 is_complete(char *bp);</com>
+  <com>parse line extern int4 finalize_bigprint(char *bp, char **out);</com>
+  <com>parse line extern int4 stack_object_call_alias(char **out);</com>
+  <com>lo fu stack_object_call_alias</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Stack object alias #1" min="1" max="1">char acStack_418 \[1048\];</stringmatch>
+<stringmatch name="Stack object alias #2" min="1" max="1">init_bigprint\(acStack_418,1,0x7fffffff\);</stringmatch>
+<stringmatch name="Stack object alias #3" min="0" max="0">char acStack_418 \[8\];</stringmatch>
+</decompilertest>


### PR DESCRIPTION
Partially addresses #9472.

## Summary

Stop splitting a stack aggregate whose address escapes into calls at its
first interior field access.

Today, a function that builds a large stack object, hands its address to
callees, and then reads an interior field at a fixed offset is recovered
with the object cut down to its leading bytes and the interior fields as
separate locals:

```c
undefined1 local_418 [8];      /* passed to callees that write ~1 KB */
int local_410;                 /* the aggregate's interior field     */
```

This model contradicts the decompiler's own alias analysis:
`ScopeLocal::markUnaliased` treats every byte at-or-above the escaped base
as potentially written by the callees and keeps the interior local's
`INDIRECT` effects across each `CALL`, while the symbol layout
simultaneously claims those bytes are an independent local that no call can
reach. Printed C cannot express the `INDIRECT`s, so the emitted shape is a
stack buffer overflow in the first callee plus reads of never-written
locals (demonstrated with an AddressSanitizer A/B harness in the issue).

## Change

`AliasChecker::gatherAdditiveBase()` already visits the `CALL`/`CALLIND`
uses of every stack-derived pointer but discarded the escape fact in its
`default:` arm. The patch records it and lets the join logic use it through
four small pieces in `varmap.cc` / `varmap.hh`:

1. `gatherAdditiveBase()` gives `CPUI_CALL`/`CPUI_CALLIND` their own case
   and records the fact in a new `AddBase::callUse` boolean. Which
   `AddBase` entries are collected is unchanged, so `hasLocalAlias`, the
   alias-offset list, and parameter-trial pruning are untouched.
2. `RangeHint` gains a documented boolean member `callAlias` ("open range
   whose base address is passed to a sub-function"), set by
   `MapState::gatherOpen()` from `AddBase::callUse` via a new defaulted
   `addRange` parameter. `highind` keeps exactly its documented meaning
   ("minimum upper bound on the array index"), with no sentinel values.
3. The property survives hint merging: `absorb()` ORs it in, `merge()`'s
   adopt-the-other-range path copies it, and `compare()` gets a final
   `callAlias` tiebreak so duplicate hints differing only in the new
   property are not arbitrarily deduplicated. With no call-aliased hints
   present the comparator is bit-identical to before.
4. `RangeHint::attemptJoin()`, which today refuses to let any open range
   with `highind < 0` absorb the following fixed range, gains one
   absorption rule ahead of that refusal. It fires only when there is no
   better evidence of the object's extent, and each guard is stated in the
   accompanying comment in model terms:
   - `callAlias`: only ranges whose base escapes into a call; everything
     else behaves exactly as before;
   - `highind < 0`: an observed indexing pattern or constant fill is
     extent evidence that takes precedence (this deliberately leaves
     indexed-array shapes to the existing array machinery);
   - element type is the 1-byte placeholder and the range is not
     type-locked; a recovered data-type is extent/alignment evidence that
     takes precedence;
   - the absorbed range is `fixed` and not type-locked; a type-locked
     range is a user assertion that a distinct object starts there, and an
     *open* range means another pointer was independently derived at that
     offset, likewise marking a distinct object.

A new datatest (`stackobjectalias.xml`, 136 reviewable instruction bytes
mirroring the FFmpeg `AVBPrint` shape) requires the object to be recovered
at its full extent, with its `certification.manifest` entry. No generated
binary files are added.

## Scope

This is a **partial** fix and is offered as such.

- It corrects the variable **model**: one object, and callees no longer
  write past its modeled end. Interior fields then print with subpiece
  notation (`local_418._8_4_`), which is still not recompilable C; this
  patch does not touch the C printer.
- Absorption extends to the end of the open region (the next type-locked
  symbol, independently-escaped object, or frame boundary). In the
  reproducer this also folds a neighboring scalar (the source `ret`
  variable, located in frame padding past the struct) into the object.
  This is address-faithful because every absorbed byte keeps its address, and
  the recompiled patched shape runs clean under ASan, but it is coarser than
  the source layout. No caller-side evidence can bound the extent more
  tightly (a direct interior write is indistinguishable from a field
  write, and cutting there would reintroduce the overflow); type-locking
  the struct recovers the exact source shape, and the rule defers to the
  lock.
- A related splitting shape is **not fixed, by design**: a
  `uint8_t in[256]` filled through an indexed loop and passed to a hash
  update still decompiles as 32 separate `undefined8` locals because the
  `highind >= 0` guard hands indexed shapes to the existing array
  machinery. That shape appears to be tracked already as #6813 and is
  noted only to delimit scope.
- Only direct `CALL`/`CALLIND` uses set the escape bit; a pointer that
  escapes through a `STORE` to memory or a `CALLOTHER` behaves as before.

## Validation

- New datatest on unpatched master (`2641302`): 1/3 checks pass (the split
  `char acStack_418 [8];` is emitted). With this patch: 3/3.
- Complete native decompiler data-test suite with this patch: 721/721
  checks pass (baseline on the same tree and harness: 719/721, failing
  exactly the two new checks).
- Native decompiler unit-test suite: 204/204 with and without the patch.
- ASan A/B on a fresh headless decompilation of the reproducer with the
  patched binary swapped into a 12.1.2 installation: original source shape
  prints `1`/exit 0; the stock split shape aborts with a
  stack-buffer-overflow in the first callee; the patched shape
  (`undefined1 local_418 [1048]`, interior access as subpiece) prints
  `1`/exit 0 with no report.
- Shape controls, headless stock vs patched, all bit-identical: an indexed
  `uint8_t[256]` loop buffer (the #6813 class), an `int` temporary passed
  by address with a directly-used neighbor, and a `long` temporary passed
  by address next to a call-result local.
- Type-lock convergence: locking the 1032-byte struct at the base yields
  one `BigPrint` symbol of exactly the type's extent with `bp.len` field
  accesses, identical under stock and patched; the rule defers to every
  stronger form of evidence.