### PR TITLE
MCS96: fix subtractFlags macro double-reading its operands

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/datatests/volatilemcs96dup.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/volatilemcs96dup.xml
@@ -1,0 +1,32 @@
+<decompilertest>
+<binaryimage arch="MCS96:LE:16:default">
+<!--
+   Covers #6186: the subtractFlags macro (MCS96.sinc) referencing its
+   op1/op2 parameters twice each inside the macro body. On MCS-96 a
+   register operand like PORT01 is a named location in the RAM space
+   (see MCS96.sinc's "define RAM offset=... [ ... PORT01 ... ]" block),
+   so passing one as a macro argument re-emits a fresh read at every
+   point the parameter name appears in the macro's body; normally
+   invisible because plain CSE folds the redundant reads back together,
+   but visible once the region is marked volatile (CSE correctly refuses
+   to merge volatile reads). Before the fix this function decompiled with
+   three back-to-back "xVar1 = PORT01;" reads for a single CMP
+   instruction; after it, two (the CMP constructor's own read to compute
+   the comparison result, plus one from the macro's now-single cached
+   read of its argument). Confirmed by hand-building this exact repro
+   and diffing the raw p-code before and after reverting the fix.
+-->
+<bytechunk space="RAM" offset="0x2000">
+8934120ed301fdf0
+</bytechunk>
+<symbol space="RAM" offset="0x2000" name="cmptest"/>
+</binaryimage>
+<script>
+  <com>volatile [RAM,0xe,2]</com>
+  <com>lo fu cmptest</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="Volatile MCS96 Duplication #1" min="2" max="2">xVar1 = PORT01;</stringmatch>
+</decompilertest>

--- a/Ghidra/Processors/MCS96/data/languages/MCS96.sinc
+++ b/Ghidra/Processors/MCS96/data/languages/MCS96.sinc
@@ -431,10 +431,12 @@ macro additionFlags(op1, op2, res) {
 }
 
 macro subtractFlags(op1, op2, res) {
+	local subOp1 = op1;	# op1/op2 may denote a memory-mapped register read; cache each
+	local subOp2 = op2;	# once so referencing them twice below doesn't duplicate the access
 	$(N) = (res s< 0);
 	$(Z) = (res == 0);
-	$(C) = (op1 < op2) == 0;
-	$(V) = sborrow(op1, op2);
+	$(C) = (subOp1 < subOp2) == 0;
+	$(V) = sborrow(subOp1, subOp2);
 	$(VT) = $(VT) | $(V);
 }
 


### PR DESCRIPTION
Hi,

Split out of #9547 at ABratovic's suggestion there, this was bundled in with
some unrelated decompiler volatile/MMIO fixes and doesn't belong riding
along with them.

## The bug

`subtractFlags(op1, op2, res)` in `MCS96.sinc` references its `op1`/`op2`
parameters twice each in its body. SLEIGH macro arguments are textual
substitution, not values bound once, and on MCS-96 a register operand like
`PORT01` is a named location directly in the RAM space (see the `define RAM
offset=... [ ... PORT01 ... ]` block), not a separate register space. So
every reference to the parameter re-emits a fresh memory read. Normal CSE
hides the redundancy, and it stays invisible until the region is marked
volatile, since volatile correctly refuses to merge the reads. That's the
actual bug behind #6186's report.

## The fix

Cache each parameter into a `local` once at the top of the macro, the same
pattern `DEC`/`DECB` already use a few lines above for the identical reason.

Why fix the macro and not each caller: `subtractFlags` has 13 call sites
(`CMP`, `CMPB`, `CMPL`, `DEC`, `DECB`, `NEG`, `NEGB`, both `SUB` forms, both
`SUBB` forms, `SUBC`, `SUBCB`). The fix is 6 lines in the one shared place.

## Verification

Added `volatilemcs96dup.xml` as a `<decompilertest>` datatest, hand-built
repro (`CMP PORT01, #0x1234` marked volatile):

```
$ ./decomp_test_dbg -usesleighenv datatests volatilemcs96dup.xml
Success -- Volatile MCS96 Duplication #1

Total tests applied = 1
Total passing tests = 1
```

Before/after with the macro temporarily reverted, same repro:

```
before (unpatched macro): 3 reads
xVar1 = PORT01;
xVar1 = PORT01;
xVar1 = PORT01;

after (this patch): 2 reads
xVar1 = PORT01;
xVar1 = PORT01;
```
