### PR TITLE
Respect namespaces when applying imported archive signatures

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/ApplyFunctionDataTypesCmd.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/cmd/function/ApplyFunctionDataTypesCmd.java
@@ -139,7 +139,7 @@ public class ApplyFunctionDataTypesCmd extends BackgroundCommand<Program> {
 
 		while (symbols.hasNext()) {
 			Symbol sym = symbols.next();
-			if (sym.isDynamic()) {
+			if (sym.isDynamic() || !isArchiveSignatureCandidate(sym, source)) {
 				continue;
 			}
 
@@ -154,6 +154,11 @@ public class ApplyFunctionDataTypesCmd extends BackgroundCommand<Program> {
 				list.add(sym);
 			}
 		}
+	}
+
+	static boolean isArchiveSignatureCandidate(Symbol sym, SourceType source) {
+		return source != SourceType.IMPORTED || sym.isExternal() ||
+			sym.getParentNamespace().isGlobal();
 	}
 
 	/**

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/cmd/function/ApplyFunctionDataTypesCmdTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/cmd/function/ApplyFunctionDataTypesCmdTest.java
@@ -1,0 +1,55 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.cmd.function;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import generic.test.AbstractGuiTest;
+import ghidra.program.database.ProgramBuilder;
+import ghidra.program.model.data.VoidDataType;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.symbol.*;
+import ghidra.test.ToyProgramBuilder;
+
+public class ApplyFunctionDataTypesCmdTest extends AbstractGuiTest {
+
+	@Test
+	public void testImportedArchiveMatchingRespectsNamespaces() throws Exception {
+		ProgramBuilder builder = new ToyProgramBuilder("Test", false, this);
+		builder.createMemory(".text", "0x1000", 0x100);
+
+		Function globalFunction = builder.createEmptyFunction("SetBkMode", "0x1000", 1,
+			VoidDataType.dataType);
+		Function namespacedFunction = builder.createEmptyFunction("SetBkMode",
+			"CGdiGraphicContext", "0x1010", 1, VoidDataType.dataType);
+		ExternalLocation externalFunction =
+			builder.createExternalFunction(null, "USER32.DLL", "SetBkMode");
+
+		assertTrue(ApplyFunctionDataTypesCmd.isArchiveSignatureCandidate(
+			globalFunction.getSymbol(), SourceType.IMPORTED));
+		assertFalse(ApplyFunctionDataTypesCmd.isArchiveSignatureCandidate(
+			namespacedFunction.getSymbol(), SourceType.IMPORTED));
+		assertTrue(ApplyFunctionDataTypesCmd.isArchiveSignatureCandidate(
+			externalFunction.getSymbol(), SourceType.IMPORTED));
+
+		// Explicit/manual application uses USER_DEFINED and keeps the existing ability to target
+		// namespaced methods deliberately.
+		assertTrue(ApplyFunctionDataTypesCmd.isArchiveSignatureCandidate(
+			namespacedFunction.getSymbol(), SourceType.USER_DEFINED));
+	}
+}


### PR DESCRIPTION
Fixes #8623.

## Summary

Prevent imported archive signature matching from applying a global C function definition to an unrelated internal function that only shares the same leaf name inside a class or namespace.

`ApplyFunctionDataTypesCmd` normalizes program symbols to leaf names before matching archive `FunctionDefinition`s. During imported archive application, that can make a method such as `CGdiGraphicContext::SetBkMode` match the unrelated global Windows `SetBkMode(HDC, int)` definition.

This change:
- keeps global program symbols eligible for imported archive matching
- keeps external/library symbols eligible, preserving normal imported API matching
- excludes non-external symbols whose parent namespace is not global when the source is `IMPORTED`
- preserves existing `USER_DEFINED`/manual behavior so explicit archive application can still target namespaced methods deliberately
- leaves name normalization, thunk handling, source-priority checks, and function creation behavior unchanged

## Testing

Added focused regression coverage with three symbols sharing the `SetBkMode` leaf name:
- a global program function remains eligible for imported matching
- an internal `CGdiGraphicContext::SetBkMode` method is excluded from imported matching
- an external `USER32.DLL::SetBkMode` function remains eligible

The regression also verifies that `USER_DEFINED` application still permits the namespaced method.

The full Ghidra test suite was not run in this environment; upstream validation remains applicable.