### PR TITLE
#9476 DWARF: don't lock signatures from subprograms with no signature info

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf/DWARFFunction.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf/DWARFFunction.java
@@ -128,7 +128,34 @@ public class DWARFFunction {
 		}
 		dfunc.varArg = !diea.getChildren(DW_TAG_unspecified_parameters).isEmpty();
 
+		if (hasNoSignatureInformation(dfunc, diea)) {
+			// The DIE carries no usable signature information.  Committing it as-is
+			// would lock an incorrect "void f(void)" signature (SourceType.IMPORTED)
+			// and prevent later analyzers from recovering the real parameters,
+			// making the result worse than for the same binary without debug info.
+			dfunc.signatureCommitMode = CommitMode.NO_PARAMS;
+		}
+
 		return dfunc;
+	}
+
+	/**
+	 * Detects subprogram DIEs that provide no signature information: no formal
+	 * parameters, no DW_AT_prototyped flag, and a DW_TAG_unspecified_type return type.
+	 * <p>
+	 * Assemblers emit this shape for functions defined in assembly source (e.g. gas
+	 * with --gdwarf only records name, address range and an unspecified return type),
+	 * where the parameters and return value are genuinely unknown rather than absent.
+	 *
+	 * @param dfunc {@link DWARFFunction} being built
+	 * @param diea DW_TAG_subprogram {@link DIEAggregate}
+	 * @return true if the DIE asserts nothing about the function's signature
+	 */
+	private static boolean hasNoSignatureInformation(DWARFFunction dfunc, DIEAggregate diea) {
+		DIEAggregate typeRef = diea.getTypeRef();
+		return dfunc.params.isEmpty() && !dfunc.varArg &&
+			!diea.getBool(DW_AT_prototyped, false) &&
+			typeRef != null && typeRef.getTag() == DW_TAG_unspecified_type;
 	}
 
 	private DWARFFunction(DIEAggregate diea, DWARFName dni, DWARFRangeList dwarfBody) {

--- a/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/bin/format/dwarf/DWARFFunctionImporterTest.java
+++ b/Ghidra/Features/Base/src/test.slow/java/ghidra/app/util/bin/format/dwarf/DWARFFunctionImporterTest.java
@@ -16,6 +16,7 @@
 package ghidra.app.util.bin.format.dwarf;
 
 import static ghidra.app.util.bin.format.dwarf.DWARFSourceLanguage.*;
+import static ghidra.app.util.bin.format.dwarf.DWARFTag.*;
 import static ghidra.app.util.bin.format.dwarf.attribs.DWARFAttributeId.*;
 import static ghidra.app.util.bin.format.dwarf.expression.DWARFExpressionOpCode.*;
 import static org.junit.Assert.*;
@@ -369,5 +370,111 @@ public class DWARFFunctionImporterTest extends DWARFTestBase {
 		Parameter[] parameters = fooFunc.getParameters();
 		assertEquals("param_1", parameters[0].getName());
 		assertEquals("param_2", parameters[1].getName());
+	}
+
+	@Test
+	public void testNoSignatureInfoFunc_SignatureNotLocked()
+			throws CancelledException, IOException, DWARFException {
+		// A subprogram DIE with no formal parameters, no DW_AT_prototyped flag and a
+		// DW_TAG_unspecified_type return type carries no information about the function's
+		// signature.  This is the shape gas emits for functions defined in assembly source.
+		// Test that the signature is not committed as an IMPORTED "void foo(void)", which
+		// would lock parameter storage and prevent later analyzers from recovering the
+		// real parameters and return value.
+		ensureCompUnit();
+		DebugInfoEntry unspecifiedDIE =
+			new DIECreator(dwarfProg, DW_TAG_unspecified_type).create();
+		newSubprogram("foo", unspecifiedDIE, 0x410, 10).create();
+
+		importFunctions();
+
+		Function fooFunc = program.getListing().getFunctionAt(addr(0x410));
+		assertNotNull(fooFunc);
+		assertEquals("foo", fooFunc.getName());
+		assertEquals(SourceType.DEFAULT, fooFunc.getSignatureSource());
+		assertEquals(0, fooFunc.getParameterCount());
+		assertEquals("undefined", fooFunc.getReturnType().getName());
+	}
+
+	@Test
+	public void testNoSignatureInfoFunc_inverse_Prototyped()
+			throws CancelledException, IOException, DWARFException {
+		// Same DIE shape as testNoSignatureInfoFunc_SignatureNotLocked, plus a
+		// DW_AT_prototyped flag: the empty parameter list is now asserted by the
+		// producer, so the signature must still be committed.
+		ensureCompUnit();
+		DebugInfoEntry unspecifiedDIE =
+			new DIECreator(dwarfProg, DW_TAG_unspecified_type).create();
+		newSubprogram("foo", unspecifiedDIE, 0x410, 10)
+				.addBoolean(DW_AT_prototyped, true)
+				.create();
+
+		importFunctions();
+
+		Function fooFunc = program.getListing().getFunctionAt(addr(0x410));
+		assertNotNull(fooFunc);
+		assertEquals(SourceType.IMPORTED, fooFunc.getSignatureSource());
+		assertEquals(0, fooFunc.getParameterCount());
+	}
+
+	@Test
+	public void testNoSignatureInfoFunc_inverse_ConcreteReturnType()
+			throws CancelledException, IOException, DWARFException {
+		// A concrete return type is real signature info, even without DW_AT_prototyped
+		// and without formal parameters (e.g. C89 "int foo()"): the signature must
+		// still be committed.
+		DebugInfoEntry intDIE = addInt();
+		newSubprogram("foo", intDIE, 0x410, 10).create();
+
+		importFunctions();
+
+		Function fooFunc = program.getListing().getFunctionAt(addr(0x410));
+		assertNotNull(fooFunc);
+		assertEquals(SourceType.IMPORTED, fooFunc.getSignatureSource());
+		assertEquals(0, fooFunc.getParameterCount());
+		assertEquals("int", fooFunc.getReturnType().getName());
+	}
+
+	@Test
+	public void testNoSignatureInfoFunc_inverse_HasParams()
+			throws CancelledException, IOException, DWARFException {
+		// Formal parameters are real signature info, even without DW_AT_prototyped
+		// (e.g. K&R-style C) and with a DW_TAG_unspecified_type return type: the
+		// signature must still be committed.
+		DebugInfoEntry intDIE = addInt();
+		DebugInfoEntry unspecifiedDIE =
+			new DIECreator(dwarfProg, DW_TAG_unspecified_type).create();
+		DebugInfoEntry fooDIE = newSubprogram("foo", unspecifiedDIE, 0x410, 10).create();
+		newFormalParam(fooDIE, "param1", intDIE, instr(DW_OP_fbreg, 0x6c)).create();
+
+		importFunctions();
+
+		Function fooFunc = program.getListing().getFunctionAt(addr(0x410));
+		assertNotNull(fooFunc);
+		assertEquals(SourceType.IMPORTED, fooFunc.getSignatureSource());
+		assertEquals(1, fooFunc.getParameterCount());
+		assertEquals("param1", fooFunc.getParameter(0).getName());
+	}
+
+	@Test
+	public void testPrototypedVoidFunc_SignatureLocked()
+			throws CancelledException, IOException, DWARFException {
+		// A properly prototyped "void foo(void)" (no DW_AT_type, DW_AT_prototyped
+		// present) must still be committed as an IMPORTED void signature.
+		ensureCompUnit();
+		new DIECreator(dwarfProg, DW_TAG_subprogram)
+				.addString(DW_AT_name, "foo")
+				.addBoolean(DW_AT_prototyped, true)
+				.addUInt(DW_AT_low_pc, 0x410)
+				.addUInt(DW_AT_high_pc, 10)
+				.create();
+
+		importFunctions();
+
+		Function fooFunc = program.getListing().getFunctionAt(addr(0x410));
+		assertNotNull(fooFunc);
+		assertEquals(SourceType.IMPORTED, fooFunc.getSignatureSource());
+		assertEquals(0, fooFunc.getParameterCount());
+		assertEquals("void", fooFunc.getReturnType().getName());
 	}
 }


### PR DESCRIPTION

Fixes #9476.

## Summary

Stop committing a locked `void f(void)` signature for `DW_TAG_subprogram`
DIEs that assert nothing about the function's signature. This is the shape gas
emits for functions defined in assembly source (no formal parameters, no
`DW_AT_prototyped`, `DW_TAG_unspecified_type` return).

Today such DIEs are imported as a definite empty prototype with
`SourceType.IMPORTED`. That locks parameter storage ("Unknown calling
convention -- yet parameter storage is locked") and suppresses the
decompiler's own parameter recovery, so every call site of such a function
loses its arguments and its consumed return value becomes a read of an
unassigned `extraout_*` variable. Stripping the debug info from the same
binary produces correct output, i.e. DWARF currently makes results worse.

## Change

One file, `DWARFFunction.java`. In `DWARFFunction.read()`, the existing
`CommitMode.NO_PARAMS` is selected when the DIE provides no signature information:

- no formal parameters and no `DW_TAG_unspecified_parameters` child,
- `DW_AT_prototyped` absent, and
- return type referencing `DW_TAG_unspecified_type`

The predicate sets `CommitMode.NO_PARAMS` instead of the default
`STORAGE`. `NO_PARAMS` commits the calling convention without setting
`SourceType`, exactly so that "other analyzers can provide param info"; it
was previously never set by anything. Name, namespace, body ranges, locals
and `noReturn` continue to be imported from DWARF.

The predicate is deliberately narrow:

- A genuine `void f(void)` C function has `DW_AT_prototyped` and no return
  type DIE → unaffected.
- K&R/unprototyped C functions have no `DW_TAG_unspecified_type` return →
  unaffected.
- Rust/Go functions carry real parameter/type DIEs and their own fixups →
  unaffected.

## Before / after (reproducer from the issue: 3-arg asm function + C caller, built with -g)

Before:

```c
int use_add3(int x)
{
  int extraout_EAX;
  ...
  add3();
  return extraout_EAX * 2;
}
void add3(void)   /* locked */
```

After:

```c
int use_add3(int x)
{
  int iVar1;
  ...
  iVar1 = add3(x,2,3);
  return iVar1 * 2;
}
int add3(int param_1,int param_2,int param_3)
```

DWARF-provided information is retained (`use_add3(int x)`, locals `j`,
`x_local`); only the assembly function's unknown signature is now
recoverable instead of locked empty.

On a real OpenSSL binary built with `-g`, the change restores arguments and
return values at 1,089 of 1,242 zero-argument call sites belonging to 243
assembly functions (`CRYPTO_memcmp`, `OPENSSL_cleanse`,
AES-NI/SHA/`bn_mul_mont*`/P-256 implementations) while C functions' DWARF
signatures are unchanged.

## Testing

- New JUnit regression tests in `DWARFFunctionImporterTest` (synthetic-DIE
  framework): the gas shape (no params, no `DW_AT_prototyped`,
  `DW_TAG_unspecified_type` return) must import with
  `getSignatureSource() == SourceType.DEFAULT` and no locked params, plus
  four negative controls that each flip one predicate conjunct
  (`DW_AT_prototyped` present; concrete return type, i.e. C89 `int g()`;
  formal parameter present, i.e. K&R; prototyped `void f(void)`) and must
  stay `SourceType.IMPORTED`. Before the fix the positive test fails
  (`expected:<DEFAULT> but was:<IMPORTED>`) and all controls pass; after
  the fix all pass.
- Predicate checked against real compiler output (gcc 14.2 / gas 2.44,
  `readelf --debug-dump=info`): K&R definitions, C89 empty-parens `int g()`
  / `void g()`, and prototyped `void h(void)` all fail at least one
  conjunct and keep their locked signatures; only gas-assembled functions
  (`--gdwarf-3/4/5`, or `.s` files built through `gcc -g`) match.
- Reproducer above, before/after, on the patched build.
- Full re-analysis of an OpenSSL binary (13,239 decompiled functions,
  patched vs stock):
  - all **243** void(void)-locked assembly functions regain a recovered
    signature, and in **243/243 cases it is byte-identical to what stock
    Ghidra recovers for the same binary stripped**. The DWARF view now
    matches the stripped view exactly, while keeping DWARF names;
  - zero-argument call sites of those functions: **1,242 → 153**. The 153
    residual sites belong to internal assembly helpers with custom register
    conventions (`__poly1305_block`, `__ecp_nistz256_subx`, …) whose
    parameters stock Ghidra also cannot recover from the stripped binary;
    those functions do now regain their return types;
  - **zero regressions**: no function lost a prototype, no non-target
    signature changed, and the function count is identical (12,428 named
    entries both runs).
- `DWARFFunction.java` compiles cleanly; the change is additive (one new
  private predicate + one assignment in `read()`), no existing behavior path
  is modified for DIEs that carry any signature information.
