### PR TITLE
#9505 Wrap long Array Values entries in the Listing

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/ArrayValuesFieldFactory.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/viewer/field/ArrayValuesFieldFactory.java
@@ -16,9 +16,12 @@
 package ghidra.app.util.viewer.field;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
 import docking.widgets.fieldpanel.field.*;
 import docking.widgets.fieldpanel.support.FieldLocation;
+import docking.widgets.fieldpanel.support.FieldUtils;
 import docking.widgets.fieldpanel.support.RowColLocation;
 import ghidra.app.util.ListingHighlightProvider;
 import ghidra.app.util.viewer.format.FieldFormatModel;
@@ -98,17 +101,19 @@ public class ArrayValuesFieldFactory extends FieldFactory {
 		int itemCount = Math.min(remaining, valuesPerLine);
 		boolean isLastLine = remaining <= itemCount;
 
-		FieldElement[] aStrings = new FieldElement[itemCount];
+		List<FieldElement> elements = new ArrayList<>();
 		for (int i = 0; i < itemCount; i++) {
 			Data child = parent.getComponent(index++);
 			boolean isLastItem = isLastLine && (i == itemCount - 1);
 			String value = getDisplayValue(child, !isLastItem);
 			AttributedString as =
 				new AttributedString(value, ListingColors.ARRAY_VALUES, getMetrics());
-			aStrings[i] = new TextFieldElement(as, i, 0);
+			TextFieldElement element = new TextFieldElement(as, i, 0);
+			elements.addAll(FieldUtils.wrap(element, width, false));
 		}
-		return ListingTextField.createPackedTextField(this, proxy, aStrings, startX + varWidth,
-			width, 1, hlProvider);
+		return ListingTextField.createPackedTextField(this, proxy,
+			elements.toArray(new FieldElement[0]), startX + varWidth, width, Integer.MAX_VALUE,
+			hlProvider);
 
 	}
 


### PR DESCRIPTION
## Summary

Fixes long array values being clipped in the Listing's `Array Values` field, including long enum representations.

`ArrayValuesFieldFactory` currently creates one `TextFieldElement` per array element and passes the elements directly to a packed field restricted to a single screen line. An individual value wider than the field is therefore clipped.

This change wraps each array-value element to the available field width before packed layout, using the existing `FieldUtils.wrap(..., false)` support, and allows the packed field to display all resulting rows.

The wrapping utility returns `TextFieldElement` substrings that retain the original data row and advance the original data-column offset. This preserves the existing cursor/program-location mapping while making the entire representation visible and selectable/copyable.

Fixes #9505

## Scope

- Changes only `ArrayValuesFieldFactory`.
- Does not change generic `FlowLayoutTextField` behavior.
- Preserves `valuesPerLine` semantics.
- Wrapped pieces retain their original array-element row/column mapping.
- Wrapping does not insert characters into copied text.

## Validation

The patch is one commit and one production file, based directly on current `master`. It reuses existing field wrapping and substring-location behavior. The full Ghidra test suite was not run in this environment; upstream module/full-suite validation remains applicable.