### PR TITLE
[x86] Zero-extend 32-bit register destinations in 64-bit mode

### DIFF
--- a/Ghidra/Processors/x86/data/languages/lockable.sinc
+++ b/Ghidra/Processors/x86/data/languages/lockable.sinc
@@ -1248,7 +1248,7 @@
    UNLOCK();
 }
 
-:XCHG^xacq_xrel_prefx^alwaysLock  m32,Reg32   is vexMode=0 & xacq_xrel_prefx & alwaysLock & opsize=1 & byte=0x87; m32 & Reg32 ...        
+:XCHG^xacq_xrel_prefx^alwaysLock  m32,Reg32   is vexMode=0 & xacq_xrel_prefx & alwaysLock & opsize=1 & byte=0x87; m32 & (check_Reg32_dest & Reg32) ...        
 { 
   build xacq_xrel_prefx;
   build alwaysLock;
@@ -1256,6 +1256,7 @@
   local tmp = m32; 
   m32 = Reg32; 
   Reg32 = tmp; 
+  build check_Reg32_dest;
   UNLOCK(); 
 }
 


### PR DESCRIPTION
Fixes #9325.

Writing a 32-bit GPR in 64-bit mode clears the upper half of the 64-bit alias (Intel SDM Vol. 1, 3.4.1.1). A few constructors assign a 32-bit register without modelling that, so the stale upper half stays live. In the case from the issue the decompiler ends up folding the `shr rax, 32` and `test` into a constant and dropping the syscall as dead code.

The hook for this already exists: the `check_*_dest` subtables in ia.sinc, built after a 32-bit write, used in about 140 places. These six constructors never picked it up, even though the register-operand forms of the same instructions did.

| missing the hook | already correct |
| --- | --- |
| `XADD m32,Reg32` (lockable.sinc) | `XADD Rmr32,Reg32` |
| `XCHG m32,Reg32` (lockable.sinc) | `XCHG Rmr32,Reg32`, `XCHG EAX,Rmr32` |
| `CMPXCHG8B m64` (lockable.sinc) | `CMPXCHG m32,Reg32` |
| `PEXTRW Reg32,mmxreg2` (ia.sinc) | `PEXTRW Reg32,XmmReg2` |
| `VMOVD rm32,XmmReg1` (avx.sinc) | `MOVD rm32,XmmReg` |
| `LODSD` (ia.sinc) | no register-operand counterpart |

XCHG with a memory operand is not in the issue list. I included it because it is the same omission in the same file as the XADD case that is listed, and its own register form already has the hook. Happy to pull it back out if you would rather keep this to the reported set.

I compiled both specs and diffed the emitted constructor templates:

- x86-64.slaspec and x86.slaspec both compile with no new errors
- each constructor gains one BUILD in the intended position, two for CMPXCHG8B since it writes EDX and EAX. For CMPXCHG8B they sit in the not-equal path only, so the success path still leaves EDX:EAX alone.
- those builds resolve to INT_ZEXT into the matching 64-bit register. check_EAX_dest emits `register(0x0,8) = zext(register(0x0,4))`, check_EDX_dest writes `register(0x10,8)`.
- in the 32-bit build every check_*_dest is empty and emits no p-code, so x86-32 is unaffected.
