### PR TITLE
#9223 allows constants to propagate into multiequals

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/merge.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/merge.cc
@@ -413,6 +413,10 @@ PcodeOp *Merge::allocateCopyTrim(Varnode *inVn,const Address &addr,PcodeOp *trim
 {
   PcodeOp *copyOp = data.newOp(1,addr);
   data.opSetOpcode(copyOp,CPUI_COPY);
+  if (inVn->getDef() != 0 && inVn->getDef()->code() == CPUI_COPY && 		// Propagate constant if one exists 
+  !inVn->isStackStore() && inVn->getDef()->getIn(0)->isConstant() && 
+  inVn->getDef()->getIn(0)->isHeritageKnown()) 
+    inVn = inVn->getDef()->getIn(0);
   Datatype *ct = inVn->getType();
   if (ct->needsResolution()) {		// If the data-type needs resolution
     if (inVn->isWritten()) {


### PR DESCRIPTION
Fixes #9223 

This makes it so when the rule mergerequired creates new copy p-codes, it checks whether the input p-code for the new copy is defined by a constant in which case the new copy uses the constant as an input instead of the original input p-code. This uses the same logic as in the rule propagatecopy with one exception: when the input p-code was originally produced by an explicit store, constants are not propagated. This is to prevent lines where a stack variable is set to a constant from being duplicated in the decompiler view.