### PR TITLE
#9567: x86-64: add dropped GPR source operand to EVEX VPBROADCASTB/W/D/Q con…

### DIFF
--- a/Ghidra/Processors/x86/data/languages/avx512.sinc
+++ b/Ghidra/Processors/x86/data/languages/avx512.sinc
@@ -10055,118 +10055,107 @@ define pcodeop vpblendmq_avx512f ;
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110617
-# WARNING: did not recognize operand "reg" (encoding ModRM:r/m (r)) for "VPBROADCASTB xmm1 {k1}{z}, reg"
-#TODO: fix
 define pcodeop vpbroadcastb_avx512vl ;
-:VPBROADCASTB XmmReg1^XmmOpMask8  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7A; (XmmReg1 & ZmmReg1 & XmmOpMask8)
+:VPBROADCASTB XmmReg1^XmmOpMask8, Rmr32  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7A; (XmmReg1 & ZmmReg1 & XmmOpMask8) & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	local tmp:16 = vpbroadcastb_avx512vl(  );
+	local tmp:16 = vpbroadcastb_avx512vl( Rmr32 );
 	build XmmOpMask8;
 	ZmmReg1 = zext(tmp);
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110619
-# WARNING: did not recognize operand "reg" (encoding ModRM:r/m (r)) for "VPBROADCASTB ymm1 {k1}{z}, reg"
-:VPBROADCASTB YmmReg1^YmmOpMask8  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7A; (YmmReg1 & ZmmReg1 & YmmOpMask8)
+:VPBROADCASTB YmmReg1^YmmOpMask8, Rmr32  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7A; (YmmReg1 & ZmmReg1 & YmmOpMask8) & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	YmmResult = vpbroadcastb_avx512vl(  );
+	YmmResult = vpbroadcastb_avx512vl( Rmr32 );
 	YmmMask = YmmReg1;
 	build YmmOpMask8;
 	ZmmReg1 = zext(YmmResult);
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110621
-# WARNING: did not recognize operand "reg" (encoding ModRM:r/m (r)) for "VPBROADCASTB zmm1 {k1}{z}, reg"
 define pcodeop vpbroadcastb_avx512bw ;
-:VPBROADCASTB ZmmReg1^ZmmOpMask8  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7A; ZmmReg1 & ZmmOpMask8
+:VPBROADCASTB ZmmReg1^ZmmOpMask8, Rmr32  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7A; ZmmReg1 & ZmmOpMask8 & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	ZmmResult = vpbroadcastb_avx512bw(  );
+	ZmmResult = vpbroadcastb_avx512bw( Rmr32 );
 	ZmmMask = ZmmReg1;
 	build ZmmOpMask8;
 	ZmmReg1 = ZmmResult;
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110623
-# WARNING: did not recognize operand "reg" (encoding ModRM:r/m (r)) for "VPBROADCASTW xmm1 {k1}{z}, reg"
 define pcodeop vpbroadcastw_avx512vl ;
-:VPBROADCASTW XmmReg1^XmmOpMask16  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7B; (XmmReg1 & ZmmReg1 & XmmOpMask16)
+:VPBROADCASTW XmmReg1^XmmOpMask16, Rmr32  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7B; (XmmReg1 & ZmmReg1 & XmmOpMask16) & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	XmmResult = vpbroadcastw_avx512vl(  );
+	XmmResult = vpbroadcastw_avx512vl( Rmr32 );
 	XmmMask = XmmReg1;
 	build XmmOpMask16;
 	ZmmReg1 = zext(XmmResult);
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110625
-# WARNING: did not recognize operand "reg" (encoding ModRM:r/m (r)) for "VPBROADCASTW ymm1 {k1}{z}, reg"
-:VPBROADCASTW YmmReg1^YmmOpMask16  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7B; (YmmReg1 & ZmmReg1 & YmmOpMask16)
+:VPBROADCASTW YmmReg1^YmmOpMask16, Rmr32  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7B; (YmmReg1 & ZmmReg1 & YmmOpMask16) & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	YmmResult = vpbroadcastw_avx512vl(  );
+	YmmResult = vpbroadcastw_avx512vl( Rmr32 );
 	YmmMask = YmmReg1;
 	build YmmOpMask16;
 	ZmmReg1 = zext(YmmResult);
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110627
-# WARNING: did not recognize operand "reg" (encoding ModRM:r/m (r)) for "VPBROADCASTW zmm1 {k1}{z}, reg"
 define pcodeop vpbroadcastw_avx512bw ;
-:VPBROADCASTW ZmmReg1^ZmmOpMask16  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7B; ZmmReg1 & ZmmOpMask16
+:VPBROADCASTW ZmmReg1^ZmmOpMask16, Rmr32  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7B; ZmmReg1 & ZmmOpMask16 & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	ZmmResult = vpbroadcastw_avx512bw(  );
+	ZmmResult = vpbroadcastw_avx512bw( Rmr32 );
 	ZmmMask = ZmmReg1;
 	build ZmmOpMask16;
 	ZmmReg1 = ZmmResult;
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110629
-# WARNING: did not recognize operand "r32" (encoding ModRM:r/m (r)) for "VPBROADCASTD xmm1 {k1}{z}, r32"
 define pcodeop vpbroadcastd_avx512vl ;
-:VPBROADCASTD XmmReg1^XmmOpMask32  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7C; (XmmReg1 & ZmmReg1 & XmmOpMask32)
+:VPBROADCASTD XmmReg1^XmmOpMask32, Rmr32  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7C; (XmmReg1 & ZmmReg1 & XmmOpMask32) & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	XmmResult = vpbroadcastd_avx512vl(  );
+	XmmResult = vpbroadcastd_avx512vl( Rmr32 );
 	XmmMask = XmmReg1;
 	build XmmOpMask32;
 	ZmmReg1 = zext(XmmResult);
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110631
-# WARNING: did not recognize operand "r32" (encoding ModRM:r/m (r)) for "VPBROADCASTD ymm1 {k1}{z}, r32"
-:VPBROADCASTD YmmReg1^YmmOpMask32  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7C; (YmmReg1 & ZmmReg1 & YmmOpMask32)
+:VPBROADCASTD YmmReg1^YmmOpMask32, Rmr32  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7C; (YmmReg1 & ZmmReg1 & YmmOpMask32) & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	YmmResult = vpbroadcastd_avx512vl(  );
+	YmmResult = vpbroadcastd_avx512vl( Rmr32 );
 	YmmMask = YmmReg1;
 	build YmmOpMask32;
 	ZmmReg1 = zext(YmmResult);
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110633
-# WARNING: did not recognize operand "r32" (encoding ModRM:r/m (r)) for "VPBROADCASTD zmm1 {k1}{z}, r32"
 define pcodeop vpbroadcastd_avx512f ;
-:VPBROADCASTD ZmmReg1^ZmmOpMask32  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7C; ZmmReg1 & ZmmOpMask32
+:VPBROADCASTD ZmmReg1^ZmmOpMask32, Rmr32  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x7C; ZmmReg1 & ZmmOpMask32 & Rmr32
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	ZmmResult = vpbroadcastd_avx512f(  );
+	ZmmResult = vpbroadcastd_avx512f( Rmr32 );
 	ZmmMask = ZmmReg1;
 	build ZmmOpMask32;
 	ZmmReg1 = ZmmResult;
 }
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110635
-# WARNING: did not recognize operand "r64" (encoding ModRM:r/m (r)) for "VPBROADCASTQ xmm1 {k1}{z}, r64"
 define pcodeop vpbroadcastq_avx512vl ;
 @ifdef IA64
-:VPBROADCASTQ XmmReg1^XmmOpMask64  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W1); byte=0x7C; (XmmReg1 & ZmmReg1 & XmmOpMask64)
+:VPBROADCASTQ XmmReg1^XmmOpMask64, Rmr64  is $(EVEX_NONE) & $(VEX_L128) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W1); byte=0x7C; (XmmReg1 & ZmmReg1 & XmmOpMask64) & Rmr64
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	XmmResult = vpbroadcastq_avx512vl(  );
+	XmmResult = vpbroadcastq_avx512vl( Rmr64 );
 	XmmMask = XmmReg1;
 	build XmmOpMask64;
 	ZmmReg1 = zext(XmmResult);
@@ -10174,12 +10163,11 @@ define pcodeop vpbroadcastq_avx512vl ;
 @endif
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110637
-# WARNING: did not recognize operand "r64" (encoding ModRM:r/m (r)) for "VPBROADCASTQ ymm1 {k1}{z}, r64"
 @ifdef IA64
-:VPBROADCASTQ YmmReg1^YmmOpMask64  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W1); byte=0x7C; (YmmReg1 & ZmmReg1 & YmmOpMask64)
+:VPBROADCASTQ YmmReg1^YmmOpMask64, Rmr64  is $(EVEX_NONE) & $(VEX_L256) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W1); byte=0x7C; (YmmReg1 & ZmmReg1 & YmmOpMask64) & Rmr64
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	YmmResult = vpbroadcastq_avx512vl(  );
+	YmmResult = vpbroadcastq_avx512vl( Rmr64 );
 	YmmMask = YmmReg1;
 	build YmmOpMask64;
 	ZmmReg1 = zext(YmmResult);
@@ -10187,13 +10175,12 @@ define pcodeop vpbroadcastq_avx512vl ;
 @endif
 
 # VPBROADCASTB/W/D/Q 5-328 PAGE 2152 LINE 110639
-# WARNING: did not recognize operand "r64" (encoding ModRM:r/m (r)) for "VPBROADCASTQ zmm1 {k1}{z}, r64"
 define pcodeop vpbroadcastq_avx512f ;
 @ifdef IA64
-:VPBROADCASTQ ZmmReg1^ZmmOpMask64  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W1); byte=0x7C; ZmmReg1 & ZmmOpMask64
+:VPBROADCASTQ ZmmReg1^ZmmOpMask64, Rmr64  is $(EVEX_NONE) & $(EVEX_L512) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W1); byte=0x7C; ZmmReg1 & ZmmOpMask64 & Rmr64
 [ evexD8Type = 1; evexTType = 3; ] # (TupleType T1S)
 {
-	ZmmResult = vpbroadcastq_avx512f(  );
+	ZmmResult = vpbroadcastq_avx512f( Rmr64 );
 	ZmmMask = ZmmReg1;
 	build ZmmOpMask64;
 	ZmmReg1 = ZmmResult;


### PR DESCRIPTION
Closes #9567.

## What

The auto-generated `avx512.sinc` constructors for the GPR-source forms of `VPBROADCASTB/W/D/Q` (EVEX map 0F38, opcodes 0x7A/0x7B/0x7C) drop the source operand: the generator's own
`# WARNING: did not recognize operand "reg"/"r32"/"r64"` comments show this, and the emitted bodies call the pcodeop with **zero arguments** (`vpbroadcastq_avx512vl(  )`). The instruction decodes at the correct length (the ModRM byte is consumed by the destination operand's pattern), so the listing looks fine, but the decompiler sees an undefined value with no input and the GPR source is lost.

## Fix

Add the register-only r/m operand to all 12 constructors and pass it to the
pcodeop:

- `Rmr64` for VPBROADCASTQ (r64 source)
- `Rmr32` for VPBROADCASTB/W/D (per the SDM all three take `r32`; the low
  byte/word/dword is what gets broadcast — this also fixes the display to
  e.g. `VPBROADCASTB YMM5,EBX` instead of `...,BL`)

One file changed: `Ghidra/Processors/x86/data/languages/avx512.sinc` (22 insertions, 35 deletions — the deletions are the WARNING/#TODO comment lines). Since the file is auto-generated from Intel's spec, the same fix presumably belongs in the generator; this PR fixes the emitted spec in the meantime.

## Verification

- `support/sleigh Ghidra/Processors/x86/data/languages/x86-64.slaspec` recompiles cleanly.
- Reproduction: (`vpbroadcastq xmm6,rax` / `vpbroadcastb ymm5,ebx` / `vpbroadcastd zmm4,ecx` / `vpbroadcastq ymm7,r8`): all four decode with correct operands and correct instruction lengths (byte-exact boundary match against objdump), including the R8-extended form.
