### PR TITLE
Add data type conflict resolution option to Version Tracking settings

### DIFF
--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/DataTypeMarkupType.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/DataTypeMarkupType.java
@@ -24,6 +24,7 @@ import ghidra.feature.vt.api.stringable.DataTypeStringable;
 import ghidra.feature.vt.api.util.Stringable;
 import ghidra.feature.vt.api.util.VersionTrackingApplyException;
 import ghidra.feature.vt.gui.util.VTMatchApplyChoices;
+import ghidra.feature.vt.gui.util.VTMatchApplyChoices.DataTypeConflictChoices;
 import ghidra.feature.vt.gui.util.VTMatchApplyChoices.ReplaceDataChoices;
 import ghidra.feature.vt.gui.util.VTOptionDefines;
 import ghidra.framework.options.Options;
@@ -331,6 +332,17 @@ public class DataTypeMarkupType extends VTMarkupType {
 		if (sourceDataLength <= 0) {
 			sourceDataLength = sourceData.getLength();
 		}
+
+		DataTypeConflictChoices conflictChoice = markupOptions.getEnum(
+			VTOptionDefines.DATA_TYPE_CONFLICT_HANDLER,
+			VTOptionDefines.DEFAULT_OPTION_FOR_DATA_TYPE_CONFLICT_HANDLER);
+		DataTypeConflictHandler conflictHandler = switch (conflictChoice) {
+			case USE_EXISTING -> DataTypeConflictHandler.KEEP_HANDLER;
+			case REPLACE_EXISTING -> DataTypeConflictHandler.REPLACE_HANDLER;
+			default -> DataTypeConflictHandler.DEFAULT_HANDLER;
+		};
+		sourceDataType =
+			destinationProgram.getDataTypeManager().resolve(sourceDataType, conflictHandler);
 
 		try {
 			return setDataType(destinationProgram, destinationAddress, sourceDataType,

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/DataTypeMarkupType.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/DataTypeMarkupType.java
@@ -207,7 +207,8 @@ public class DataTypeMarkupType extends VTMarkupType {
 	}
 
 	private boolean setDataType(Program program, Address startAddress, DataType dataType,
-			int dataLength, VTMatchApplyChoices.ReplaceDataChoices replaceChoice)
+			int dataLength, VTMatchApplyChoices.ReplaceDataChoices replaceChoice,
+			DataTypeConflictHandler conflictHandler)
 			throws CodeUnitInsertionException, VersionTrackingApplyException {
 
 		Listing listing = program.getListing();
@@ -259,15 +260,17 @@ public class DataTypeMarkupType extends VTMarkupType {
 		}
 
 		if (replaceFirstOnly && hasOtherDefinedData) {
-			// Just return since we are only replacing first data and this has some defined 
+			// Just return since we are only replacing first data and this has some defined
 			// data that would be overwritten following the first data in the destination.
 			return false;
 		}
+		
+		DataType resolvedDataType = program.getDataTypeManager().resolve(dataType, conflictHandler);
 
 		listing.clearCodeUnits(startAddress, endAddress, false); // Clear the necessary code units.
 
 		try {
-			listing.createData(startAddress, dataType, dataLength);
+			listing.createData(startAddress, resolvedDataType, dataLength);
 		}
 		catch (CodeUnitInsertionException e) {
 			tryToRestoreOriginalData(listing, startAddress, originalDataType, originalDataLength);
@@ -341,12 +344,10 @@ public class DataTypeMarkupType extends VTMarkupType {
 			case REPLACE_EXISTING -> DataTypeConflictHandler.REPLACE_HANDLER;
 			default -> DataTypeConflictHandler.DEFAULT_HANDLER;
 		};
-		sourceDataType =
-			destinationProgram.getDataTypeManager().resolve(sourceDataType, conflictHandler);
 
 		try {
 			return setDataType(destinationProgram, destinationAddress, sourceDataType,
-				sourceDataLength, replaceChoice);
+				sourceDataLength, replaceChoice, conflictHandler);
 		}
 		catch (CodeUnitInsertionException e) {
 			throw new VersionTrackingApplyException(getApplyFailedMessage(sourceAddress,
@@ -397,7 +398,8 @@ public class DataTypeMarkupType extends VTMarkupType {
 
 		try {
 			setDataType(destinationProgram, destinationAddress, originalDataType,
-				originalDataLength, VTMatchApplyChoices.ReplaceDataChoices.REPLACE_ALL_DATA);
+				originalDataLength, VTMatchApplyChoices.ReplaceDataChoices.REPLACE_ALL_DATA,
+				DataTypeConflictHandler.DEFAULT_HANDLER);
 		}
 		catch (CodeUnitInsertionException e) {
 			throw new VersionTrackingApplyException("Couldn't unapply data type markup @ " +

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/DataTypeMarkupType.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/api/markuptype/DataTypeMarkupType.java
@@ -341,8 +341,7 @@ public class DataTypeMarkupType extends VTMarkupType {
 			VTOptionDefines.DEFAULT_OPTION_FOR_DATA_TYPE_CONFLICT_HANDLER);
 		DataTypeConflictHandler conflictHandler = switch (conflictChoice) {
 			case USE_EXISTING -> DataTypeConflictHandler.KEEP_HANDLER;
-			case REPLACE_EXISTING -> DataTypeConflictHandler.REPLACE_HANDLER;
-			default -> DataTypeConflictHandler.DEFAULT_HANDLER;
+			case RENAME_AND_ADD -> DataTypeConflictHandler.DEFAULT_HANDLER;
 		};
 
 		try {

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/matchtable/ApplyMarkupPropertyEditor.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/matchtable/ApplyMarkupPropertyEditor.java
@@ -51,6 +51,9 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 	// help tooltips
 	private static final String DATA_MATCH_DATA_TYPE_TOOLTIP =
 		"<html>The apply action for the <b>data type on a data match</b> when performing bulk apply operations</html>";
+	private static final String DATA_TYPE_CONFLICT_HANDLER_TOOLTIP =
+		"<html>How to resolve a conflict when the <b>data type being applied</b> already exists " +
+			"but differs in the destination program</html>";
 	private static final String LABELS_TOOLTIP =
 		"<html>The apply action for <b>labels</b> when performing bulk apply operations</html>";
 	private static final String FUNCTION_NAME_TOOLTIP =
@@ -116,6 +119,7 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 	private JComponent editorComponent;
 
 	private JLabel dataMatchDataTypeLabel;
+	private JLabel dataTypeConflictHandlerLabel;
 	private JLabel functionNameLabel;
 	private JLabel functionSignatureLabel;
 	private JLabel useFunctionNamespaceLabel;
@@ -136,6 +140,7 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 	private JLabel postCommentsLabel;
 
 	private JComboBox<Enum<?>> dataMatchDataTypeComboBox;
+	private JComboBox<Enum<?>> dataTypeConflictHandlerComboBox;
 	private JComboBox<Enum<?>> functionNameComboBox;
 	private JComboBox<Enum<?>> functionSignatureComboBox;
 	private JCheckBox useFunctionNamespaceCheckBox;
@@ -416,6 +421,8 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 
 		panel.add(dataMatchDataTypeLabel);
 		panel.add(dataMatchDataTypeComboBox);
+		panel.add(dataTypeConflictHandlerLabel);
+		panel.add(dataTypeConflictHandlerComboBox);
 		panel.add(labelsLabel);
 		panel.add(labelsComboBox);
 		panel.add(functionNameLabel);
@@ -434,6 +441,10 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 		dataMatchDataTypeLabel = new GDLabel("Data Match Data Type", SwingConstants.RIGHT);
 		dataMatchDataTypeLabel.setToolTipText(DATA_MATCH_DATA_TYPE_TOOLTIP);
 
+		dataTypeConflictHandlerLabel =
+			new GDLabel("Data Type Conflict Handler", SwingConstants.RIGHT);
+		dataTypeConflictHandlerLabel.setToolTipText(DATA_TYPE_CONFLICT_HANDLER_TOOLTIP);
+
 		labelsLabel = new GDLabel("Labels", SwingConstants.RIGHT);
 		labelsLabel.setToolTipText(LABELS_TOOLTIP);
 
@@ -451,6 +462,10 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 		dataMatchDataTypeComboBox = createComboBox(VTOptionDefines.DATA_MATCH_DATA_TYPE,
 			DEFAULT_OPTION_FOR_DATA_MATCH_DATA_TYPE);
 		dataMatchDataTypeComboBox.setToolTipText(DATA_MATCH_DATA_TYPE_TOOLTIP);
+
+		dataTypeConflictHandlerComboBox = createComboBox(VTOptionDefines.DATA_TYPE_CONFLICT_HANDLER,
+			DEFAULT_OPTION_FOR_DATA_TYPE_CONFLICT_HANDLER);
+		dataTypeConflictHandlerComboBox.setToolTipText(DATA_TYPE_CONFLICT_HANDLER_TOOLTIP);
 
 		labelsComboBox = createComboBox(VTOptionDefines.LABELS, DEFAULT_OPTION_FOR_LABELS);
 		labelsComboBox.setToolTipText(LABELS_TOOLTIP);
@@ -546,6 +561,10 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 		ReplaceDataChoices dataMatchDataTypeChoice =
 			(ReplaceDataChoices) dataMatchDataTypeComboBox.getSelectedItem();
 		options.setEnum(DATA_MATCH_DATA_TYPE, dataMatchDataTypeChoice);
+
+		DataTypeConflictChoices dataTypeConflictHandlerChoice =
+			(DataTypeConflictChoices) dataTypeConflictHandlerComboBox.getSelectedItem();
+		options.setEnum(DATA_TYPE_CONFLICT_HANDLER, dataTypeConflictHandlerChoice);
 
 		LabelChoices labelsChoice = (LabelChoices) labelsComboBox.getSelectedItem();
 		options.setEnum(LABELS, labelsChoice);
@@ -652,6 +671,12 @@ public class ApplyMarkupPropertyEditor implements OptionsEditor {
 			options.getEnum(DATA_MATCH_DATA_TYPE, DEFAULT_OPTION_FOR_DATA_MATCH_DATA_TYPE);
 		if (dataMatchDataTypeChoice != dataMatchDataTypeComboBox.getSelectedItem()) {
 			dataMatchDataTypeComboBox.setSelectedItem(dataMatchDataTypeChoice);
+		}
+
+		DataTypeConflictChoices dataTypeConflictHandlerChoice = options
+				.getEnum(DATA_TYPE_CONFLICT_HANDLER, DEFAULT_OPTION_FOR_DATA_TYPE_CONFLICT_HANDLER);
+		if (dataTypeConflictHandlerChoice != dataTypeConflictHandlerComboBox.getSelectedItem()) {
+			dataTypeConflictHandlerComboBox.setSelectedItem(dataTypeConflictHandlerChoice);
 		}
 
 		LabelChoices labelsChoice = options.getEnum(LABELS, DEFAULT_OPTION_FOR_LABELS);

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/matchtable/VTMatchTableProvider.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/provider/matchtable/VTMatchTableProvider.java
@@ -686,6 +686,11 @@ public class VTMatchTableProvider extends ComponentProviderAdapter
 			null,
 			"The default apply action <b>for the data type on a data match</b> when performing bulk apply operations");
 
+		vtOptions.registerOption(DATA_TYPE_CONFLICT_HANDLER,
+			DEFAULT_OPTION_FOR_DATA_TYPE_CONFLICT_HANDLER, null,
+			"How to resolve a conflict when the data type being applied already exists but " +
+				"differs in the destination program");
+
 		vtOptions.registerOption(LABELS, DEFAULT_OPTION_FOR_LABELS, null,
 			"The default apply action <b>for labels</b> when performing bulk apply operations");
 

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMatchApplyChoices.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMatchApplyChoices.java
@@ -241,8 +241,7 @@ public class VTMatchApplyChoices {
 
 	public static enum DataTypeConflictChoices {
 		USE_EXISTING("Use Existing Data Type"),
-		RENAME_AND_ADD("Rename New Data Type"),
-		REPLACE_EXISTING("Replace Existing Data Type");
+		RENAME_AND_ADD("Rename New Data Type");
 
 		private String optionDisplayString;
 

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMatchApplyChoices.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTMatchApplyChoices.java
@@ -239,4 +239,21 @@ public class VTMatchApplyChoices {
 		}
 	}
 
+	public static enum DataTypeConflictChoices {
+		USE_EXISTING("Use Existing Data Type"),
+		RENAME_AND_ADD("Rename New Data Type"),
+		REPLACE_EXISTING("Replace Existing Data Type");
+
+		private String optionDisplayString;
+
+		private DataTypeConflictChoices(String optionDisplayString) {
+			this.optionDisplayString = optionDisplayString;
+		}
+
+		@Override
+		public String toString() {
+			return optionDisplayString;
+		}
+	}
+
 }

--- a/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTOptionDefines.java
+++ b/Ghidra/Features/VersionTracking/src/main/java/ghidra/feature/vt/gui/util/VTOptionDefines.java
@@ -36,6 +36,8 @@ public class VTOptionDefines {
 	public static boolean DEFAULT_OPTION_FOR_PARAMETER_NAMES_REPLACE_IF_SAME_PRIORITY = false;
 	public static ReplaceDataChoices DEFAULT_OPTION_FOR_DATA_MATCH_DATA_TYPE =
 		ReplaceDataChoices.REPLACE_UNDEFINED_DATA_ONLY;
+	public static DataTypeConflictChoices DEFAULT_OPTION_FOR_DATA_TYPE_CONFLICT_HANDLER =
+		DataTypeConflictChoices.USE_EXISTING;
 	public static FunctionNameChoices DEFAULT_OPTION_FOR_FUNCTION_NAME =
 		FunctionNameChoices.ADD_AS_PRIMARY;
 	public static FunctionSignatureChoices DEFAULT_OPTION_FOR_FUNCTION_SIGNATURE =
@@ -83,6 +85,8 @@ public class VTOptionDefines {
 	public static final String POST_COMMENT = APPLY_MARKUP_OPTIONS_NAME + ".Post Comment";
 	public static final String DATA_MATCH_DATA_TYPE = APPLY_MARKUP_OPTIONS_NAME +
 		".Data Match Data Type";
+	public static final String DATA_TYPE_CONFLICT_HANDLER = APPLY_MARKUP_OPTIONS_NAME +
+		".Data Type Conflict Handler";
 	public static final String FUNCTION_SIGNATURE = APPLY_MARKUP_OPTIONS_NAME +
 		".Function Signature";
 	public static final String CALLING_CONVENTION = APPLY_MARKUP_OPTIONS_NAME +

--- a/Ghidra/Features/VersionTracking/src/test.slow/java/ghidra/feature/vt/api/markupitem/DataTypeMarkupItemTest.java
+++ b/Ghidra/Features/VersionTracking/src/test.slow/java/ghidra/feature/vt/api/markupitem/DataTypeMarkupItemTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import ghidra.feature.vt.api.main.*;
 import ghidra.feature.vt.api.markuptype.DataTypeMarkupType;
+import ghidra.feature.vt.gui.util.VTMatchApplyChoices.DataTypeConflictChoices;
 import ghidra.feature.vt.gui.util.VTMatchApplyChoices.ReplaceDataChoices;
 import ghidra.feature.vt.gui.util.VTOptionDefines;
 import ghidra.framework.options.ToolOptions;
@@ -310,6 +311,38 @@ public class DataTypeMarkupItemTest extends AbstractVTMarkupItemTest {
 	}
 
 	@Test
+	public void testRejectedApplyDoesNotMutateDestinationDataTypeManager() throws Exception {
+		
+		Address sourceAddress = addr("0x010074e6", sourceProgram); // LoadCursorW
+		StructureDataType sourceDataType = new StructureDataType("RejectedApplyStruct", 0);
+		sourceDataType.add(new DWordDataType());
+		Data sourceData =
+			setDataType(sourceProgram, sourceAddress, sourceDataType, sourceDataType.getLength());
+
+		Address destinationAddress = addr("0x010074e6", destinationProgram); // LoadCursorW
+		StringDataType destinationDataType = new StringDataType();
+		Data destinationData =
+			setDataType(destinationProgram, destinationAddress, destinationDataType, 4); // Get "Load".
+		setDataType(destinationProgram, destinationAddress.add(4), destinationDataType, 6); // Get "Cursor".
+
+		DataTypeManager destinationDTM = destinationProgram.getDataTypeManager();
+		assertNull("Test setup invalid - destination should not already have this data type",
+			destinationDTM.getDataType(sourceDataType.getCategoryPath(),
+				sourceDataType.getName()));
+
+		DataTypeValidator validator = new DataTypeValidator(sourceData, destinationData,
+			ReplaceDataChoices.REPLACE_UNDEFINED_DATA_ONLY);
+		validator.setConflictChoice(DataTypeConflictChoices.RENAME_AND_ADD);
+		doTestFindAndApplyMarkupItem_NoEffect(validator);
+
+		assertNull(
+			"Rejected apply must not add the source data type to the destination data type " +
+				"manager",
+			destinationDTM.getDataType(sourceDataType.getCategoryPath(),
+				sourceDataType.getName()));
+	}
+
+	@Test
 	public void testReplaceUndefinedOnlyWithLargerWhenBlockedByInstruction() throws Exception {
 
 		Address sourceAddress = addr("0x010074e6", sourceProgram); // LoadCursorW
@@ -404,6 +437,7 @@ public class DataTypeMarkupItemTest extends AbstractVTMarkupItemTest {
 		private int sourceLength;
 		private int originalDestinationLength;
 		private ReplaceDataChoices dataTypeChoice;
+		private DataTypeConflictChoices conflictChoice;
 
 		DataTypeValidator(Data sourceData, Data destinationData,
 				ReplaceDataChoices dataTypeChoice) {
@@ -418,6 +452,10 @@ public class DataTypeMarkupItemTest extends AbstractVTMarkupItemTest {
 			this.originalDestinationDataType =
 				originalDestinationDataType.clone(originalDestinationDataType.getDataTypeManager());
 			this.originalDestinationLength = destinationData.getLength();
+		}
+
+		void setConflictChoice(DataTypeConflictChoices conflictChoice) {
+			this.conflictChoice = conflictChoice;
 		}
 
 		@Override
@@ -481,6 +519,9 @@ public class DataTypeMarkupItemTest extends AbstractVTMarkupItemTest {
 		public ToolOptions getOptions() {
 			ToolOptions vtOptions = super.getOptions();
 			vtOptions.setEnum(VTOptionDefines.DATA_MATCH_DATA_TYPE, dataTypeChoice);
+			if (conflictChoice != null) {
+				vtOptions.setEnum(VTOptionDefines.DATA_TYPE_CONFLICT_HANDLER, conflictChoice);
+			}
 
 			return vtOptions;
 		}


### PR DESCRIPTION
There was no way to keep destination-side edits to a data type across repeated `Apply Markup` calls during version tracking: it always renamed and added a `.conflictN` copy instead, because two datatypes are not in sync anymore.
This PR adds a `DATA_TYPE_CONFLICT_HANDLER` option to `Apply Markup Options`: keep the existing data type, rename and add the incoming one, or replace the existing one. Defaults to `Use Existing Data Type`

`DataTypeMarkupType.applyMarkup()` now resolves the data type explicitly with the chosen handler before applying it.