### PR TITLE
Report oversized uncompressed SLA files

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/utils/SlaFormat.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/pcode/utils/SlaFormat.java
@@ -39,7 +39,7 @@ public class SlaFormat {
 	public static final int FORMAT_VERSION = 4;
 
 	/**
-	 * Absolute limit on the number of bytes in a .sla file
+	 * Absolute limit on the number of uncompressed bytes in a .sla file
 	 */
 	public static final int MAX_FILE_SIZE = 1 << 24;		// 16 Megabytes
 	// Attributes
@@ -265,6 +265,11 @@ public class SlaFormat {
 
 			try (InflaterInputStream inflaterStream = new InflaterInputStream(stream)) {
 				decoder.ingestStream(inflaterStream);
+				if (inflaterStream.read() != -1) {
+					throw new IOException(
+						"Uncompressed .sla file exceeds maximum supported size of " +
+							MAX_FILE_SIZE + " bytes");
+				}
 			}
 
 			decoder.endIngest();

--- a/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcode/utils/SlaFormatTest.java
+++ b/Ghidra/Framework/SoftwareModeling/src/test/java/ghidra/pcode/utils/SlaFormatTest.java
@@ -1,0 +1,52 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.pcode.utils;
+
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.util.zip.DeflaterOutputStream;
+
+import org.junit.Test;
+
+import generic.jar.ResourceFile;
+
+public class SlaFormatTest {
+
+	@Test
+	public void testBuildDecoderRejectsOversizedUncompressedSla() throws Exception {
+		File slaFile = File.createTempFile("oversized", ".sla");
+		slaFile.deleteOnExit();
+
+		try (OutputStream fileStream = new BufferedOutputStream(new FileOutputStream(slaFile))) {
+			SlaFormat.writeSlaHeader(fileStream);
+			try (DeflaterOutputStream compressedStream = new DeflaterOutputStream(fileStream)) {
+				byte[] buffer = new byte[8192];
+				int remaining = SlaFormat.MAX_FILE_SIZE + 1;
+				while (remaining > 0) {
+					int length = Math.min(remaining, buffer.length);
+					compressedStream.write(buffer, 0, length);
+					remaining -= length;
+				}
+			}
+		}
+
+		IOException exception = assertThrows(IOException.class,
+			() -> SlaFormat.buildDecoder(new ResourceFile(slaFile)));
+		assertEquals("Uncompressed .sla file exceeds maximum supported size of " +
+			SlaFormat.MAX_FILE_SIZE + " bytes", exception.getMessage());
+	}
+}


### PR DESCRIPTION
Fixes #9575

The Java `.sla` loader caps decompressed input at `SlaFormat.MAX_FILE_SIZE` (16 MiB). `LinkedByteBuffer.ingestStream()` stops normally when that limit is reached, so an oversized `.sla` was silently truncated and could later surface as a misleading format violation.

This change checks the inflater immediately after the capped ingest. If another uncompressed byte is available, `buildDecoder()` now throws an `IOException` that identifies the 16 MiB uncompressed-size limit. The check deliberately stops after the first excess byte rather than draining a potentially very large compressed stream, and the existing size ceiling remains unchanged.

A regression test creates a real SLA header followed by a deflated `MAX_FILE_SIZE + 1` payload and verifies the explicit size-limit error.