### PR TITLE
9588: Compare block model names by value

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/blockmodel/BlockModelServicePlugin.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/plugin/core/blockmodel/BlockModelServicePlugin.java
@@ -480,7 +480,7 @@ public class BlockModelServicePlugin extends ProgramPlugin
 		@Override
 		public boolean equals(Object obj) {
 			if (obj instanceof BlockModelInfo) {
-				return modelName == ((BlockModelInfo) obj).modelName;
+				return modelName.equals(((BlockModelInfo) obj).modelName);
 			}
 			return false;
 		}

--- a/Ghidra/Features/Base/src/test/java/ghidra/app/plugin/core/blockmodel/BlockModelServicePluginTest.java
+++ b/Ghidra/Features/Base/src/test/java/ghidra/app/plugin/core/blockmodel/BlockModelServicePluginTest.java
@@ -1,0 +1,48 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.plugin.core.blockmodel;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.Test;
+
+import ghidra.program.model.block.SimpleBlockModel;
+
+public class BlockModelServicePluginTest {
+
+	@Test
+	public void testBlockModelInfoEqualsComparesModelNamesByValue() throws Exception {
+		String firstName = new String("Test Model");
+		String secondName = new String("Test Model");
+		assertNotSame(firstName, secondName);
+
+		Object first = newBlockModelInfo(firstName);
+		Object second = newBlockModelInfo(secondName);
+
+		assertEquals(first, second);
+		assertEquals(first.hashCode(), second.hashCode());
+	}
+
+	private Object newBlockModelInfo(String modelName) throws Exception {
+		Class<?> infoClass = Class.forName(
+			"ghidra.app.plugin.core.blockmodel.BlockModelServicePlugin$BlockModelInfo");
+		Constructor<?> constructor = infoClass.getDeclaredConstructor(String.class, Class.class);
+		constructor.setAccessible(true);
+		return constructor.newInstance(modelName, SimpleBlockModel.class);
+	}
+}


### PR DESCRIPTION
Fixes #9588

`BlockModelInfo.equals()` compares `modelName` using reference identity, while `hashCode()` is based on the string value. Two model descriptors with equal names can therefore compare unequal when their names are distinct `String` instances.

Compare model names by value instead, keeping `equals()` and `hashCode()` consistent.

The regression test constructs two descriptors with separate `String` objects containing the same model name and verifies they compare equal and have the same hash code.