### PR TITLE
Correct register sorting in storage editor

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/editor/VarnodeLocationCellEditor.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/function/editor/VarnodeLocationCellEditor.java
@@ -51,8 +51,6 @@ class VarnodeLocationCellEditor extends AbstractCellEditor
 	private AddressInput addressInput;
 	private IntegerTextField offsetInput;
 
-	private Comparator<Register> registerWrapperComparator =
-		(r1, r2) -> r1.toString().compareToIgnoreCase(r2.toString());
 	private VarnodeInfo currentVarnode;
 
 	VarnodeLocationCellEditor(StorageAddressModel model) {
@@ -176,19 +174,7 @@ class VarnodeLocationCellEditor extends AbstractCellEditor
 	}
 
 	private Component createRegisterCombo(VarnodeInfo varnode) {
-		ProgramContext programContext = program.getProgramContext();
-
-		List<Register> registers = new ArrayList<>(programContext.getRegisters());
-
-		for (Iterator<Register> iter = registers.iterator(); iter.hasNext();) {
-			Register register = iter.next();
-			if (register.isProcessorContext() || register.isHidden()) {
-				iter.remove();
-			}
-		}
-
-		Collections.sort(registers, registerWrapperComparator);
-		//Register[] registers = validItems.toArray(new Register[validItems.size()]);
+		List<Register> registers = getSortedVisibleRegisters(program.getProgramContext());
 
 		RegisterDropDownSelectionDataModel registerModel =
 			new RegisterDropDownSelectionDataModel(registers);
@@ -232,5 +218,19 @@ class VarnodeLocationCellEditor extends AbstractCellEditor
 		});
 
 		return registerEntryTextField;
+	}
+
+	static List<Register> getSortedVisibleRegisters(ProgramContext programContext) {
+		List<Register> registers = new ArrayList<>(programContext.getRegisters());
+
+		for (Iterator<Register> iter = registers.iterator(); iter.hasNext();) {
+			Register register = iter.next();
+			if (register.isProcessorContext() || register.isHidden()) {
+				iter.remove();
+			}
+		}
+
+		Collections.sort(registers);
+		return registers;
 	}
 }

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/plugin/core/function/editor/VarnodeLocationCellEditorTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/plugin/core/function/editor/VarnodeLocationCellEditorTest.java
@@ -1,0 +1,54 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.plugin.core.function.editor;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.junit.Test;
+
+import generic.test.AbstractGenericTest;
+import ghidra.program.database.ProgramBuilder;
+import ghidra.program.model.lang.Register;
+
+public class VarnodeLocationCellEditorTest extends AbstractGenericTest {
+	private static final int AARCH64_GENERAL_REGISTER_MAX = 30;
+
+	@Test
+	public void testAarch64XRegistersUseNumericOrder() throws Exception {
+		ProgramBuilder builder = new ProgramBuilder("TestProgram", ProgramBuilder._AARCH64);
+		try {
+			List<Register> registers = VarnodeLocationCellEditor.getSortedVisibleRegisters(
+				builder.getProgram().getProgramContext());
+			List<String> xRegisters = new ArrayList<>();
+			for (Register register : registers) {
+				if (register.getName().matches("x\\d+")) {
+					xRegisters.add(register.getName());
+				}
+			}
+
+			List<String> expected = new ArrayList<>();
+			for (int i = 0; i <= AARCH64_GENERAL_REGISTER_MAX; i++) {
+				expected.add("x" + i);
+			}
+			assertEquals(expected, xRegisters);
+		}
+		finally {
+			builder.dispose();
+		}
+	}
+}


### PR DESCRIPTION
The Storage Address Editor sorted register names lexicographically, causing
numbered registers such as x10 to appear before x2.

Use Registers existing natural ordering.

Fixes #928 