### PR TITLE
MCS96: fix SUBB breg, oper8 never writing its result back

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/datatests/mcs96subbwriteback.xml
+++ b/Ghidra/Features/Decompiler/src/decompile/datatests/mcs96subbwriteback.xml
@@ -1,0 +1,27 @@
+<decompilertest>
+<binaryimage arch="MCS96:LE:16:default">
+<!--
+   The 2-op form of SUBB (SUBB breg, oper8) computed its subtraction into a
+   local and fed that local into subtractFlags for the flag bits, but never
+   wrote the result back to breg. Every other arithmetic constructor in
+   MCS96.sinc (SUB, ADD, ADDB, DEC, DECB, ...) writes its result back;
+   this one silently dropped it, so the destination register was left
+   unmodified by an instruction whose whole purpose is to modify it.
+
+   782005f0 is SUBB HSI_timehi, R20 (op6=0x1e, oper8=R20, breg=HSI_timehi)
+   followed by RET (0xf0). Before the fix this decompiled to just
+   "return;", with the subtraction computed and its result discarded.
+-->
+<bytechunk space="RAM" offset="0x2000">
+782005f0
+</bytechunk>
+<symbol space="RAM" offset="0x2000" name="subbtest"/>
+</binaryimage>
+<script>
+  <com>lo fu subbtest</com>
+  <com>decompile</com>
+  <com>print C</com>
+  <com>quit</com>
+</script>
+<stringmatch name="SUBB writeback #1" min="1" max="1">HSI_timehi = HSI_timehi - R20;</stringmatch>
+</decompilertest>

--- a/Ghidra/Processors/MCS96/data/languages/MCS96.sinc
+++ b/Ghidra/Processors/MCS96/data/languages/MCS96.sinc
@@ -1242,6 +1242,7 @@ cc: "E"    is cond=15 { tmp:1 = ($(Z) == 1); export tmp; }
 :SUBB breg, oper8                   is op6=0x1e ... & oper8; breg {
 	local tmp = breg - oper8;
 	subtractFlags(breg, oper8, tmp);
+	breg = tmp;
 }
 
 :SUBB dbreg, breg, oper8            is op6=0x16 ... & oper8; breg; dbreg {


### PR DESCRIPTION
The 2-op form of `SUBB breg, oper8` computes the subtraction into a local and passes that local into `subtractFlags` for the carry/overflow bits, but never assigns it back to `breg`. Every other in-place arithmetic constructor in `MCS96.sinc` (`SUB`, `ADD`, `ADDB`, `DEC`, `DECB`, ...) writes its result back to the destination register; this one silently drops it, so the instruction's whole effect besides the flags is lost.

Before:
```
:SUBB breg, oper8                   is op6=0x1e ... & oper8; breg {
	local tmp = breg - oper8;
	subtractFlags(breg, oper8, tmp);
}
```

After:
```
:SUBB breg, oper8                   is op6=0x1e ... & oper8; breg {
	local tmp = breg - oper8;
	subtractFlags(breg, oper8, tmp);
	breg = tmp;
}
```

Added a decompiler regression test (`mcs96subbwriteback.xml`) asserting the destination register actually gets assigned. Before the fix, `SUBB HSI_timehi, R20` decompiled to just `return;`, with the subtraction computed and its result discarded. After, it decompiles to `HSI_timehi = HSI_timehi - R20;`.

Found while auditing this file for an unrelated bug (`subtractFlags`/`additionFlags` callers double-reading volatile operands, see #9570), and split out on its own since it's a different bug.

Verified: `MCS96.slaspec` recompiles clean, and the full decompiler datatest suite passes (734/734, including the new test).