### PR TITLE
#9373 Allow commas in Ghidra project paths

### DIFF
--- a/Ghidra/Framework/FileSystem/src/main/java/ghidra/util/NamingUtilities.java
+++ b/Ghidra/Framework/FileSystem/src/main/java/ghidra/util/NamingUtilities.java
@@ -37,7 +37,7 @@ public final class NamingUtilities {
 
 	public final static Set<Character> VALID_NAME_CHARSET =
 		Collections.unmodifiableSet(
-			Set.of('.', '-', '=', '@', ' ', '_', '(', ')', '[', ']', '~'));
+			Set.of('.', '-', '=', '@', ' ', '_', '(', ')', '[', ']', '~', ','));
 
 	private NamingUtilities() {
 	}
@@ -50,7 +50,7 @@ public final class NamingUtilities {
 	 * <li>Name may not be blank (i.e., no characters or all space characters)</li>
 	 * <li>Name may not start with period</li>
 	 * <li>All characters must be a letter, digit (0..9), or within the allowed character set:
-	 *    '.', '-', '=', '@', ' ', '_', '(', ')', '[', ']', '~' </li>
+	 *    '.', '-', '=', '@', ' ', '_', '(', ')', '[', ']', '~', ',' </li>
 	 * </ul>
 	 * 
 	 * @param name name to validate
@@ -88,7 +88,7 @@ public final class NamingUtilities {
 	 * <li>Path element may not start with a '.' which may result in path traversal or hidden 
 	 *     file/folder use.</li>
 	 * <li>Path element may only contain the letters, numbers, or the following characters:
-	 *     '.', '-', '=', '@', ' ', '_', '(', ')', '[', ']', '~' </li>
+	 *     '.', '-', '=', '@', ' ', '_', '(', ')', '[', ']', '~', ',' </li>
 	 * </ul>
 	 * 
 	 * @param pathElement project or file path element (use of leading and trailing spaces should be 

--- a/Ghidra/Framework/Project/src/test/java/ghidra/framework/protocol/ghidra/GhidraURLCommaPathTest.java
+++ b/Ghidra/Framework/Project/src/test/java/ghidra/framework/protocol/ghidra/GhidraURLCommaPathTest.java
@@ -1,0 +1,47 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.framework.protocol.ghidra;
+
+import static org.junit.Assert.*;
+
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import generic.test.AbstractGenericTest;
+import ghidra.framework.model.ProjectLocator;
+import ghidra.util.NamingUtilities;
+
+public class GhidraURLCommaPathTest extends AbstractGenericTest {
+
+	@Before
+	public void setUp() {
+		Handler.registerHandler();
+	}
+
+	@Test
+	public void testCommaInProjectFilePathRoundTrips() {
+		String filePath = "/notepad, 1.exe";
+		NamingUtilities.checkName("notepad, 1.exe", null);
+
+		ProjectLocator locator = new ProjectLocator("/tmp", "Test");
+		URL url = GhidraURL.makeURL(locator, filePath, null);
+
+		assertEquals(filePath, GhidraURL.getProjectPathname(url));
+		assertEquals(locator, GhidraURL.getProjectStorageLocator(url));
+	}
+}


### PR DESCRIPTION
Fixes #9373.

## Summary

Allow commas in Ghidra project path elements so project files such as `notepad, 1.exe` can be represented by `ghidra:` URLs.

Imported domain files can contain commas, but `GhidraFileData.getLocalProjectURL()` ultimately validates each project-path element with `NamingUtilities`. Because comma was not in the allowed set, debugger workflows that create static mappings could fail before emulation with `Path element contains invalid character: ','`.

A comma is safe in a URI path component: it is not a path separator, traversal marker, query delimiter, or fragment delimiter.

This change:
- adds comma to the documented Ghidra path-element character whitelist
- allows local `ghidra:` URLs to represent existing comma-containing project files
- leaves path-separator, leading-dot, blank-name, and other character restrictions unchanged
- does not add handling specific to the debugger, so other URL-producing workflows benefit from the same fix

## Testing

Added a focused `GhidraURL` regression using `/notepad, 1.exe`. The test verifies that the name passes path validation, survives `GhidraURL.makeURL(...)`, round-trips through `GhidraURL.getProjectPathname(...)`, and preserves the project locator.

The full Ghidra test suite was not run in this environment; upstream validation remains applicable.