### PR TITLE
#9465 Make JVM class-name test self-contained

### DIFF
--- a/Ghidra/Test/DebuggerIntegrationTest/src/test/java/ghidra/app/plugin/core/debug/gui/tracermi/launcher/TraceRmiLauncherServicePluginTest.java
+++ b/Ghidra/Test/DebuggerIntegrationTest/src/test/java/ghidra/app/plugin/core/debug/gui/tracermi/launcher/TraceRmiLauncherServicePluginTest.java
@@ -18,14 +18,16 @@ package ghidra.app.plugin.core.debug.gui.tracermi.launcher;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
-import java.nio.file.Paths;
+import java.io.*;
+import java.nio.file.*;
 import java.util.*;
+
+import javax.tools.*;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import db.Transaction;
-import generic.jar.ResourceFile;
 import ghidra.app.plugin.core.analysis.AnalysisBackgroundCommand;
 import ghidra.app.plugin.core.analysis.AutoAnalysisManager;
 import ghidra.app.plugin.core.debug.gui.AbstractGhidraHeadedDebuggerTest;
@@ -35,7 +37,6 @@ import ghidra.app.util.opinion.LoadResults;
 import ghidra.debug.api.ValStr;
 import ghidra.debug.api.tracermi.TraceRmiLaunchOffer;
 import ghidra.debug.api.tracermi.TraceRmiLaunchOffer.*;
-import ghidra.framework.Application;
 import ghidra.framework.OperatingSystem;
 import ghidra.framework.cmd.Command;
 import ghidra.framework.plugintool.AutoConfigState.PathIsFile;
@@ -75,11 +76,26 @@ public class TraceRmiLauncherServicePluginTest extends AbstractGhidraHeadedDebug
 		};
 	}
 
+	private File createHelloWorldClassFile() throws IOException {
+		File tempDir = createTempDirectory("hello-world-class");
+		Path sourceFile = tempDir.toPath().resolve("HelloWorld.java");
+		Files.writeString(sourceFile, "public class HelloWorld {}\n");
+
+		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		assertNotNull("Tests require a JDK with a Java compiler", compiler);
+		int result = compiler.run(null, null, null, "-d", tempDir.getAbsolutePath(),
+			sourceFile.toString());
+		assertEquals("Failed to compile HelloWorld.java", 0, result);
+
+		File classFile = new File(tempDir, "HelloWorld.class");
+		assertTrue("Compiled HelloWorld.class was not created", classFile.isFile());
+		return classFile;
+	}
+
 	@Test
 	public void testGetClassName() throws Exception {
-		ResourceFile rf = Application.getModuleDataFile("TestResources", "HelloWorld.class");
 		try (LoadResults<Program> results = ProgramLoader.builder()
-				.source(rf.getFile(false))
+				.source(createHelloWorldClassFile())
 				.project(env.getProject())
 				.monitor(monitor)
 				.load()) {


### PR DESCRIPTION
Fixes #9465.

## Summary

Make `TraceRmiLauncherServicePluginTest.testGetClassName()` self-contained instead of depending on the missing `TestResources/HelloWorld.class` fixture.

The test now writes a minimal `HelloWorld.java` source file into its temporary test directory, compiles it with the JDK compiler, and feeds the resulting class file through the same `ProgramLoader` and analysis path as before.

This keeps the behavior under test unchanged while avoiding a checked-in/generated `.class` binary, which would otherwise be easy to miss because class files are ignored by the repository.

## Scope

- removes the dependency on the absent `TestResources` fixture
- uses the JDK compiler already required by the Ghidra development environment
- keeps the real JVM class import, analysis, and `tryProgramJvmClass()` assertion intact
- creates all generated source/class files only in the test temporary directory
- changes one test file only

## Testing

The regression is the existing `testGetClassName()` itself: on a clean checkout it can now create the class input it needs before exercising the importer/analyzer path. The full Ghidra test suite was not run in this environment; upstream test validation remains applicable