### PR TITLE
eBPF: add GOTOX, the indirect jump

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/app/plugin/assembler/sleigh/eBPFAssemblyTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/app/plugin/assembler/sleigh/eBPFAssemblyTest.java
@@ -1,0 +1,37 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.plugin.assembler.sleigh;
+
+import org.junit.Test;
+
+import ghidra.program.model.lang.LanguageID;
+
+public class eBPFAssemblyTest extends AbstractAssemblyTest {
+	@Override
+	protected LanguageID getLanguageID() {
+		return new LanguageID("eBPF:LE:64:default");
+	}
+
+	@Test
+	public void testAssemble_GOTOX_R2() {
+		assertOneCompatRestExact("GOTOX R2", "0d:02:00:00:00:00:00:00");
+	}
+
+	@Test
+	public void testAssemble_CALLX_R2() {
+		assertOneCompatRestExact("CALLX R2", "8d:02:00:00:00:00:00:00");
+	}
+}

--- a/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
+++ b/Ghidra/Processors/eBPF/data/languages/eBPF.sinc
@@ -427,6 +427,11 @@ cond: "SLE" is op_alu_jmp_opcode=0xd & op_insn_class=0x6 & DST4 & SRC4 { local c
     if (cond) goto joff;
 }
 
+# Indirect jump, the BPF_X form of JA. Same relationship to JA that CALLX has to CALL.
+:GOTOX dst is op_alu_jmp_opcode=0x0 & op_alu_jmp_source=1 & op_insn_class=0x5 & src=0 & imm=0 & dst {
+    goto [dst];
+}
+
 
 SysCall:  imm is imm { export *[syscall]:1 imm; }
 


### PR DESCRIPTION
What's good, hope everyone is fine.

One quick problem I found: Ghidra does not decode `gotox`, the indirect jump added to eBPF. Opcode `0x0d` currently falls through to no constructor at all, so it shows up as a bad instruction.

    0d02000000000000

    Reference (llvm-mc):  gotox r2
    Existing spec:        BAD (Unable to resolve constructor)
    Patched spec:         GOTOX R2

That opcode is kinda just the `BPF_X` corner of a group the spec already covers. Using the values in `linux/bpf_common.h`:

    BPF_JA(0x00)   | BPF_K(0x00) | BPF_JMP(0x05) = 0x05   JA      present
    BPF_JA(0x00)   | BPF_X(0x08) | BPF_JMP(0x05) = 0x0d   GOTOX   missing
    BPF_CALL(0x80) | BPF_K(0x00) | BPF_JMP(0x05) = 0x85   CALL    present
    BPF_CALL(0x80) | BPF_X(0x08) | BPF_JMP(0x05) = 0x8d   CALLX   present

So three of the four corners are there already and this is the fourth. It has the same relationship to `JA` that `CALLX` already has to `CALL`, which is why the new constructor is a direct one-to-one copy of the `CALLX` one with `goto` instead of `call`:

    :GOTOX dst is op_alu_jmp_opcode=0x0 & op_alu_jmp_source=1 & op_insn_class=0x5 & src=0 & imm=0 & dst {
        goto [dst];
    }

If it is easier to confirm without building, llvm will do both directions on the exact bytes from the top of this post:

    $ echo 'gotox r2' | llvm-mc --triple=bpfel --show-encoding
        gotox r2    # encoding: [0x0d,0x02,0x00,0x00,0x00,0x00,0x00,0x00]

    $ echo '0x0d 0x02 0x00 0x00 0x00 0x00 0x00 0x00' | llvm-mc --triple=bpfel --disassemble
        gotox r2

    $ echo '0x8d 0x02 0x00 0x00 0x00 0x00 0x00 0x00' | llvm-mc --triple=bpfel --disassemble
        callx r2

Those last two are one opcode byte apart. `0x8d` is the `CALLX` that master already decodes and `0x0d` is the `GOTOX` it does not, so pasting both eight byte sequences into a listing set to eBPF shows the split straight away: `callx r2` comes out fine, `gotox r2` comes back BAD. That was with llvm 22.1.8, an older llvm may not know the mnemonic yet.

I kept the `src=0 & imm=0` constraint because that is what the existing `CALLX` constructor does, and it keeps the two consistent. llvm's disassembler is looser here and will print `gotox r2` for `0d 12 ...` with a nonzero source field too, but its assembler only ever emits `src=0`, and Ghidra already rejects the same shape for `CALLX` (`8d 12 ...` is BAD on master today). I'm glad to relax both if you would rather match llvm's leniency, but I thought that should be a separate call for you guys to make.

I swept all 256 opcodes against llvm-mc before and after. No existing decode changes, the sleigh warning count is the same 2 either way, and `gotox` goes from BAD to matching the reference.

There was no eBPF assembly test, so I added a small one with the `GOTOX` case plus a `CALLX` case next to it, basically so the pair stays covered together.

One thing I left out: `may_goto` (opcode `0xe5`, `BPF_JCOND`) is also undecoded, the same sweep found it. That one needs a new opcode group and its semantics are a verifier hint rather than a plain branch, so it did not seem to belong in here. Again, glad to do that one separately if you want it, or to make any other changes you'd like. I intend to keep helping out here, so if there are specific areas you want me to look at, let me know.
