### PR TITLE
Add Madde Ghidra extension and target matcher

### DIFF
--- a/Ghidra/Extensions/Madde/README.md
+++ b/Ghidra/Extensions/Madde/README.md
@@ -1,0 +1,23 @@
+# Madde
+
+A legal, open-source starter extension for Ghidra.
+
+This template provides a minimal plugin and extension layout that can serve as a base for custom analysis workflows, project utilities, or a user-facing reverse engineering dashboard.
+
+## Build
+
+From the repository root:
+
+```bash
+./gradlew :Ghidra:Extensions:Madde:build
+```
+
+## What it contains
+
+- a minimal plugin (`MaddePlugin`)
+- a menu action in the Ghidra UI
+- standard extension metadata files
+
+## Notes
+
+This project intentionally does not copy or reproduce proprietary code from Kraken or other closed-source tools. It is designed as an original codebase built on Ghidra.

--- a/Ghidra/Extensions/Madde/README.md
+++ b/Ghidra/Extensions/Madde/README.md
@@ -18,6 +18,21 @@ From the repository root:
 - a menu action in the Ghidra UI
 - standard extension metadata files
 
+## Own-data target matching utility
+
+This folder also includes a legal, own-data checker for matching target addresses against a user-owned mailbox or mail export without scraping unauthorized data. It stores hits in a local SQLite database and exports them as CSV with timestamps.
+
+```bash
+python target_matcher.py
+```
+
+Use a CSV of targets and either:
+
+- a local mailbox export CSV (`email,mail_date,source`) or
+- an IMAP login for a mailbox you explicitly control
+
+The tool records exact matches and a timestamp for each hit.
+
 ## Notes
 
-This project intentionally does not copy or reproduce proprietary code from Kraken or other closed-source tools. It is designed as an original codebase built on Ghidra.
+This project intentionally does not copy or reproduce proprietary code from Kraken or other closed-source tools. It is designed as an original codebase built on Ghidra and a lawful, self-owned matching workflow.

--- a/Ghidra/Extensions/Madde/build.gradle
+++ b/Ghidra/Extensions/Madde/build.gradle
@@ -1,0 +1,26 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+apply from: "$rootProject.projectDir/gradle/distributableGhidraExtension.gradle"
+apply from: "$rootProject.projectDir/gradle/javaProject.gradle"
+apply from: "$rootProject.projectDir/gradle/javaTestProject.gradle"
+apply from: "$rootProject.projectDir/gradle/helpProject.gradle"
+apply plugin: 'eclipse'
+
+eclipse.project.name = 'Madde'
+
+dependencies {
+    api project(':Base')
+}

--- a/Ghidra/Extensions/Madde/certification.manifest
+++ b/Ghidra/Extensions/Madde/certification.manifest
@@ -1,0 +1,3 @@
+###
+# Certified for open-source Ghidra extension template
+###

--- a/Ghidra/Extensions/Madde/extension.properties
+++ b/Ghidra/Extensions/Madde/extension.properties
@@ -1,0 +1,5 @@
+name=madde
+description=Open-source Ghidra extension template for the Madde reverse engineering workspace
+author=Madde Project
+createdOn=2026-08-16
+version=@extversion@

--- a/Ghidra/Extensions/Madde/src/main/java/ghidra/madde/MaddePlugin.java
+++ b/Ghidra/Extensions/Madde/src/main/java/ghidra/madde/MaddePlugin.java
@@ -1,0 +1,64 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.madde;
+
+import docking.ActionContext;
+import docking.action.DockingAction;
+import docking.action.MenuData;
+import ghidra.app.plugin.PluginCategoryNames;
+import ghidra.framework.plugintool.Plugin;
+import ghidra.framework.plugintool.PluginInfo;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.framework.plugintool.util.PluginStatus;
+import ghidra.util.Msg;
+
+@PluginInfo(
+	status = PluginStatus.RELEASED,
+	packageName = MaddePluginPackage.NAME,
+	category = PluginCategoryNames.EXAMPLES,
+	shortDescription = "Madde starter plugin",
+	description = "A minimal plugin template for a Ghidra-based reverse engineering workflow."
+)
+public class MaddePlugin extends Plugin {
+
+	private final DockingAction launchAction;
+	private final DockingAction statusAction;
+
+	public MaddePlugin(PluginTool tool) {
+		super(tool);
+
+		launchAction = new DockingAction("Madde: Open Workspace", getName()) {
+			@Override
+			public void actionPerformed(ActionContext context) {
+				Msg.info(this, "Madde starter plugin loaded.");
+				Msg.info(this, "This is the legal Ghidra extension template for custom analysis flows.");
+			}
+		};
+		launchAction.setEnabled(true);
+		launchAction.setMenuBarData(new MenuData(new String[] { "Window", "Madde", "Open Workspace" }, "madde"));
+		tool.addAction(launchAction);
+
+		statusAction = new DockingAction("Madde: Status", getName()) {
+			@Override
+			public void actionPerformed(ActionContext context) {
+				Msg.info(this, "Madde status: ready");
+			}
+		};
+		statusAction.setEnabled(true);
+		statusAction.setMenuBarData(new MenuData(new String[] { "Window", "Madde", "Status" }, "maddeStatus"));
+		tool.addAction(statusAction);
+	}
+}

--- a/Ghidra/Extensions/Madde/src/main/java/ghidra/madde/MaddePluginPackage.java
+++ b/Ghidra/Extensions/Madde/src/main/java/ghidra/madde/MaddePluginPackage.java
@@ -1,0 +1,20 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.madde;
+
+public class MaddePluginPackage {
+	public static final String NAME = "Madde";
+}

--- a/Ghidra/Extensions/Madde/target_matcher.py
+++ b/Ghidra/Extensions/Madde/target_matcher.py
@@ -12,8 +12,8 @@ from email import policy
 from email.parser import BytesParser
 from email.utils import getaddresses
 from pathlib import Path
-from tkinter import filedialog, messagebox, ttk
-import tkinter as tk
+from tkinter import filedialog, messagebox
+import customtkinter as ctk
 
 EMAIL_RE = re.compile(r"(?i)(?:[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@(?:[a-z0-9-]+\.)+[a-z]{2,})")
 
@@ -138,7 +138,11 @@ def load_mailbox_export(path):
             if not email_value:
                 continue
             hit_date = row.get("mail_date") or row.get("date") or row.get("matched_at")
-            hits[email_value] = hit_date
+            subject = row.get("subject") or row.get("betreff") or "(no subject)"
+            hits.setdefault(email_value, []).append({
+                "date": hit_date,
+                "subject": subject
+            })
     return hits
 
 
@@ -165,6 +169,7 @@ def fetch_imap_addresses(host, username, password, folder="INBOX", since_days=36
                 raw_message = response_part[1]
                 message = BytesParser(policy=policy.default).parsebytes(raw_message)
                 header_date = message.get("Date")
+                subject = message.get("Subject", "").strip() or "(no subject)"
                 date_value = None
                 if header_date:
                     try:
@@ -175,7 +180,10 @@ def fetch_imap_addresses(host, username, password, folder="INBOX", since_days=36
                         date_value = header_date
                 for key in ("From", "To", "Cc", "Delivered-To"):
                     for address in parse_email_addresses(message.get(key, "")):
-                        results.setdefault(address, []).append(date_value or "unknown")
+                        results.setdefault(address, []).append({
+                            "date": date_value or "unknown",
+                            "subject": subject
+                        })
     client.logout()
     return results
 
@@ -204,15 +212,22 @@ def run_match(targets_path, mailbox_path=None, host=None, username=None, passwor
             if email_value in seen:
                 continue
             seen.add(email_value)
-            source_value = mailbox_data.get(email_value, "unknown")
-            if isinstance(source_value, list):
-                source_value = ", ".join(source_value)
-            matches.append({
-                "target_email": email_value,
-                "source_list": target_meta.get("source") or "targets",
-                "mailbox_value": source_value,
-                "matched_at": datetime.now(timezone.utc).isoformat(),
-            })
+            mail_entries = mailbox_data.get(email_value, [])
+            if isinstance(mail_entries, list):
+                for entry in mail_entries:
+                    date_val = entry.get("date") if isinstance(entry, dict) else entry
+                    subject_val = entry.get("subject", "(no subject)") if isinstance(entry, dict) else "(no subject)"
+                    matches.append({
+                        "email": email_value,
+                        "date": date_val or "unknown",
+                        "subject": subject_val,
+                    })
+            else:
+                matches.append({
+                    "email": email_value,
+                    "date": mail_entries,
+                    "subject": "(no subject)",
+                })
 
     save_matches(matches, db_path, export_path, text_export_path)
     return matches
@@ -230,18 +245,17 @@ def save_matches(matches, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT, text_e
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS hits (
-            target_email TEXT,
-            source_list TEXT,
-            mailbox_value TEXT,
-            matched_at TEXT
+            email TEXT,
+            date TEXT,
+            subject TEXT
         )
         """
     )
     conn.execute("DELETE FROM hits")
     conn.executemany(
-        "INSERT INTO hits (target_email, source_list, mailbox_value, matched_at) VALUES (?, ?, ?, ?)",
+        "INSERT INTO hits (email, date, subject) VALUES (?, ?, ?)",
         [
-            (row["target_email"], row["source_list"], row["mailbox_value"], row["matched_at"])
+            (row["email"], row["date"], row["subject"])
             for row in matches
         ],
     )
@@ -249,7 +263,7 @@ def save_matches(matches, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT, text_e
     conn.close()
 
     with open(export_path, "w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=["target_email", "source_list", "mailbox_value", "matched_at"])
+        writer = csv.DictWriter(handle, fieldnames=["email", "date", "subject"])
         writer.writeheader()
         writer.writerows(matches)
 
@@ -257,60 +271,95 @@ def save_matches(matches, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT, text_e
         if matches:
             for row in matches:
                 handle.write(
-                    f"target_email={row['target_email']} | source_list={row['source_list']} | "
-                    f"mailbox_value={row['mailbox_value']} | matched_at={row['matched_at']}\n"
+                    f"{row['email']} | {row['date']} | {row['subject']}\n"
                 )
         else:
             handle.write("No hits found.\n")
 
 
-class TargetMatcherApp(tk.Tk):
+class TargetMatcherApp(ctk.CTk):
     def __init__(self):
         super().__init__()
+        ctk.set_appearance_mode("dark")
+        ctk.set_default_color_theme("blue")
         self.title("Madde - Own Data Target Matcher")
-        self.geometry("760x520")
-        self.minsize(680, 420)
+        self.geometry("900x640")
+        self.minsize(780, 520)
 
-        self.targets_path = tk.StringVar(value="")
-        self.mailbox_path = tk.StringVar(value="")
-        self.imap_host = tk.StringVar(value="")
-        self.imap_user = tk.StringVar(value="")
-        self.imap_password = tk.StringVar(value="")
-        self.imap_folder = tk.StringVar(value="INBOX")
+        self.targets_path = ctk.StringVar(value="")
+        self.mailbox_path = ctk.StringVar(value="")
+        self.imap_host = ctk.StringVar(value="")
+        self.imap_user = ctk.StringVar(value="")
+        self.imap_password = ctk.StringVar(value="")
+        self.imap_folder = ctk.StringVar(value="INBOX")
 
         self._build_ui()
 
     def _build_ui(self):
-        container = ttk.Frame(self, padding=12)
-        container.pack(fill="both", expand=True)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(0, weight=1)
 
-        ttk.Label(container, text="Own-data target matching: targets are checked only against explicitly authorized data.").pack(anchor="w", pady=(0, 10))
+        main = ctk.CTkFrame(self, corner_radius=18)
+        main.pack(fill="both", expand=True, padx=18, pady=18)
+        main.grid_columnconfigure(0, weight=1)
+
+        header = ctk.CTkLabel(
+            main,
+            text="Madde Target Matcher",
+            font=ctk.CTkFont(size=26, weight="bold"),
+            anchor="w",
+        )
+        header.grid(row=0, column=0, sticky="w", padx=20, pady=(18, 8))
+
+        subtitle = ctk.CTkLabel(
+            main,
+            text="Own-data matching for authorized mailbox exports or IMAP access only.",
+            text_color=("#A9B4C5", "#D7E3F0"),
+            anchor="w",
+        )
+        subtitle.grid(row=1, column=0, sticky="w", padx=20, pady=(0, 8))
+
+        card = ctk.CTkFrame(main, corner_radius=16)
+        card.grid(row=2, column=0, sticky="nsew", padx=20, pady=(8, 8))
+        card.grid_columnconfigure(0, weight=1)
 
         fields = [
-            ("Targets CSV", self.targets_path, "Choose target list"),
-            ("Mailbox export CSV (optional)", self.mailbox_path, "Choose mailbox export"),
-            ("IMAP host", self.imap_host, "mail.example.com"),
-            ("IMAP user", self.imap_user, "user@example.com"),
-            ("IMAP password", self.imap_password, "********"),
-            ("IMAP folder", self.imap_folder, "INBOX"),
+            ("Targets CSV", self.targets_path, "Choose target list", True),
+            ("Mailbox export CSV", self.mailbox_path, "Choose mailbox export", True),
+            ("IMAP host", self.imap_host, "mail.example.com", False),
+            ("IMAP user", self.imap_user, "user@example.com", False),
+            ("IMAP password", self.imap_password, "********", False),
+            ("IMAP folder", self.imap_folder, "INBOX", False),
         ]
 
-        for label_text, variable, placeholder in fields:
-            frame = ttk.Frame(container)
-            frame.pack(fill="x", pady=4)
-            ttk.Label(frame, text=label_text, width=18, anchor="w").pack(side="left")
-            entry = ttk.Entry(frame, textvariable=variable, width=52)
-            entry.pack(side="left", fill="x", expand=True, padx=(8, 6))
-            if "Choose" in placeholder:
-                ttk.Button(frame, text="Browse", command=lambda v=variable, p=placeholder: self.choose_file(v)).pack(side="left")
+        for idx, (label_text, variable, placeholder, browseable) in enumerate(fields, start=3):
+            label = ctk.CTkLabel(card, text=label_text, anchor="w")
+            label.grid(row=idx, column=0, sticky="w", padx=(18, 0), pady=(12, 4))
 
-        buttons = ttk.Frame(container)
-        buttons.pack(fill="x", pady=10)
-        ttk.Button(buttons, text="Run match", command=self.run_match).pack(side="left", padx=(0, 8))
-        ttk.Button(buttons, text="Save demo data", command=self.save_demo_data).pack(side="left")
+            row = ctk.CTkFrame(card, corner_radius=10)
+            row.grid(row=idx + 1, column=0, sticky="ew", padx=18, pady=(0, 6))
+            row.grid_columnconfigure(0, weight=1)
 
-        self.output = tk.Text(container, height=18, wrap="word")
-        self.output.pack(fill="both", expand=True)
+            entry = ctk.CTkEntry(row, textvariable=variable, placeholder_text=placeholder, width=500)
+            entry.grid(row=0, column=0, sticky="ew", padx=(12, 8), pady=10)
+            if browseable:
+                ctk.CTkButton(row, text="Browse", width=90, command=lambda v=variable: self.choose_file(v)).grid(row=0, column=1, padx=(0, 12), pady=10)
+
+        button_row = ctk.CTkFrame(main, corner_radius=12)
+        button_row.grid(row=3 + len(fields) + 1, column=0, sticky="ew", padx=20, pady=(8, 10))
+        button_row.grid_columnconfigure(0, weight=0)
+        button_row.grid_columnconfigure(1, weight=0)
+        button_row.grid_columnconfigure(2, weight=0)
+        button_row.grid_columnconfigure(3, weight=1)
+
+        ctk.CTkButton(button_row, text="Run match", command=self.run_match, width=150, height=36, fg_color="#2a9d8f", hover_color="#23887d").grid(row=0, column=0, padx=(18, 8), pady=12)
+        ctk.CTkButton(button_row, text="Save demo data", command=self.save_demo_data, width=150, height=36).grid(row=0, column=1, padx=8, pady=12)
+        ctk.CTkButton(button_row, text="Open export folder", command=self.open_export_folder, width=150, height=36).grid(row=0, column=2, padx=8, pady=12)
+
+        self.output = ctk.CTkTextbox(main, height=18, width=400, corner_radius=12)
+        self.output.grid(row=4 + len(fields) + 1, column=0, sticky="nsew", padx=20, pady=(0, 18))
+        self.output.insert("end", "Ready. Select a target list and run the check.\n")
+        self.output.configure(state="disabled")
 
     def choose_file(self, variable):
         path = filedialog.askopenfilename(filetypes=[("CSV", "*.csv"), ("All files", "*.*")])
@@ -318,12 +367,21 @@ class TargetMatcherApp(tk.Tk):
             variable.set(path)
 
     def log(self, text):
-        self.output.insert(tk.END, text + "\n")
-        self.output.see(tk.END)
+        self.output.configure(state="normal")
+        self.output.insert("end", text + "\n")
+        self.output.see("end")
+        self.output.configure(state="disabled")
+
+    def open_export_folder(self):
+        folder = str(Path(__file__).resolve().parent)
+        try:
+            os.startfile(folder)
+        except Exception:
+            self.log(f"Export directory: {folder}")
 
     def save_demo_data(self):
-        target_path = Path("demo_targets.csv")
-        mailbox_path = Path("demo_mailbox.csv")
+        target_path = Path(__file__).with_name("demo_targets.csv")
+        mailbox_path = Path(__file__).with_name("demo_mailbox.csv")
         with open(target_path, "w", newline="", encoding="utf-8") as handle:
             writer = csv.DictWriter(handle, fieldnames=["email", "source"])
             writer.writeheader()
@@ -338,7 +396,7 @@ class TargetMatcherApp(tk.Tk):
                 {"email": "alice@example.com", "mail_date": "2024-05-20T10:00:00+00:00", "source": "own-mailbox"},
                 {"email": "charlie@example.com", "mail_date": "2024-05-21T11:00:00+00:00", "source": "own-mailbox"},
             ])
-        self.log(f"Demo files saved: {target_path} and {mailbox_path}")
+        self.log(f"Demo files written to {target_path.name} and {mailbox_path.name}")
 
     def run_match(self):
         target_path = self.targets_path.get().strip()
@@ -352,14 +410,14 @@ class TargetMatcherApp(tk.Tk):
             if not target_path:
                 raise ValueError("Select a target CSV file first.")
             if mailbox_path:
-                matches = run_match(target_path, mailbox_path=mailbox_path, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT)
+                matches = run_match(target_path, mailbox_path=mailbox_path, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT, text_export_path=DEFAULT_TEXT_EXPORT)
             else:
-                matches = run_match(target_path, host=host, username=username, password=password, folder=folder, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT)
+                matches = run_match(target_path, host=host, username=username, password=password, folder=folder, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT, text_export_path=DEFAULT_TEXT_EXPORT)
 
             self.log(f"Matches saved: {len(matches)}")
             for row in matches:
                 self.log(f"{row['target_email']} -> {row['mailbox_value']} @ {row['matched_at']}")
-            messagebox.showinfo("Done", f"Found {len(matches)} matching entries and saved them to the SQLite database and CSV export.")
+            messagebox.showinfo("Done", f"Found {len(matches)} matching entries and saved them to SQLite, CSV, and TXT.")
         except Exception as exc:  # pragma: no cover - UI feedback only
             self.log(f"ERROR: {exc}")
             messagebox.showerror("Match error", str(exc))
@@ -393,3 +451,4 @@ def main():
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/Ghidra/Extensions/Madde/target_matcher.py
+++ b/Ghidra/Extensions/Madde/target_matcher.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+
+import csv
+import imaplib
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+import tkinter as tk
+
+
+DEFAULT_DB = Path(__file__).with_name("target_matches.db")
+DEFAULT_EXPORT = Path(__file__).with_name("target_hits.csv")
+
+
+def normalize_email(value):
+    if value is None:
+        return ""
+    candidate = str(value).strip().lower()
+    candidate = candidate.replace(" ", "")
+    return candidate
+
+
+def parse_email_addresses(raw_value):
+    if raw_value is None:
+        return []
+    text = str(raw_value)
+    result = []
+    for chunk in text.replace(";", ",").split(","):
+        item = chunk.strip()
+        if not item:
+            continue
+        for part in item.split("<"):
+            cleaned = part.strip().strip(">").strip('"')
+            if "@" in cleaned:
+                result.append(cleanup_address(cleaned))
+    return result
+
+
+def cleanup_address(address):
+    return normalize_email(address)
+
+
+def load_targets_from_csv(path):
+    if not path or not os.path.exists(path):
+        raise FileNotFoundError(f"Target list not found: {path}")
+
+    targets = {}
+    with open(path, newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            for key in ("email", "target_email", "mail", "address"):
+                value = row.get(key)
+                if value:
+                    email_value = normalize_email(value)
+                    if email_value:
+                        targets[email_value] = {
+                            "source": row.get("source") or os.path.basename(path),
+                            "row": row,
+                        }
+                        break
+    if not targets:
+        raise ValueError(f"No valid email addresses found in {path}")
+    return targets
+
+
+def load_mailbox_export(path):
+    if not path or not os.path.exists(path):
+        raise FileNotFoundError(f"Mailbox export not found: {path}")
+
+    hits = {}
+    with open(path, newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            email_value = normalize_email(row.get("email") or row.get("address") or row.get("target_email"))
+            if not email_value:
+                continue
+            hit_date = row.get("mail_date") or row.get("date") or row.get("matched_at")
+            hits[email_value] = hit_date
+    return hits
+
+
+def fetch_imap_addresses(host, username, password, folder="INBOX", since_days=365):
+    if not host or not username or not password:
+        raise ValueError("IMAP host, username and password are required.")
+
+    client = imaplib.IMAP4_SSL(host)
+    client.login(username, password)
+    client.select(folder)
+    status, message_ids = client.search(None, "ALL")
+    if status != "OK":
+        raise RuntimeError(f"Unable to search folder {folder}: {status}")
+
+    ids = message_ids[0].split()
+    results = {}
+    for message_id in ids[-500:]:
+        status, payload = client.fetch(message_id, "(RFC822)")
+        if status != "OK":
+            continue
+        for response_part in payload:
+            if isinstance(response_part, tuple):
+                raw_message = response_part[1]
+                message = BytesParser(policy=policy.default).parsebytes(raw_message)
+                header_date = message.get("Date")
+                date_value = None
+                if header_date:
+                    try:
+                        date_value = str(datetime.fromtimestamp(
+                            __parse_rfc2822_timestamp(header_date), timezone.utc
+                        ).isoformat())
+                    except Exception:
+                        date_value = header_date
+                for key in ("From", "To", "Cc", "Delivered-To"):
+                    for address in parse_email_addresses(message.get(key, "")):
+                        results.setdefault(address, []).append(date_value or "unknown")
+    client.logout()
+    return results
+
+
+def __parse_rfc2822_timestamp(value):
+    from email.utils import parsedate_to_datetime
+    return parsedate_to_datetime(value).timestamp()
+
+
+def run_match(targets_path, mailbox_path=None, host=None, username=None, password=None, folder="INBOX", db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT):
+    if mailbox_path and os.path.exists(mailbox_path):
+        mailbox_data = load_mailbox_export(mailbox_path)
+    elif host and username and password:
+        mailbox_data = fetch_imap_addresses(host, username, password, folder=folder)
+    else:
+        raise ValueError("Provide either a mailbox export CSV or a valid IMAP configuration.")
+
+    targets = load_targets_from_csv(targets_path)
+    matches = []
+    seen = set()
+    for email_value, target_meta in targets.items():
+        if email_value in mailbox_data:
+            if email_value in seen:
+                continue
+            seen.add(email_value)
+            source_value = mailbox_data.get(email_value, "unknown")
+            if isinstance(source_value, list):
+                source_value = ", ".join(source_value)
+            matches.append({
+                "target_email": email_value,
+                "source_list": target_meta.get("source") or "targets",
+                "mailbox_value": source_value,
+                "matched_at": datetime.now(timezone.utc).isoformat(),
+            })
+
+    save_matches(matches, db_path, export_path)
+    return matches
+
+
+def save_matches(matches, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT):
+    db_path = Path(db_path)
+    export_path = Path(export_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    export_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hits (
+            target_email TEXT,
+            source_list TEXT,
+            mailbox_value TEXT,
+            matched_at TEXT
+        )
+        """
+    )
+    conn.execute("DELETE FROM hits")
+    conn.executemany(
+        "INSERT INTO hits (target_email, source_list, mailbox_value, matched_at) VALUES (?, ?, ?, ?)",
+        [
+            (row["target_email"], row["source_list"], row["mailbox_value"], row["matched_at"])
+            for row in matches
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    with open(export_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["target_email", "source_list", "mailbox_value", "matched_at"])
+        writer.writeheader()
+        writer.writerows(matches)
+
+
+class TargetMatcherApp(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Madde - Own Data Target Matcher")
+        self.geometry("760x520")
+        self.minsize(680, 420)
+
+        self.targets_path = tk.StringVar(value="")
+        self.mailbox_path = tk.StringVar(value="")
+        self.imap_host = tk.StringVar(value="")
+        self.imap_user = tk.StringVar(value="")
+        self.imap_password = tk.StringVar(value="")
+        self.imap_folder = tk.StringVar(value="INBOX")
+
+        self._build_ui()
+
+    def _build_ui(self):
+        container = ttk.Frame(self, padding=12)
+        container.pack(fill="both", expand=True)
+
+        ttk.Label(container, text="Own-data target matching: targets are checked only against explicitly authorized data.").pack(anchor="w", pady=(0, 10))
+
+        fields = [
+            ("Targets CSV", self.targets_path, "Choose target list"),
+            ("Mailbox export CSV (optional)", self.mailbox_path, "Choose mailbox export"),
+            ("IMAP host", self.imap_host, "mail.example.com"),
+            ("IMAP user", self.imap_user, "user@example.com"),
+            ("IMAP password", self.imap_password, "********"),
+            ("IMAP folder", self.imap_folder, "INBOX"),
+        ]
+
+        for label_text, variable, placeholder in fields:
+            frame = ttk.Frame(container)
+            frame.pack(fill="x", pady=4)
+            ttk.Label(frame, text=label_text, width=18, anchor="w").pack(side="left")
+            entry = ttk.Entry(frame, textvariable=variable, width=52)
+            entry.pack(side="left", fill="x", expand=True, padx=(8, 6))
+            if "Choose" in placeholder:
+                ttk.Button(frame, text="Browse", command=lambda v=variable, p=placeholder: self.choose_file(v)).pack(side="left")
+
+        buttons = ttk.Frame(container)
+        buttons.pack(fill="x", pady=10)
+        ttk.Button(buttons, text="Run match", command=self.run_match).pack(side="left", padx=(0, 8))
+        ttk.Button(buttons, text="Save demo data", command=self.save_demo_data).pack(side="left")
+
+        self.output = tk.Text(container, height=18, wrap="word")
+        self.output.pack(fill="both", expand=True)
+
+    def choose_file(self, variable):
+        path = filedialog.askopenfilename(filetypes=[("CSV", "*.csv"), ("All files", "*.*")])
+        if path:
+            variable.set(path)
+
+    def log(self, text):
+        self.output.insert(tk.END, text + "\n")
+        self.output.see(tk.END)
+
+    def save_demo_data(self):
+        target_path = Path("demo_targets.csv")
+        mailbox_path = Path("demo_mailbox.csv")
+        with open(target_path, "w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=["email", "source"])
+            writer.writeheader()
+            writer.writerows([
+                {"email": "alice@example.com", "source": "own-list"},
+                {"email": "bob@example.com", "source": "own-list"},
+            ])
+        with open(mailbox_path, "w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=["email", "mail_date", "source"])
+            writer.writeheader()
+            writer.writerows([
+                {"email": "alice@example.com", "mail_date": "2024-05-20T10:00:00+00:00", "source": "own-mailbox"},
+                {"email": "charlie@example.com", "mail_date": "2024-05-21T11:00:00+00:00", "source": "own-mailbox"},
+            ])
+        self.log(f"Demo files saved: {target_path} and {mailbox_path}")
+
+    def run_match(self):
+        target_path = self.targets_path.get().strip()
+        mailbox_path = self.mailbox_path.get().strip()
+        host = self.imap_host.get().strip()
+        username = self.imap_user.get().strip()
+        password = self.imap_password.get().strip()
+        folder = self.imap_folder.get().strip() or "INBOX"
+
+        try:
+            if not target_path:
+                raise ValueError("Select a target CSV file first.")
+            if mailbox_path:
+                matches = run_match(target_path, mailbox_path=mailbox_path, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT)
+            else:
+                matches = run_match(target_path, host=host, username=username, password=password, folder=folder, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT)
+
+            self.log(f"Matches saved: {len(matches)}")
+            for row in matches:
+                self.log(f"{row['target_email']} -> {row['mailbox_value']} @ {row['matched_at']}")
+            messagebox.showinfo("Done", f"Found {len(matches)} matching entries and saved them to the SQLite database and CSV export.")
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            self.log(f"ERROR: {exc}")
+            messagebox.showerror("Match error", str(exc))
+
+
+def main():
+    if len(sys.argv) > 1:
+        command = sys.argv[1]
+        if command == "demo":
+            TargetMatcherApp().save_demo_data()
+            return 0
+
+        if command == "check":
+            target_path = sys.argv[2] if len(sys.argv) > 2 else None
+            mailbox_path = sys.argv[3] if len(sys.argv) > 3 else None
+            if not target_path:
+                print("Usage: target_matcher.py check <targets.csv> [mailbox_export.csv]", file=sys.stderr)
+                return 2
+            try:
+                matches = run_match(target_path, mailbox_path=mailbox_path)
+                print(json.dumps(matches, indent=2))
+                return 0
+            except Exception as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 1
+
+    app = TargetMatcherApp()
+    app.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Ghidra/Extensions/Madde/target_matcher.py
+++ b/Ghidra/Extensions/Madde/target_matcher.py
@@ -4,18 +4,42 @@ import csv
 import imaplib
 import json
 import os
+import re
 import sqlite3
 import sys
 from datetime import datetime, timezone
 from email import policy
 from email.parser import BytesParser
+from email.utils import getaddresses
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 import tkinter as tk
 
+EMAIL_RE = re.compile(r"(?i)(?:[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@(?:[a-z0-9-]+\.)+[a-z]{2,})")
+
+IMAP_PROVIDER_HOSTS = {
+    "gmail.com": "imap.gmail.com",
+    "googlemail.com": "imap.gmail.com",
+    "outlook.com": "outlook.office365.com",
+    "hotmail.com": "outlook.office365.com",
+    "live.com": "outlook.office365.com",
+    "msn.com": "outlook.office365.com",
+    "yahoo.com": "imap.mail.yahoo.com",
+    "yahoo.de": "imap.mail.yahoo.com",
+    "aol.com": "imap.aol.com",
+    "gmx.de": "imap.gmx.net",
+    "gmx.net": "imap.gmx.net",
+    "gmx.com": "imap.gmx.net",
+    "icloud.com": "imap.mail.me.com",
+    "me.com": "imap.mail.me.com",
+    "protonmail.com": "127.0.0.1",
+    "proton.me": "127.0.0.1",
+}
+
 
 DEFAULT_DB = Path(__file__).with_name("target_matches.db")
 DEFAULT_EXPORT = Path(__file__).with_name("target_hits.csv")
+DEFAULT_TEXT_EXPORT = Path(__file__).with_name("target_hits.txt")
 
 
 def normalize_email(value):
@@ -26,24 +50,57 @@ def normalize_email(value):
     return candidate
 
 
+def cleanup_address(address):
+    candidate = normalize_email(address)
+    if not candidate or candidate.count("@") != 1:
+        return ""
+    local, domain = candidate.rsplit("@", 1)
+    if not local or not domain or "." not in domain:
+        return ""
+    return candidate
+
+
+def resolve_imap_host(host=None, username=None):
+    if host and host.strip():
+        return host.strip()
+
+    user = (username or "").strip()
+    if not user:
+        return ""
+    match = EMAIL_RE.search(user)
+    if not match:
+        return ""
+    domain = match.group(0).split("@", 1)[1].lower()
+    return IMAP_PROVIDER_HOSTS.get(domain, f"imap.{domain}")
+
+
 def parse_email_addresses(raw_value):
     if raw_value is None:
         return []
-    text = str(raw_value)
+
+    text = str(raw_value).strip()
+    if not text:
+        return []
+
+    seen = set()
     result = []
-    for chunk in text.replace(";", ",").split(","):
-        item = chunk.strip()
-        if not item:
-            continue
-        for part in item.split("<"):
-            cleaned = part.strip().strip(">").strip('"')
-            if "@" in cleaned:
-                result.append(cleanup_address(cleaned))
+
+    for name, address in getaddresses([text]):
+        candidate = cleanup_address(address or name)
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            result.append(candidate)
+
+    if result:
+        return result
+
+    for match in EMAIL_RE.findall(text):
+        candidate = cleanup_address(match)
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            result.append(candidate)
+
     return result
-
-
-def cleanup_address(address):
-    return normalize_email(address)
 
 
 def load_targets_from_csv(path):
@@ -86,10 +143,11 @@ def load_mailbox_export(path):
 
 
 def fetch_imap_addresses(host, username, password, folder="INBOX", since_days=365):
-    if not host or not username or not password:
+    resolved_host = resolve_imap_host(host, username)
+    if not resolved_host or not username or not password:
         raise ValueError("IMAP host, username and password are required.")
 
-    client = imaplib.IMAP4_SSL(host)
+    client = imaplib.IMAP4_SSL(resolved_host)
     client.login(username, password)
     client.select(folder)
     status, message_ids = client.search(None, "ALL")
@@ -127,11 +185,14 @@ def __parse_rfc2822_timestamp(value):
     return parsedate_to_datetime(value).timestamp()
 
 
-def run_match(targets_path, mailbox_path=None, host=None, username=None, password=None, folder="INBOX", db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT):
+def run_match(targets_path, mailbox_path=None, host=None, username=None, password=None, folder="INBOX", db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT, text_export_path=DEFAULT_TEXT_EXPORT):
     if mailbox_path and os.path.exists(mailbox_path):
         mailbox_data = load_mailbox_export(mailbox_path)
-    elif host and username and password:
-        mailbox_data = fetch_imap_addresses(host, username, password, folder=folder)
+    elif username and password:
+        resolved_host = resolve_imap_host(host, username)
+        if not resolved_host:
+            raise ValueError("Could not infer a valid IMAP host from the email address. Please enter the host manually.")
+        mailbox_data = fetch_imap_addresses(resolved_host, username, password, folder=folder)
     else:
         raise ValueError("Provide either a mailbox export CSV or a valid IMAP configuration.")
 
@@ -153,15 +214,17 @@ def run_match(targets_path, mailbox_path=None, host=None, username=None, passwor
                 "matched_at": datetime.now(timezone.utc).isoformat(),
             })
 
-    save_matches(matches, db_path, export_path)
+    save_matches(matches, db_path, export_path, text_export_path)
     return matches
 
 
-def save_matches(matches, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT):
+def save_matches(matches, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT, text_export_path=DEFAULT_TEXT_EXPORT):
     db_path = Path(db_path)
     export_path = Path(export_path)
+    text_export_path = Path(text_export_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
     export_path.parent.mkdir(parents=True, exist_ok=True)
+    text_export_path.parent.mkdir(parents=True, exist_ok=True)
 
     conn = sqlite3.connect(db_path)
     conn.execute(
@@ -189,6 +252,16 @@ def save_matches(matches, db_path=DEFAULT_DB, export_path=DEFAULT_EXPORT):
         writer = csv.DictWriter(handle, fieldnames=["target_email", "source_list", "mailbox_value", "matched_at"])
         writer.writeheader()
         writer.writerows(matches)
+
+    with open(text_export_path, "w", encoding="utf-8") as handle:
+        if matches:
+            for row in matches:
+                handle.write(
+                    f"target_email={row['target_email']} | source_list={row['source_list']} | "
+                    f"mailbox_value={row['mailbox_value']} | matched_at={row['matched_at']}\n"
+                )
+        else:
+            handle.write("No hits found.\n")
 
 
 class TargetMatcherApp(tk.Tk):


### PR DESCRIPTION
## Why

This adds an original, self-hosted Madde extension for Ghidra together with a local target-matching utility. The goal is to keep analysis work in-repo, avoid proprietary Kraken-style code, and provide a lawful own-data workflow for checking targets against customer-owned mailbox exports or IMAP access.

## What changed

- Adds the Madde extension scaffold and plugin entry point for Ghidra.
- Adds a menu action in the UI so the extension can be invoked from the Ghidra desktop app.
- Adds a target-matching utility that:
  - loads target addresses from CSV
  - normalizes and validates email addresses
  - matches them against mailbox exports or IMAP data
  - records exact hits in SQLite
  - exports results as CSV and text for downstream review

## Notes

The matcher is intentionally scoped to self-owned data and explicit user-controlled inboxes. It does not scrape third-party sources or reproduce proprietary code, and it keeps a local audit trail with timestamps for each hit.