### PR TITLE
AARCH64: omit LSL extend when index shift amount is omitted

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/app/plugin/assembler/sleigh/AARCH64BEAssemblyTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/app/plugin/assembler/sleigh/AARCH64BEAssemblyTest.java
@@ -127,4 +127,16 @@ public class AARCH64BEAssemblyTest extends AbstractAssemblyTest {
 		// This one's really stalling up the solver :(
 		assertOneCompatRestExact("mov w0,#0x0", "00:00:80:52");
 	}
+
+	@Test
+	public void testAssemble_strb_w2_mx0_x1m() {
+		// GitHub #9042: with option=LSL and S=0 the extend specifier is omitted
+		assertOneCompatRestExact("strb w2,[x0, x1]", "02:68:21:38");
+	}
+
+	@Test
+	public void testAssemble_ldr_x2_mx0_x1_LSL_0x3m() {
+		// The S=1 form still prints and assembles with the explicit shift
+		assertOneCompatRestExact("ldr x2,[x0, x1, LSL #0x3]", "02:78:61:f8");
+	}
 }

--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64instructions.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64instructions.sinc
@@ -2261,7 +2261,7 @@ addrExtendRegShift64: ExtendReg64^addrRegShift64 is aa_extreg_option=2 & aa_extr
 addrExtendRegShift64: ExtendReg64^addrRegShift64 is aa_extreg_option=3 & aa_extreg_imm3 & addrRegShift64 & ExtendReg64 { tmp:8 = ExtendReg64; tmp = tmp << addrRegShift64; export tmp; }
 addrExtendRegShift64: ExtendReg64^addrRegShift64 is aa_extreg_option=6 & aa_extreg_imm3 & addrRegShift64 & ExtendReg64 { tmp:8 = ExtendReg64; tmp = tmp << addrRegShift64; export tmp; }
 addrExtendRegShift64: ExtendReg64^addrRegShift64 is aa_extreg_option=7 & aa_extreg_imm3 & addrRegShift64 & ExtendReg64 { tmp:8 = ExtendReg64; tmp = tmp << addrRegShift64; export tmp; }
-addrExtendRegShift64: Rm_GPR64 is Rm_GPR64 & aa_extreg_option=3 & aa_extreg_imm3=0 & ExtendReg64 { export Rm_GPR64; }
+addrExtendRegShift64: Rm_GPR64 is Rm_GPR64 & aa_extreg_option=3 & b_1212=0 & ExtendReg64 { export Rm_GPR64; }
 addrExtendRegShift64: Rm_GPR64 is Rm_GPR64 & aa_extreg_option=7 & aa_extreg_imm3=0 & ExtendReg64 { export Rm_GPR64; }
 
 # unsigned offset


### PR DESCRIPTION
Hey, hope you're all doing well.

This fixes #9042 — the load/store register-offset addressing mode prints a dangling extend when the index shift amount is omitted. For `38216802`:

    Reference (llvm-mc):  strb w2, [x0, x1]
    Existing spec:        strb w2, [x0, x1, LSL ]
    Patched spec:         strb w2, [x0, x1]

Arm ARM C6.2.325 describes `<extend>` as "the index extend/shift specifier, defaulting to LSL, and which must be omitted for the LSL option when `<amount>` is omitted", so the trailing `LSL` shouldn't be there. The S bit is the only thing that separates the two spellings:

    $ echo 'strb w2, [x0, x1]
    strb w2, [x0, x1, lsl #0]' | llvm-mc --triple=aarch64 --show-encoding
        strb    w2, [x0, x1]            // encoding: [0x02,0x68,0x21,0x38]
        strb    w2, [x0, x1, lsl #0]    // encoding: [0x02,0x78,0x21,0x38]

The interesting part is that `addrExtendRegShift64` already has a constructor for the omitted case, it just never actually matches:

```sleigh
addrExtendRegShift64: Rm_GPR64 is Rm_GPR64 & aa_extreg_option=3 & aa_extreg_imm3=0 & ExtendReg64 { export Rm_GPR64; }
```

`aa_extreg_imm3` is bits `(10,12)`, and every load/store register-offset encoding fixes bits 11:10 to `0b10`, so the field can only ever be 2 (S=0) or 6 (S=1) — never 0. Matching falls through to the general constructor, which prints `ExtendReg64` (`"LSL "`) followed by an empty `addrRegShift64`. Constraining on the S bit instead makes the intended constructor match, which is the one-line change here.

I changed `addrExtendRegShift64` rather than `ExtendReg64`, because `ExtendReg64` is shared with the ADD/SUB extended-register instructions, whereas `addrExtendRegShift64` is only referenced by the register-offset `addrIndexed`.

13 forms change, one per integer load/store register-offset variant, and each matches llvm-mc afterwards. The wider access sizes print `LSL #0x0` rather than a bare `LSL `, but it is the same constructor and the same rule — and the SIMD&FP path already omits the extend at every access size (`extend_spec` / `extend_amount`, AARCH64neon.sinc:11515-11530), so this kinda just brings the integer path in line with what neon already does. P-code is unchanged apart from dropping a shift-by-zero and the temporary copy feeding it.

I added two cases to `AARCH64BEAssemblyTest`, for S=0 and S=1; reverting the `.sinc` hunk fails only the S=0 one.

@liamwhite already proposed a fix for this in #9082, which predates this PR — I kinda missed it before opening this one, sorry for the overlap. That patch splits `ExtendReg64` on the S bit, which handles the byte forms, but `addrRegShift64` still supplies `#0x0` for the wider access sizes, and with the `LSL ` text gone there is nothing left to separate them:

    master:  strh w2, [x0, x1, LSL #0x0]
    #9082:   strh w2, [x0, x1#0x0]
    here:    strh w2, [x0, x1]

Moving the constraint into `addrExtendRegShift64` instead drops the extend and the amount together, so all 13 forms come out right. If you'd rather keep #9082 since he reported the issue, I'm happy to close this and let him fold the same change in.

One thing I deliberately left alone: the sibling constructor on the next line is unreachable in the same way for `option=7` (SXTX). The Arm ARM only permits omitting the extend for LSL, so making that one reachable would just trade one display bug for another. Happy to just delete it instead if you'd rather not leave dead code sitting there, or to fold in the `UXTW #0x0` / `SXTW #0x0` cases if you want those to match llvm too.

P.S. @liamwhite has actually since closed #9082 in favour of this one, so that offer is dead. A generous call, and thank you for it. He found the bug first and had already pinned it on the S bit. The comparison above is there to explain why this touches `addrExtendRegShift64` rather than `ExtendReg64`, not because there was anything wrong with the diagnosis. Thanks again man!
