### PR TITLE
Make unitTestReport fail after aggregate test failures

### DIFF
--- a/gradle/javaTestProject.gradle
+++ b/gradle/javaTestProject.gradle
@@ -23,6 +23,17 @@
 		apply from: "$rootProject.projectDir/gradle/support/javaTestProject.gradle"
  *****************************************************************************************/
 
+if (!rootProject.ext.has('unitTestFailureCount')) {
+	rootProject.ext.unitTestFailureCount = new java.util.concurrent.atomic.AtomicLong(0)
+	rootProject.unitTestReport.doLast {
+		long failedTestCount = rootProject.ext.unitTestFailureCount.get()
+		if (failedTestCount > 0) {
+			throw new GradleException(
+				"Unit tests failed: ${failedTestCount} failure(s). See ${rootProject.ext.reportDir}/unitTests")
+		}
+	}
+}
+
 test { t ->
 
 	forkEvery = 1
@@ -42,6 +53,12 @@ test { t ->
 	// Do not include suite classes; they trigger the tests in the suite to get run twice
 	// (once by normal jUnit and again when the suite runs).
 	excludes = ['**/*Suite*']
+
+	afterSuite { descriptor, result ->
+		if (descriptor.parent == null) {
+			rootProject.ext.unitTestFailureCount.addAndGet(result.failedTestCount)
+		}
+	}
 
 	doFirst {
 		startTestTimer(t)


### PR DESCRIPTION
## Summary

Makes `unitTestReport` expose unit-test failures through its process exit status while preserving complete aggregate report generation.

Ghidra intentionally configures project `Test` tasks with `ignoreFailures = true` so the full test suite can finish and `unitTestReport` can aggregate the results. The side effect is that the aggregate task currently completes successfully even when constituent unit tests failed.

This change records the failed-test count from the root suite of each project unit-test task in a thread-safe aggregate counter. `unitTestReport` checks that counter in a final action, after the report has been generated, and throws `GradleException` when failures were recorded.

This avoids depending on a new Gradle `TestReport` failure-propagation feature and does not stop the suite on the first failing test.

Fixes #9467

## Behaviour

- All unit-test tasks still run with `ignoreFailures = true`.
- The aggregate HTML report is generated before the final status check.
- `unitTestReport` exits nonzero when one or more unit tests failed.
- Integration, p-code and cspec test-report behaviour is unchanged.
- The counter uses `AtomicLong` so project test tasks can contribute safely when execution is concurrent.

## Validation

The patch is isolated to `gradle/javaTestProject.gradle`. It uses the root-suite `afterSuite` result, where `failedTestCount` represents the completed project test task, and attaches the final assertion with `unitTestReport.doLast` so it runs after report generation.

The full Ghidra unit suite was not re-run in this environment; upstream full-suite validation remains applicable.