### PR TITLE
PyGhidra: fix extension.properties parsing of values containing '='

### DIFF
--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/version.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/version.py
@@ -77,10 +77,14 @@ class ExtensionDetails:
         def cast(key, value):
             return cls.__annotations__[key](value)
         lines = ext_path.read_text().splitlines()
+        # `sep` is empty for a line with no '=' at all (e.g. a stray bare "id"
+        # line). Without checking it, such a line would be silently accepted
+        # as a valid field with an empty value if the line happened to match
+        # a field name exactly.
         kwargs = {
             key: cast(key, value)
             for key, sep, value in map(lambda l: l.partition("="), lines)
-            if sep and key in valid_fields
+            if key in valid_fields and sep
         }
         return cls(**kwargs)
 

--- a/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/version.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/src/pyghidra/version.py
@@ -79,8 +79,8 @@ class ExtensionDetails:
         lines = ext_path.read_text().splitlines()
         kwargs = {
             key: cast(key, value)
-            for key, value in map(lambda l: l.split("="), lines)
-            if key in valid_fields
+            for key, sep, value in map(lambda l: l.partition("="), lines)
+            if sep and key in valid_fields
         }
         return cls(**kwargs)
 

--- a/Ghidra/Features/PyGhidra/src/main/py/tests/test_version.py
+++ b/Ghidra/Features/PyGhidra/src/main/py/tests/test_version.py
@@ -1,0 +1,57 @@
+## ###
+# IP: GHIDRA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+from pathlib import Path
+
+from pyghidra.version import ExtensionDetails
+
+
+def test_extension_details_round_trip(tmp_path: Path):
+    details = ExtensionDetails(
+        name="Demo",
+        description="A normal description",
+        author="tester"
+    )
+    path = tmp_path / "extension.properties"
+    path.write_text(str(details))
+    parsed = ExtensionDetails.from_file(path)
+    assert parsed.name == details.name
+    assert parsed.description == details.description
+    assert parsed.author == details.author
+
+
+def test_extension_details_value_containing_equals(tmp_path: Path):
+    # _install_plugin writes the properties file with str(details) and
+    # _uninstall_old_plugin reads it back, so a value containing '=' must survive
+    details = ExtensionDetails(
+        name="Demo",
+        description="Parses key=value pairs",
+        author="tester"
+    )
+    path = tmp_path / "extension.properties"
+    path.write_text(str(details))
+    assert ExtensionDetails.from_file(path).description == "Parses key=value pairs"
+
+
+def test_extension_details_ignores_comments_and_blank_lines(tmp_path: Path):
+    path = tmp_path / "extension.properties"
+    path.write_text(
+        "# a comment\n"
+        "\n"
+        "name=Demo\n"
+        "description=A normal description\n"
+        "author=tester\n"
+    )
+    assert ExtensionDetails.from_file(path).name == "Demo"


### PR DESCRIPTION
Hi, hope you're all doing well.

`ExtensionDetails.from_file` splits each line on every `=`, so it raises `ValueError` on a properties file whose value contains an `=`. PyGhidra writes this file itself. `_install_plugin` does `ext.write_text(str(details))` and `_uninstall_old_plugin` reads it back, so a plugin whose description contains an `=` produces a file PyGhidra cannot parse.

For this `extension.properties`:

    name=Demo
    description=Parses key=value pairs
    author=tester

    Reference (java.util.Properties):  description = Parses key=value pairs
    Existing pyghidra:                 ValueError: too many values to unpack (expected 2, got 3)
    Patched pyghidra:                  description = Parses key=value pairs

The reference there is not arbitrary. `ExtensionUtils.tryToLoadExtensionFromProperties` reads this same file with `Properties.load(in)` (`ExtensionUtils.java:377`), so basically Ghidra and PyGhidra currently disagree about a file format they share. `Properties.load` terminates the key at the first unescaped `=`, and skips blank lines and `#` comments. The current code does neither, so a comment or blank line fails the other way:

    # a comment

    name=Demo

    Existing pyghidra:  ValueError: not enough values to unpack (expected 2, got 1)

If it is easier to confirm without building anything, the failing expression is self-contained and needs no Ghidra or pyghidra install:

    $ printf 'name=Demo\ndescription=Parses key=value pairs\n' > extension.properties
    $ python3 -c '{k: v for k, v in map(lambda l: l.split("="), open("extension.properties").read().splitlines())}'
    ValueError: too many values to unpack (expected 2, got 3)

    $ printf '# a comment\n\nname=Demo\n' > extension.properties
    $ python3 -c '{k: v for k, v in map(lambda l: l.split("="), open("extension.properties").read().splitlines())}'
    ValueError: not enough values to unpack (expected 2, got 1)

Swapping `l.split("=")` for `l.partition("=")` and dropping lines with no separator is the whole change, and both files then parse.

The call in `_uninstall_old_plugin` sits inside a bare `except:` that only logs `failed to uninstall plugin`, so nothing crashes. The outdated extension is left installed instead, which is the situation the comment above that loop describes as leading to "a confusing and unrelated error about the InterpreterConsole class not being found".

`str.partition` keeps the first `=` as the separator and lets lines without one be skipped, which is what `ApplicationInfo.from_file` twelve lines up already does with its regex. I kept the change to that one expression rather than reaching for `configparser` or reimplementing the format: this only needs to round-trip what `__repr__` writes, and a real `.properties` parser would also have to handle `:` separators, leading-whitespace keys and line continuations, none of which PyGhidra emits. Happy to go further if you would rather it accept the full format.

I added three cases in a new `tests/test_version.py`; reverting the one-line change fails two of them. `pytest tests -m "not plugin"` is otherwise unchanged. `test_core.py::test_import_ghidra_base_java_packages` fails both before and after, it wants a full Ghidra install.

One thing I did leave alone: `version` defaults to `None` and is written out as the literal string `None`, so it reads back as `'None'` rather than `None`. Separate roundtrip-ish problem, and I did not want to widen this PR. I would be very glad to also do that one next if you guys want it.
