### PR TITLE
Preserve consume masks for big-endian register splits

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/transform.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/transform.cc
@@ -197,6 +197,7 @@ void TransformVar::createReplacement(Funcdata *fd)
       if ((bytePos & 7) != 0)
 	throw LowlevelError("Varnode piece is not byte aligned");
       bytePos >>= 3;
+      int4 significanceOffset = bytePos;
       if (vn->getSpace()->isBigEndian())
 	bytePos = vn->getSize() - bytePos - byteSize;
       Address addr = vn->getAddr() + bytePos;
@@ -205,7 +206,7 @@ void TransformVar::createReplacement(Funcdata *fd)
 	replacement = fd->newVarnode(byteSize,addr);
       else
 	replacement = fd->newVarnodeOut(byteSize, addr, def->replacement);
-      fd->transferVarnodeProperties(vn,replacement,bytePos);
+      fd->transferVarnodeProperties(vn,replacement,significanceOffset);
       break;
     }
     case TransformVar::constant_iop:

--- a/Ghidra/Features/Decompiler/src/decompile/datatests/splitflowbe.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/splitflowbe.xml
@@ -1,0 +1,26 @@
+<decompilertest>
+<binaryimage arch="6809:BE:16:default">
+<!--
+  A split of the big-endian D register must preserve the consume mask of the
+  significant A byte.  If A inherits B's mask, the count becomes zero and
+  the reachable store at 0x0410 is removed.
+-->
+<bytechunk space="ram" offset="0x400">
+cc0000f610004cf7100126f781072303b7100239
+</bytechunk>
+<bytechunk space="ram" offset="0x1000">
+000000
+</bytechunk>
+<symbol space="ram" offset="0x400" name="splitflow_be"/>
+<symbol space="ram" offset="0x1000" name="loop_input"/>
+<symbol space="ram" offset="0x1001" name="loop_output"/>
+<symbol space="ram" offset="0x1002" name="count_output"/>
+</binaryimage>
+<script>
+  <com>lo fu splitflow_be</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Big-endian splitflow keeps live high byte" min="1" max="1">count_output</stringmatch>
+</decompilertest>


### PR DESCRIPTION
## Summary

Preserve the logical significance offset when transferring Varnode properties for split register pieces on big-endian architectures.

`TransformVar::createReplacement()` converts the logical piece offset into a storage byte position for big-endian address construction. That converted storage offset was also passed to `transferVarnodeProperties()`, which caused consume-mask bits to be taken from the wrong half of split registers.

Keep the converted offset for the replacement address, but pass the original significance offset when transferring Varnode properties.

Fixes #9511.

## Testing

Added a focused `6809:BE:16:default` decompiler datatest using the 20-byte reproducer from the issue. It checks that the live high byte survives splitflow and that the reachable store to `count_output` is not deleted.