### PR TITLE
#9474 Decompiler: Don't truncate a pending call-output trial to an unjustifiable piece

### DIFF
--- a/Ghidra/Features/Decompiler/certification.manifest
+++ b/Ghidra/Features/Decompiler/certification.manifest
@@ -80,6 +80,8 @@ src/decompile/datatests/ptrtoarray.xml||GHIDRA||||END|
 src/decompile/datatests/readvolatile.xml||GHIDRA||||END|
 src/decompile/datatests/retspecial.xml||GHIDRA||||END|
 src/decompile/datatests/retstruct.xml||GHIDRA||||END|
+src/decompile/datatests/retvalhighhalf.xml||GHIDRA||||END|
+src/decompile/datatests/retvalhighhalf_be.xml||GHIDRA||||END|
 src/decompile/datatests/revisit.xml||GHIDRA||||END|
 src/decompile/datatests/sbyte.xml||GHIDRA||||END|
 src/decompile/datatests/skipnext2.xml||GHIDRA||||END|

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/ruleaction.cc
@@ -997,6 +997,20 @@ int4 RulePullsubIndirect::applyOp(PcodeOp *op,Funcdata &data)
 
   if (indir->isIndirectCreation()) {
     bool possibleout = !indir->getIn(0)->isIndirectZero();
+    if (possibleout) {
+      FuncCallSpecs *fc = data.getCallSpecs(targ_op);
+      if (fc != (FuncCallSpecs *)0 && fc->isOutputActive()) {
+	// The storage may still become the call's formal output. Truncating it to a
+	// piece the prototype model cannot justify would leave return value recovery
+	// with nothing to bind, so the call would be recovered as void and this
+	// Varnode would remain as a read of storage that is never written.
+	// A piece is justified precisely when it contains the least significant byte
+	// of \b vn.  minMaxUse() indexes bytes by significance (lsb=0), and
+	// ParamEntry::justifiedContain computes this same significance offset for
+	// either endianness, so no endian test is needed here.
+	if (minByte != 0) return 0;
+      }
+    }
     new_ind = data.newIndirectCreation(targ_op,smalladdr2,newSize,possibleout);
     small2 = new_ind->getOut();
   }

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/retvalhighhalf.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/retvalhighhalf.xml
@@ -1,0 +1,33 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+  <!--
+      seed_hi_only (0x1129):  call make_value ; shr rax,32 ; mov rax,rdx
+                              xor with a global dword ; ret
+      main         (0x114a):  call seed_hi_only ; mov eax,<global> ; ret
+      make_value   (0x115b):  64-bit LCG over a static ; returns 8 bytes in RAX
+
+      The caller consumes ONLY the high 32 bits of make_value's 64-bit return
+      value.  No prototype is supplied for make_value: return value recovery in
+      the caller must deduce the output from the read of RAX after the CALL.
+      The read is real (the machine code performs SHR RAX,32 and stores the
+      result), so the call must not be recovered as void, and no variable may
+      be read without ever being written.
+  -->
+<bytechunk space="ram" offset="0x1129" readonly="true">
+554889e5e82900000048c1e8204889c28b05a52f000031d089059d2f0000905dc3
+554889e5e8d6ffffff8b058b2f00005dc3
+554889e5488b05aa2e000048ba2d7f954c2df45158480fafc24883c001488905912e0000488b058a2e00005dc3
+</bytechunk>
+</binaryimage>
+<script>
+  <com>map fun r0x1129 seed_hi_only</com>
+  <com>map fun r0x115b make_value</com>
+  <com>lo fu seed_hi_only</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Return high half #1" min="1" max="1">= make_value\(\)</stringmatch>
+<stringmatch name="Return high half #2" min="0" max="0">extraout</stringmatch>
+<stringmatch name="Return high half #3" min="1" max="1">&gt;&gt; 0x20</stringmatch>
+</decompilertest>

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/retvalhighhalf_be.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/retvalhighhalf_be.xml
@@ -1,0 +1,37 @@
+<decompilertest>
+<binaryimage arch="PowerPC:BE:64:default:default">
+  <!--
+      seed_hi_only (0x1000):  mflr r0 ; std r0,16(r1) ; stdu r1,-32(r1)
+                              bl make_value ; srdi r3,r3,32
+                              lis r4,0x10 ; stw r3,0(r4)
+                              addi r1,r1,32 ; ld r0,16(r1) ; mtlr r0 ; blr
+      make_value   (0x1100):  li r3,1 ; blr
+
+      Big-endian mirror of retvalhighhalf.xml: the caller consumes ONLY the
+      high 32 bits (most significant, LOWEST addressed bytes of r3) of
+      make_value's 64-bit return value.  No prototype is supplied for
+      make_value.  The piece is NOT justified in r3 (its least significant
+      byte does not reach r3's least significant byte), so truncating the
+      indirect creation must be refused, the full 8-byte return must bind,
+      and the call must not become void.
+  -->
+<bytechunk space="ram" offset="0x1000" readonly="true">
+7c0802a6f8010010f821ffe1480000f5786300223c80001090640000
+38210020e80100107c0803a64e800020
+</bytechunk>
+<bytechunk space="ram" offset="0x1100" readonly="true">
+386000014e800020
+</bytechunk>
+</binaryimage>
+<script>
+  <com>map fun r0x1000 seed_hi_only</com>
+  <com>map fun r0x1100 make_value</com>
+  <com>lo fu seed_hi_only</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Return high half BE #1" min="1" max="1">= make_value\(\)</stringmatch>
+<stringmatch name="Return high half BE #2" min="0" max="0">extraout</stringmatch>
+<stringmatch name="Return high half BE #3" min="1" max="1">&gt;&gt; 0x20</stringmatch>
+</decompilertest>


### PR DESCRIPTION
Fixes #9474.

## What happens

When a caller consumes only the upper 32 bits of a callee's 64-bit return
value (`x = f() >> 32` shapes), default analysis of a stripped binary
recovers the call as returning nothing and emits a read of a never-assigned
`extraout_var`, even though it recovers the callee itself with the correct 64-bit
return. Full details, reproducer and machine code in the issue.

## Root cause

`RulePullsubIndirect` replaces the 8-byte INDIRECT-creation Varnode that
heritage registered as the call's output trial with a smaller
indirect-creation at the consumed piece (RAX+4:4). When
`ActionActiveReturn` later resolves the trial, only the truncated piece
remains; `ParamListStandardOut` cannot justify a little-endian high piece as
return storage (`justifiedContain` = −1), every trial is marked no-use, and
`buildOutputFromTrials` recovers the call as void. The orphaned
indirect-creation then prints as the unassigned `extraout_var`.

The sequence was confirmed with rule/action breakpoints: the 8-byte creation
exists before `pullsub_indirect` fires and only the unjustified 4-byte piece
exists by the time `activereturn` runs.

## The change

One guard in `RulePullsubIndirect::applyOp`: if the indirect creation is a
possible call output (`possibleout`), the call's output trial is still
active (`FuncCallSpecs::isOutputActive()`), and the truncated piece would
not be justified within the storage (`minByte != 0`, i.e. the piece does not
contain the storage's least significant byte), the rule does not apply. The
test needs no endian conditional: `minMaxUse()` indexes bytes by
significance (lsb=0), and `ParamEntry::justifiedContain` computes that same
significance offset for both endiannesses, so `minByte == 0` is exactly the
"justified" condition return recovery will later apply. Return recovery then
sees the intact 8-byte read, binds the return value, and the consumer prints
as an explicit shift:

```c
xVar1 = make_value();
... ^ (uint)((ulong)xVar1 >> 0x20);
```

which matches what Ghidra already produces for the same binary when the
callee's signature is committed manually.

- Justified (low-piece) truncations still fire: the existing narrowing that
  recovers `int` returns for 32-bit consumers is unchanged (verified on the
  low-half control and on the full data-test suite).
- Calls whose prototype is already resolved are unaffected: with
  `isOutputActive()` false the rule behaves exactly as before, so locked
  prototypes with genuinely-extra side-register reads keep their
  `extraout_` representation.
- The rule only *defers*: once the output is bound, later simplification
  reduces the shift/subpiece chain normally.

## Scope

- With an unknown prototype, a read of the stale high half after a
  *genuinely void* callee is now recovered as an 8-byte return value rather
  than an `extraout_var`. That is the same read-after-call-implies-return
  inference the trial system already applies to low-half reads (reading
  stale EAX after a void callee recovers an `int` return today); machine
  code cannot distinguish the two without a prototype. No test in the
  existing suite exercises the stale-high-half-of-a-void-callee shape.
- Middle pieces (neither end justified) are likewise kept whole until the
  output resolves.

## Validation

- New regression test `datatests/retvalhighhalf.xml` (x86-64 LE, 95
  instruction bytes, caller + callee, no prototype supplied): 0/3 checks
  pass on unpatched master, 3/3 with this patch. The checks assert the value
  is bound (`= make_value()`), no `extraout` appears, and the high half is
  consumed via `>> 0x20`.
- New regression test `datatests/retvalhighhalf_be.xml` (PowerPC:BE:64,
  hand-assembled `bl; srdi r3,r3,32; stw` caller, same three checks): 0/3 on
  unpatched master and 3/3 with this patch. The justification test is
  execution-covered on a big-endian architecture, not just x86. A
  big-endian low-half (justified-piece) mirror was also verified correct
  with and without the patch.
- Complete native decompiler data-test suite: 722/722 with the patch
  (716/716 on the same tree before adding the two new tests; the stock and
  patched runs of the pre-existing 716 checks produce byte-identical logs).
- Native decompiler unit tests: identical results with and without the
  patch (183/204 in the validation environment; the 21 failures are a
  missing compiled Toy-processor SLEIGH environment artifact, identical on
  both sides and unrelated to this change).
- Whole-binary A/B over two real stripped FFmpeg executables (245 and 92
  functions): the only textual change across both binaries is the witness
  function (`get_generic_seed`), whose high-half XOR becomes correct; its
  low-half XOR and every other function are byte-identical.

## Field evidence

Found by differential testing of decompiled-then-recompiled FFmpeg:
`get_generic_seed` contains both `buffer[13] ^= AV_READ_TIME();` (recovered
correctly) and `buffer[41] ^= AV_READ_TIME() >> 32;` (recovered as the
unassigned `extraout_var` read) in one function. In a corpus of 650,463
decompiled functions, `extraout_*` locals appear in 4,420 functions (14,911
declarations), none ever assigned.