### PR TITLE
9582: Read versioned GUID bytes as unsigned

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/datatype/microsoft/GuidUtil.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/datatype/microsoft/GuidUtil.java
@@ -283,9 +283,9 @@ public class GuidUtil {
 		// retVal = retVal.toUpperCase();
 
 		guidString += " v";
-		versionData[0] = (bytes[17] << 8) + bytes[16];
+		versionData[0] = readVersion(bytes, 16);
 		guidString += Integer.toString(versionData[0]) + ".";
-		versionData[1] = (bytes[19] << 8) + bytes[18];
+		versionData[1] = readVersion(bytes, 18);
 		guidString += Integer.toString(versionData[1]);
 
 		if (validate && !NewGuid.isOKForGUID(bytes, 0)) {
@@ -293,6 +293,10 @@ public class GuidUtil {
 		}
 
 		return guidString;
+	}
+
+	static int readVersion(byte[] bytes, int offset) {
+		return (Byte.toUnsignedInt(bytes[offset + 1]) << 8) | Byte.toUnsignedInt(bytes[offset]);
 	}
 
 	private static final String MS_GUID_PREFIX = "_GUID_";

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/util/datatype/microsoft/GuidUtilTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/util/datatype/microsoft/GuidUtilTest.java
@@ -1,0 +1,44 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.datatype.microsoft;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class GuidUtilTest {
+
+	@Test
+	public void testReadVersionTreatsHighByteAsUnsigned() {
+		byte[] bytes = { 0x42, (byte) 0x80 };
+
+		assertEquals(0x8042, GuidUtil.readVersion(bytes, 0));
+	}
+
+	@Test
+	public void testReadVersionTreatsLowByteAsUnsigned() {
+		byte[] bytes = { (byte) 0x80, 0x00 };
+
+		assertEquals(0x0080, GuidUtil.readVersion(bytes, 0));
+	}
+
+	@Test
+	public void testReadVersionSupportsMaximumUnsignedValue() {
+		byte[] bytes = { (byte) 0xff, (byte) 0xff };
+
+		assertEquals(0xffff, GuidUtil.readVersion(bytes, 0));
+	}
+}


### PR DESCRIPTION
Fixes #9582

`getVersionedGuidString()` assembles each 16-bit version component from two bytes. Java promotes signed `byte` values during arithmetic, so either byte having bit 7 set can make the resulting version negative or otherwise incorrect.

This change converts both bytes to unsigned integers before combining them in little-endian order. This also handles the low-byte case that masking the final sum alone would not correct.

The regression tests cover a signed high byte, a signed low byte, and the maximum 16-bit unsigned value.