### PR TITLE
Refuse comments at unbacked addressess

### DIFF
--- a/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramView.java
+++ b/Ghidra/Debug/Framework-TraceModeling/src/main/java/ghidra/trace/database/program/DBTraceProgramView.java
@@ -844,6 +844,18 @@ public class DBTraceProgramView implements TraceProgramView {
 	public void setExecutablePath(String path) {
 		trace.setExecutablePath(path);
 	}
+	
+	@Override
+	public LoadState getLoadState() {
+		// TODO: not yet implemented
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setLoadState(LoadState state) {
+		// TODO: not yet implemented
+		throw new UnsupportedOperationException();
+	}
 
 	@Override
 	public String getExecutableFormat() {

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/AbstractLibrarySupportLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/AbstractLibrarySupportLoader.java
@@ -37,6 +37,7 @@ import ghidra.plugin.importer.ImporterPlugin;
 import ghidra.program.model.lang.*;
 import ghidra.program.model.listing.Library;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.listing.Program.LoadState;
 import ghidra.program.model.symbol.ExternalManager;
 import ghidra.util.StringUtilities;
 import ghidra.util.exception.CancelledException;
@@ -928,12 +929,14 @@ public abstract class AbstractLibrarySupportLoader extends AbstractProgramLoader
 		Program program = createProgram(settings);
 
 		int transactionID = program.startTransaction("Loading");
+		program.setLoadState(LoadState.LOADING);
 		boolean success = false;
 		try {
 			log.appendMsg("Loading %s...".formatted(settings.provider().getFSRL()));
 			load(program, settings);
 			createDefaultMemoryBlocks(program, settings);
 			libraryNameList.addAll(getLibraryNames(settings.provider(), program));
+			program.setLoadState(LoadState.LOADED);
 			success = true;
 			return program;
 		}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ProgramDB.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/ProgramDB.java
@@ -202,6 +202,7 @@ public class ProgramDB extends DomainObjectAdapterDB implements Program, ChangeM
 	private static final int NUM_MANAGERS = 15;
 
 	private ManagerDB[] managers = new ManagerDB[NUM_MANAGERS];
+	private LoadState loadState;
 	private OldFunctionManager oldFunctionMgr;
 	private MemoryMapDB memoryManager;
 	private GlobalNamespace globalNamespace;
@@ -253,6 +254,7 @@ public class ProgramDB extends DomainObjectAdapterDB implements Program, ChangeM
 				"unsupported compilerSpec: " + compilerSpec.getClass().getName());
 		}
 
+		this.setLoadState(LoadState.INDETERMINATE);
 		this.language = language;
 		this.compilerSpec = ProgramCompilerSpec.getProgramCompilerSpec(this, compilerSpec);
 
@@ -317,6 +319,7 @@ public class ProgramDB extends DomainObjectAdapterDB implements Program, ChangeM
 			throws IOException, VersionException, LanguageNotFoundException, CancelledException {
 
 		super(dbh, "Untitled", 500, consumer);
+		this.setLoadState(LoadState.INDETERMINATE);
 
 		if (monitor == null) {
 			monitor = TaskMonitor.DUMMY;
@@ -329,6 +332,7 @@ public class ProgramDB extends DomainObjectAdapterDB implements Program, ChangeM
 		boolean success = false;
 		try {
 			int id = startTransaction("create program");
+			this.setLoadState(LoadState.LOADING);
 			recordChanges = false;
 			changeable = (openMode != OpenMode.IMMUTABLE);
 
@@ -414,6 +418,7 @@ public class ProgramDB extends DomainObjectAdapterDB implements Program, ChangeM
 			registerCompilerSpecOptions();
 			getCodeManager().activateContextLocking();
 			success = true;
+			this.setLoadState(LoadState.LOADED);
 		}
 		finally {
 			dbh.closeScratchPad();
@@ -691,6 +696,16 @@ public class ProgramDB extends DomainObjectAdapterDB implements Program, ChangeM
 	public void setExecutablePath(String path) {
 		Options pl = getOptions(PROGRAM_INFO);
 		pl.setString(EXECUTABLE_PATH, path);
+	}
+	
+	@Override
+	public LoadState getLoadState() {
+		return loadState;
+	}
+
+	@Override
+	public void setLoadState(LoadState state) {
+		loadState = state;
 	}
 
 	@Override

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
@@ -2965,14 +2965,20 @@ public class CodeManager implements ErrorHandler, ManagerDB {
 	 * @param commentType either EOL_COMMENT, PRE_COMMENT, POST_COMMENT, PLATE_COMMENT, or 
 	 * REPEATABLE_COMMENT
 	 * @param comment comment to set at the address
-	 * @throws IllegalArgumentException if type is not one of the types of comments supported
+	 * @throws IllegalArgumentException if type is not one of the types of comments supported or
+	 * address does not exist in memory.
 	 */
 	public void setComment(Address address, CommentType commentType, String comment) {
 		try (Closeable c = lock.write()) {
+			if (program.getMemory().getBlock(address) == null) {
+				throw new IllegalArgumentException("Cannot set comment: address not in known memory region." +
+						"\nAddress must exist in memory prior to comment creation.");
+			}
 			CodeUnit cu = getCodeUnitAt(address);
 			if (cu != null) {
 				cu.setComment(commentType, comment);
 				return;
+
 			}
 			long addr = addrMap.getKey(address, true);
 

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java
@@ -34,6 +34,7 @@ import ghidra.program.model.data.*;
 import ghidra.program.model.lang.*;
 import ghidra.program.model.lang.InstructionError.InstructionErrorType;
 import ghidra.program.model.listing.*;
+import ghidra.program.model.listing.Program.LoadState;
 import ghidra.program.model.mem.*;
 import ghidra.program.model.symbol.*;
 import ghidra.program.model.util.*;
@@ -2970,7 +2971,7 @@ public class CodeManager implements ErrorHandler, ManagerDB {
 	 */
 	public void setComment(Address address, CommentType commentType, String comment) {
 		try (Closeable c = lock.write()) {
-			if (program.getMemory().getBlock(address) == null) {
+			if (program.getMemory().getBlock(address) == null && program.getLoadState() == LoadState.LOADED) {
 				throw new IllegalArgumentException("Cannot set comment: address not in known memory region." +
 						"\nAddress must exist in memory prior to comment creation.");
 			}

--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/Program.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/Program.java
@@ -87,6 +87,17 @@ public interface Program extends DataTypeManagerDomainObject, ProgramArchitectur
 	/** Name of cold entry point addresses property map **/
 	public static final String COLD_ENTRY_MAP_NAME = "ColdEntries";
 
+	public enum LoadState {
+		/** Load state is not known **/
+		INDETERMINATE,
+	
+		/** Program is fully loaded **/
+		LOADED,
+	
+		/** Program is in the process of being loaded **/
+		LOADING
+	}
+
 	/**
 	 * Get the listing object.
 	 * @return the Listing interface to the listing object.
@@ -251,6 +262,25 @@ public interface Program extends DataTypeManagerDomainObject, ProgramArchitectur
 	 * @param path  the path to the program's exe
 	 */
 	public void setExecutablePath(String path);
+
+	/**
+	 * Gets programs LoadState, an Enum which indicates whether the Program has been fully
+	 * constructed or not.
+	 *
+	 * @return loadState  the current loadState
+	 */
+	public LoadState getLoadState();
+
+	/**
+	 * Sets programs LoadState, an Enum which indicates whether the Program has been fully
+	 * constructed or not.
+	 * 
+	 * NOTE: the current implementation of loadState (where / how it's set) is approximate,
+	 * further review is recommended if relying on loadState for a critical use case
+	 *
+	 * @param state - the updated LoadState
+	 */
+	public void setLoadState(LoadState state);
 
 	/**
 	 * Returns a value corresponding to the original file format.

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/model/StubProgram.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/program/model/StubProgram.java
@@ -32,6 +32,7 @@ import ghidra.program.model.address.*;
 import ghidra.program.model.data.CategoryPath;
 import ghidra.program.model.lang.*;
 import ghidra.program.model.listing.*;
+import ghidra.program.model.listing.Program.LoadState;
 import ghidra.program.model.mem.Memory;
 import ghidra.program.model.pcode.Varnode;
 import ghidra.program.model.reloc.RelocationTable;
@@ -422,6 +423,16 @@ public class StubProgram implements Program {
 
 	@Override
 	public void setExecutablePath(String path) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public LoadState getLoadState() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setLoadState(LoadState state) {
 		throw new UnsupportedOperationException();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/ghidra/issues/9444

Issue is comments can be created at addresses which are not in "backed" (see reference 1 below for definition of "backed") memory. Some code which manages artifacts of analysis rely on an assumption comments are only associated with addresses in backed memory, resulting in a silent loss of such comments in certain cases.

Ghidra team indicates the desired behavior is to prevent the creation of comments that are not in backed memory.

1. Successfully reproduced.
2. Added code to raise exception when comment is set at unbacked address.
3. Validated change manually.

Things to review:

1. My understanding of "backed" (see reference 1 below for definition of "backed")
2. [`loadState`](https://github.com/NationalSecurityAgency/ghidra/pull/9574/changes/433c55770be3e751375b286b386eb17a5f238fd9): it's implications and correctness

## Trace

`Listing` interace's `setComment` is defined in `/Framework SoftwareModeling/src/main/java/ghidra/program/model/listing/Listing.java`. Ghidra's main implemetation of `Listing` is defined in `/Framework SoftwareModeling/src/main/java/ghidra/program/database/ListingDB.java` with the following implementation of `setComment`

```
	@Override
	public void setComment(Address address, CommentType commentType, String comment) {
		codeMgr.setComment(address, commentType, comment);
	}
```

`codeMgr` belongs to the `ProgramDB` member. `setComment` is defined by CodeManager in `/Framework SoftwareModeling/src/main/java/ghidra/program/database/code/CodeManager.java`


## Considerations

### *How many ways can comments be set outside of backed memory?*

By testing through the UI I found comments can't be set at unbacked addresses via the comment dialog. The two ways I found comments can be set at unbacked addresses:

1. Using a PyGhidra script
2. Using a Java Ghidra script

In either case the following code will suffice:

```
currentProgram.getListing().setComment(toAddr(0x1500), 0, "test")
currentProgram.getListing().getComment(0, toAddr(0x1500))
```

This PR addresses both these cases.

### *This PR makes it so that the ProgramDB object's Memory member must have a memory region containing the address before CodeManager allows a comment to be set. Is this ever not the case?*

I found this was the case for both a dummy ELF program and an arbitrary Windows system DLL (PE) I used to test. I saw this behavior, stemming from https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java, specifically `markupInterpreter` and also `markupElfInfoProducers` (I did some other tests which rearranged these, for unrelated reasons, and found they both exhibit this behavior). 

<img width="897" height="943" alt="comment_set_unbacked" src="https://github.com/user-attachments/assets/7f0983b4-7924-4254-aebc-33b4acd6eef6" />

I talk about this a bit [here](https://github.com/NationalSecurityAgency/ghidra/issues/9444#issuecomment-5501490058), this is the reason for the second commit which attempts to use a flag to approximate the point at which all memory regions will be created for a program to avoid this issue. This worked in testing, although I only tested with an dummy ELF and arbitrary Windows system DLL (to use as PE). Without the check introduced in the second commit, the file may not be able to be imported at all (this was the case with the PE I tested with because the exception was not caught). 

This is something worth reviewing closely as hitting this exception while importing a file can cause the file to fail to be imported. This would completely prevent the use of Ghidra for affected files. There are some ways around doing a change that introduces this possibility, although they undesirable and impractical.

If `loadState` is reliably only set to `LOADED` after all the memory associated with the program is created, then this won't be an issue.


## Validation

After building the updated branch I see the expected behavior in both scenarios described in considerations above.

Using Java script:

<img width="646" height="757" alt="java_script_validation" src="https://github.com/user-attachments/assets/0df56ddb-59ee-4c74-bad7-7567754bfa6b" />

Using PyGhidra script:

<img width="749" height="744" alt="pyghidra_validation" src="https://github.com/user-attachments/assets/5b2dd137-f937-45c3-a10d-cda39882d7e6" />

## Reproduction

 Steps I took to reproduce (on Ubuntu 24.04):

1. Retrieve and build a development version of Ghidra.

2. Using `<install_dir>/server/svrInstall` install and initialize Ghidra server.

3. Create two users (using `svrAdmin`): one for default user and one for root.

4. Launch Ghidra from default user and create a new shared project and repository.

5. From default user, add a dummy binary to the project to analyze.

6. From default user, analyze the file, save it, then add it to version control and check it out.  Using the provided pyghidra script add a comment at an unbacked address:

`currentProgram.getListing().setComment(toAddr(0x1500), 0, "test")`

`currentProgram.getListing().getComment(0, toAddr(0x1500))`

Result:

<img width="744" height="204" alt="unbacked_comment_added" src="https://github.com/user-attachments/assets/93d68525-dafd-4946-b077-24bd41879a4e" />

7. From default user, save the file but do not check it in and close client.

8. From root user, launch the client and check out the dummy binary. Add a comment at arbitrary address, so long as it's backed, save the file, then check in the changes and close the client.

9. From default user, reopen client and check in changes. Open dummy binary again and try to find comment created in step 6.
Result:

<img width="744" height="204" alt="unbacked_comment_removed" src="https://github.com/user-attachments/assets/01113725-719a-4ec2-8737-f6b3fd51343a" />


Reproduction successful. Other observations were that after creating the comment in step 6 it was not visible in the "Comments" window. Ghidra Help also notes "Comments can be added to any instruction or data item.".

I wouldn't recommend doing these steps in a non-development environment. Creating the user for the root account was something I did just to avoid having to use an additional VM.

## References

### 1) Definition of "backed" memory

By "backed" here I mean a memory address that is known to be used by the program or to contain data or code necessary to execute the program, based on compiler conventions and the binary properties. Within the context of Ghidra, a backed address is one accessible using the "Go to" utility in Code Browser. If an address is not accessible using the "Go to" utility in Code Browser, it is not backed. I don't think this is necessarily the same as any address in the virtual address space of a process created with the program once it's loaded into a process and is running on a system.

This is my assumption based on the way that the term has been used in discussions associated with this issue.