### PR TITLE
#2445 Fix 64-bit token equality constraints

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghpatexpress/EqualEquation.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghpatexpress/EqualEquation.java
@@ -26,6 +26,13 @@ public class EqualEquation extends ValExpressEquation {
         super(location, l, r);
     }
 
+    static boolean isValueInRange(long value, long min, long max) {
+        if (min <= max) {
+            return value >= min && value <= max;
+        }
+        return value >= min || value <= max;
+    }
+
     @Override
     public void genPattern(VectorSTL<TokenPattern> ops) {
         long lhsmin = lhs.minValue();
@@ -42,7 +49,7 @@ public class EqualEquation extends ValExpressEquation {
 
         do {
             long val = rhs.getSubValue(cur);
-            if ((val >= lhsmin) && (val <= lhsmax)) {
+            if (isValueInRange(val, lhsmin, lhsmax)) {
                 if (count == 0)
                     setTokenPattern(ExpressUtils.buildPattern(lhs, val, semval, cur));
                 else

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghpatexpress/EqualEquation.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcodeCPort/slghpatexpress/EqualEquation.java
@@ -27,10 +27,7 @@ public class EqualEquation extends ValExpressEquation {
     }
 
     static boolean isValueInRange(long value, long min, long max) {
-        if (min <= max) {
-            return value >= min && value <= max;
-        }
-        return value >= min || value <= max;
+        return Long.compareUnsigned(value, min) >= 0 && Long.compareUnsigned(value, max) <= 0;
     }
 
     @Override

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcodeCPort/slghpatexpress/EqualEquationTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcodeCPort/slghpatexpress/EqualEquationTest.java
@@ -36,11 +36,12 @@ public class EqualEquationTest {
 	}
 
 	@Test
-	public void testWrappedRange() {
-		assertFalse(EqualEquation.isValueInRange(4, 5, -1));
-		assertTrue(EqualEquation.isValueInRange(5, 5, -1));
-		assertTrue(EqualEquation.isValueInRange(Long.MAX_VALUE, 5, -1));
-		assertTrue(EqualEquation.isValueInRange(Long.MIN_VALUE, 5, -1));
-		assertTrue(EqualEquation.isValueInRange(-1, 5, -1));
+	public void testUnsignedRangeCrossingSignedBoundary() {
+		assertFalse(EqualEquation.isValueInRange(4, 5, -2));
+		assertTrue(EqualEquation.isValueInRange(5, 5, -2));
+		assertTrue(EqualEquation.isValueInRange(Long.MAX_VALUE, 5, -2));
+		assertTrue(EqualEquation.isValueInRange(Long.MIN_VALUE, 5, -2));
+		assertTrue(EqualEquation.isValueInRange(-2, 5, -2));
+		assertFalse(EqualEquation.isValueInRange(-1, 5, -2));
 	}
 }

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcodeCPort/slghpatexpress/EqualEquationTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcodeCPort/slghpatexpress/EqualEquationTest.java
@@ -1,0 +1,46 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pcodeCPort.slghpatexpress;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class EqualEquationTest {
+
+	@Test
+	public void testNormalRange() {
+		assertTrue(EqualEquation.isValueInRange(0x1234, 0, 0xffff));
+		assertFalse(EqualEquation.isValueInRange(-1, 0, 0xffff));
+	}
+
+	@Test
+	public void testFullWidthUnsignedRange() {
+		assertTrue(EqualEquation.isValueInRange(0, 0, -1));
+		assertTrue(EqualEquation.isValueInRange(Long.MAX_VALUE, 0, -1));
+		assertTrue(EqualEquation.isValueInRange(Long.MIN_VALUE, 0, -1));
+		assertTrue(EqualEquation.isValueInRange(-1, 0, -1));
+	}
+
+	@Test
+	public void testWrappedRange() {
+		assertFalse(EqualEquation.isValueInRange(4, 5, -1));
+		assertTrue(EqualEquation.isValueInRange(5, 5, -1));
+		assertTrue(EqualEquation.isValueInRange(Long.MAX_VALUE, 5, -1));
+		assertTrue(EqualEquation.isValueInRange(Long.MIN_VALUE, 5, -1));
+		assertTrue(EqualEquation.isValueInRange(-1, 5, -1));
+	}
+}


### PR DESCRIPTION
## Summary

Fixes equality constraints on full-width 64-bit SLEIGH token fields.

`TokenField.maxValue()` represents the maximum 64-bit bit pattern as a Java `long`. For a field spanning bits 0 through 63 that value is `0xffffffffffffffff`, represented as `-1`. `EqualEquation` currently performs a normal signed range check, so a valid field range is seen as `[0, -1]` and even a small constant such as `0x1234` is rejected with `Equal constraint is impossible to match`.

This change compares the candidate value and range bounds with Long.compareUnsigned(...). That preserves the intended bit-pattern ordering for narrower fields and correctly treats 0xffffffffffffffff as the unsigned 64-bit maximum.

The change is deliberately limited to equality constraints. Relational constraints enumerate candidate values and have different scaling/semantic considerations for a full 64-bit domain.

Fixes #2445

## Validation

- Added unit coverage for a normal bounded range.
- Added coverage for the full-width `0 .. 0xffffffffffffffff` representation.
- Added coverage for a partial range that crosses the signed `long` boundary.
- Production change is isolated to `EqualEquation` and does not modify `TokenField` representation or other constraint operators.

The full Ghidra test suite was not run in this environment; the focused regression is included for upstream validation.