### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build-ghidra-multi-platform-artifact.yml
+++ b/.github/workflows/build-ghidra-multi-platform-artifact.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "JDK_VER=$(awk -F'=' '$1=="application.java.min" {print $2}' Ghidra/application.properties)" >> $GITHUB_ENV 
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '${{ env.JDK_VER }}'

--- a/.github/workflows/build-ghidra.yml
+++ b/.github/workflows/build-ghidra.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "JDK_VER=$(awk -F'=' '$1=="application.java.min" {print $2}' Ghidra/application.properties)" >> $GITHUB_ENV 
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '${{ env.JDK_VER }}'

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "JDK_VER=$(awk -F'=' '$1=="application.java.min" {print $2}' Ghidra/application.properties)" >> $GITHUB_ENV 
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '${{ env.JDK_VER }}'


### PR DESCRIPTION
Upgrade all active build and dependency-submission workflows from `actions/setup-java@v5` to `actions/setup-java@v6`.

Verification: checked all active `.github/workflows/*.yml` and `.yaml` files; no older setup-java references remain.