### PR TITLE
#9468 Route test logs to the test output directory

### DIFF
--- a/gradle/javaTestProject.gradle
+++ b/gradle/javaTestProject.gradle
@@ -144,6 +144,9 @@ def initTestJVM(Task task, String rootDirName) {
 
 	def testTempDir = file(rootTestDir).getAbsolutePath()
 	def testReportDir = file(reportDir).getAbsolutePath()
+	def testLogBaseName = task.path.replace(':', '_')
+	def applicationLogFile = new File(testOutputDir, testLogBaseName + '.log').getAbsolutePath()
+	def scriptLogFile = new File(testOutputDir, testLogBaseName + '-script.log').getAbsolutePath()
 
 	task.doFirst {
 		println "Test Machine Name: " + machineName
@@ -181,6 +184,8 @@ def initTestJVM(Task task, String rootDirName) {
 			'-DupgradeProgramErrorMessage=' + upgradeProgramErrorMessage,
 			'-DupgradeTimeErrorMessage=' + upgradeTimeErrorMessage,
 			'-Dlog4j.configurationFile=' + logPropertiesUrl,
+			'-DlogFilename=' + applicationLogFile,
+			'-DscriptLogFilename=' + scriptLogFile,
 			'-Dghidra.test.property.batch.mode=true',
 			'-Dghidra.test.property.parallel.mode=' + parallelMode,
 			'-Dghidra.test.property.output.dir=' + testOutputDir,


### PR DESCRIPTION
Fixes #9468.

## Summary

Provide the Log4j filename system properties expected by Ghidra's test logging configuration for every Gradle test JVM.

`generic.log4jtest.xml` includes rolling-file appenders that use `${sys:logFilename}` and `${sys:scriptLogFilename}`, but `initTestJVM()` did not set either property. When the placeholders are unresolved, test runs can create files literally named `${sys:logFilename}` and `${sys:scriptLogFilename}` in module source directories.

This change routes both logs into the existing `testOutputDir`.

## Details

- derives a unique log basename from the Gradle `task.path`
- sets `logFilename` and `scriptLogFilename` before the test JVM starts
- keeps logs under the designated test output directory
- gives each project/test task distinct filenames so parallel task execution does not share the same rolling log
- leaves the existing Log4j configuration and application logging behavior unchanged
- changes only `gradle/javaTestProject.gradle`

## Testing

The fix is confined to test JVM configuration. The full Ghidra test suite was not run in this environment; upstream test validation remains applicable