### PR TITLE
AARCH64: Fix scalar FMIN/FMAX/FMAXNM lifting when Rd == Rm

### DIFF
--- a/Ghidra/Processors/AARCH64/data/languages/AARCH64neon.sinc
+++ b/Ghidra/Processors/AARCH64/data/languages/AARCH64neon.sinc
@@ -7368,11 +7368,13 @@ is b_31=0 & b_30=1 & b_2129=0b001110010 & b_1015=0b001101 & Rd_VPR128.8H & Rn_VP
 :fmax Rd_FPR64, Rn_FPR64, Rm_FPR64
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=1 & b_2121=1 & Rm_FPR64 & b_1215=0x4 & b_1011=2 & Rn_FPR64 & Rd_FPR64 & Zd
 {
-	Rd_FPR64 = Rn_FPR64;
+	local lhs64:8 = Rn_FPR64;
+	local rhs64:8 = Rm_FPR64;
+	Rd_FPR64 = lhs64;
 	zext_zd(Zd); # zero upper 24 bytes of Zd
-	local tmp1:1 = Rn_FPR64 f> Rm_FPR64;
+	local tmp1:1 = lhs64 f> rhs64;
 	if (tmp1) goto inst_next;
-	Rd_FPR64 = Rm_FPR64;
+	Rd_FPR64 = rhs64;
 	zext_zd(Zd); # zero upper 24 bytes of Zd
 }
 
@@ -7385,11 +7387,13 @@ is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=1 & b_2121=1 & Rm_FPR64 & b_1215=0
 :fmax Rd_FPR32, Rn_FPR32, Rm_FPR32
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=0 & b_2121=1 & Rm_FPR32 & b_1215=0x4 & b_1011=2 & Rn_FPR32 & Rd_FPR32 & Zd
 {
-	Rd_FPR32 = Rn_FPR32;
+	local lhs32:4 = Rn_FPR32;
+	local rhs32:4 = Rm_FPR32;
+	Rd_FPR32 = lhs32;
 	zext_zs(Zd); # zero upper 28 bytes of Zd
-	local tmp1:1 = Rn_FPR32 f> Rm_FPR32;
+	local tmp1:1 = lhs32 f> rhs32;
 	if (tmp1) goto inst_next;
-	Rd_FPR32 = Rm_FPR32;
+	Rd_FPR32 = rhs32;
 	zext_zs(Zd); # zero upper 28 bytes of Zd
 }
 
@@ -7401,11 +7405,13 @@ is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=0 & b_2121=1 & Rm_FPR32 & b_1215=0
 :fmax Rd_FPR16, Rn_FPR16, Rm_FPR16
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=3 & b_2121=1 & Rm_FPR16 & b_1215=0x4 & b_1011=2 & Rn_FPR16 & Rd_FPR16 & Zd
 {
-	Rd_FPR16 = Rn_FPR16;
+	local lhs16:2 = Rn_FPR16;
+	local rhs16:2 = Rm_FPR16;
+	Rd_FPR16 = lhs16;
 	zext_zh(Zd); # zero upper 30 bytes of Zd
-	local tmp1:1 = Rn_FPR16 f> Rm_FPR16;
+	local tmp1:1 = lhs16 f> rhs16;
 	if (tmp1) goto inst_next;
-	Rd_FPR16 = Rm_FPR16;
+	Rd_FPR16 = rhs16;
 	zext_zh(Zd);# zero upper 30 bytes of Zd
 }
 
@@ -7475,11 +7481,13 @@ is b_31=0 & b_30=1 & b_2129=0b001110010 & b_1015=0b000001 & Rd_VPR128.8H & Rn_VP
 :fmaxnm Rd_FPR64, Rn_FPR64, Rm_FPR64
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=1 & b_2121=1 & Rm_FPR64 & b_1215=0x6 & b_1011=2 & Rn_FPR64 & Rd_FPR64 & Zd
 {
-	Rd_FPR64 = Rn_FPR64;
+	local lhs64:8 = Rn_FPR64;
+	local rhs64:8 = Rm_FPR64;
+	Rd_FPR64 = lhs64;
 	zext_zd(Zd); # zero upper 24 bytes of Zd
-	local tmp1:1 = Rn_FPR64 f> Rm_FPR64;
+	local tmp1:1 = lhs64 f> rhs64;
 	if (tmp1) goto inst_next;
-	Rd_FPR64 = Rm_FPR64;
+	Rd_FPR64 = rhs64;
 	zext_zd(Zd); # zero upper 24 bytes of Zd
 }
 
@@ -7492,11 +7500,13 @@ is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=1 & b_2121=1 & Rm_FPR64 & b_1215=0
 :fmaxnm Rd_FPR32, Rn_FPR32, Rm_FPR32
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=0 & b_2121=1 & Rm_FPR32 & b_1215=0x6 & b_1011=2 & Rn_FPR32 & Rd_FPR32 & Zd
 {
-	Rd_FPR32 = Rn_FPR32;
+	local lhs32:4 = Rn_FPR32;
+	local rhs32:4 = Rm_FPR32;
+	Rd_FPR32 = lhs32;
 	zext_zs(Zd); # zero upper 28 bytes of Zd
-	local tmp1:1 = Rn_FPR32 f> Rm_FPR32;
+	local tmp1:1 = lhs32 f> rhs32;
 	if (tmp1) goto inst_next;
-	Rd_FPR32 = Rm_FPR32;
+	Rd_FPR32 = rhs32;
 	zext_zs(Zd); # zero upper 28 bytes of Zd
 }
 
@@ -7509,11 +7519,13 @@ is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=0 & b_2121=1 & Rm_FPR32 & b_1215=0
 :fmaxnm Rd_FPR16, Rn_FPR16, Rm_FPR16
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=3 & b_2121=1 & Rm_FPR16 & b_1215=0x6 & b_1011=2 & Rn_FPR16 & Rd_FPR16 & Zd
 {
-	Rd_FPR16 = Rn_FPR16;
+	local lhs16:2 = Rn_FPR16;
+	local rhs16:2 = Rm_FPR16;
+	Rd_FPR16 = lhs16;
 	zext_zh(Zd); # zero upper 30 bytes of Zd
-	local tmp1:1 = Rn_FPR16 f> Rm_FPR16;
+	local tmp1:1 = lhs16 f> rhs16;
 	if (tmp1) goto inst_next;
-	Rd_FPR16 = Rm_FPR16;
+	Rd_FPR16 = rhs16;
 	zext_zh(Zd); # zero upper 30 bytes of Zd
 }
 
@@ -7834,11 +7846,13 @@ is b_31=0 & b_30=1 & b_2129=0b001110110 & b_1015=0b001101 & Rd_VPR128.8H & Rn_VP
 :fmin Rd_FPR64, Rn_FPR64, Rm_FPR64
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=1 & b_2121=1 & Rm_FPR64 & b_1215=0x5 & b_1011=2 & Rn_FPR64 & Rd_FPR64 & Zd
 {
-	Rd_FPR64 = Rn_FPR64;
+	local lhs64:8 = Rn_FPR64;
+	local rhs64:8 = Rm_FPR64;
+	Rd_FPR64 = lhs64;
 	zext_zd(Zd); # zero upper 24 bytes of Zd
-	local tmp1:1 = Rn_FPR64 f<= Rm_FPR64;
+	local tmp1:1 = lhs64 f<= rhs64;
 	if (tmp1) goto inst_next;
-	Rd_FPR64 = Rm_FPR64;
+	Rd_FPR64 = rhs64;
 	zext_zd(Zd); # zero upper 24 bytes of Zd
 }
 
@@ -7850,11 +7864,13 @@ is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=1 & b_2121=1 & Rm_FPR64 & b_1215=0
 :fmin Rd_FPR32, Rn_FPR32, Rm_FPR32
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=0 & b_2121=1 & Rm_FPR32 & b_1215=0x5 & b_1011=2 & Rn_FPR32 & Rd_FPR32 & Zd
 {
-	Rd_FPR32 = Rn_FPR32;
+	local lhs32:4 = Rn_FPR32;
+	local rhs32:4 = Rm_FPR32;
+	Rd_FPR32 = lhs32;
 	zext_zs(Zd); # zero upper 28 bytes of Zd
-	local tmp1:1 = Rn_FPR32 f<= Rm_FPR32;
+	local tmp1:1 = lhs32 f<= rhs32;
 	if (tmp1) goto inst_next;
-	Rd_FPR32 = Rm_FPR32;
+	Rd_FPR32 = rhs32;
 	zext_zs(Zd); # zero upper 28 bytes of Zd
 }
 
@@ -7866,11 +7882,13 @@ is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=0 & b_2121=1 & Rm_FPR32 & b_1215=0
 :fmin Rd_FPR16, Rn_FPR16, Rm_FPR16
 is m=0 & b_3030=0 & s=0 & b_2428=0x1e & ftype=3 & b_2121=1 & Rm_FPR16 & b_1215=0x5 & b_1011=2 & Rn_FPR16 & Rd_FPR16 & Zd
 {
-	Rd_FPR16 = Rn_FPR16;
+	local lhs16:2 = Rn_FPR16;
+	local rhs16:2 = Rm_FPR16;
+	Rd_FPR16 = lhs16;
 	zext_zh(Zd); # zero upper 30 bytes of Zd
-	local tmp1:1 = Rn_FPR16 f<= Rm_FPR16;
+	local tmp1:1 = lhs16 f<= rhs16;
 	if (tmp1) goto inst_next;
-	Rd_FPR16 = Rm_FPR16;
+	Rd_FPR16 = rhs16;
 	zext_zh(Zd);# zero upper 30 bytes of Zd
 }
 

--- a/Ghidra/Processors/AARCH64/src/test.slow/java/ghidra/program/emulation/Aarch64ScalarMinMaxTest.java
+++ b/Ghidra/Processors/AARCH64/src/test.slow/java/ghidra/program/emulation/Aarch64ScalarMinMaxTest.java
@@ -1,0 +1,157 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.program.emulation;
+
+import static org.junit.Assert.*;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.junit.Test;
+
+import ghidra.app.plugin.processors.sleigh.SleighLanguage;
+import ghidra.pcode.exec.*;
+import ghidra.pcode.exec.PcodeArithmetic.Purpose;
+import ghidra.pcode.exec.PcodeExecutorStatePiece.Reason;
+import ghidra.program.database.ProgramBuilder;
+import ghidra.program.model.lang.Register;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.Program;
+import ghidra.test.AbstractGhidraHeadlessIntegrationTest;
+
+public class Aarch64ScalarMinMaxTest extends AbstractGhidraHeadlessIntegrationTest {
+	private static final String ENTRY = "0x00400000";
+
+	private static final Map<String, String> ENCODINGS = Map.ofEntries(
+		Map.entry("fmin h0,h1,h0", "20 58 e0 1e"),
+		Map.entry("fmin s0,s1,s0", "20 58 20 1e"),
+		Map.entry("fmin d0,d1,d0", "20 58 60 1e"),
+		Map.entry("fmax h0,h1,h0", "20 48 e0 1e"),
+		Map.entry("fmax s0,s1,s0", "20 48 20 1e"),
+		Map.entry("fmax d0,d1,d0", "20 48 60 1e"),
+		Map.entry("fmaxnm h0,h1,h0", "20 68 e0 1e"),
+		Map.entry("fmaxnm s0,s1,s0", "20 68 20 1e"),
+		Map.entry("fmaxnm d0,d1,d0", "20 68 60 1e"),
+		Map.entry("fmin s0,s1,s2", "20 58 22 1e"),
+		Map.entry("fmax s0,s1,s2", "20 48 22 1e"),
+		Map.entry("fmin s0,s0,s1", "00 58 21 1e"));
+
+	private static final String F16_ONE = "3c00";
+	private static final String F16_TWO = "4000";
+	private static final String F32_ONE = "3f800000";
+	private static final String F32_TWO = "40000000";
+	private static final String F64_ONE = "3ff0000000000000";
+	private static final String F64_TWO = "4000000000000000";
+
+	private void assertResultIsInitialValueOf(String assembly, Map<String, String> initialState,
+			String winningRegister) throws Exception {
+		String resultRegister = assembly.substring(assembly.indexOf(' ') + 1).split(",")[0].trim();
+		String expected = initialState.get(winningRegister);
+		assertNotNull(winningRegister + " has no initial value in " + assembly, expected);
+		String encoding = ENCODINGS.get(assembly);
+		assertNotNull("no encoding recorded for " + assembly, encoding);
+
+		ProgramBuilder builder = new ProgramBuilder("minmax", ProgramBuilder._AARCH64);
+		try {
+			builder.setBytes(ENTRY, encoding);
+			builder.disassemble(ENTRY, 4);
+
+			Program program = builder.getProgram();
+			SleighLanguage language = (SleighLanguage) program.getLanguage();
+			Instruction instruction = program.getListing().getInstructionAt(builder.addr(ENTRY));
+			assertNotNull("nothing decoded from " + encoding, instruction);
+			assertEquals(encoding, assembly, instruction.toString());
+
+			BytesPcodeExecutorState state =
+				new BytesPcodeExecutorState(language, PcodeStateCallbacks.NONE);
+			PcodeArithmetic<byte[]> arithmetic = state.getArithmetic();
+			PcodeExecutor<byte[]> executor = new PcodeExecutor<>(state, Reason.EXECUTE_READ);
+
+			for (Map.Entry<String, String> entry : initialState.entrySet()) {
+				Register register = language.getRegister(entry.getKey());
+				state.setVar(register, arithmetic.fromConst(new BigInteger(entry.getValue(), 16),
+					register.getNumBytes()));
+			}
+
+			executor.execute(PcodeProgram.fromInstruction(instruction), PcodeUseropLibrary.nil());
+
+			Register result = language.getRegister(resultRegister);
+			assertEquals(assembly + ": " + resultRegister + " should hold the initial " +
+				winningRegister, expected,
+				arithmetic.toBigInteger(state.getVar(result, Reason.INSPECT), Purpose.INSPECT)
+						.toString(16));
+		}
+		finally {
+			builder.dispose();
+		}
+	}
+
+	@Test
+	public void testAliasedMinimumKeepsTheDestinationOperand() throws Exception {
+		assertResultIsInitialValueOf("fmin h0,h1,h0", Map.of("h0", F16_ONE, "h1", F16_TWO), "h0");
+		assertResultIsInitialValueOf("fmin s0,s1,s0", Map.of("s0", F32_ONE, "s1", F32_TWO), "s0");
+		assertResultIsInitialValueOf("fmin d0,d1,d0", Map.of("d0", F64_ONE, "d1", F64_TWO), "d0");
+	}
+
+	@Test
+	public void testAliasedMaximumKeepsTheDestinationOperand() throws Exception {
+		assertResultIsInitialValueOf("fmax h0,h1,h0", Map.of("h0", F16_TWO, "h1", F16_ONE), "h0");
+		assertResultIsInitialValueOf("fmax s0,s1,s0", Map.of("s0", F32_TWO, "s1", F32_ONE), "s0");
+		assertResultIsInitialValueOf("fmax d0,d1,d0", Map.of("d0", F64_TWO, "d1", F64_ONE), "d0");
+	}
+
+	@Test
+	public void testAliasedMaximumNumberKeepsTheDestinationOperand() throws Exception {
+		assertResultIsInitialValueOf("fmaxnm h0,h1,h0", Map.of("h0", F16_TWO, "h1", F16_ONE), "h0");
+		assertResultIsInitialValueOf("fmaxnm s0,s1,s0", Map.of("s0", F32_TWO, "s1", F32_ONE), "s0");
+		assertResultIsInitialValueOf("fmaxnm d0,d1,d0", Map.of("d0", F64_TWO, "d1", F64_ONE), "d0");
+	}
+
+	@Test
+	public void testAliasedMinimumKeepsTheSourceOperand() throws Exception {
+		assertResultIsInitialValueOf("fmin h0,h1,h0", Map.of("h0", F16_TWO, "h1", F16_ONE), "h1");
+		assertResultIsInitialValueOf("fmin s0,s1,s0", Map.of("s0", F32_TWO, "s1", F32_ONE), "s1");
+		assertResultIsInitialValueOf("fmin d0,d1,d0", Map.of("d0", F64_TWO, "d1", F64_ONE), "d1");
+	}
+
+	@Test
+	public void testAliasedMaximumKeepsTheSourceOperand() throws Exception {
+		assertResultIsInitialValueOf("fmax h0,h1,h0", Map.of("h0", F16_ONE, "h1", F16_TWO), "h1");
+		assertResultIsInitialValueOf("fmax s0,s1,s0", Map.of("s0", F32_ONE, "s1", F32_TWO), "s1");
+		assertResultIsInitialValueOf("fmax d0,d1,d0", Map.of("d0", F64_ONE, "d1", F64_TWO), "d1");
+	}
+
+	@Test
+	public void testAliasedMaximumNumberKeepsTheSourceOperand() throws Exception {
+		assertResultIsInitialValueOf("fmaxnm h0,h1,h0", Map.of("h0", F16_ONE, "h1", F16_TWO), "h1");
+		assertResultIsInitialValueOf("fmaxnm s0,s1,s0", Map.of("s0", F32_ONE, "s1", F32_TWO), "s1");
+		assertResultIsInitialValueOf("fmaxnm d0,d1,d0", Map.of("d0", F64_ONE, "d1", F64_TWO), "d1");
+	}
+
+	@Test
+	public void testThreeDistinctRegisters() throws Exception {
+		assertResultIsInitialValueOf("fmin s0,s1,s2", Map.of("s1", F32_TWO, "s2", F32_ONE), "s2");
+		assertResultIsInitialValueOf("fmin s0,s1,s2", Map.of("s1", F32_ONE, "s2", F32_TWO), "s1");
+		assertResultIsInitialValueOf("fmax s0,s1,s2", Map.of("s1", F32_TWO, "s2", F32_ONE), "s1");
+		assertResultIsInitialValueOf("fmax s0,s1,s2", Map.of("s1", F32_ONE, "s2", F32_TWO), "s2");
+	}
+
+	@Test
+	public void testDestinationAliasingTheFirstSource() throws Exception {
+		assertResultIsInitialValueOf("fmin s0,s0,s1", Map.of("s0", F32_TWO, "s1", F32_ONE), "s1");
+		assertResultIsInitialValueOf("fmin s0,s0,s1", Map.of("s0", F32_ONE, "s1", F32_TWO), "s0");
+	}
+}


### PR DESCRIPTION
Fixes #9586.

The scalar `FMIN`/`FMAX`/`FMAXNM` constructors assign `Rd` before reading `Rm`. When an encoding
names the same register for both — `fmin s0, s6, s0` — the first assignment destroys the operand the
comparison then reads. The comparison folds to a constant, the branch becomes unconditional, and the
instruction lifts as `s0 = s6` with the bound dropped entirely.

`FMIN` at least leaves a `Removing unreachable block` warning behind. `FMAX` folds the other way, so
the branch is simply never taken: no unreachable block, no warning, and the instruction is mis-lifted
with nothing to indicate it.

Reading both operands into locals before writing `Rd` repairs all nine constructors (three
operations x three widths). `FMINNM` uses an opaque pcodeop and is unaffected.

### Before and after

Decompiling `fmin s0, s6, s0` and `fmax s0, s6, s0` as two separate functions — kept separate
because `max(a, min(a, b))` folds back to `a`, which would mask the difference.

Raw p-code for `fmin`, on master:

```
s0   COPY s6                  <-- clobbers Rm
tmp  FLOAT_LESSEQUAL s6, s0   <-- compares s6 with itself
---  CBRANCH
s0   COPY s0
```

and on this branch:

```
u1   COPY s6
u2   COPY s0
s0   COPY u1
tmp  FLOAT_LESSEQUAL u1, u2
---  CBRANCH
s0   COPY u2
```

Decompiler output on master — both functions lose the instruction, and only `fmin` says anything:

```c
/* WARNING: Removing unreachable block (ram,0x00000000) */
undefined4 fmin_repro(void) { undefined4 in_s6; return in_s6; }

undefined4 fmax_repro(void) { undefined4 in_s6; return in_s6; }
```

and on this branch:

```c
float fmin_repro(float param_1) { float in_s6; if (param_1 < in_s6) in_s6 = param_1; return in_s6; }

float fmax_repro(float param_1) { float in_s6; if (in_s6 <= param_1) in_s6 = param_1; return in_s6; }
```

The second operand is missing from the master output altogether; with the fix it reaches the
signature as `param_1` and the instructions become a real minimum and maximum. This was run on the
12.1.3 release engine — the file is byte-identical between it and master, so only the grammar
differs — not on a full master build.

### Regression test

`Ghidra/Processors/AARCH64/src/test.slow/java/ghidra/program/emulation/Aarch64ScalarMinMaxTest.java`
takes the p-code of each instruction, runs it in the p-code emulator and asserts the register that
comes out — behaviour rather than decompiler text.

All nine constructors are covered in the aliased form, where the result has to be the initial `Rm`.
So are the mirror cases, where it has to be the initial `Rn`: without those, a constructor that
simply always returned `Rm` would pass. Two more hold the ordinary encodings in place — three
distinct registers, and `Rd == Rn`, which is idempotent and lifts correctly either way.

The class passes on this branch. Against master's grammar the three aliased cases fail and the rest
still pass.

`sleigh -a` compiles AARCH64, AARCH64BE and AARCH64_AppleSilicon from this branch with the same set
of compiler warnings as master.

This does not touch the template's pre-existing disagreement with the ARM specification on NaN and
signed zero, which is orthogonal to the self-clobber and would be a separate change.