### PR TITLE
#9478 Decompiler: preserve direct stack parameter trials across register holes

### DIFF
--- a/Ghidra/Features/Decompiler/certification.manifest
+++ b/Ghidra/Features/Decompiler/certification.manifest
@@ -53,6 +53,7 @@ src/decompile/datatests/inlinetarget.xml||GHIDRA||||END|
 src/decompile/datatests/longdouble.xml||GHIDRA||||END|
 src/decompile/datatests/loopcomment.xml||GHIDRA||||END|
 src/decompile/datatests/lzcount.xml||GHIDRA||||END|
+src/decompile/datatests/memclassparam.xml||GHIDRA||||END|
 src/decompile/datatests/mixfloatint.xml||GHIDRA||||END|
 src/decompile/datatests/modulo.xml||GHIDRA||||END|
 src/decompile/datatests/modulo2.xml||GHIDRA||||END|

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.cc
@@ -620,6 +620,20 @@ ParamListStandard::~ParamListStandard(void)
   }
 }
 
+/// A \e direct stack assignment means a ModelRule (such as \<goto_stack>) can place a
+/// parameter at the stack resource even though earlier register resources are unconsumed.
+/// \return \b true if the model contains such a rule
+bool ParamListStandard::hasDirectStackAssignment(void) const
+
+{
+  list<ModelRule>::const_iterator iter;
+  for(iter=modelRules.begin();iter!=modelRules.end();++iter) {
+    if ((*iter).assignsStackDirectly())
+      return true;
+  }
+  return false;
+}
+
 /// \param tiles will contain the set of matching entries
 /// \param type is the storage class
 /// \return the first matching iterator
@@ -1299,9 +1313,35 @@ void ParamListStandard::fillinMap(ParamActive *active) const
     // Definitely not used -- overrides active
     forceNoUse(active,trialStart[i],trialStart[i+1]);
   }
+  // The model may be able to assign a parameter to the stack without consuming register
+  // resources (e.g. a <goto_stack> rule for data-types the ABI passes in memory).  A chain of
+  // unused register entries then implies nothing about trials in the stack region, so the chain
+  // and hole rules are enforced separately on the register and stack portions of a section.
+  // This is restricted to recovering the active function's own parameters:  for a sub-function
+  // call site, a caller-side spill that happens to sit in the outgoing argument area is
+  // indistinguishable from a stack argument, and the chain rule is kept as a filter.
+  bool directStack = hasDirectStackAssignment() && !active->isRecoverSubcall();
   for(int4 i=0;i<numSection;++i) {
     // Chains of inactivity override later actives
-    forceInactiveChain(active,2,trialStart[i],trialStart[i+1],resourceStart[i]);
+    int4 sectionStart = trialStart[i];
+    int4 sectionStop = trialStart[i+1];
+    int4 stackStart = sectionStop;
+    if (directStack) {
+      for(int4 j=sectionStart;j<sectionStop;++j) {
+	const ParamEntry *curEntry = active->getTrial(j).getEntry();
+	if (curEntry == (const ParamEntry *)0) continue;
+	if (!curEntry->isExclusion() && curEntry->getSpace()->getType() == IPTR_SPACEBASE) {
+	  stackStart = j;
+	  break;
+	}
+      }
+    }
+    if (sectionStart < stackStart && stackStart < sectionStop) {
+      forceInactiveChain(active,2,sectionStart,stackStart,resourceStart[i]);
+      forceInactiveChain(active,2,stackStart,sectionStop,active->getTrial(stackStart).getEntry()->getGroup());
+    }
+    else
+      forceInactiveChain(active,2,sectionStart,sectionStop,resourceStart[i]);
   }
 
   // Mark every active trial as used

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/fspec.hh
@@ -598,6 +598,7 @@ protected:
   list<ModelRule> modelRules;		///< Rules to apply when assigning addresses
   AddrSpace *spacebase;			///< Address space containing relative offset parameters
   const ParamEntry *findEntry(const Address &loc,int4 size,bool just) const;	///< Given storage location find matching ParamEntry
+  bool hasDirectStackAssignment(void) const;	///< Return \b true if a rule can assign stack storage while skipping registers
   const ParamEntry *selectUnreferenceEntry(int4 grp,type_class prefType) const;	///< Select entry to fill an unreferenced param
   void buildTrialMap(ParamActive *active) const;	///< Build map from parameter trials to model ParamEntrys
   void separateSections(ParamActive *active,vector<int4> &trialStart) const;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/modelrules.hh
@@ -312,6 +312,15 @@ public:
   /// \return \b true if the trials could form a valid return value
   virtual bool fillinOutputMap(ParamActive *active) const;
 
+  /// \brief Return \b true if \b this action can assign a parameter to the stack resource
+  /// without consuming any register resources
+  ///
+  /// By default, an input parameter is assigned to the stack only after all register resources
+  /// (in its resource section) are consumed.  An action returning \b true here (GotoStack) can
+  /// assign a parameter to the stack while skipping unused register resources entirely.
+  /// \return \b true if the action can assign stack storage while registers remain unconsumed
+  virtual bool assignsStackDirectly(void) const { return false; }
+
   /// \brief Configure any details of how \b this action should behave from the stream
   ///
   /// \param decoder is the given stream decoder
@@ -333,6 +342,7 @@ public:
   virtual uint4 assignAddress(Datatype *dt,const PrototypePieces &proto,int4 pos,TypeFactory &tlist,
 			      vector<int4> &status,ParameterPieces &res) const;
   virtual bool fillinOutputMap(ParamActive *active) const;
+  virtual bool assignsStackDirectly(void) const { return true; }
   virtual void decode(Decoder &decoder);
 };
 
@@ -550,6 +560,7 @@ public:
 		      vector<int4> &status,ParameterPieces &res) const;
   bool fillinOutputMap(ParamActive *active) const;	///< Test and mark the trial(s) that can be valid return value
   bool canAffectFillinOutput(void) const;		///< Return \b true if fillinOutputMap is active for \b this rule
+  bool assignsStackDirectly(void) const;	///< Return \b true if \b this rule can assign stack storage while skipping registers
   void decode(Decoder &decoder,const ParamListStandard *res);		///< Decode \b this rule from stream
 };
 
@@ -567,6 +578,13 @@ inline bool ModelRule::canAffectFillinOutput(void) const
 
 {
   return assign->canAffectFillinOutput();
+}
+
+/// \return \b true if the assign action can place a parameter on the stack while registers remain unconsumed
+inline bool ModelRule::assignsStackDirectly(void) const
+
+{
+  return (assign != (AssignAction *)0) && assign->assignsStackDirectly();
 }
 
 } // End namespace ghidra

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/memclassparam.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/memclassparam.xml
@@ -1,0 +1,68 @@
+<decompilertest>
+<binaryimage arch="x86:LE:64:default:gcc">
+<!--
+  Compiled from (gcc -O0, x86-64 System V):
+
+    const char *to_human(long double size, char *buf) {
+      const char units[] = "\0KMGTPEZY";
+      unsigned i = 0;
+      while (size >= 1024) { size /= 1024; i++; }
+      sprintf(buf, "%.2Lf%c", size, units[i]);
+      return buf;
+    }
+    struct desc { void *ptr; unsigned long len; unsigned long long off; }; /* 24 bytes */
+    unsigned long long sum_desc(struct desc d, int tag) {
+      return (unsigned long long)d.len + d.off + (unsigned)tag;
+    }
+
+  Both functions take a SysV MEMORY-class parameter (long double / 24-byte
+  aggregate) passed on the stack while a LATER parameter still occupies the
+  first integer register.  The register sequence therefore has a "hole"
+  (RSI-R9 unused, stack used), which the chain heuristic must not treat as
+  evidence against the stack trials: the model's <goto_stack> rule says
+  MEMORY-class parameters consume no registers.
+  to_human @0x1149, sum_desc @0x11c9, main @0x11e5, sprintf@plt @0x1040,
+  printf@plt @0x1030, rodata (format strings, 1024.0L, 1234567.0L) @0x2000.
+-->
+<bytechunk space="ram" offset="0x1020" readonly="true">
+ff35ca2f0000ff25cc2f00000f1f4000ff25ca2f00006800000000e9e0ffffffff25c22f00006801000000e9d0ffffffff258a2f000066900000000000000000
+31ed4989d15e4889e24883e4f050544531c031c9488d3d6a010000ff153f2f0000f4662e0f1f8400000000000f1f4000488d3d892f0000488d05822f00004839
+f87415488b051e2f00004885c07409ffe00f1f8000000000c30f1f8000000000488d3d592f0000488d35522f00004829fe4889f048c1ee3f48c1f8034801c648
+d1fe7414488b05ed2e00004885c07408ffe0660f1f440000c30f1f8000000000f30f1efa803d152f000000752b5548833dca2e0000004889e5740c488b3df62e
+0000e829ffffffe864ffffffc605ed2e0000015dc30f1f00c30f1f8000000000f30f1efae977ffffff554889e54883ec2048897de848b8004b4d475450455a48
+8945f266c745fa5900c745fc00000000eb12db6d10db2db50e0000def9db7d108345fc01db2da60e0000db6d10dff1ddd873df8b45fc0fb64405f20fbed0488b
+45e8ff7518ff7510488d0d610e00004889ce4889c7b800000000e881feffff4883c410488b45e8c9c3554889e5897dfc488b5518488b45204801d08b55fc89d2
+4801d05dc3554889e5534883ec48488d45d0488945b048c745b80700000048c745c0090000004883ec184889e1488b45b0488b55b848890148895108488b45c0
+48894110bf03000000e89bffffff4883c4184889c3488d45d0db2d010e0000488d6424f0db3c244889c7e8fafeffff4883c4104889da4889c6488d05b80d0000
+4889c7b800000000e8c3fdffffb800000000488b5df8c9c3
+</bytechunk>
+<bytechunk space="ram" offset="0x2000" readonly="true">
+01000200000000000000000000000000252e324c66256300257320256c6c750a0000000000000000000000000000000000000000000000800940000000000000
+000000000038b4961340000000000000
+</bytechunk>
+</binaryimage>
+<script>
+  <com>map fun r0x1030 printf</com>
+  <com>map fun r0x1040 sprintf</com>
+  <com>map fun r0x1149 to_human</com>
+  <com>map fun r0x11c9 sum_desc</com>
+  <com>map fun r0x11e5 main</com>
+  <com>parse line extern int4 printf(char * format,...);</com>
+  <com>parse line extern int4 sprintf(char * s,char * format,...);</com>
+  <com>lo fu to_human</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>lo fu sum_desc</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>lo fu main</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Memory-class param #1" min="0" max="0">in_stack_</stringmatch>
+<stringmatch name="Memory-class param #2" min="1" max="1">char \* to_human\(char \*param_1,xunknown8 param_2,xunknown2 param_3\)</stringmatch>
+<stringmatch name="Memory-class param #3" min="1" max="1">int8 sum_desc\(uint4 param_1,xunknown8 param_2,int8 param_3,int8 param_4\)</stringmatch>
+<stringmatch name="Memory-class param #4" min="1" max="1">return param_4 \+ param_3 \+ \(uint8\)param_1;</stringmatch>
+<stringmatch name="Memory-class param #5" min="1" max="1">param_2 = SUB108\(fVar1,0\);</stringmatch>
+</decompilertest>


### PR DESCRIPTION

Fixes #9478.

## Summary

Preserve active stack parameter trials when the calling-convention model can
assign a parameter directly to the stack without consuming earlier register
resources.

On x86-64 System V, this occurs for MEMORY-class arguments such as
`long double` and by-value aggregates larger than 16 bytes. A later argument
can still occupy RDI while the earlier value is passed on the stack. Current
parameter recovery interprets the unused RSI through R9 sequence as a long
inactive chain and discards the valid stack trials that follow it.

The resulting prototype omits the stack parameter, while the body reads its
bytes through unbound `in_stack_*` Varnodes:

```c
char *to_human(char *param_1)             /* long double omitted */
long sum_desc(uint param_1)               /* 24-byte aggregate omitted */
```

The same binary with DWARF decompiles with the correct source prototypes, so
the storage model can represent these parameters. The failure is confined to
trial-based input recovery.

## Root cause

`ParamListStandard::fillinMap()` builds a trial map in resource order and runs
`forceInactiveChain()` over each resource section. When an active stack trial
appears after unused registers, `buildTrialMap()` creates inactive trials for
the register holes. The chain reaches `maxchain` before the stack entries and
marks the later active stack trials inactive.

The chain heuristic assumes that registers must be consumed before the stack.
That is not true for models containing a `<goto_stack/>` rule. Such a rule
exists specifically so a matching data type can use stack storage while
register resources remain available.

## Change

The implementation is structural and does not depend on architecture names or
data-type names:

1. Add `AssignAction::assignsStackDirectly()`, which defaults to `false` and
   is overridden by `GotoStack`.
2. Expose that property through `ModelRule` and add
   `ParamListStandard::hasDirectStackAssignment()`.
3. In `ParamListStandard::fillinMap()`, split the inactive-chain walk at the
   first non-exclusion `IPTR_SPACEBASE` entry when the model permits direct
   stack assignment and the trials belong to the active function's own input
   recovery.
4. Apply `forceInactiveChain()` independently to the register and stack
   portions. The existing `maxchain=2` rule is retained within each portion.

The second walk starts with the stack entry's own resource group, so an unused
register sequence cannot invalidate justified stack trials and cannot cause
the hole-filling pass to invent intermediate register parameters.

A new native data test, `memclassparam.xml`, contains compiled x86-64 bytes for
both reproducing shapes and checks that:

- no `in_stack_` value remains;
- the `long double` storage pieces are represented as parameters;
- the aggregate storage pieces are represented as parameters;
- the aggregate body uses the recovered parameters;
- the high part of the floating value is bound during the loop.

The test is added to `certification.manifest`. No generated binary file is
added.

## Scope

- The alternate path is gated on a model rule whose assignment action reports
  direct stack use. Models without such a rule retain the previous path.
- The change applies only to recovery of the active function's own inputs.
  Call-site recovery keeps the existing chain filter because an ordinary
  caller spill in the outgoing argument area can look like a stack argument.
  An ungated version invented an extra call argument in measured controls.
- The inactive-chain limit remains active within the stack portion. Parameters
  beyond more than two unread stack slots can therefore remain unrecovered.
- Committing the repaired prototype, manually or through Decompiler Parameter
  ID, allows normal prototype propagation to repair non-variadic call sites.
  Default call-site inference and variadic stack arguments are unchanged.
- The direct-stack model path exists on several architectures. The focused
  reproducer and corpus checks cover x86-64. Other models received only the
  general regression coverage provided by the complete native data-test suite.

## Validation

- Focused `memclassparam.xml` test: **0/5** on unpatched master and **5/5**
  with this patch.
- Complete native decompiler data-test suite: **723/723** with the patch.
  Baseline on the same tree and harness is **718/723**, with exactly the five
  new checks failing.
- Native decompiler unit-test suite: **204/204** with and without the patch.
- Headless same-base comparison on the stripped reproducer: `to_human` and
  `sum_desc` contain no `in_stack_*` values after the patch.
- Headless same-base comparison on a stripped LZ4 witness binary: functions
  containing `in_stack_*` decrease from 12 to 2, and occurrences decrease
  from 104 to 9. Ten of twelve field witnesses are fully repaired, one is
  partial, and one remains unchanged because of the retained intra-stack
  inactive-chain limit.
- A 166-function stripped PCRE2 control binary with no direct-stack parameter
  shape produces identical decompilation before and after the patch.
- With Decompiler Parameter ID enabled on the reproducer, the repaired callee
  prototypes propagate the stack values to the non-variadic calls in `main`.