### PR TITLE
Fix setMinStoreLoadOffset assigning wrong field in ConstantPropagationContextEvaluator

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ConstantPropagationContextEvaluator.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/analysis/ConstantPropagationContextEvaluator.java
@@ -119,13 +119,13 @@ public class ConstantPropagationContextEvaluator extends ContextEvaluatorAdapter
 	}
 
 	/**
-	 * Set maximum speculative memory offset for references
+	 * Set minimum offset from the start or end of memory for computed store/load references
 	 * 
-	 * @param minStoreLoadRefAddress maximum address offset
+	 * @param minStoreLoadRefAddress minimum address offset
 	 * @return this
 	 */
 	public ConstantPropagationContextEvaluator setMinStoreLoadOffset(long minStoreLoadRefAddress) {
-		maxSpeculativeOffset = minStoreLoadRefAddress;
+		minStoreLoadOffset = minStoreLoadRefAddress;
 		return this;
 	}
 


### PR DESCRIPTION
In `ConstantPropagationContextEvaluator`, `setMinStoreLoadOffset` assigns `maxSpeculativeOffset` instead of `minStoreLoadOffset`.

The setter is chained **last** in `ConstantPropagationAnalyzer.flowConstants`:

```java
new ConstantPropagationContextEvaluator(monitor)
    .setTrustWritableMemory(...)
    .setMinSpeculativeOffset(minSpeculativeRefAddress)
    .setMaxSpeculativeOffset(maxSpeculativeRefAddress)
    .setMinStoreLoadOffset(minStoreLoadRefAddress)     // <-- clobbers maxSpeculativeOffset
    .setCreateComplexDataFromPointers(...)
```

so there are two consequences:

1. **`maxSpeculativeOffset` is overwritten** with `minStoreLoadRefAddress`, discarding the value `setMaxSpeculativeOffset` installed on the line before. `evaluateConstant` uses `maxSpeculativeOffset` as an end-of-memory rejection window; with the default options that window shrinks from the computed value to 4.
2. **`minStoreLoadOffset` never receives the option value.** It stays at its constructor default of 4, which makes the user-visible analysis option "Min absolute reference" (`MINSTORELOADREFADDRESS`) inert.

The three-argument constructor assigns both fields correctly, which is why this has gone unnoticed: the bug is only reachable through the fluent form - which is the form the analyzer itself uses.

This affects the base `ConstantPropagationAnalyzer` and every per-processor subclass that repeats the same chain (MIPS, ARM, PowerPC, x86, SH4, PIC16, 68K, Hexagon, RISC-V, Sparc, NDS32, LoongArch, and the Toy analyzer).

I noticed this on a 16-bit target, where "Min absolute reference" is exactly the option a user has to lower to get zero-page references; the option appears to do nothing.

The javadoc on the setter is also corrected; it was duplicated from `setMaxSpeculativeOffset`.