### PR TITLE
#9492 Fix decompiler save state command

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/consolemain.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/consolemain.cc
@@ -214,7 +214,7 @@ int main(int argc,char **argv)
     // Extra commands specific to the console application
     status->registerCom(new IfcLoadFile(),"load","file");
     status->registerCom(new IfcAddpath(),"addpath");
-    status->registerCom(new IfcSave(),"save");
+    status->registerCom(new IfcSave(),"save","state");
     status->registerCom(new IfcRestore(),"restore");
 
     if (initscript != (const char *)0) {


### PR DESCRIPTION
## Summary

Register the standalone decompiler state-save command as `save state` rather than the ambiguous one-word `save` command.

The interface parser consumes command tokens until a unique registered command is selected. Because other `save ...` commands are registered by the decompiler modules, `save state.xml` treats the filename as another command token and fails with `ERROR: Invalid command`.

With this registration the command is unambiguous and the existing `IfcSave::execute()` receives the filename as its argument:

`save state <filename>`

Fixes #9492.

## Testing

Verified the registration against the existing `IfaceStatus::expandCom()` command parsing rules and the issue reproduction path. No state serialization code is changed.