### PR TITLE
[MCS96] Put the MCS-96 division quotient in the low word

### DIFF
--- a/Ghidra/Processors/MCS96/data/languages/MCS96.sinc
+++ b/Ghidra/Processors/MCS96/data/languages/MCS96.sinc
@@ -643,7 +643,7 @@ macro setSignedShiftRightCarryFlag(shiftee,amount) {
 	local den = oper16;
 	local div = num s/ sext(den);
 	local rem = num s% sext(den);
-	lreg = zext(div:2 << 16) | rem;
+	lreg = (zext(rem:2) << 16) | zext(div:2);
 @if defined(C196KB) || defined(C196KC)
 	$(V) = ((div s> 0x7fff) | (div s< 0x8001));
 @endif
@@ -655,7 +655,7 @@ macro setSignedShiftRightCarryFlag(shiftee,amount) {
 	local den = oper8;
 	local div = num s/ sext(den);
 	local rem = num s% sext(den);
-	wreg = zext(div:1 << 8) | rem;
+	wreg = (zext(rem:1) << 8) | zext(div:1);
 @if defined(C196KB) || defined(C196KC)
 	$(V) = ((div s> 0x7f) | (div s< 0x81));
 @endif
@@ -667,7 +667,7 @@ macro setSignedShiftRightCarryFlag(shiftee,amount) {
 	local den = oper16;
 	local div = num / zext(den);
 	local rem = num % zext(den);
-	lreg = zext(div:2 << 16) | rem;
+	lreg = (zext(rem:2) << 16) | zext(div:2);
 	$(V) = (div > 0xffff);
 	$(VT) = $(VT) | $(V);
 }
@@ -677,7 +677,7 @@ macro setSignedShiftRightCarryFlag(shiftee,amount) {
 	local den = oper8;
 	local div = num / zext(den);
 	local rem = num % zext(den);
-	wreg = zext(div:1 << 8) | rem;
+	wreg = (zext(rem:1) << 8) | zext(div:1);
 	$(V) = (div > 0xff);
 	$(VT) = $(VT) | $(V);
 }


### PR DESCRIPTION
Fixes #6205.

All four division instructions wrote their result as

```
lreg = zext(div:2 << 16) | rem;
```

which is wrong in two separate ways.

The halves are swapped, as noted on the issue: the MCS-96 leaves the quotient in the low half of the destination and the remainder in the high half.

The shift is also evaluated at the width of its left operand. `div:2` is two bytes, so `div:2 << 16` shifts every bit out and `zext` then widens a zero. The compiled p-code shows it plainly, an `INT_LEFT` whose input and output are both two bytes against a shift of `0x10`:

```
SUBPIECE  unique size=0x2
INT_LEFT  out size=0x2, in size=0x2, shift const=0x10
```

So the destination ended up holding only the remainder. That is what the reporter was seeing: a modulo in the decompiler where the program divides. `DIVB` and `DIVUB` had the same shape at byte width, an `INT_LEFT` of one byte by 8.

Widening before the shift fixes both halves of the problem at once. Rebuilding the spec, the value-forming p-code changes from

```
SUBPIECE INT_LEFT INT_ZEXT INT_OR
```

to

```
SUBPIECE INT_ZEXT INT_LEFT ...
```

with the shift now taking its width from the destination handle rather than a truncated temporary, so the quotient survives and lands in the low half.

The flag logic is untouched: `$(V)` and `$(VT)` still read the untruncated `div`, so overflow detection is unchanged. The spec compiles clean, and MCS96 has only the one language variant.

I have not run this against a real MCS-96 binary, so the check here is the emitted p-code rather than a decompilation of the reporter's firmware.
