### PR TITLE
x86: Implement AMX instructions

### DIFF
--- a/Ghidra/Processors/x86/data/languages/amx.sinc
+++ b/Ghidra/Processors/x86/data/languages/amx.sinc
@@ -1,0 +1,39 @@
+
+:TILEZERO tmmreg is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_F2) & $(VEX_0F38) & $(VEX_W0); byte=0x49; tmmreg ... { tmmreg = 0; }
+
+define pcodeop amx_store_tile;
+:TILESTORED Mem, tmmreg is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_F3) & $(VEX_0F38) & $(VEX_W0); byte=0x4B; tmmreg ... & Mem { *:1 Mem = amx_store_tile(tmmreg); }
+
+define pcodeop amx_release_tile;
+:TILERELEASE is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_NONE) & $(VEX_0F38) & $(VEX_W0); byte=0x49; byte=0xC0 { amx_release_tile(); }
+
+define pcodeop amx_load_tile;
+:TILELOADDT1 tmmreg, Mem is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x4B; tmmreg ... & Mem { tmmreg = amx_load_tile(Mem); }
+:TILELOAD tmmreg, Mem is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_F2) & $(VEX_0F38) & $(VEX_W0); byte=0x4B; tmmreg ... & Mem { tmmreg = amx_load_tile(Mem); }
+
+define pcodeop amx_tdpbuud;
+:TDPBUUD tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_NONE) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x5E; tmmreg1 & tmmreg { tmmreg = amx_tdpbuud(vexVVVV_tmm, tmmreg1); }
+define pcodeop amx_tdpbusd;
+:TDPBUSD tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x5E; tmmreg1 & tmmreg { tmmreg = amx_tdpbusd(vexVVVV_tmm, tmmreg1); }
+define pcodeop amx_tdpbsud;
+:TDPBSUD tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_F3) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x5E; tmmreg1 & tmmreg { tmmreg = amx_tdpbsud(vexVVVV_tmm, tmmreg1); }
+define pcodeop amx_tdpbssd;
+:TDPBSSD tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_F2) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x5E; tmmreg1 & tmmreg { tmmreg = amx_tdpbssd(vexVVVV_tmm, tmmreg1); }
+
+define pcodeop amx_tdpfp16ps;
+:TDPFP16PS tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_F2) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x5C; tmmreg1 & tmmreg { tmmreg = amx_tdpfp16ps(vexVVVV_tmm, tmmreg1); }
+
+define pcodeop amx_tcmmimfp16ps;
+:TCMMIMFP16PS tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x6C; tmmreg1 & tmmreg { tmmreg = amx_tcmmimfp16ps(vexVVVV_tmm, tmmreg1); }
+
+define pcodeop amx_tcmmrlfp16ps;
+:TCMMRLFP16PS tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_NONE) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x6C; tmmreg1 & tmmreg { tmmreg = amx_tcmmrlfp16ps(vexVVVV_tmm, tmmreg1); }
+
+define pcodeop amx_tdpbf16ps;
+:TDPBF16PS tmmreg, vexVVVV_tmm, tmmreg1 is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_F3) & $(VEX_0F38) & $(VEX_W0) & vexVVVV_tmm; byte=0x5C; tmmreg1 & tmmreg { tmmreg = amx_tdpbf16ps(vexVVVV_tmm, tmmreg1); }
+
+define pcodeop amx_tile_cfg;
+:STTILECFG Mem is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_66) & $(VEX_0F38) & $(VEX_W0); byte=0x49; reg_opcode=0 ... & Mem { *:64 Mem = amx_tile_cfg(); }
+
+define pcodeop amx_load_tile_cfg;
+:LDTILECFG Mem is $(VEX_NDS) & $(VEX_LZ) & $(VEX_PRE_NONE) & $(VEX_0F38) & $(VEX_W0); byte=0x49; reg_opcode=0 ... & Mem { amx_load_tile_cfg(*:64 Mem); }

--- a/Ghidra/Processors/x86/data/languages/ia.sinc
+++ b/Ghidra/Processors/x86/data/languages/ia.sinc
@@ -364,6 +364,17 @@ define register offset=0x1200 size=64  [
 	ZMM30	ZMM31
 ];
 
+define register offset=0x3000 size=1024  [
+	TMM0
+	TMM1
+	TMM2
+	TMM3
+	TMM4
+	TMM5
+	TMM6
+	TMM7
+];
+
 # Define context bits
 define register offset=0x2000 size=8   contextreg;
 
@@ -444,6 +455,7 @@ define context contextreg
   vexVVVV=(25,28)       # value of vex byte for matching
   vexVVVV_r32=(25,28)   # value of vex byte for matching a normal 32 bit register
   vexVVVV_r64=(25,28)   # value of vex byte for matching a normal 64 bit register
+  vexVVVV_tmm=(25,28)   # value of vex byte for matching a tmm register
   vexVVVV_XmmReg=(25,28)       # value of vex byte for matching XmmReg
   vexVVVV_YmmReg=(25,28)       # value of vex byte for matching YmmReg
   vexVVVV_ZmmReg=(25,28)       # value of vex byte for matching ZmmReg
@@ -556,6 +568,8 @@ define token modrm (8)
   debugreg      = (3,5)
   debugreg_x    = (3,5)
   testreg       = (3,5)
+  tmmreg        = (3,5)
+  tmmreg1       = (0,2)
   r8            = (0,2)
   r16           = (0,2)
   r32           = (0,2)
@@ -736,12 +750,16 @@ attach variables [ evexV5_YmmReg ] [ YMM0  YMM1  YMM2  YMM3  YMM4  YMM5  YMM6  Y
 attach variables [ evexV5_ZmmReg ] [ ZMM0  ZMM1  ZMM2  ZMM3  ZMM4  ZMM5  ZMM6  ZMM7  ZMM8  ZMM9  ZMM10 ZMM11 ZMM12 ZMM13 ZMM14 ZMM15
 	                                 ZMM16 ZMM17 ZMM18 ZMM19 ZMM20 ZMM21 ZMM22 ZMM23 ZMM24 ZMM25 ZMM26 ZMM27 ZMM28 ZMM29 ZMM30 ZMM31 ];
 
+attach variables [ tmmreg tmmreg1 ] [ TMM0 TMM1 TMM2 TMM3 TMM4 TMM5 TMM6 TMM7 ];
+
 @ifdef IA64
 attach variables [ vexVVVV_r32 ] [ EAX  ECX  EDX  EBX  ESP  EBP  ESI  EDI R8D  R9D  R10D R11D R12D R13D R14D R15D ];
 attach variables [ vexVVVV_r64 ] [ RAX  RCX  RDX  RBX  RSP  RBP  RSI  RDI R8   R9   R10  R11  R12  R13  R14  R15 ];
 @else
 attach variables [ vexVVVV_r32 ] [ EAX  ECX  EDX  EBX  ESP  EBP  ESI  EDI _    _    _    _    _    _    _    _ ];
 @endif
+
+attach variables [ vexVVVV_tmm ] [ TMM0  TMM1  TMM2  TMM3  TMM4  TMM5  TMM6  TMM7 _    _    _    _    _    _    _    _ ];
 
 attach variables [ evexOpmask opmaskreg opmaskrm evexVopmask ] [ K0  K1  K2  K3  K4  K5  K6  K7 ];
 

--- a/Ghidra/Processors/x86/data/languages/x86.slaspec
+++ b/Ghidra/Processors/x86/data/languages/x86.slaspec
@@ -20,4 +20,5 @@ with : lockprefx=0 {
 @include "cet.sinc"
 @include "rdrand.sinc"
 @include "rao.sinc"
+@include "amx.sinc"
 }


### PR DESCRIPTION
Implements the new x86 registers and instructions introduced as part of the Intel Advanced Matrix Extensions (AMX).

Fixes #9598