### PR TITLE
Use m68k ABI data alignment

### DIFF
--- a/Ghidra/Processors/68000/data/languages/68000.cspec
+++ b/Ghidra/Processors/68000/data/languages/68000.cspec
@@ -5,7 +5,7 @@
 	<absolute_max_alignment value="0" />
 	<machine_alignment value="8" />
 	<default_alignment value="1" />
-	<default_pointer_alignment value="4" />
+	<default_pointer_alignment value="2" />
 	<pointer_size value="4" />
 	<wchar_size value="4" />
 	<short_size value="2" />
@@ -18,8 +18,8 @@
 	<size_alignment_map>
 		<entry size="1" alignment="1" />
 		<entry size="2" alignment="2" />
-		<entry size="4" alignment="4" />
-		<entry size="8" alignment="4" />
+		<entry size="4" alignment="2" />
+		<entry size="8" alignment="2" />
 	</size_alignment_map>
   </data_organization>
   

--- a/Ghidra/Processors/68000/src/test/java/ghidra/test/processors/M68000DataOrganizationTest.java
+++ b/Ghidra/Processors/68000/src/test/java/ghidra/test/processors/M68000DataOrganizationTest.java
@@ -1,0 +1,41 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.test.processors;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import ghidra.program.model.data.DataOrganization;
+import ghidra.program.model.lang.Language;
+import ghidra.program.model.lang.LanguageID;
+import ghidra.program.util.DefaultLanguageService;
+import ghidra.test.AbstractGhidraHeadlessIntegrationTest;
+
+public class M68000DataOrganizationTest extends AbstractGhidraHeadlessIntegrationTest {
+
+	@Test
+	public void testDefaultCompilerSpecUsesTwoByteDataAlignment() throws Exception {
+		Language language = DefaultLanguageService.getLanguageService()
+				.getLanguage(new LanguageID("68000:BE:32:default"));
+		DataOrganization dataOrganization = language.getDefaultCompilerSpec().getDataOrganization();
+
+		assertEquals(2, dataOrganization.getDefaultPointerAlignment());
+		assertEquals(2, dataOrganization.getSizeAlignment(4));
+		assertEquals(2, dataOrganization.getSizeAlignment(8));
+		assertEquals(2, dataOrganization.getSizeAlignment(10));
+	}
+}


### PR DESCRIPTION
Fixes #2375

The default m68k compiler specification currently aligns pointers and 4-/8-byte primitive values to 4-byte boundaries. The GCC reproduction in the issue shows the m68k ABI uses 2-byte structure-member alignment; for example, a `double` following a `short` begins at offset 2 rather than offset 4.

Update `68000.cspec` so pointer, 4-byte, and 8-byte data alignment is 2 bytes. Calling-convention and stack-argument alignment rules are left unchanged.

Add a regression test that loads `68000:BE:32:default` and verifies 2-byte pointer alignment plus 2-byte alignment for 4-, 8-, and 10-byte data.